### PR TITLE
minibuffer.c: Fix bug caused by switch to g_path_get_basename

### DIFF
--- a/ROX-Filer/src/minibuffer.c
+++ b/ROX-Filer/src/minibuffer.c
@@ -374,11 +374,13 @@ static void path_return_pressed(FilerWindow *filer_window, GdkEventKey *event)
 	int		flags = OPEN_FROM_MINI | OPEN_SAME_WINDOW;
 	ViewIter	iter;
 	DirItem		*item;
-	gchar *base;
 
 	path = gtk_entry_get_text(GTK_ENTRY(filer_window->minibuffer));
-	base = g_path_get_basename(path);
-	pattern = base;
+	pattern = strrchr(path, G_DIR_SEPARATOR);
+	if (pattern == NULL) /* No G_DIR_SEPARATOR found. */
+		pattern = path;
+	else
+		pattern++;
 
 	view_get_cursor(filer_window->view, &iter);
 
@@ -388,7 +390,6 @@ static void path_return_pressed(FilerWindow *filer_window, GdkEventKey *event)
 		gdk_beep();
 		return;
 	}
-	g_free(base);
 
 	if ((event->state & GDK_SHIFT_MASK) != 0)
 		flags |= OPEN_SHIFT;
@@ -519,7 +520,6 @@ static void path_changed(FilerWindow *filer_window)
 	char		*path;
 	char		*new = NULL;
 	gboolean	error = FALSE;
-	gchar 		*base;
 
 	rawnew = gtk_entry_get_text(GTK_ENTRY(mini));
 	if (!*rawnew)
@@ -575,8 +575,12 @@ static void path_changed(FilerWindow *filer_window)
 	}
 
 
-	base = g_path_get_basename(new);
-	leaf = base;
+	leaf = strrchr(new, G_DIR_SEPARATOR);
+	if (leaf == NULL) /* No G_DIR_SEPARATOR found. */
+		leaf = new;
+	else
+		leaf++;
+
 	if (leaf == new)
 		path = g_strdup("/");
 	else
@@ -610,7 +614,6 @@ static void path_changed(FilerWindow *filer_window)
 
 	g_free(new);
 	g_free(path);
-	g_free(base);
 
 	entry_set_error(mini, error);
 }
@@ -697,18 +700,19 @@ static void search_in_dir(FilerWindow *filer_window, int dir)
 {
 	const char *path, *pattern;
 	ViewIter iter;
-	gchar *base;
 
 	path = gtk_entry_get_text(GTK_ENTRY(filer_window->minibuffer));
-	base = g_path_get_basename(path);
-	pattern = base;
+	pattern = strrchr(path, G_DIR_SEPARATOR);
+	if (pattern == NULL) /* No G_DIR_SEPARATOR found. */
+		pattern = path;
+	else
+		pattern++;
 
 	view_get_cursor(filer_window->view, &iter);
 	view_set_base(filer_window->view, &iter);
 	find_next_match(filer_window, pattern, dir);
 	view_get_cursor(filer_window->view, &iter);
 	view_set_base(filer_window->view, &iter);
-	g_free(base);
 }
 
 /*			SHELL COMMANDS			*/


### PR DESCRIPTION
g_path_get_basename does not behave the same way as g_basename
when the path ends with a "/"

This can be tested by pressing the "/" ( forward slash ) key in a ROX-Filer window and deleting the path shown, then using the up and down arrow keys to select different items.  Start typing in a path and the up and down arrows select possible items that start with the path typed.