### PR TITLE
Movable columns in detail view

### DIFF
--- a/ROX-Filer/src/view_details.c
+++ b/ROX-Filer/src/view_details.c
@@ -1096,36 +1096,45 @@ static void view_details_init(GTypeInstance *object, gpointer gclass)
 	ADD_TEXT_COLUMN(_("_Name"), COL_LEAF);
 	gtk_tree_view_column_set_sort_column_id(column, COL_LEAF);
 	gtk_tree_view_column_set_resizable(column, TRUE);
+	gtk_tree_view_column_set_reorderable(column, TRUE);
 	ADD_TEXT_COLUMN(_("_Type"), COL_TYPE);
 	gtk_tree_view_column_set_sort_column_id(column, COL_TYPE);
 	gtk_tree_view_column_set_resizable(column, TRUE);
-	ADD_TEXT_COLUMN(_("_Permissions"), COL_PERM);
-	g_object_set(G_OBJECT(cell), "font", "monospace", NULL);
-	g_signal_connect_after(object, "realize",
-			       G_CALLBACK(set_column_mono_font),
-			       G_OBJECT(cell));
-	ADD_TEXT_COLUMN(_("_Owner"), COL_OWNER);
-	gtk_tree_view_column_set_sort_column_id(column, COL_OWNER);
-	ADD_TEXT_COLUMN(_("_Group"), COL_GROUP);
-	gtk_tree_view_column_set_sort_column_id(column, COL_GROUP);
+	gtk_tree_view_column_set_reorderable(column, TRUE);
 	ADD_TEXT_COLUMN(_("_Size"), COL_SIZE);
 	g_object_set(G_OBJECT(cell), "xalign", 1.0, "font", "monospace", NULL);
 	g_signal_connect_after(object, "realize",
 			       G_CALLBACK(set_column_mono_font),
 			       G_OBJECT(cell));
 	gtk_tree_view_column_set_sort_column_id(column, COL_SIZE);
+	gtk_tree_view_column_set_reorderable(column, TRUE);
+	
+	ADD_TEXT_COLUMN(_("_Permissions"), COL_PERM);
+	gtk_tree_view_column_set_reorderable(column, TRUE);
+	g_object_set(G_OBJECT(cell), "font", "monospace", NULL);
+	g_signal_connect_after(object, "realize",
+			       G_CALLBACK(set_column_mono_font),
+			       G_OBJECT(cell));
+	ADD_TEXT_COLUMN(_("_Owner"), COL_OWNER);
+	gtk_tree_view_column_set_sort_column_id(column, COL_OWNER);
+	gtk_tree_view_column_set_reorderable(column, TRUE);
+	ADD_TEXT_COLUMN(_("_Group"), COL_GROUP);
+	gtk_tree_view_column_set_sort_column_id(column, COL_GROUP);
+	gtk_tree_view_column_set_reorderable(column, TRUE);
 	ADD_TEXT_COLUMN(_("Last _Modified"), COL_MTIME);
 	g_object_set(G_OBJECT(cell), "font", "monospace", NULL);
 	g_signal_connect_after(object, "realize",
 			       G_CALLBACK(set_column_mono_font),
 			       G_OBJECT(cell));
 	gtk_tree_view_column_set_sort_column_id(column, COL_MTIME);
+	gtk_tree_view_column_set_reorderable(column, TRUE);
 	ADD_TEXT_COLUMN(_("Last _Changed"), COL_CTIME);
 	g_object_set(G_OBJECT(cell), "font", "monospace", NULL);
 	g_signal_connect_after(object, "realize",
 			       G_CALLBACK(set_column_mono_font),
 			       G_OBJECT(cell));
 	gtk_tree_view_column_set_sort_column_id(column, COL_CTIME);
+	gtk_tree_view_column_set_reorderable(column, TRUE);
 }
 
 /* Create the handers for the View interface */


### PR DESCRIPTION
This is a mod that's been in use in Puppy Linux world for years.
It makes possible to reorder columns in detail view.
It also moves 'Size' column more to the left (to be right after 'Type').

I'm not the author of this patch, I only made it compliant with current sources.
I think it all started right here:
http://www.murga-linux.com/puppy/viewtopic.php?t=57166
and Otter & Rocket are the users responsible for this mod.

What do you think about it?