### PR TITLE
Preserve ownership of copied/duplicated files

### DIFF
--- a/ROX-Filer/src/action.c
+++ b/ROX-Filer/src/action.c
@@ -1679,7 +1679,10 @@ static void do_copy2(const char *path, const char *dest)
 			g_error_free(err);
 		}
 		else
+		{
+			lchown(dest_path, info.st_uid, info.st_gid);
 			send_check_path(dest_path);
+		}
 
 		g_object_unref(srcf);
 		g_object_unref(destf);


### PR DESCRIPTION
Regarding this issue: https://github.com/jun7/rox-filer/issues/179
It seems that it fixed the problem, but I'm not sure if it's _the_ proper fix; I'm not that familiar with ROX's internals.