### PR TITLE
fix update-po script; update *.po files

### DIFF
--- a/ROX-Filer/src/po/cs.po
+++ b/ROX-Filer/src/po/cs.po
@@ -8,59 +8,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rox\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-08-09 14:02+0100\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Jan 'jenik' Provaznik <xprovazn@fi.muni.cz>\n"
 "Language-Team:\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=iso-8859-2\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: abox.c:127
-msgid "<dir>"
-msgstr "<adresáø>"
+msgid "<src>"
+msgstr ""
 
-#: abox.c:219
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Potichu"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Quiet"
 msgstr "Potichu"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Don't confirm every operation"
-msgstr "Nepotvrzovat ka¾dou operaci"
+msgstr "Nepotvrzovat kaÅ¾dou operaci"
 
-#: abox.c:455 tips:60
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
-msgstr "Jméno"
+msgstr "JmÃ©no"
 
-#: abox.c:461 menu.c:232
+#: abox.c:447 menu.c:751
 msgid "Directory"
-msgstr "Adresáø"
+msgstr "AdresÃ¡Å™"
 
-#: abox.c:550
+#: abox.c:546
 msgid "Expression:"
-msgstr "Vıraz:"
+msgstr "VÃ½raz:"
 
-#: action.c:58
+#: action.c:57
 msgid "See the attr(5) man page for full details."
 msgstr ""
 
-#: action.c:60
+#: action.c:59
 msgid "See the fsattr(5) man page for full details."
 msgstr ""
 
-#: action.c:62
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr ""
 
-#: action.c:188
+#: action.c:198
 msgid "Find expression reference"
-msgstr "Najít referenci vırazu"
+msgstr "NajÃ­t referenci vÃ½razu"
 
-#: action.c:199
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -98,49 +103,49 @@ msgid ""
 "a % in 'command' is replaced with the path of the current file)\n"
 "<b>prune</b> (false, and prevents searching the contents of a directory)."
 msgstr ""
-"<u>Rychlı Start</u>\n"
-"Jméno souboru, kterı hledáte vlo¾te mezi jednoduché uvozovky:\n"
-"<b>'index.html'</b> (pokud chcete najít soubor 'index.html')\n"
+"<u>RychlÃ½ Start</u>\n"
+"JmÃ©no souboru, kterÃ½ hledÃ¡te vloÅ¾te mezi jednoduchÃ© uvozovky:\n"
+"<b>'index.html'</b> (pokud chcete najÃ­t soubor 'index.html')\n"
 "\n"
-"<u>Pøíklady</u>\n"
+"<u>PÅ™Ã­klady</u>\n"
 "<b>'*.htm', '*.html'</b> (najde HTML soubory)\n"
-"<b>IsDir 'lib'</b> (najde adresáøe 'lib')\n"
-"<b>IsReg 'core'</b> (najde bì¾nı soubor 'core')\n"
-"<b>! (IsDir, IsReg)</b> (není ani adresáø ani bì¾nı soubor)\n"
-"<b>mtime after 1 day ago and size > 1Mb</b> (velkı a nedávno modifikovanı)\n"
-"<b>'CVS' prune, isreg</b> (bì¾nı soubor, kterı není v CVS)\n"
+"<b>IsDir 'lib'</b> (najde adresÃ¡Å™e 'lib')\n"
+"<b>IsReg 'core'</b> (najde bÄ›Å¾nÃ½ soubor 'core')\n"
+"<b>! (IsDir, IsReg)</b> (nenÃ­ ani adresÃ¡Å™ ani bÄ›Å¾nÃ½ soubor)\n"
+"<b>mtime after 1 day ago and size > 1Mb</b> (velkÃ½ a nedÃ¡vno modifikovanÃ½)\n"
+"<b>'CVS' prune, isreg</b> (bÄ›Å¾nÃ½ soubor, kterÃ½ nenÃ­ v CVS)\n"
 "<b>IsReg system(grep -q fred \"%\")</b> (obsahuje slovo 'fred')\n"
 "\n"
-"<u>Jednoduché Testy</u>\n"
+"<u>JednoduchÃ© Testy</u>\n"
 "<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
 "b> (typy)\n"
 "<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
-"(práva)\n"
+"(prÃ¡va)\n"
 "<b>IsEmpty, IsMine</b>\n"
-"Vıraz v jednoduchıch závorkách je vıraz shellového typu, mù¾e obsahovat "
-"magické znaky. Pokud\n"
-"obsahuje lomítko, kontroluje se shoda vzhledem k celé cestì; jinak pouze\n"
-"ke jménu bez cesty.\n"
+"VÃ½raz v jednoduchÃ½ch zÃ¡vorkÃ¡ch je vÃ½raz shellovÃ©ho typu, mÅ¯Å¾e obsahovat "
+"magickÃ© znaky. Pokud\n"
+"obsahuje lomÃ­tko, kontroluje se shoda vzhledem k celÃ© cestÄ›; jinak pouze\n"
+"ke jmÃ©nu bez cesty.\n"
 "\n"
-"<u>Porovnání</u>\n"
-"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (porovnají dvì "
+"<u>PorovnÃ¡nÃ­</u>\n"
+"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (porovnajÃ­ dvÄ› "
 "hodnoty)\n"
-"<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (velikosti souborù)\n"
-"<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (èasy)\n"
+"<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (velikosti souborÅ¯)\n"
+"<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (Äasy)\n"
 "<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
 "(hodnoty)\n"
 "\n"
-"<u>Zvlá¹tní pøíkazy</u>\n"
-"<b>system(command)</b> (true pokud 'command' vrátil 0;\n"
-"% v 'command' je nahrazen cestou souèasného souboru)\n"
-"<b>prune</b> (false, zabrání prohledávání obsahu adresáøe)."
+"<u>ZvlÃ¡Å¡tnÃ­ pÅ™Ã­kazy</u>\n"
+"<b>system(command)</b> (true pokud 'command' vrÃ¡til 0;\n"
+"% v 'command' je nahrazen cestou souÄasnÃ©ho souboru)\n"
+"<b>prune</b> (false, zabrÃ¡nÃ­ prohledÃ¡vÃ¡nÃ­ obsahu adresÃ¡Å™e)."
 
-#: action.c:246
+#: action.c:256
 #, fuzzy
 msgid "Change permissions reference"
-msgstr "Najít referenci vırazu"
+msgstr "NajÃ­t referenci vÃ½razu"
 
-#: action.c:257
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -170,39 +175,39 @@ msgid ""
 "\n"
 "See the chmod(1) man page for full details."
 msgstr ""
-"Normálnì staèí vybrat pøíkaz z nabídky (kliknìte \n"
-"na ¹ipku vedle pøíkazového boxu). Nìkdy je potøeba více...\n"
+"NormÃ¡lnÄ› staÄÃ­ vybrat pÅ™Ã­kaz z nabÃ­dky (kliknÄ›te \n"
+"na Å¡ipku vedle pÅ™Ã­kazovÃ©ho boxu). NÄ›kdy je potÅ™eba vÃ­ce...\n"
 "\n"
-"Formát pøíkazu je: <b>ZMÌNA, ZMÌNA, ...</b>\n"
-"Ka¾dá <b>ZMÌNA</b> je: <b>KDO JAK PRÁVA</b>\n"
-"<b>KDO</b> je kombinace <b>u</b>, <b>g</b> a <b>o</b>, která urèuje, jestli\n"
-"zmìnit práva pro U¾ivatele (vlastník), Skupinu nebo Ostatní.\n"
-"<b>JAK</b> je <b>+</b>, <b>-</b> nebo <b>=</b> pro pøidání, odebrání nebo "
-"pøesné nastavení práv.\n"
-"<b>PRÁVA</b> je kombinace znakù <b>rwxXstugo</b>\n"
+"FormÃ¡t pÅ™Ã­kazu je: <b>ZMÄšNA, ZMÄšNA, ...</b>\n"
+"KaÅ¾dÃ¡ <b>ZMÄšNA</b> je: <b>KDO JAK PRÃVA</b>\n"
+"<b>KDO</b> je kombinace <b>u</b>, <b>g</b> a <b>o</b>, kterÃ¡ urÄuje, jestli\n"
+"zmÄ›nit prÃ¡va pro UÅ¾ivatele (vlastnÃ­k), Skupinu nebo OstatnÃ­.\n"
+"<b>JAK</b> je <b>+</b>, <b>-</b> nebo <b>=</b> pro pÅ™idÃ¡nÃ­, odebrÃ¡nÃ­ nebo "
+"pÅ™esnÃ© nastavenÃ­ prÃ¡v.\n"
+"<b>PRÃVA</b> je kombinace znakÅ¯ <b>rwxXstugo</b>\n"
 "\n"
-"Uzávorkovanı text a mezery jsou ignorovány.\n"
+"UzÃ¡vorkovanÃ½ text a mezery jsou ignorovÃ¡ny.\n"
 "\n"
-"<u>Pøíklady</u>\n"
-"<b>u+rw</b>: vlastník souboru získá práva ètení a zápisu\n"
-"<b>g=u</b>: práva skupiny jsou nastavena na stejná práva jako má u¾ivatel\n"
-"<b>o=u-w</b>: ostatní získají stejná práva jako vlastník kromì práva zápisu\n"
-"<b>a+x</b>: <b>V</b>¹ichni získají právo provedení/pøístupu - stejné jako "
+"<u>PÅ™Ã­klady</u>\n"
+"<b>u+rw</b>: vlastnÃ­k souboru zÃ­skÃ¡ prÃ¡va ÄtenÃ­ a zÃ¡pisu\n"
+"<b>g=u</b>: prÃ¡va skupiny jsou nastavena na stejnÃ¡ prÃ¡va jako mÃ¡ uÅ¾ivatel\n"
+"<b>o=u-w</b>: ostatnÃ­ zÃ­skajÃ­ stejnÃ¡ prÃ¡va jako vlastnÃ­k kromÄ› prÃ¡va zÃ¡pisu\n"
+"<b>a+x</b>: <b>V</b>Å¡ichni zÃ­skajÃ­ prÃ¡vo provedenÃ­/pÅ™Ã­stupu - stejnÃ© jako "
 "<b>ugo+x</b>\n"
-"<b>a+X</b>: adresáøe se stanou pøístupné pro v¹echny; soubory, které mìly\n"
-"pro nìkoho právo spu¹tìní se stanou spustitelné pro v¹echny\n"
-"<b>u+rw, go+r</b>: dva pøíkazy v jednom!\n"
-"<b>u+s</b>: nastaví SetUID bit - èasto nemá efekt u skriptù\n"
-"<b>755</b>: nastaví práva pøímo\n"
+"<b>a+X</b>: adresÃ¡Å™e se stanou pÅ™Ã­stupnÃ© pro vÅ¡echny; soubory, kterÃ© mÄ›ly\n"
+"pro nÄ›koho prÃ¡vo spuÅ¡tÄ›nÃ­ se stanou spustitelnÃ© pro vÅ¡echny\n"
+"<b>u+rw, go+r</b>: dva pÅ™Ã­kazy v jednom!\n"
+"<b>u+s</b>: nastavÃ­ SetUID bit - Äasto nemÃ¡ efekt u skriptÅ¯\n"
+"<b>755</b>: nastavÃ­ prÃ¡va pÅ™Ã­mo\n"
 "\n"
-"Pro úplné informace ètìte manovou stránku chmod(1)."
+"Pro ÃºplnÃ© informace ÄtÄ›te manovou strÃ¡nku chmod(1)."
 
-#: action.c:298
+#: action.c:308
 #, fuzzy
 msgid "Set type reference"
-msgstr "Najít referenci vırazu"
+msgstr "NajÃ­t referenci vÃ½razu"
 
-#: action.c:309
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -218,278 +223,295 @@ msgid ""
 "on certain file systems and where the OS implements them.\n"
 msgstr ""
 
-#: action.c:416
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
-"Proces pøeru¹en.\n"
+"Proces pÅ™eruÅ¡en.\n"
 
-#: action.c:432
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Nastala jedna chyba.\n"
 
-#: action.c:434
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Nastalo %d chyb.\n"
 
-#: action.c:458
+#: action.c:516
 msgid "ERROR reading"
-msgstr "CHYBA ètení"
+msgstr "CHYBA ÄtenÃ­"
 
-#: action.c:501
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Hotovo\n"
 
-#: action.c:557 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "CHYBA"
 
-#: action.c:711 main.c:674 main.c:681 main.c:688
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Ano"
 
-#: action.c:714 main.c:676 main.c:690
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Ne"
 
-#: action.c:732
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
 msgstr ""
 "\n"
-"®ádost o ukonèení potomka...\n"
+"Å½Ã¡dost o ukonÄenÃ­ potomka...\n"
 
-#: action.c:739
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
 msgstr ""
 "\n"
-"Zkou¹ím zabít run-away proces...\n"
+"ZkouÅ¡Ã­m zabÃ­t run-away proces...\n"
 
-#: action.c:892
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Count contents of %s?"
 
-#: action.c:928
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Smazat %s'%s'?"
 
-#: action.c:929
+#: action.c:1047
 msgid "WRITE-PROTECTED "
-msgstr "CHRÁNÌNO PROTI ZÁPISU"
+msgstr "CHRÃNÄšNO PROTI ZÃPISU"
 
-#: action.c:936
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
-msgstr "Ma¾u '%s'\n"
+msgstr "MaÅ¾u '%s'\n"
 
-#: action.c:949
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
-msgstr "Adresáø '%s' smazán\n"
+msgstr "AdresÃ¡Å™ '%s' smazÃ¡n\n"
 
-#: action.c:982
+#: action.c:1104
 #, fuzzy, c-format
 msgid "?Eject '%s'?"
 msgstr "?Zkontrolovat '%s'?"
 
-#: action.c:989
+#: action.c:1111
 #, fuzzy, c-format
 msgid "'Eject '%s'\n"
-msgstr "Ma¾u '%s'\n"
+msgstr "MaÅ¾u '%s'\n"
 
-#: action.c:1008
+#: action.c:1130
 #, fuzzy, c-format
 msgid ""
 "!%s\n"
 "eject failed\n"
 msgstr ""
 "!%s\n"
-"Pøipojení selhalo\n"
+"PÅ™ipojenÃ­ selhalo\n"
 
-#: action.c:1027 action.c:1046
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Zkontrolovat '%s'?"
 
-#: action.c:1043
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
-msgstr "!Neplatná podmínka pro vyhledávání - zmìòte ji a zkuste znovu\n"
+msgstr "!NeplatnÃ¡ podmÃ­nka pro vyhledÃ¡vÃ¡nÃ­ - zmÄ›Åˆte ji a zkuste znovu\n"
 
-#: action.c:1053
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
-msgstr "'(pøi kontrole '%s')\n"
+msgstr "'(pÅ™i kontrole '%s')\n"
 
-#: action.c:1127 action.c:1152
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
-msgstr "?Zmìnit práva '%s'?"
+msgstr "?ZmÄ›nit prÃ¡va '%s'?"
 
-#: action.c:1133
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
-msgstr "'Mìním práva '%s'\n"
+msgstr "'MÄ›nÃ­m prÃ¡va '%s'\n"
 
-#: action.c:1150
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
-msgstr "!Neplatnı mód pøíkazu - zmìòte jej a zkuste znovu\n"
+msgstr "!NeplatnÃ½ mÃ³d pÅ™Ã­kazu - zmÄ›Åˆte jej a zkuste znovu\n"
 
-#: action.c:1207 action.c:1227
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?ZmÄ›nit prÃ¡va '%s'?"
+
+#: action.c:1335 action.c:1355
 #, fuzzy, c-format
 msgid "?Change type of '%s'?"
-msgstr "?Zmìnit práva '%s'?"
+msgstr "?ZmÄ›nit prÃ¡va '%s'?"
 
-#: action.c:1224
+#: action.c:1352
 #, fuzzy
 msgid "!Invalid type - change it and try again\n"
-msgstr "!Neplatnı mód pøíkazu - zmìòte jej a zkuste znovu\n"
+msgstr "!NeplatnÃ½ mÃ³d pÅ™Ã­kazu - zmÄ›Åˆte jej a zkuste znovu\n"
 
-#: action.c:1246
+#: action.c:1374
 #, fuzzy, c-format
 msgid "'Changing type of '%s' to '%s'\n"
-msgstr "'Mìním práva '%s'\n"
+msgstr "'MÄ›nÃ­m prÃ¡va '%s'\n"
 
-#: action.c:1325
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'MÄ›nÃ­m prÃ¡va '%s'\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
-msgstr "?'%s' u¾ existuje - %s?"
+msgstr "?'%s' uÅ¾ existuje - %s?"
 
-#: action.c:1327
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "spojit obsah"
 
-#: action.c:1328
+#: action.c:1551 action.c:1860
 msgid "overwrite"
-msgstr "pøepsat"
+msgstr "pÅ™epsat"
 
-#: action.c:1344
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
-msgstr "'Pøesto zkou¹ím zkopírovat...\n"
+msgstr "'PÅ™esto zkouÅ¡Ã­m zkopÃ­rovat...\n"
 
-#: action.c:1353
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
-msgstr "?Zkopírovat %s jako %s?"
+msgstr "?ZkopÃ­rovat %s jako %s?"
 
-#: action.c:1357
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
-msgstr "'Kopíruji %s jako %s\n"
+msgstr "'KopÃ­ruji %s jako %s\n"
 
-#: action.c:1372
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
-msgstr "!CHYBA: Cíl u¾ existuje, ale není to adresáø\n"
+msgstr "!CHYBA: CÃ­l uÅ¾ existuje, ale nenÃ­ to adresÃ¡Å™\n"
 
-#: action.c:1444
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
 "Failed to copy '%s'\n"
 msgstr ""
 "!%s\n"
-"Kopírování '%s' selhalo\n"
+"KopÃ­rovÃ¡nÃ­ '%s' selhalo\n"
 
-#: action.c:1488
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' u¾ existuje - pøepsat?"
-
-#: action.c:1503
-msgid "'Trying move anyway...\n"
-msgstr "'Pøesto zkou¹ím zkopírovat...\n"
-
-#: action.c:1511
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Pøesunout %s na %s?"
-
-#: action.c:1515
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Pøesunuji %s na %s\n"
-
-#: action.c:1523
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
 "Failed to move %s as %s\n"
 msgstr ""
 "!%s\n"
-"Pøesunutí %s do %s selhalo\n"
+"PÅ™esunutÃ­ %s do %s selhalo\n"
 
-#: action.c:1544
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'PÅ™esto zkouÅ¡Ã­m zkopÃ­rovat...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?PÅ™esunout %s na %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'PÅ™esunuji %s na %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
-msgstr "!CHYBA: Nelze zkopírovat objekt do sebe\n"
+msgstr "!CHYBA: Nelze zkopÃ­rovat objekt do sebe\n"
 
-#: action.c:1559
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
-msgstr "!CHYBA: Nelze pøesunout/pøejmenovat objekt do sebe\n"
+msgstr "!CHYBA: Nelze pÅ™esunout/pÅ™ejmenovat objekt do sebe\n"
 
-#: action.c:1571
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
-msgstr "'Vytváøím odkaz %s na %s\n"
+msgstr "'VytvÃ¡Å™Ã­m odkaz %s na %s\n"
 
-#: action.c:1576
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
-msgstr "?Vytvoøit odkaz %s na %s?"
+msgstr "?VytvoÅ™it odkaz %s na %s?"
 
-#: action.c:1618
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
-msgstr "'Pøipojuji %s\n"
+msgstr "'PÅ™ipojuji %s\n"
 
-#: action.c:1619
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Odpojuji %s\n"
 
-#: action.c:1622
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
-msgstr "?Pøipojit %s?"
+msgstr "?PÅ™ipojit %s?"
 
-#: action.c:1623
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?Odpojit %s?"
 
-#: action.c:1643
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
 "Mount failed\n"
 msgstr ""
 "!%s\n"
-"Pøipojení selhalo\n"
+"PÅ™ipojenÃ­ selhalo\n"
 
-#: action.c:1644
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
 "Unmount failed\n"
 msgstr ""
 "!%s\n"
-"Odpojení selhalo\n"
+"OdpojenÃ­ selhalo\n"
 
-#: action.c:1652
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr ""
 
-#: action.c:1698
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -498,297 +520,321 @@ msgstr ""
 "'\n"
 "Celkem: %s ("
 
-#: action.c:1704
+#: action.c:2108
 msgid "file"
 msgstr "soubor"
 
-#: action.c:1704
+#: action.c:2108
 msgid "files"
 msgstr "soubory"
 
-#: action.c:1708
+#: action.c:2112
 msgid "no directories)\n"
-msgstr "¾ádné adresáøe)\n"
+msgstr "Å¾Ã¡dnÃ© adresÃ¡Å™e)\n"
 
-#: action.c:1712
+#: action.c:2116
 msgid "directory"
-msgstr "adresáø"
+msgstr "adresÃ¡Å™"
 
-#: action.c:1713
+#: action.c:2117
 msgid "directories"
-msgstr "adresáøe"
+msgstr "adresÃ¡Å™e"
 
-#: action.c:1754
+#: action.c:2155
 msgid "!No mount points selected!\n"
-msgstr "!Nejsou zvoleny ¾ádné body pro pøipojení!\n"
+msgstr "!Nejsou zvoleny Å¾Ã¡dnÃ© body pro pÅ™ipojenÃ­!\n"
 
-#: action.c:1839
+#: action.c:2231
 msgid "?Another search?"
-msgstr "?Dal¹í hledání?"
+msgstr "?DalÅ¡Ã­ hledÃ¡nÃ­?"
 
-#: action.c:1869 action.c:1900
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
-msgstr "!'%s' je symbolickı odkaz\n"
+msgstr "!'%s' je symbolickÃ½ odkaz\n"
 
-#: action.c:1940
+#: action.c:2342
 msgid "You need to select some items to search through"
-msgstr "Musíte zvolit nìjaké polo¾ky ve kterıch se má hledat"
+msgstr "MusÃ­te zvolit nÄ›jakÃ© poloÅ¾ky ve kterÃ½ch se mÃ¡ hledat"
 
-#: action.c:1950 menu.c:223
+#: action.c:2352 menu.c:728
 msgid "Find"
-msgstr "Najít"
+msgstr "NajÃ­t"
 
-#: action.c:1983
+#: action.c:2387
 msgid "You need to select some items to count"
-msgstr "Musíte zvolit nìjaké polo¾ky pro spoèítání velikosti"
+msgstr "MusÃ­te zvolit nÄ›jakÃ© poloÅ¾ky pro spoÄÃ­tÃ¡nÃ­ velikosti"
 
-#: action.c:1987
+#: action.c:2391
 msgid "Disk Usage"
-msgstr "Vyu¾ití disku"
+msgstr "VyuÅ¾itÃ­ disku"
 
-#: action.c:2021
+#: action.c:2429
 msgid "Mount / Unmount"
-msgstr "Pøipojit / Odpojit"
+msgstr "PÅ™ipojit / Odpojit"
 
-#: action.c:2034
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr ""
-"ROX-Filer zatím nepodporuje pøipojovací body na Va¹em systému. Promiòte."
+"ROX-Filer zatÃ­m nepodporuje pÅ™ipojovacÃ­ body na VaÅ¡em systÃ©mu. PromiÅˆte."
 
-#: action.c:2048 menu.c:210 tips:208
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Smazat"
 
-#: action.c:2058 tips:213
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
-msgstr "Bez potvrzení"
+msgstr "Bez potvrzenÃ­"
 
-#: action.c:2058
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
-msgstr "Nepotvrzovat smazání polo¾ek, které nemají právo zápisu"
+msgstr "Nepotvrzovat smazÃ¡nÃ­ poloÅ¾ek, kterÃ© nemajÃ­ prÃ¡vo zÃ¡pisu"
 
-#: action.c:2061 action.c:2116 action.c:2175 action.c:2228 action.c:2264
-#: tips:215
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
-msgstr "Struènì"
+msgstr "StruÄnÄ›"
 
-#: action.c:2061
+#: action.c:2479
 msgid "Only log directories being deleted"
-msgstr "Vypisovat pouze smazané adresáøe?"
+msgstr "Vypisovat pouze smazanÃ© adresÃ¡Å™e?"
 
-#: action.c:2078
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
-msgstr "Musíte zvolit polo¾ky, u kterıch chcete zmìnit práva"
+msgstr "MusÃ­te zvolit poloÅ¾ky, u kterÃ½ch chcete zmÄ›nit prÃ¡va"
 
-#: action.c:2086
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
-msgstr "a+x (Povolit spou¹tìní/pøístup)"
+msgstr "a+x (Povolit spouÅ¡tÄ›nÃ­/pÅ™Ã­stup)"
 
-#: action.c:2088
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
-msgstr "a-x (Zakázat spou¹tìní/pøístup)"
+msgstr "a-x (ZakÃ¡zat spouÅ¡tÄ›nÃ­/pÅ™Ã­stup)"
 
-#: action.c:2090
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
-msgstr "u+rw (Povolit vlastníkovi èíst+zapisovat)"
+msgstr "u+rw (Povolit vlastnÃ­kovi ÄÃ­st+zapisovat)"
 
-#: action.c:2092
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
-msgstr "go-rwx (Soukromé - pøístup povolen pouze vlastníkovi)"
+msgstr "go-rwx (SoukromÃ© - pÅ™Ã­stup povolen pouze vlastnÃ­kovi)"
 
-#: action.c:2094
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
-msgstr "go=u-w (Pøístup povolen v¹em, bez práva zápisu)"
+msgstr "go=u-w (PÅ™Ã­stup povolen vÅ¡em, bez prÃ¡va zÃ¡pisu)"
 
-#: action.c:2105 menu.c:184 menu.c:221 tips:75
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
-msgstr "Pøístupová práva"
+msgstr "PÅ™Ã­stupovÃ¡ prÃ¡va"
 
-#: action.c:2116 action.c:2175
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
-msgstr "Nevypisovat zpracované soubory"
+msgstr "Nevypisovat zpracovanÃ© soubory"
 
-#: action.c:2119 action.c:2178 tips:217
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
-msgstr "Rekurzivnì"
+msgstr "RekurzivnÄ›"
 
-#: action.c:2119
+#: action.c:2543
 msgid "Also change contents of subdirectories"
-msgstr "Zmìnit i obsah podadresáøù"
+msgstr "ZmÄ›nit i obsah podadresÃ¡Å™Å¯"
 
-#: action.c:2123
+#: action.c:2547
 msgid "Command:"
-msgstr "Pøíkaz:"
+msgstr "PÅ™Ã­kaz:"
 
-#: action.c:2151
+#: action.c:2577
 #, fuzzy
 msgid "You need to select the items whose type you want to change"
-msgstr "Musíte zvolit polo¾ky, u kterıch chcete zmìnit práva"
+msgstr "MusÃ­te zvolit poloÅ¾ky, u kterÃ½ch chcete zmÄ›nit prÃ¡va"
 
-#: action.c:2164
+#: action.c:2590
 #, fuzzy
 msgid "Set type"
-msgstr "Tøídit podle typu"
+msgstr "TÅ™Ã­dit podle typu"
 
-#: action.c:2178
+#: action.c:2608
 #, fuzzy
 msgid "Change contents of subdirectories"
-msgstr "Zmìnit i obsah podadresáøù"
+msgstr "ZmÄ›nit i obsah podadresÃ¡Å™Å¯"
 
-#: action.c:2185 infobox.c:615
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Typ:"
 
-#: action.c:2214 dnd.c:124 menu.c:1999 tips:202
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
-msgstr "Kopírovat"
+msgstr "KopÃ­rovat"
 
-#: action.c:2224 action.c:2260 tips:219
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Nepotvrzovat kaÅ¾dou operaci"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "PÅ™epsat jen kdyÅ¾ je zdroj novÄ›jÅ¡Ã­ neÅ¾ cÃ­l."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
-msgstr "Novìj¹í"
+msgstr "NovÄ›jÅ¡Ã­"
 
-#: action.c:2225 action.c:2261 tips:220
-msgid "Only over-write if source is newer than destination."
-msgstr "Pøepsat jen kdy¾ je zdroj novìj¹í ne¾ cíl."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
+msgstr "PÅ™epsat jen kdyÅ¾ je zdroj novÄ›jÅ¡Ã­ neÅ¾ cÃ­l."
 
-#: action.c:2228
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "adresÃ¡Å™e"
+
+#: action.c:2695
 #, fuzzy
 msgid "Only log directories as they are copied"
-msgstr "Vypisovat pouze smazané adresáøe?"
+msgstr "Vypisovat pouze smazanÃ© adresÃ¡Å™e?"
 
-#: action.c:2250 dnd.c:125 tips:204
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
-msgstr "Pøesunout"
+msgstr "PÅ™esunout"
 
-#: action.c:2264
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr ""
 
-#: action.c:2284 tips:206
+#: action.c:2775 tips:244
 msgid "Link"
-msgstr "Vytvoøit odkaz"
+msgstr "VytvoÅ™it odkaz"
 
-#: action.c:2303 appmenu.c:113
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr ""
 
-#: action.c:2360
+#: action.c:2875
 msgid "Deleting items such as "
-msgstr "Ma¾u polo¾ky jako "
+msgstr "MaÅ¾u poloÅ¾ky jako "
 
-#: action.c:2364
+#: action.c:2879
 msgid "Deleting the item "
-msgstr "Ma¾u polo¾ku "
+msgstr "MaÅ¾u poloÅ¾ku "
 
-#: action.c:2366
+#: action.c:2881
 msgid "Deleting the items "
-msgstr "Ma¾u polo¾ky "
+msgstr "MaÅ¾u poloÅ¾ky "
 
-#: action.c:2385
+#: action.c:2900
 msgid " and "
 msgstr " a "
 
-#: action.c:2394
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
-msgstr " po¹kodí nìkteré polo¾ky na plo¹e nebo panelu - opravdu smazat?"
+msgstr " poÅ¡kodÃ­ nÄ›kterÃ© poloÅ¾ky na ploÅ¡e nebo panelu - opravdu smazat?"
 
-#: action.c:2401
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
-msgstr " po¹kodí nìkteré polo¾ky na plo¹e nebo panelu - opravdu smazat?"
+msgstr " poÅ¡kodÃ­ nÄ›kterÃ© poloÅ¾ky na ploÅ¡e nebo panelu - opravdu smazat?"
 
-#: appmenu.c:198
+#: appmenu.c:206
 msgid "<missing label>"
-msgstr "<chybí název>"
+msgstr "<chybÃ­ nÃ¡zev>"
 
-#: appmenu.c:295
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
 "menu for all items of this type (%s/%s)."
 msgstr ""
 
-#: appmenu.c:339 menu.c:234
+#: appmenu.c:331 menu.c:753
 #, fuzzy
 msgid "Customise Menu..."
 msgstr "Nastavit"
 
-#: appmenu.c:396 menu.c:251 toolbar.c:159
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
-msgstr "Nápovìda"
+msgstr "NÃ¡povÄ›da"
 
-#: bookmarks.c:147
+#: bookmarks.c:268
+#, fuzzy
+msgid "Title"
+msgstr "DlaÅ¾dice"
+
+#: bookmarks.c:276 log.c:176
 msgid "Path"
 msgstr ""
 
-#: bookmarks.c:155
-#, fuzzy
-msgid "Title"
-msgstr "Dla¾dice"
-
-#: bookmarks.c:304
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
-msgstr "Nelze vytvoøit zálo¾ku nelokálního zdroje '%s'\n"
+msgstr "Nelze vytvoÅ™it zÃ¡loÅ¾ku nelokÃ¡lnÃ­ho zdroje '%s'\n"
 
-#: bookmarks.c:312 bookmarks.c:630
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
-msgstr "'%s' není adresáø"
+msgstr "'%s' nenÃ­ adresÃ¡Å™"
 
-#: bookmarks.c:518
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
-msgstr "Nejprve zvolte nìjaké øádky ke smazání"
+msgstr "Nejprve zvolte nÄ›jakÃ© Å™Ã¡dky ke smazÃ¡nÃ­"
 
-#: bookmarks.c:542
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
-msgstr "Pro pøesun umístìte kurzor na polo¾ku seznamu"
+msgstr "Pro pÅ™esun umÃ­stÄ›te kurzor na poloÅ¾ku seznamu"
 
-#: bookmarks.c:562
+#: bookmarks.c:755
 msgid "This item is already at the end"
-msgstr "Tato polo¾ka u¾ je na konci"
+msgstr "Tato poloÅ¾ka uÅ¾ je na konci"
 
-#: bookmarks.c:636
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
-msgstr "Nelze vytvoøit zálo¾ku nelokálních adresáøù jako je '%s'"
+msgstr "Nelze vytvoÅ™it zÃ¡loÅ¾ku nelokÃ¡lnÃ­ch adresÃ¡Å™Å¯ jako je '%s'"
 
-#: bookmarks.c:778
+#: bookmarks.c:998
 msgid "Add New Bookmark"
-msgstr "Pøidat novou zálo¾ku"
+msgstr "PÅ™idat novou zÃ¡loÅ¾ku"
 
-#: bookmarks.c:785
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
-msgstr "Upravit zálo¾ky"
+msgstr "Upravit zÃ¡loÅ¾ky"
 
-#: bookmarks.c:790
+#: bookmarks.c:1010
 msgid "Recently Visited"
-msgstr "Nedávno nav¹tívené"
+msgstr "NedÃ¡vno navÅ¡tÃ­venÃ©"
 
-#: bulk_rename.c:68
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr ""
 
-#: bulk_rename.c:71
+#: bulk_rename.c:72
 #, fuzzy
 msgid "Reset"
-msgstr "_Vrátit zpìt"
+msgstr "_VrÃ¡tit zpÄ›t"
 
-#: bulk_rename.c:76
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr ""
 
-#: bulk_rename.c:81
+#: bulk_rename.c:82
 #, fuzzy
 msgid "_Rename"
-msgstr "Pøejmenovat"
+msgstr "PÅ™ejmenovat"
 
-#: bulk_rename.c:94
+#: bulk_rename.c:95
 #, fuzzy
 msgid "Replace:"
 msgstr "_Nahradit"
 
-#: bulk_rename.c:101
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -800,62 +846,63 @@ msgstr ""
 #: bulk_rename.c:109
 #, fuzzy
 msgid "With:"
-msgstr "polo¾ka"
+msgstr "poloÅ¾ka"
 
 #: bulk_rename.c:116
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr ""
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
 msgstr ""
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr ""
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 #, fuzzy
 msgid "New name"
-msgstr "Pøejmenovat"
+msgstr "PÅ™ejmenovat"
 
-#: bulk_rename.c:259
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr ""
 
-#: bulk_rename.c:264
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr ""
 
-#: bulk_rename.c:267
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr ""
 
-#: bulk_rename.c:293
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr ""
 
-#: bulk_rename.c:310
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr ""
 
-#: bulk_rename.c:343
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr ""
 
-#: bulk_rename.c:348
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -863,75 +910,91 @@ msgid ""
 "Aborting bulk rename."
 msgstr ""
 
-#: bulk_rename.c:410
+#: bulk_rename.c:447
 #, fuzzy, c-format
 msgid "A file called '%s' already exists"
-msgstr "?'%s' u¾ existuje - %s?"
+msgstr "?'%s' uÅ¾ existuje - %s?"
 
-#: bulk_rename.c:421
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
 "files to end up in different directories. Continue?"
 msgstr ""
 
-#: bulk_rename.c:436
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr ""
 
-#: choices.c:428
-#, fuzzy
-msgid "Choices migration"
-msgstr "Èínsky (tradièní)"
+#: choices.c:434
+#, c-format
+msgid "%d directories could not be migrated"
+msgstr ""
 
 #: choices.c:436
 #, c-format
 msgid ""
 "Choices have been moved from \n"
-"<b>%s</b>\n"
+"%s\n"
 " to the new location \n"
-"<b>%s</b>\n"
+"%s\n"
+"%s"
 msgstr ""
 
-#: choices.c:447
-#, c-format
-msgid "%d directories could not be migrated"
-msgstr ""
-
-#: dir.c:982
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Can't stat directory: %s"
 
-#: dir.c:991
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
-msgstr "Nelze otevøít adresáø: %s"
+msgstr "Nelze otevÅ™Ã­t adresÃ¡Å™: %s"
 
-#: display.c:588
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Velikost"
+
+#: display.c:705
+msgid "â”¤"
+msgstr ""
+
+#: display.c:706
+msgid "â”"
+msgstr ""
+
+#: display.c:707
+msgid "â”˜"
+msgstr ""
+
+#: display.c:709
+msgid "â”œ"
+msgstr ""
+
+#: display.c:709
+msgid "â”Œ"
+msgstr ""
+
+#: display.c:710
+msgid "â”¼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) selhalo: %s"
 
-#: dnd.c:126
-msgid "Link (relative)"
-msgstr ""
-
-#: dnd.c:127
-msgid "Link (absolute)"
-msgstr ""
-
-#: dnd.c:426
+#: dnd.c:423
 msgid "Internal error - bad info type"
-msgstr "Interní chyba - bad info type"
+msgstr "InternÃ­ chyba - bad info type"
 
 #: dnd.c:565
 msgid "Drag a directory here to bookmark it."
-msgstr "K pøidání adresáøe mezi zálo¾ky jej sem pøetáhnìte."
+msgstr "K pÅ™idÃ¡nÃ­ adresÃ¡Å™e mezi zÃ¡loÅ¾ky jej sem pÅ™etÃ¡hnÄ›te."
 
 #: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
-msgstr "Chyba protokolu XDS: leafname nemá obsahovat '/'\n"
+msgstr "Chyba protokolu XDS: leafname nemÃ¡ obsahovat '/'\n"
 
 #: dnd.c:605
 msgid ""
@@ -943,13 +1006,13 @@ msgstr ""
 
 #: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
-msgstr "Promiòte - je vy¾adován cíl typu text/uri-list nebo XdndDirectSave0."
+msgstr "PromiÅˆte - je vyÅ¾adovÃ¡n cÃ­l typu text/uri-list nebo XdndDirectSave0."
 
 #: dnd.c:621
 msgid ""
 "Sorry - I require a target type of text/uri-list or application/octet-stream."
 msgstr ""
-"Promiòte - je vy¾adován cíl typu text/uri-list nebo application/octet-stream."
+"PromiÅˆte - je vyÅ¾adovÃ¡n cÃ­l typu text/uri-list nebo application/octet-stream."
 
 #: dnd.c:691
 #, c-format
@@ -962,486 +1025,551 @@ msgstr ""
 
 #: dnd.c:766
 msgid "Unknown target"
-msgstr "Neznámı cíl"
+msgstr "NeznÃ¡mÃ½ cÃ­l"
 
 #: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
-msgstr "Vzdálená aplikace mi nemù¾e nebo nechce poslat data - sorry"
+msgstr "VzdÃ¡lenÃ¡ aplikace mi nemÅ¯Å¾e nebo nechce poslat data - sorry"
 
 #: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
-msgstr "chyba protokolu XDS: návratovı kód by mìl bıt 'S', 'F' nebo 'E'\n"
+msgstr "chyba protokolu XDS: nÃ¡vratovÃ½ kÃ³d by mÄ›l bÃ½t 'S', 'F' nebo 'E'\n"
 
 #: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
 msgstr ""
-"Promiòte, nemohu zobrazit nabídku akcí pro vzdálené soubory / nezpracovaná"
-"(syrová) data."
+"PromiÅˆte, nemohu zobrazit nabÃ­dku akcÃ­ pro vzdÃ¡lenÃ© soubory / "
+"nezpracovanÃ¡(syrovÃ¡) data."
 
 #: dnd.c:861
 msgid "UntitledData"
-msgstr "NepojmenovanáData"
+msgstr "NepojmenovanÃ¡Data"
 
 #: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
-msgstr "Chyba pøi ukládání souboru: %s"
+msgstr "Chyba pÅ™i uklÃ¡dÃ¡nÃ­ souboru: %s"
 
 #: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
-msgstr "®ádné URI v text/uri-seznamu (není co dìlat)"
+msgstr "Å½Ã¡dnÃ© URI v text/uri-seznamu (nenÃ­ co dÄ›lat)"
 
 #: dnd.c:993
 msgid ""
 "Can't get data from remote machine (application/octet-stream not provided)"
 msgstr ""
-"Nelze získat data ze vzdáleného poèítaèe (application/octet-stream není "
-"poskytován)"
+"Nelze zÃ­skat data ze vzdÃ¡lenÃ©ho poÄÃ­taÄe (application/octet-stream nenÃ­ "
+"poskytovÃ¡n)"
 
-#: dnd.c:1016
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
-"Nìkteré z tìchto souborù jsou na vzdáleném poèítaèi - tyto soubory budou "
-"ignorovány - sorry"
+"NÄ›kterÃ© z tÄ›chto souborÅ¯ jsou na vzdÃ¡lenÃ©m poÄÃ­taÄi - tyto soubory budou "
+"ignorovÃ¡ny - sorry"
 
-#: dnd.c:1023
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
 msgstr ""
-"®ádnı z tìchto souborù není na tomto poèítaèi - nemohu pracovat s více "
-"vzdálenımi soubory - promiòte."
+"Å½Ã¡dnÃ½ z tÄ›chto souborÅ¯ nenÃ­ na tomto poÄÃ­taÄi - nemohu pracovat s vÃ­ce "
+"vzdÃ¡lenÃ½mi soubory - promiÅˆte."
 
-#: dnd.c:1036
+#: dnd.c:1040
 msgid "Unknown action requested"
-msgstr "Po¾adována neznámá akce"
+msgstr "PoÅ¾adovÃ¡na neznÃ¡mÃ¡ akce"
 
-#: dnd.c:1044
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
-msgstr "Chyba pøi získání seznamu souborù: %s"
+msgstr "Chyba pÅ™i zÃ­skÃ¡nÃ­ seznamu souborÅ¯: %s"
 
-#: dropbox.c:114
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr ""
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr ""
+
+#: dnd.c:1109
+msgid "Link (relative, sym path)"
+msgstr ""
+
+#: dnd.c:1110
+msgid "Link (absolute, sym path)"
+msgstr ""
+
+#: dropbox.c:112
 msgid "Show"
-msgstr "Ukázat"
+msgstr "UkÃ¡zat"
 
-#: dropbox.c:120
+#: dropbox.c:118
 msgid "Show the current choice in a filer window"
-msgstr "Ukázat souèasnı vıbìr v oknì správce souborù"
+msgstr "UkÃ¡zat souÄasnÃ½ vÃ½bÄ›r v oknÄ› sprÃ¡vce souborÅ¯"
 
-#: dropbox.c:174
+#: dropbox.c:172
 msgid "<nothing>"
 msgstr "<nic>"
 
-#: dropbox.c:239
+#: dropbox.c:237
 msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
 msgstr ""
-"Nemohu zobrazit nastavenou polo¾ku, proto¾e ¾ádná není nastavena. Pøetáhnìte "
-"nìjakou na toto místo!"
+"Nemohu zobrazit nastavenou poloÅ¾ku, protoÅ¾e Å¾Ã¡dnÃ¡ nenÃ­ nastavena. PÅ™etÃ¡hnÄ›te "
+"nÄ›jakou na toto mÃ­sto!"
 
-#: dropbox.c:263
+#: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
-msgstr "Promiòte, na toto místo musíte pøetáhnout právì jeden soubor."
+msgstr "PromiÅˆte, na toto mÃ­sto musÃ­te pÅ™etÃ¡hnout prÃ¡vÄ› jeden soubor."
 
-#: dropbox.c:273
+#: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
-msgstr "Promiòte, nemohu pou¾ít '%s' proto¾e to není místní soubor."
+msgstr "PromiÅˆte, nemohu pouÅ¾Ã­t '%s' protoÅ¾e to nenÃ­ mÃ­stnÃ­ soubor."
 
-#: dropbox.c:280 pinboard.c:853
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
 "%s"
 msgstr ""
-"Nemám pøístup k '%s':\n"
+"NemÃ¡m pÅ™Ã­stup k '%s':\n"
 "%s"
 
-#: filer.c:453
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
 "%s\n"
 msgstr ""
-"Chyba pøi prozkoumávání '%s':\n"
+"Chyba pÅ™i prozkoumÃ¡vÃ¡nÃ­ '%s':\n"
 "%s\n"
 
-#: filer.c:457
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Chyba pøi prozkoumávání '%s':\n"
-"%s"
-
-#: filer.c:562
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
 "Unmounting a device makes it safe to remove the disk."
 msgstr ""
-"Chcete odpojit toto zaøízení?\n"
+"Chcete odpojit toto zaÅ™Ã­zenÃ­?\n"
 "\n"
-"Odpojení disku umo¾òuje bezpeèné vyjmutí disku."
+"OdpojenÃ­ disku umoÅ¾Åˆuje bezpeÄnÃ© vyjmutÃ­ disku."
 
-#: filer.c:566
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 #, fuzzy
 msgid "No change"
 msgstr "Nic"
 
-#: filer.c:572 menu.c:862
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Odpojit"
 
-#: filer.c:669
-msgid "Directory missing/deleted"
-msgstr "Adresáø chybí/je smazán"
-
-#: filer.c:1031
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
 "Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"Skupina %s není nastavena. Pro nastavení skupiny vyberte nìjaké soubory a "
-"stisknìte  Ctrl+%s. Pozdìji mù¾ete tyto soubory znovu vybrat stisknutím %s.\n"
-"Ujistìte se, ¾e je zapnutı NumLock v pøípadì, ¾e pou¾íváte keypad."
+"Skupina %s nenÃ­ nastavena. Pro nastavenÃ­ skupiny vyberte nÄ›jakÃ© soubory a "
+"stisknÄ›te  Ctrl+%s. PozdÄ›ji mÅ¯Å¾ete tyto soubory znovu vybrat stisknutÃ­m %s.\n"
+"UjistÄ›te se, Å¾e je zapnutÃ½ NumLock v pÅ™Ã­padÄ›, Å¾e pouÅ¾Ã­vÃ¡te keypad."
 
-#: filer.c:1267
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Adresáø '%s' není pøístupnı"
+#: filer.c:2655
+msgid "A"
+msgstr "A"
 
-#: filer.c:1419
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Adresáø '%s' nenalezen."
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
 
-#: filer.c:1713
-msgid "Cancel"
-msgstr "Zavøít"
+#: filer.c:2659 find.c:923
+msgid "G"
+msgstr ""
 
-#: filer.c:2002
+#: filer.c:2664
 msgid "S"
 msgstr "S"
 
-#: filer.c:2004
+#: filer.c:2669
 msgid "T"
 msgstr "T"
 
-#: filer.c:2026
+#: filer.c:2670
+msgid "D"
+msgstr ""
+
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
+#, c-format
+msgid "Glob (%s), "
+msgstr ""
+
+#: filer.c:2694
 msgid "Scanning, "
-msgstr "Prozkoumávám"
+msgstr "ProzkoumÃ¡vÃ¡m"
 
-#: filer.c:2028
+#: filer.c:2697
 msgid "Thumbs, "
-msgstr "Náhledy, "
+msgstr "NÃ¡hledy, "
 
-#: filer.c:2304
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "NÃ¡hledy, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
-msgstr "Symbolickı odkaz na "
+msgstr "SymbolickÃ½ odkaz na "
 
-#: filer.c:2335
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr ""
-"Toto není platné jméno souboru v kódování UTF-8. Mìli by jste jej "
-"pøejmenovat.\n"
+"Toto nenÃ­ platnÃ© jmÃ©no souboru v kÃ³dovÃ¡nÃ­ UTF-8. MÄ›li by jste jej "
+"pÅ™ejmenovat.\n"
 
-#: filer.c:2643 menu.c:1989
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
-msgstr "Polo¾ka u¾ neexistuje"
+msgstr "PoloÅ¾ka uÅ¾ neexistuje"
 
-#: filer.c:3327
+#: filer.c:4451
+msgid "â–¼"
+msgstr ""
+
+#: filer.c:4451
+msgid "â–½"
+msgstr ""
+
+#: filer.c:4462
+msgid "â–·"
+msgstr ""
+
+#: filer.c:4462
+msgid "â–¶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr ""
 
-#: filer.c:3334
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "DefaultnÃ­ nastavenÃ­"
+
+#: filer.c:4727
 #, fuzzy
 msgid "Position"
-msgstr "®ádnı popis"
+msgstr "Å½Ã¡dnÃ½ popis"
 
-#: filer.c:3339 toolbar.c:135 toolbar.c:139 tips:63
-msgid "Size"
-msgstr "Velikost"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Okno"
 
-#: filer.c:3344
+#: filer.c:4737
 #, fuzzy
 msgid "Show hidden"
-msgstr "Zobrazit skryté"
+msgstr "Zobrazit skrytÃ©"
 
-#: filer.c:3350
+#: filer.c:4743
 #, fuzzy
-msgid "Display style"
+msgid "Display style (Icon size)"
 msgstr "Zobrazit"
 
-#: filer.c:3356
+#: filer.c:4749
 #, fuzzy
 msgid "Sort type and order"
-msgstr "Tøídit podle vlastníka"
+msgstr "TÅ™Ã­dit podle vlastnÃ­ka"
 
-#: filer.c:3361 toolbar.c:143
+#: filer.c:4754
 msgid "Details"
 msgstr "Podrobnosti"
 
-#: filer.c:3366 tips:114 tips:115
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
-msgstr "Náhledy"
+msgstr "NÃ¡hledy"
 
-#: filer.c:3372
+#: filer.c:4765
 #, fuzzy
 msgid "Filter"
 msgstr "Soubor"
 
-#: find.c:487
+#: find.c:485
 msgid "And"
 msgstr "And"
 
-#: find.c:511
+#: find.c:509
 msgid "Not"
 msgstr "Not"
 
-#: find.c:554
+#: find.c:552
 msgid "system"
 msgstr "system"
 
-#: find.c:562
+#: find.c:560
 msgid "prune"
 msgstr "prune"
 
-#: find.c:650
+#: find.c:648
 msgid "After"
 msgstr "After"
 
-#: find.c:652
+#: find.c:650
 msgid "Before"
 msgstr "Before"
 
-#: find.c:746
+#: find.c:744
 msgid "IsReg"
 msgstr "IsReg"
 
-#: find.c:748
+#: find.c:746
 msgid "IsLink"
 msgstr "IsLink"
 
-#: find.c:750
+#: find.c:748
 msgid "IsDir"
 msgstr "IsDir"
 
-#: find.c:752
+#: find.c:750
 msgid "IsChar"
 msgstr "IsChar"
 
-#: find.c:754
+#: find.c:752
 msgid "IsBlock"
 msgstr "IsBlock"
 
-#: find.c:756
+#: find.c:754
 msgid "IsDev"
 msgstr "IsDev"
 
-#: find.c:758
+#: find.c:756
 msgid "IsPipe"
 msgstr "IsPipe"
 
-#: find.c:760
+#: find.c:758
 msgid "IsSocket"
 msgstr "IsSocket"
 
-#: find.c:762
+#: find.c:760
 msgid "IsDoor"
 msgstr "IsDoor"
 
-#: find.c:764
+#: find.c:762
 msgid "IsSUID"
 msgstr "IsSUID"
 
-#: find.c:766
+#: find.c:764
 msgid "IsSGID"
 msgstr "IsSGID"
 
-#: find.c:768
+#: find.c:766
 msgid "IsSticky"
 msgstr "IsSticky"
 
-#: find.c:770
+#: find.c:768
 msgid "IsReadable"
 msgstr "IsReadable"
 
-#: find.c:772
+#: find.c:770
 msgid "IsWriteable"
 msgstr "IsWriteable"
 
-#: find.c:774
+#: find.c:772
 msgid "IsExecutable"
 msgstr "IsExecutable"
 
-#: find.c:776
+#: find.c:774
 msgid "IsEmpty"
 msgstr "IsEmpty"
 
-#: find.c:778
+#: find.c:776
 msgid "IsMine"
 msgstr "IsMine"
 
-#: find.c:906
+#: find.c:904
 msgid "Now"
 msgstr "Now"
 
-#: find.c:919
+#: find.c:917
 msgid "Byte"
 msgstr "Byte"
 
-#: find.c:919
+#: find.c:917
 msgid "Bytes"
 msgstr "Bytes"
 
-#: find.c:921
+#: find.c:919
 msgid "Kb"
 msgstr ""
 
-#: find.c:921
+#: find.c:919
 msgid "K"
 msgstr ""
 
-#: find.c:923
+#: find.c:921
 msgid "Mb"
 msgstr ""
 
-#: find.c:923
+#: find.c:921
 msgid "M"
 msgstr ""
 
-#: find.c:925
+#: find.c:923
 msgid "Gb"
 msgstr ""
 
 #: find.c:925
-msgid "G"
-msgstr ""
-
-#: find.c:927
 msgid "Sec"
 msgstr "Sec"
 
-#: find.c:927
+#: find.c:925
 msgid "Secs"
 msgstr "Secs"
 
-#: find.c:929
+#: find.c:927
 msgid "Min"
 msgstr "Min"
 
-#: find.c:929
+#: find.c:927
 msgid "Mins"
 msgstr "Mins"
 
-#: find.c:931
+#: find.c:929
 msgid "Hour"
 msgstr "Hour"
 
-#: find.c:931
+#: find.c:929
 msgid "Hours"
 msgstr "Hours"
 
-#: find.c:933
+#: find.c:931
 msgid "Day"
 msgstr "Day"
 
-#: find.c:933
+#: find.c:931
 msgid "Days"
 msgstr "Days"
 
-#: find.c:935
+#: find.c:933
 msgid "Week"
 msgstr "Week"
 
-#: find.c:935
+#: find.c:933
 msgid "Weeks"
 msgstr "Weeks"
 
-#: find.c:937
+#: find.c:935
 msgid "Year"
 msgstr "Year"
 
-#: find.c:937
+#: find.c:935
 msgid "Years"
 msgstr "Years"
 
-#: find.c:946
+#: find.c:944
 msgid "Ago"
 msgstr "Ago"
 
-#: find.c:948
+#: find.c:946
 msgid "Hence"
 msgstr "Hence"
 
-#: find.c:963
+#: find.c:961
 msgid "atime"
 msgstr "atime"
 
-#: find.c:965
+#: find.c:963
 msgid "ctime"
 msgstr "ctime"
 
-#: find.c:967
+#: find.c:965
 msgid "mtime"
 msgstr "mtime"
 
-#: find.c:969
+#: find.c:967
 msgid "size"
 msgstr "size"
 
-#: find.c:971
+#: find.c:969
 msgid "inode"
 msgstr "inode"
 
-#: find.c:973
+#: find.c:971
 msgid "nlinks"
 msgstr "nlinks"
 
-#: find.c:975
+#: find.c:973
 msgid "uid"
 msgstr "uid"
 
-#: find.c:977
+#: find.c:975
 msgid "gid"
 msgstr "gid"
 
-#: find.c:979
+#: find.c:977
 msgid "blocks"
 msgstr "blocks"
 
-#: gtksavebox.c:251
+#: gtksavebox.c:249
 msgid "Save As:"
-msgstr "Ulo¾ jako:"
+msgstr "UloÅ¾ jako:"
 
-#: gtksavebox.c:397
+#: gtksavebox.c:401
 msgid "Unnamed"
-msgstr "Nepojmenované"
+msgstr "NepojmenovanÃ©"
 
-#: gtksavebox.c:473
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
 msgstr ""
-"Vzdálená aplikace chce pou¾ít Direct Save, ale nemù¾u èíst XdndDirectSave0 "
+"VzdÃ¡lenÃ¡ aplikace chce pouÅ¾Ã­t Direct Save, ale nemÅ¯Å¾u ÄÃ­st XdndDirectSave0 "
 "(typ text/plain) vlastnost.\n"
 
-#: gtksavebox.c:598
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
 msgstr ""
-"Pøetáhnìte ikonu do prohlí¾eèe adresáøù\n"
+"PÅ™etÃ¡hnÄ›te ikonu do prohlÃ­Å¾eÄe adresÃ¡Å™Å¯\n"
 "(nebo zadejte celou cestu)"
 
-#: gui_support.c:331
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1449,220 +1577,245 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:400
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
-msgstr "Ètu XML soubor jako textovı soubor. Soubor '%s' mù¾e bıt po¹kozen."
+msgstr "ÄŒtu XML soubor jako textovÃ½ soubor. Soubor '%s' mÅ¯Å¾e bÃ½t poÅ¡kozen."
 
-#: gui_support.c:417
-#, c-format
+#: gui_support.c:542
+#, fuzzy, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
 "This may be due to upgrading from a previous version of ROX-Filer. Open the "
-"Options window and click on Save.\n"
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
-"Chyba v souboru '%s' na øádku %d: \n"
+"Chyba v souboru '%s' na Å™Ã¡dku %d: \n"
 "\"%s\"\n"
-"Toto mù¾e bıt zpùsobeno upgradem z pøedchozí verze ROX-Fileru. Otevøete okno "
-"Mo¾nosti a kliknìte na Ulo¾it.\n"
-"Dal¹í chyby budou ignorovány."
+"Toto mÅ¯Å¾e bÃ½t zpÅ¯sobeno upgradem z pÅ™edchozÃ­ verze ROX-Fileru. OtevÅ™ete okno "
+"MoÅ¾nosti a kliknÄ›te na UloÅ¾it.\n"
+"DalÅ¡Ã­ chyby budou ignorovÃ¡ny."
 
-#: gui_support.c:1000
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
-msgstr "Chybnı nebo chybìjící konec øádku v text/uri-list datech"
+msgstr "ChybnÃ½ nebo chybÄ›jÃ­cÃ­ konec Å™Ã¡dku v text/uri-list datech"
 
-#: gui_support.c:1332
+#: gui_support.c:1473
 #, fuzzy, c-format
 msgid "Failed to open file '%s': %s"
 msgstr ""
 "!%s\n"
-"Kopírování '%s' selhalo\n"
+"KopÃ­rovÃ¡nÃ­ '%s' selhalo\n"
 
-#: gui_support.c:1376
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
 msgstr ""
 
-#: gui_support.c:1427
+#: gui_support.c:1583
+#, c-format
 msgid ""
-"This program cannot be run, as the 0launch command is not available. It can "
-"be downloaded from here:\n"
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
 
-#: i18n.c:38
+#: i18n.c:39
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
 msgstr ""
-"Musíte ulo¾it Va¹e volby a restartovat filer, aby bylo nové nastavení jazyka "
-"plnì funkèní."
+"MusÃ­te uloÅ¾it VaÅ¡e volby a restartovat filer, aby bylo novÃ© nastavenÃ­ jazyka "
+"plnÄ› funkÄnÃ­."
 
-#: icon.c:78
+#: icon.c:77
 msgid "(click to set)"
-msgstr "(kliknìte pro nastavení)"
+msgstr "(kliknÄ›te pro nastavenÃ­)"
 
-#: icon.c:133
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:134 menu.c:252
-msgid "About ROX-Filer..."
-msgstr "O programu ROX-Filer..."
-
-#: icon.c:135 menu.c:253
-msgid "Show Help Files"
-msgstr "Zobrazit Nápovìdu"
-
-#: icon.c:136 menu.c:254
-msgid "Manual"
-msgstr "Manuál"
-
-#: icon.c:138 menu.c:230
-msgid "Options..."
-msgstr "Mo¾nosti..."
-
-#: icon.c:139 menu.c:239
-msgid "Home Directory"
-msgstr "Domovskı adresáø"
-
-#: icon.c:140 icon.c:1340 menu.c:206 type.c:212
-msgid "File"
-msgstr "Soubor"
-
-#: icon.c:141 menu.c:212 menu.c:875
-msgid "Shift Open"
-msgstr "Shift Otevøení"
-
-#: icon.c:142 menu.c:218
-msgid "Properties"
-msgstr ""
-
-#: icon.c:143 menu.c:216
-msgid "Set Run Action..."
-msgstr "Nastavit spou¹tìcí akci..."
-
-#: icon.c:144 menu.c:217
-msgid "Set Icon..."
-msgstr "Nastavit ikonu..."
-
-#: icon.c:145 icon.c:806
-msgid "Edit Item"
-msgstr "Upravit polo¾ku"
-
-#: icon.c:146
-msgid "Show Location"
-msgstr "Zobrazit umístìní"
-
-#: icon.c:147
-msgid "Remove Item(s)"
-msgstr "Odebrat polo¾ku(y)"
-
-#: icon.c:278 menu.c:764
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr ""
 
-#: icon.c:291
+#: icon.c:311
 msgid "Nothing"
 msgstr "Nic"
 
-#: icon.c:547
+#: icon.c:576
 msgid "The location must contain at least one character!"
-msgstr "Umístìní musí obsahovat alespoò jeden znak!"
+msgstr "UmÃ­stÄ›nÃ­ musÃ­ obsahovat alespoÅˆ jeden znak!"
 
-#: icon.c:613
+#: icon.c:641
+#, c-format
+msgid "You must unlock '%s' before removing it"
+msgstr ""
+
+#: icon.c:651
 msgid "You must first select some items to remove"
-msgstr "Nejprve musíte oznaèit nìjaké polo¾ky pro odebrání"
+msgstr "Nejprve musÃ­te oznaÄit nÄ›jakÃ© poloÅ¾ky pro odebrÃ¡nÃ­"
 
-#: icon.c:627
+#: icon.c:657
+msgid "An item must be unlocked before it can be removed."
+msgstr ""
+
+#: icon.c:671
 msgid "You must open the menu over an item"
-msgstr "Nabídku musíte otevøít nad polo¾kou"
+msgstr "NabÃ­dku musÃ­te otevÅ™Ã­t nad poloÅ¾kou"
 
-#: icon.c:652 menu.c:1260
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
-msgstr "Spou¹tìcí akci mù¾ete nastavit jen pro bì¾né soubory"
+msgstr "SpouÅ¡tÄ›cÃ­ akci mÅ¯Å¾ete nastavit jen pro bÄ›Å¾nÃ© soubory"
 
-#: icon.c:738
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
-msgstr "Stisknìte po¾adovanou zkratku (napø. Control+F1)"
+msgstr "StisknÄ›te poÅ¾adovanou zkratku (napÅ™. Control+F1)"
 
-#: icon.c:760
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
-msgstr "Chyba pøi snímání klávesové zkratky!"
+msgstr "Chyba pÅ™i snÃ­mÃ¡nÃ­ klÃ¡vesovÃ© zkratky!"
 
-#: icon.c:809
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Upravit poloÅ¾ku"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
-msgstr "Kliknutí na ikonu otevøe:"
+msgstr "KliknutÃ­ na ikonu otevÅ™e:"
 
-#: icon.c:819
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr ""
 
-#: icon.c:833
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "Text zobrazen pod ikonou je:"
 
-#: icon.c:846
+#: icon.c:890
 msgid "The keyboard shortcut is:"
-msgstr "Klávesová zkratka je:"
+msgstr "KlÃ¡vesovÃ¡ zkratka je:"
 
-#: infobox.c:112
-#, c-format
-msgid "Are you sure you want to open %d windows?"
-msgstr "Opravdu otevøít %d oken?"
+#: icon.c:910
+#, fuzzy
+msgid "Locked"
+msgstr "Soket"
+
+#: icon.c:915
+msgid "Locking an item prevents it from being accidentally removed"
+msgstr ""
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "O programu ROX-Filer..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Zobrazit NÃ¡povÄ›du"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "ManuÃ¡l"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "MoÅ¾nosti..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "DomovskÃ½ adresÃ¡Å™"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Soubor"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Shift OtevÅ™enÃ­"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr ""
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Nastavit spouÅ¡tÄ›cÃ­ akci..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Nastavit ikonu..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Zobrazit umÃ­stÄ›nÃ­"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Odebrat poloÅ¾ku(y)"
 
 #: infobox.c:113
+#, c-format
+msgid "Are you sure you want to open %d windows?"
+msgstr "Opravdu otevÅ™Ã­t %d oken?"
+
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Zobrazit Info"
 
-#: infobox.c:135 menu.c:769
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
-msgstr "(¹patné utf-8)"
+msgstr "(Å¡patnÃ© utf-8)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Zobrazit _Help soubory"
 
-#: infobox.c:272
+#: infobox.c:291
 #, fuzzy
 msgid "<b>Permissions</b>"
-msgstr "Pøístupová práva"
+msgstr "PÅ™Ã­stupovÃ¡ prÃ¡va"
 
-#: infobox.c:286
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr ""
 
-#: infobox.c:423 infobox.c:560 support.c:349
-msgid "bytes"
-msgstr "bytù"
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Vypisovat pouze smazanÃ© adresÃ¡Å™e?"
 
-#: infobox.c:446
+#: infobox.c:455 infobox.c:600 support.c:379
+msgid "bytes"
+msgstr "bytÅ¯"
+
+#: infobox.c:480
 #, fuzzy
 msgid "Failed to read size"
 msgstr ""
 "!%s\n"
-"Kopírování '%s' selhalo\n"
+"KopÃ­rovÃ¡nÃ­ '%s' selhalo\n"
 
-#: infobox.c:504
+#: infobox.c:543
 #, fuzzy, c-format
 msgid "'%s' is no longer a symlink"
-msgstr "!'%s' je symbolickı odkaz\n"
+msgstr "!'%s' je symbolickÃ½ odkaz\n"
 
-#: infobox.c:511
+#: infobox.c:550
 #, fuzzy, c-format
 msgid ""
 "Failed to unlink '%s':\n"
 "%s"
 msgstr ""
 "!%s\n"
-"Kopírování '%s' selhalo\n"
+"KopÃ­rovÃ¡nÃ­ '%s' selhalo\n"
 
-#: infobox.c:516
+#: infobox.c:555
 #, fuzzy, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1670,157 +1823,206 @@ msgid ""
 "(note: old link has been deleted)"
 msgstr ""
 "!%s\n"
-"Kopírování '%s' selhalo\n"
+"KopÃ­rovÃ¡nÃ­ '%s' selhalo\n"
 
-#: infobox.c:539 tips:270
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Chyba:"
 
-#: infobox.c:546
+#: infobox.c:586
 msgid "Real directory:"
-msgstr "Skuteènı adresáø:"
+msgstr "SkuteÄnÃ½ adresÃ¡Å™:"
 
-#: infobox.c:549
+#: infobox.c:589
 msgid "Owner, Group:"
-msgstr "Vlastník, Skupina:"
+msgstr "VlastnÃ­k, Skupina:"
 
-#: infobox.c:556 infobox.c:571 infobox.c:580
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Velikost:"
 
-#: infobox.c:581
+#: infobox.c:621
 #, fuzzy
 msgid "Scanning"
-msgstr "Prozkoumávám"
+msgstr "ProzkoumÃ¡vÃ¡m"
 
-#: infobox.c:602
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr ""
 
-#: infobox.c:609
+#: infobox.c:653
 msgid "Change time:"
-msgstr "Èas zmìny:"
+msgstr "ÄŒas zmÄ›ny:"
 
-#: infobox.c:611
+#: infobox.c:655
 msgid "Modify time:"
-msgstr "Èas úpravy:"
+msgstr "ÄŒas Ãºpravy:"
 
-#: infobox.c:613
+#: infobox.c:657
 msgid "Access time:"
-msgstr "Èas pøístupu:"
+msgstr "ÄŒas pÅ™Ã­stupu:"
 
-#: infobox.c:621
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr ""
 
-#: infobox.c:623
+#: infobox.c:667
 msgid "Present"
 msgstr ""
 
-#: infobox.c:624
+#: infobox.c:668
 msgid "None"
-msgstr "®ádnı"
+msgstr "Å½Ã¡dnÃ½"
 
-#: infobox.c:625
+#: infobox.c:669
 #, fuzzy
 msgid "Not supported"
 msgstr "Dnotify support"
 
-#: infobox.c:637
+#: infobox.c:681
 #, fuzzy
 msgid "Link target:"
-msgstr "Neznámı cíl"
+msgstr "NeznÃ¡mÃ½ cÃ­l"
 
-#: infobox.c:649 infobox.c:652
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
-msgstr "Spou¹tìcí akce"
+msgstr "SpouÅ¡tÄ›cÃ­ akce"
 
-#: infobox.c:649
+#: infobox.c:693
 msgid "Execute file"
-msgstr "Spustitelnı soubor"
+msgstr "SpustitelnÃ½ soubor"
 
-#: infobox.c:744
+#: infobox.c:805
+#, fuzzy
+msgid "Comment"
+msgstr "PÅ™Ã­kaz:"
+
+#: infobox.c:807
+#, fuzzy
+msgid "Execute"
+msgstr "SpustitelnÃ½ soubor"
+
+#: infobox.c:822
 msgid "<nothing yet>"
-msgstr "<zatím nic>"
+msgstr "<zatÃ­m nic>"
 
-#: infobox.c:814
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
-msgstr "file(1) identifikuje polo¾ku jako... %s"
+msgstr "file(1) identifikuje poloÅ¾ku jako... %s"
 
-#: infobox.c:871
+#: infobox.c:952
 #, fuzzy, c-format
 msgid "Could not change permissions: %s"
-msgstr "?Zmìnit práva '%s'?"
+msgstr "?ZmÄ›nit prÃ¡va '%s'?"
 
-#: infobox.c:889
+#: infobox.c:970 tips:120
 #, fuzzy
 msgid "Owner"
-msgstr "_Vlastník"
+msgstr "_VlastnÃ­k"
 
-#: infobox.c:891
+#: infobox.c:972 tips:122
 #, fuzzy
 msgid "Group"
 msgstr "_Skupina"
 
-#: infobox.c:893
+#: infobox.c:974
 msgid "World"
 msgstr ""
 
-#: infobox.c:896
+#: infobox.c:977
 #, fuzzy
 msgid "Read"
-msgstr "Pøejmenovat"
+msgstr "PÅ™ejmenovat"
 
-#: infobox.c:898
+#: infobox.c:980
 #, fuzzy
 msgid "Write"
-msgstr "polo¾ka"
+msgstr "poloÅ¾ka"
 
-#: infobox.c:900
+#: infobox.c:983
 msgid "Exec"
 msgstr ""
 
-#: infobox.c:917
+#: infobox.c:1001
 #, fuzzy
 msgid "SUID"
 msgstr "IsSUID"
 
-#: infobox.c:924
+#: infobox.c:1008
 #, fuzzy
 msgid "SGID"
 msgstr "IsSGID"
 
-#: infobox.c:931
+#: infobox.c:1015
 #, fuzzy
 msgid "Sticky"
 msgstr "IsSticky"
 
-#: infobox.c:953
-msgid "Symbolic link"
-msgstr "Symbolickı odkaz"
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<nic>"
 
-#: infobox.c:956
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
+msgid "Symbolic link"
+msgstr "SymbolickÃ½ odkaz"
+
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX aplikace"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "mounted"
-msgstr "pøipojeno"
+msgstr "pÅ™ipojeno"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "odpojeno"
 
-#: infobox.c:968
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
-msgstr "Bod pøipojení pro %s (%s)"
+msgstr "Bod pÅ™ipojenÃ­ pro %s (%s)"
 
-#: infobox.c:971
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
-msgstr "Bod pøipojení (%s)"
+msgstr "Bod pÅ™ipojenÃ­ (%s)"
+
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d poloÅ¾ek"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "KopÃ­rovat..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "Upravit poloÅ¾ku"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "ÄŒasy"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "MoÅ¾nosti"
 
 #: main.c:95
 #, fuzzy
@@ -1841,11 +2043,11 @@ msgstr ""
 
 #: main.c:104
 msgid "Try `ROX-Filer/AppRun --help' for more information.\n"
-msgstr "Zkuste `ROX-Filer/AppRun --help' pro více informací.\n"
+msgstr "Zkuste `ROX-Filer/AppRun --help' pro vÃ­ce informacÃ­.\n"
 
 #: main.c:107
 msgid "Try `ROX-Filer/AppRun -h' for more information.\n"
-msgstr "Zkuste `ROX-Filer/AppRun -h' pro více informací.\n"
+msgstr "Zkuste `ROX-Filer/AppRun -h' pro vÃ­ce informacÃ­.\n"
 
 #: main.c:109
 msgid ""
@@ -1853,12 +2055,12 @@ msgid ""
 "you must use the short versions instead.\n"
 "\n"
 msgstr ""
-"POZNÁMKA: Vá¹ systém nepodporuje dlouhé volby - \n"
-"musíte pou¾ít krátké verze.\n"
+"POZNÃMKA: VÃ¡Å¡ systÃ©m nepodporuje dlouhÃ© volby - \n"
+"musÃ­te pouÅ¾Ã­t krÃ¡tkÃ© verze.\n"
 "\n"
 
 #: main.c:115
-#, fuzzy
+#, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Open each directory or file listed, or the current working\n"
@@ -1880,42 +2082,38 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
-"Report bugs to "
-msgstr ""
-"Pou¾ití: ROX-Filer/AppRun [VOLBY]... [SOUBOR]...\n"
-"Otevøe v¹echny zadané adresáøe a soubory, nebo pracovní\n"
-"adresáø, pokud nejsou zadány ¾ádné argumenty.\n"
-"\n"
-"  -b, --bottom=PANEL\totevøe PAN jako panel na dolním okraji\n"
-"  -c, --client-id=ID\tpou¾ito pro správce sezení\n"
-"  -d, --dir=ADR\t\totevøe ADR jako adresáø (ne jako aplikaci)\n"
-"  -D, --close=ADR\tzavøe ADR a jeho podadresáøe\n"
-"  -h, --help\t\tzobrazí tuto nápovìdu a skonèí\n"
-"  -l, --left=PANEL\totevøe PAN jako panel na levém okraji\n"
-"  -m, --mime-type=SOUB\tvypí¹e MIME typ souboru SOUB a skonèí\n"
-"  -n, --new\t\tspustí novou kopii; pro ladìní správce souborù\n"
-"  -p, --pinboard=PIN\tpou¾ije pluchu PIN jako plochu\n"
-"  -r, --right=PANEL\totevøe panel PAN panel na pravém okraji\n"
-"  -R, --RPC\t\tnastavit ètení volání metod ze stand. vstupu\n"
-"  -s, --show=SOUB\totevøe adresáø a soubor SOUB je zobrazen\n"
-"  -t, --top=PANEL\totevøe PANEL jako panel na horním okraji\n"
-"  -u, --user\t\tzobrazí u¾ivatelské jméno v ka¾dém oknì \n"
-"  -v, --version\t\tzobrazí informace o verzi a skonèí\n"
-"  -x, --examine=SOUB\tSOUB se zmìnil - znovu jej prozkoumat\n"
-"\n"
-"Chyby hlaste na <tal197@users.sourceforge.net>.\n"
-"Domovská stránka (vèetnì novıch verzí): http://rox.sourceforge.net/\n"
-
-#: main.c:136
-msgid ""
-".\n"
+"Report bugs to %s.\n"
 "Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
+"PouÅ¾itÃ­: ROX-Filer/AppRun [VOLBY]... [SOUBOR]...\n"
+"OtevÅ™e vÅ¡echny zadanÃ© adresÃ¡Å™e a soubory, nebo pracovnÃ­\n"
+"adresÃ¡Å™, pokud nejsou zadÃ¡ny Å¾Ã¡dnÃ© argumenty.\n"
+"\n"
+"  -b, --bottom=PANEL\totevÅ™e PAN jako panel na dolnÃ­m okraji\n"
+"  -c, --client-id=ID\tpouÅ¾ito pro sprÃ¡vce sezenÃ­\n"
+"  -d, --dir=ADR\t\totevÅ™e ADR jako adresÃ¡Å™ (ne jako aplikaci)\n"
+"  -D, --close=ADR\tzavÅ™e ADR a jeho podadresÃ¡Å™e\n"
+"  -h, --help\t\tzobrazÃ­ tuto nÃ¡povÄ›du a skonÄÃ­\n"
+"  -l, --left=PANEL\totevÅ™e PAN jako panel na levÃ©m okraji\n"
+"  -m, --mime-type=SOUB\tvypÃ­Å¡e MIME typ souboru SOUB a skonÄÃ­\n"
+"  -n, --new\t\tspustÃ­ novou kopii; pro ladÄ›nÃ­ sprÃ¡vce souborÅ¯\n"
+"  -p, --pinboard=PIN\tpouÅ¾ije pluchu PIN jako plochu\n"
+"  -r, --right=PANEL\totevÅ™e panel PAN panel na pravÃ©m okraji\n"
+"  -R, --RPC\t\tnastavit ÄtenÃ­ volÃ¡nÃ­ metod ze stand. vstupu\n"
+"  -s, --show=SOUB\totevÅ™e adresÃ¡Å™ a soubor SOUB je zobrazen\n"
+"  -t, --top=PANEL\totevÅ™e PANEL jako panel na hornÃ­m okraji\n"
+"  -u, --user\t\tzobrazÃ­ uÅ¾ivatelskÃ© jmÃ©no v kaÅ¾dÃ©m oknÄ› \n"
+"  -v, --version\t\tzobrazÃ­ informace o verzi a skonÄÃ­\n"
+"  -x, --examine=SOUB\tSOUB se zmÄ›nil - znovu jej prozkoumat\n"
+"\n"
+"Chyby hlaste na <tal197@users.sourceforge.net>.\n"
+"DomovskÃ¡ strÃ¡nka (vÄetnÄ› novÃ½ch verzÃ­): http://rox.sourceforge.net/\n"
 
-#: main.c:234
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1923,7 +2121,7 @@ msgid ""
 "Trying to continue..."
 msgstr ""
 
-#: main.c:382
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
@@ -1931,284 +2129,380 @@ msgstr ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
 
-#: main.c:489
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
-msgstr "Bì¾í pod u¾ivatelem '%s'"
+msgstr "BÄ›Å¾Ã­ pod uÅ¾ivatelem '%s'"
 
-#: main.c:666
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
-msgstr "Pøelo¾eno s GTK verzí %s\n"
+msgstr "PÅ™eloÅ¾eno s GTK verzÃ­ %s\n"
 
-#: main.c:667
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
-msgstr "Spu¹tìno s GTK verzí %d.%d.%d\n"
-
-#: main.c:671
-msgid "features set at compile time"
-msgstr "vlastnosti nastavené v dobì pøekladu"
-
-#: main.c:672
-msgid "Large File Support"
-msgstr "Podpora velkıch souborù"
-
-#: main.c:679
-msgid "GNOME-VFS library"
-msgstr "GNOME-VFS knihovna"
-
-#: main.c:683
-msgid "No (need 2.8.0 or later)"
-msgstr ""
-
-#: main.c:686
-msgid "Dnotify support"
-msgstr "Dnotify support"
+msgstr "SpuÅ¡tÄ›no s GTK verzÃ­ %d.%d.%d\n"
 
 #: main.c:693
+msgid "features set at compile time"
+msgstr "vlastnosti nastavenÃ© v dobÄ› pÅ™ekladu"
+
+#: main.c:694
+msgid "Large File Support"
+msgstr "Podpora velkÃ½ch souborÅ¯"
+
+#: main.c:701
 #, fuzzy
 msgid "Binary compatibility"
 msgstr "Kompatibilita"
 
-#: main.c:695
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr ""
 
-#: main.c:697
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr ""
 
-#: menu.c:180 tips:52
+#: main.c:709
+#, fuzzy
+msgid "Extended attribute support"
+msgstr "NepouÅ¾Ã­vat jmÃ©na poÄÃ­taÄÅ¯"
+
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr ""
+"!%s\n"
+"KopÃ­rovÃ¡nÃ­ '%s' selhalo\n"
+
+#: main.c:895
+#, c-format
+msgid ""
+"Left-click to run %s.\n"
+"Right-click for a list of versions."
+msgstr ""
+
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Chyba pÅ™i vytvÃ¡Å™enÃ­ '%s': %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "UloÅ¾ jako:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Zobrazit"
 
-#: menu.c:181 tips:57
+#: menu.c:641 tips:49
 msgid "Icons View"
-msgstr "Ikonovı pohled"
+msgstr "IkonovÃ½ pohled"
 
-#: menu.c:182
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "Ikony, S..."
 
-#: menu.c:183 tips:74
-msgid "Sizes"
-msgstr "Velikostmi"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Ikonifikovat "
 
-#: menu.c:185 tips:254
-msgid "Types"
-msgstr "Typy"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "PÅ™Ã­stupovÃ¡ prÃ¡va"
 
-#: menu.c:186 tips:77
-msgid "Times"
-msgstr "Èasy"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Ikony, S..."
 
-#: menu.c:187 tips:58 tips:92
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
-msgstr "Seznamovı pohled"
+msgstr "SeznamovÃ½ pohled"
 
-#: menu.c:189
+#: menu.c:651
 msgid "Bigger Icons"
-msgstr "Vìt¹í ikony"
+msgstr "VÄ›tÅ¡Ã­ ikony"
 
-#: menu.c:190
+#: menu.c:653
 msgid "Smaller Icons"
-msgstr "Men¹í ikony"
+msgstr "MenÅ¡Ã­ ikony"
 
-#: menu.c:191 tips:71
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Automaticky"
 
-#: menu.c:193
+#: menu.c:661
 msgid "Sort by Name"
-msgstr "Tøídit podle jména"
+msgstr "TÅ™Ã­dit podle jmÃ©na"
 
-#: menu.c:194
+#: menu.c:662
 msgid "Sort by Type"
-msgstr "Tøídit podle typu"
+msgstr "TÅ™Ã­dit podle typu"
 
-#: menu.c:195
-msgid "Sort by Date"
-msgstr "Tøídit podle data"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
+msgstr "TÅ™Ã­dit podle data"
 
-#: menu.c:196
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "TÅ™Ã­dit podle data"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "TÅ™Ã­dit podle data"
+
+#: menu.c:666
 msgid "Sort by Size"
-msgstr "Tøídit podle velikosti"
+msgstr "TÅ™Ã­dit podle velikosti"
 
-#: menu.c:197
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "PÅ™Ã­stupovÃ¡ prÃ¡va"
+
+#: menu.c:668
 msgid "Sort by Owner"
-msgstr "Tøídit podle vlastníka"
+msgstr "TÅ™Ã­dit podle vlastnÃ­ka"
 
-#: menu.c:198
+#: menu.c:669
 msgid "Sort by Group"
-msgstr "Tøídit podle skupiny"
+msgstr "TÅ™Ã­dit podle skupiny"
 
-#: menu.c:199
+#: menu.c:671
 msgid "Reversed"
-msgstr "Opaènì"
+msgstr "OpaÄnÄ›"
 
-#: menu.c:201
+#: menu.c:675
 msgid "Show Hidden"
-msgstr "Zobrazit skryté"
+msgstr "Zobrazit skrytÃ©"
 
-#: menu.c:202
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Zobrazit NÃ¡povÄ›du"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "Å¾Ã¡dnÃ© adresÃ¡Å™e)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr ""
 
-#: menu.c:203
-msgid "Show Thumbnails"
-msgstr "Zobrazit náhledy"
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Soubor"
 
-#: menu.c:204
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
+msgid "Show Thumbnails"
+msgstr "Zobrazit nÃ¡hledy"
+
+#: menu.c:683
 msgid "Refresh"
 msgstr "Obnovit"
 
-#: menu.c:205
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Obnovit"
+
+#: menu.c:686
 msgid "Save Display Settings..."
 msgstr ""
 
-#: menu.c:207
-msgid "Copy..."
-msgstr "Kopírovat..."
+#: menu.c:687
+msgid "Save Display Settings to parent ..."
+msgstr ""
 
-#: menu.c:208
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "PoÄet"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
-msgstr "Pøejmenovat..."
+msgstr "PÅ™ejmenovat..."
 
-#: menu.c:209
+#: menu.c:700
 msgid "Link..."
-msgstr "Vytvoøit odkaz..."
+msgstr "VytvoÅ™it odkaz..."
 
-#: menu.c:213
-msgid "Open AVFS"
-msgstr "Otevøít AFVS"
-
-#: menu.c:214
+#: menu.c:708
 msgid "Send To..."
 msgstr "Poslat na..."
 
-#: menu.c:219
-msgid "Count"
-msgstr "Poèet"
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "NepouÅ¾Ã­vat jmÃ©na poÄÃ­taÄÅ¯"
 
-#: menu.c:220
+#: menu.c:721
+msgid "Count"
+msgstr "PoÄet"
+
+#: menu.c:723
 #, fuzzy
 msgid "Set Type..."
 msgstr "Poslat na..."
 
-#: menu.c:224 toolbar.c:155
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Vybrat"
 
-#: menu.c:225
+#: menu.c:733
 msgid "Select All"
-msgstr "Vybrat v¹e"
+msgstr "Vybrat vÅ¡e"
 
-#: menu.c:226
+#: menu.c:735
 msgid "Clear Selection"
-msgstr "Odznaèit vybrané"
+msgstr "OdznaÄit vybranÃ©"
 
-#: menu.c:227
+#: menu.c:736
 msgid "Invert Selection"
-msgstr "Invertovat vıbìr"
+msgstr "Invertovat vÃ½bÄ›r"
 
-#: menu.c:228
+#: menu.c:737
 #, fuzzy
 msgid "Select by Name..."
-msgstr "Tøídit podle jména"
+msgstr "TÅ™Ã­dit podle jmÃ©na"
 
-#: menu.c:229
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Vybrat pokud..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Vybrat pokud..."
 
-#: menu.c:231
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
-msgstr "Novı"
+msgstr "NovÃ½"
 
-#: menu.c:233
+#: menu.c:752
 msgid "Blank file"
-msgstr "Prázdnı soubor"
+msgstr "PrÃ¡zdnÃ½ soubor"
 
-#: menu.c:235 tasklist.c:308
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Okno"
 
-#: menu.c:236
+#: menu.c:758
 msgid "Parent, New Window"
-msgstr "Nadøazenı adresáø, Nové okno"
+msgstr "NadÅ™azenÃ½ adresÃ¡Å™, NovÃ© okno"
 
-#: menu.c:237
+#: menu.c:759
 msgid "Parent, Same Window"
-msgstr "Nadøazenı adresáø, Stejné okno"
+msgstr "NadÅ™azenÃ½ adresÃ¡Å™, StejnÃ© okno"
 
-#: menu.c:238
+#: menu.c:761 tips:44
 msgid "New Window"
-msgstr "Nové okno"
+msgstr "NovÃ© okno"
 
-#: menu.c:240
+#: menu.c:764
 msgid "Show Bookmarks"
-msgstr "Zobrazit zálo¾ky"
+msgstr "Zobrazit zÃ¡loÅ¾ky"
 
-#: menu.c:241
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Zobrazit Info"
+
+#: menu.c:768
 msgid "Follow Symbolic Links"
-msgstr "Následovat symbolické odkazy"
+msgstr "NÃ¡sledovat symbolickÃ© odkazy"
 
-#: menu.c:242
+#: menu.c:769
 msgid "Resize Window"
 msgstr "Upravit velikost okna"
 
-#: menu.c:245
+#: menu.c:771
 msgid "Close Window"
-msgstr "Zavøít okno"
+msgstr "ZavÅ™Ã­t okno"
 
-#: menu.c:247
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Zadat cestu..."
 
-#: menu.c:248
+#: menu.c:778
 msgid "Shell Command..."
-msgstr "Shell pøíkaz"
+msgstr "Shell pÅ™Ã­kaz"
 
-#: menu.c:249
-msgid "Xterm Here"
-msgstr "Xterm v tomto adresáøi"
+#: menu.c:780
+#, fuzzy
+msgid "Terminal Here"
+msgstr "Xterm v tomto adresÃ¡Å™i"
 
-#: menu.c:250
-msgid "Switch to xterm"
-msgstr "Pøepnout do xtermu"
+#: menu.c:782
+#, fuzzy
+msgid "Switch to Terminal"
+msgstr "PÅ™epnout do xtermu"
 
-#: menu.c:718
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr ""
-"Mìli by jste stisknout Shift a menu tlaèítko nad souborem, abyste jej nìkam "
-"poslali"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Nastavit"
 
-#: menu.c:754
+#: menu.c:976
 msgid "Next Click"
-msgstr "Dal¹í kliknutí"
+msgstr "DalÅ¡Ã­ kliknutÃ­"
 
-#: menu.c:776
+#: menu.c:998
 #, c-format
 msgid "%d items"
-msgstr "%d polo¾ek"
+msgstr "%d poloÅ¾ek"
 
-#: menu.c:864
+#: menu.c:1094
 msgid "Open unmounted"
-msgstr "Otevøít odpojené"
+msgstr "OtevÅ™Ã­t odpojenÃ©"
 
-#: menu.c:867
+#: menu.c:1097
 msgid "Show Target"
-msgstr "Zobrazit cíl"
+msgstr "Zobrazit cÃ­l"
 
-#: menu.c:869
+#: menu.c:1099
 msgid "Look Inside"
-msgstr "Podívat se dovnitø"
+msgstr "PodÃ­vat se dovnitÅ™"
 
-#: menu.c:871
+#: menu.c:1101
 msgid "Open As Text"
-msgstr "Otevøít jako text"
+msgstr "OtevÅ™Ã­t jako text"
 
-#: menu.c:1031
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2217,63 +2511,73 @@ msgid ""
 "mount option ('user_xattr' on Linux)."
 msgstr ""
 
-#: menu.c:1037
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr ""
 
-#: menu.c:1072
+#: menu.c:1364
 msgid "_Relative link"
-msgstr "_Relativní odkaz"
+msgstr "_RelativnÃ­ odkaz"
 
-#: menu.c:1078
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
 "If off, the path from the root directory is stored - use this if the symlink "
 "may move but the target will stay put."
 msgstr ""
-"Pokud je zapnuto, symbolickı odkaz ulo¾í cestu ze symb. odkazu do cílového "
-"souboru. Pou¾ijte, pokud symb. odkaz a cíl budou pøesunuty spoleènì.\n"
-"Pokud je vypnuto, je ulo¾ena cesta z koøenového adresáøe - pu¾ijte, pokud se "
-"symb. odkaz mù¾e pøesunout, ale cíl ne."
+"Pokud je zapnuto, symbolickÃ½ odkaz uloÅ¾Ã­ cestu ze symb. odkazu do cÃ­lovÃ©ho "
+"souboru. PouÅ¾ijte, pokud symb. odkaz a cÃ­l budou pÅ™esunuty spoleÄnÄ›.\n"
+"Pokud je vypnuto, je uloÅ¾ena cesta z koÅ™enovÃ©ho adresÃ¡Å™e - puÅ¾ijte, pokud se "
+"symb. odkaz mÅ¯Å¾e pÅ™esunout, ale cÃ­l ne."
 
-#: menu.c:1148
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
-msgstr "Nová cesta není absolutní"
+msgstr "NovÃ¡ cesta nenÃ­ absolutnÃ­"
 
-#: menu.c:1214
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
-msgstr "Symbolickı odkaz  z '%s' u¾ existuje. Nahradit ho odkazem na '%s'?"
+msgstr "SymbolickÃ½ odkaz  z '%s' uÅ¾ existuje. Nahradit ho odkazem na '%s'?"
 
-#: menu.c:1220
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Nahradit"
 
-#: menu.c:1351 menu.c:1392 menu.c:1452
-msgid "Create"
-msgstr "Vytvoøit"
-
-#: menu.c:1352
+#: menu.c:1704
 msgid "NewDir"
-msgstr "Novı adresáø"
+msgstr "NovÃ½ adresÃ¡Å™"
 
-#: menu.c:1366 menu.c:1372
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Chyba pøi vytváøení '%s': %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "VytvoÅ™it"
 
-#: menu.c:1393
+#: menu.c:1755
 msgid "NewFile"
-msgstr "Novı soubor"
+msgstr "NovÃ½ soubor"
 
-#: menu.c:1411
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
-msgstr "Chyba pøi vytváøení souboru: nemohu najít ¹ablonu pro %s"
+msgstr "Chyba pÅ™i vytvÃ¡Å™enÃ­ souboru: nemohu najÃ­t Å¡ablonu pro %s"
 
-#: menu.c:1482
-#, c-format
+#: menu.c:1847
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2285,34 +2589,35 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
-"Menu `Poslat na' je rychlı zpùsob, jak poslat soubory nìjaké aplikaci. "
-"Nabízené aplikace jsou ty, které jsou v tìchto adresáøích:\n"
+"Menu `Poslat na' je rychlÃ½ zpÅ¯sob, jak poslat soubory nÄ›jakÃ© aplikaci. "
+"NabÃ­zenÃ© aplikace jsou ty, kterÃ© jsou v tÄ›chto adresÃ¡Å™Ã­ch:\n"
 "\n"
 "%s\n"
 "%s\n"
-"Menu `Poslat na' je mo¾né otevøít pomocí Shift+Menu kliknutí na souboru.\n"
+"Menu `Poslat na' je moÅ¾nÃ© otevÅ™Ã­t pomocÃ­ Shift+Menu kliknutÃ­ na souboru.\n"
 "\n"
-"Pokroèilé pou¾ití:\n"
-"Mù¾ete také vytváøet podadresáøe nazvané `.text_html', `.text', atd., které "
-"budou zobrazeny pouze pro danı typ. `.group' je zobrazeno jen kdy¾ je "
-"vybráno více souborù"
+"PokroÄilÃ© pouÅ¾itÃ­:\n"
+"MÅ¯Å¾ete takÃ© vytvÃ¡Å™et podadresÃ¡Å™e nazvanÃ© `.text_html', `.text', atd., kterÃ© "
+"budou zobrazeny pouze pro danÃ½ typ. `.group' je zobrazeno jen kdyÅ¾ je "
+"vybrÃ¡no vÃ­ce souborÅ¯"
 
-#: menu.c:1493
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
 msgstr ""
-"Nyní zobrazím Vá¹ `Poslat na' adresáø; meli by jste vytvoøit symbolické "
-"odkazy (Ctrl+Shift pøetáhnutí) na aplikace, které tam chcete mít."
+"NynÃ­ zobrazÃ­m VÃ¡Å¡ `Poslat na' adresÃ¡Å™; meli by jste vytvoÅ™it symbolickÃ© "
+"odkazy (Ctrl+Shift pÅ™etÃ¡hnutÃ­) na aplikace, kterÃ© tam chcete mÃ­t."
 
-#: menu.c:1496 menu.c:1536
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
-msgstr "Nastavení Va¹í promìnné CHOICESPATH znemo¾òuje zmìny - promiòte."
+msgstr "NastavenÃ­ VaÅ¡Ã­ promÄ›nnÃ© CHOICESPATH znemoÅ¾Åˆuje zmÄ›ny - promiÅˆte."
 
-#: menu.c:1529
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2324,102 +2629,136 @@ msgid ""
 "%s\n"
 msgstr ""
 
-#: menu.c:1534
+#: menu.c:1936
 #, fuzzy
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
 msgstr ""
-"Nyní zobrazím Vá¹ `Poslat na' adresáø; meli by jste vytvoøit symbolické "
-"odkazy (Ctrl+Shift pøetáhnutí) na aplikace, které tam chcete mít."
+"NynÃ­ zobrazÃ­m VÃ¡Å¡ `Poslat na' adresÃ¡Å™; meli by jste vytvoÅ™it symbolickÃ© "
+"odkazy (Ctrl+Shift pÅ™etÃ¡hnutÃ­) na aplikace, kterÃ© tam chcete mÃ­t."
 
-#: menu.c:1651
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Nastavit"
 
-#: menu.c:1717
-msgid "This is already the canonical name for this directory."
-msgstr "Toto u¾ je kanonické jméno pro tento adresáø."
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Nastavit"
 
-#: menu.c:1748
+#: menu.c:2169
+msgid "This is already the canonical name for this directory."
+msgstr "Toto uÅ¾ je kanonickÃ© jmÃ©no pro tento adresÃ¡Å™."
+
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
 msgstr ""
-"Nemù¾ete otevøít druhı pohled na tento adresáø, proto¾e volba `Unikátní "
-"okna' je zapnuta v oknì Mo¾nosti."
+"NemÅ¯Å¾ete otevÅ™Ã­t druhÃ½ pohled na tento adresÃ¡Å™, protoÅ¾e volba `UnikÃ¡tnÃ­ "
+"okna' je zapnuta v oknÄ› MoÅ¾nosti."
 
-#: menu.c:1869
-msgid "Copy ... ?"
-msgstr "Kopírovat ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1872
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?ZkopÃ­rovat %s jako %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?ZkopÃ­rovat %s jako %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
-msgstr "Pøejmenovat ... ?"
+msgstr "PÅ™ejmenovat ... ?"
 
-#: menu.c:1875
+#: menu.c:2462
 msgid "Symlink ... ?"
-msgstr "Symbolickı odkaz ... ?"
+msgstr "SymbolickÃ½ odkaz ... ?"
 
-#: menu.c:1878
+#: menu.c:2465
 msgid "Shift Open ... ?"
-msgstr "Shift Otevøení ... ?"
+msgstr "Shift OtevÅ™enÃ­ ... ?"
 
-#: menu.c:1881
+#: menu.c:2468
 #, fuzzy
 msgid "Properties of ... ?"
-msgstr "Spoèítat velikost ... ?"
+msgstr "SpoÄÃ­tat velikost ... ?"
 
-#: menu.c:1884
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "NepouÅ¾Ã­vat jmÃ©na poÄÃ­taÄÅ¯"
+
+#: menu.c:2476
 #, fuzzy
 msgid "Set type of ... ?"
 msgstr "Nastavit ikonu pro ... ?"
 
-#: menu.c:1887
+#: menu.c:2479
 msgid "Set run action for ... ?"
-msgstr "Nastavit spou¹tìcí akci pro ... ?"
+msgstr "Nastavit spouÅ¡tÄ›cÃ­ akci pro ... ?"
 
-#: menu.c:1890
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Nastavit ikonu pro ... ?"
 
-#: menu.c:1893
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Poslat ... na ... ?"
 
-#: menu.c:1896
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "SMAZAT ... ?"
 
-#: menu.c:1899
+#: menu.c:2491
 msgid "Count the size of ... ?"
-msgstr "Spoèítat velikost ... ?"
+msgstr "SpoÄÃ­tat velikost ... ?"
 
-#: menu.c:1902
+#: menu.c:2494
 msgid "Set permissions on ... ?"
-msgstr "Nastavit práva pro ... ?"
+msgstr "Nastavit prÃ¡va pro ... ?"
 
-#: menu.c:1905
+#: menu.c:2497
 msgid "Search inside ... ?"
-msgstr "Hledat uvnitø ... ?"
+msgstr "Hledat uvnitÅ™ ... ?"
 
-#: menu.c:1908
-msgid "Look inside ... ?"
-msgstr "Podívat se do ... ?"
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "KopÃ­rovat ... ?"
 
-#: menu.c:1972
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
-msgstr "Nemù¾ete pou¾ít souèasnì na více polo¾ek"
+msgstr "NemÅ¯Å¾ete pouÅ¾Ã­t souÄasnÄ› na vÃ­ce poloÅ¾ek"
 
-#: menu.c:2004
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
-msgstr "Pøejmenovat"
+msgstr "PÅ™ejmenovat"
 
-#: menu.c:2009
+#: menu.c:2619
 msgid "Symlink"
-msgstr "Symbolickı odkaz"
+msgstr "SymbolickÃ½ odkaz"
 
-#: menu.c:2041
+#: menu.c:2654
 #, fuzzy
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
@@ -2432,14 +2771,14 @@ msgid ""
 "\tgtk-can-change-accels = 1\n"
 "\t(this only works if NOT using XSETTINGS)"
 msgstr ""
-"V Gtk2 jsou u¾ivatelsky definovatelné klávesové zkratky defaultnì zakázané a "
-"Vy jste je nepovolili. Tuto volbu mù¾ete zapnout takto:\n"
-"1) pomocí správce X vlastností, jako je ROX-Session\n"
+"V Gtk2 jsou uÅ¾ivatelsky definovatelnÃ© klÃ¡vesovÃ© zkratky defaultnÄ› zakÃ¡zanÃ© a "
+"Vy jste je nepovolili. Tuto volbu mÅ¯Å¾ete zapnout takto:\n"
+"1) pomocÃ­ sprÃ¡vce X vlastnostÃ­, jako je ROX-Session\n"
 "nebo\n"
-"2) pøidáním této øádky do ~/.gtkrc-2.0:\n"
+"2) pÅ™idÃ¡nÃ­m tÃ©to Å™Ã¡dky do ~/.gtkrc-2.0:\n"
 "\tgtk-can-change-accels = 1"
 
-#: menu.c:2052
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2450,56 +2789,77 @@ msgid ""
 "The key will appear next to the menu item and you can just press that key "
 "without opening the menu in future."
 msgstr ""
-"Pro nastavení klávesové zkratky pro polo¾ku nabídky:\n"
+"Pro nastavenÃ­ klÃ¡vesovÃ© zkratky pro poloÅ¾ku nabÃ­dky:\n"
 "\n"
-"- Otevøete nabídku ve správci souborù,\n"
-"- Pøesuòte kurzor na polo¾ku, kterou chcete pou¾ít ,\n"
-"- Stisknìte klávesouvou zkratku, kterou jí chcete pøiøadit.\n"
+"- OtevÅ™ete nabÃ­dku ve sprÃ¡vci souborÅ¯,\n"
+"- PÅ™esuÅˆte kurzor na poloÅ¾ku, kterou chcete pouÅ¾Ã­t ,\n"
+"- StisknÄ›te klÃ¡vesouvou zkratku, kterou jÃ­ chcete pÅ™iÅ™adit.\n"
 "\n"
-"Zkratka se pøí¹tì objeví vedle polo¾ky nabídky a mù¾ete rovnou pou¾ívat "
-"zkratku bez otevírání nabídky."
+"Zkratka se pÅ™Ã­Å¡tÄ› objevÃ­ vedle poloÅ¾ky nabÃ­dky a mÅ¯Å¾ete rovnou pouÅ¾Ã­vat "
+"zkratku bez otevÃ­rÃ¡nÃ­ nabÃ­dky."
 
-#: menu.c:2067
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
-msgstr "Nastavit klávesovou zkratku"
+msgstr "Nastavit klÃ¡vesovou zkratku"
 
-#: minibuffer.c:131
+#: minibuffer.c:140
 msgid "Goto:"
-msgstr "Jít do:"
+msgstr "JÃ­t do:"
 
-#: minibuffer.c:132
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Shell:"
 
-#: minibuffer.c:133
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Vybrat pokud:"
 
-#: minibuffer.c:134
+#: minibuffer.c:143
 #, fuzzy
 msgid "Select Named:"
 msgstr "Vybrat pokud:"
 
-#: minibuffer.c:135
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Vybrat pokud:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr ""
 
-#: minibuffer.c:264
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
 msgstr ""
-"Zadejte jméno souboru a já ho zobrazím. Stisknìte Tab pro doplnìní "
-"nejdel¹ího odpovídajícího jména, Escape pokud chcete zavøít minibuffer."
+"Zadejte jmÃ©no souboru a jÃ¡ ho zobrazÃ­m. StisknÄ›te Tab pro doplnÄ›nÃ­ "
+"nejdelÅ¡Ã­ho odpovÃ­dajÃ­cÃ­ho jmÃ©na, Escape pokud chcete zavÅ™Ã­t minibuffer."
 
-#: minibuffer.c:270
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
-"Zadejte shellovı pøíkaz k provedení. Kliknìte na soubor pro jeho pøidání do "
+"Zadejte shellovÃ½ pÅ™Ã­kaz k provedenÃ­. KliknÄ›te na soubor pro jeho pÅ™idÃ¡nÃ­ do "
 "bufferu."
 
-#: minibuffer.c:275
+#: minibuffer.c:331
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2510,175 +2870,188 @@ msgid ""
 "*.png means any name ending in '.png'"
 msgstr ""
 
-#: minibuffer.c:287
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
 msgstr ""
 
-#: minibuffer.c:895
-msgid "Invalid Find condition"
-msgstr "Neplatná podmínka pro Hledání"
+#: minibuffer.c:358
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
 
-#: mount.c:374
+#: minibuffer.c:1045
+msgid "Invalid Find condition"
+msgstr "NeplatnÃ¡ podmÃ­nka pro HledÃ¡nÃ­"
+
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr ""
 
-#: options.c:277
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
-msgstr "ROX-Filer pøevedl Vá¹ soubor s nastavením do nového XML formátu"
+msgstr "ROX-Filer pÅ™evedl VÃ¡Å¡ soubor s nastavenÃ­m do novÃ©ho XML formÃ¡tu"
 
-#: options.c:535 options.c:1258
+#: options.c:560 options.c:1250
 msgid "(use default)"
-msgstr "(pou¾ít defaultní)"
+msgstr "(pouÅ¾Ã­t defaultnÃ­)"
 
-#: options.c:806
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
-msgstr "Intern9 chyba: %s nejde pøeèíst"
+msgstr "Intern9 chyba: %s nejde pÅ™eÄÃ­st"
 
-#: options.c:917
+#: options.c:929
 msgid "Options"
-msgstr "Mo¾nosti"
+msgstr "MoÅ¾nosti"
 
-#: options.c:962
+#: options.c:974
 msgid "_Revert"
-msgstr "_Vrátit zpìt"
+msgstr "_VrÃ¡tit zpÄ›t"
 
-#: options.c:968
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
-msgstr "Obnovit v¹echny volby tak jak byly pøi otevøení boxu Mo¾nosti."
+msgstr "Obnovit vÅ¡echny volby tak jak byly pÅ™i otevÅ™enÃ­ boxu MoÅ¾nosti."
 
-#: options.c:983
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
 "%s"
 msgstr ""
-"Volby budou ulo¾eny jako:\n"
+"Volby budou uloÅ¾eny jako:\n"
 "%s"
 
-#: options.c:991
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
-msgstr "(ulo¾ení není povoleno kvùli  CHOICESPATH)"
+msgstr "(uloÅ¾enÃ­ nenÃ­ povoleno kvÅ¯li  CHOICESPATH)"
 
-#: options.c:1164 usericons.c:450
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
-msgstr "Chyba pøi ukládání %s: %s"
+msgstr "Chyba pÅ™i uklÃ¡dÃ¡nÃ­ %s: %s"
 
-#: options.c:1794
+#: options.c:1813
 msgid "Missing '='"
-msgstr "Chybí '='"
+msgstr "ChybÃ­ '='"
 
-#: panel.c:439
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr ""
+"!%s\n"
+"KopÃ­rovÃ¡nÃ­ '%s' selhalo\n"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr ""
-"Vá¹ starı soubor s nastavením panelu byl oøeveden do nového XML formátu."
+"VÃ¡Å¡ starÃ½ soubor s nastavenÃ­m panelu byl oÅ™eveden do novÃ©ho XML formÃ¡tu."
 
-#: panel.c:546
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
 msgstr ""
-"Zkusili jste zavøít panel pøes správce oken - to mù¾e zpùsobit problémy... "
-"opravdu zavøít?"
+"Zkusili jste zavÅ™Ã­t panel pÅ™es sprÃ¡vce oken - to mÅ¯Å¾e zpÅ¯sobit problÃ©my... "
+"opravdu zavÅ™Ã­t?"
 
-#: panel.c:639
+#: panel.c:771
 msgid "Missing < or > in panel config file"
-msgstr "V konfiguraèním souboru panelu chybí < nebo >"
+msgstr "V konfiguraÄnÃ­m souboru panelu chybÃ­ < nebo >"
 
-#: panel.c:1519
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
-msgstr "Chyba pøi ukládání panelu %s: %s"
+msgstr "Chyba pÅ™i uklÃ¡dÃ¡nÃ­ panelu %s: %s"
 
-#: panel.c:1835
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
-msgstr "Applet skonèil ani¾ by vytvoøil widget!"
+msgstr "Applet skonÄil aniÅ¾ by vytvoÅ™il widget!"
 
-#: panel.c:1934
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
 "%s"
 msgstr ""
-"Chyba pøi spu¹tìní appletu:\n"
+"Chyba pÅ™i spuÅ¡tÄ›nÃ­ appletu:\n"
 "%s"
 
-#: panel.c:2335
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "Opravdu otevÅ™Ã­t %d oken?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Odebrat poloÅ¾ku(y)"
+
+#: panel.c:2777
 #, fuzzy
 msgid "Panel Options..."
-msgstr "Mo¾nosti..."
+msgstr "MoÅ¾nosti..."
 
-#: panel.c:2427
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr ""
 
-#: panel.c:2502
+#: panel.c:2897
+msgid "Top"
+msgstr ""
+
+#: panel.c:2899
+msgid "Bottom"
+msgstr ""
+
+#: panel.c:2901
+msgid "Left"
+msgstr ""
+
+#: panel.c:2903
+msgid "Right"
+msgstr ""
+
+#: panel.c:2905
 #, fuzzy
-msgid "Panel Options"
-msgstr "Mo¾nosti"
+msgid "Default"
+msgstr "DefaultnÃ­ velikost"
 
-#: panel.c:2517
-#, fuzzy, c-format
-msgid "Panel: %s"
-msgstr "Panely"
-
-#: panel.c:2525
-msgid "Select the panel's position:"
-msgstr ""
-
-#: panel.c:2531
-msgid "Top-edge panel"
-msgstr ""
-
-#: panel.c:2532
-msgid "Top edge"
-msgstr ""
-
-#: panel.c:2533
-msgid "Bottom edge panel"
-msgstr ""
-
-#: panel.c:2534
-msgid "Bottom edge"
-msgstr ""
-
-#: panel.c:2535
-msgid "Left edge panel"
-msgstr ""
-
-#: panel.c:2536
-msgid "Left edge"
-msgstr ""
-
-#: panel.c:2537
-msgid "Right-edge panel"
-msgstr ""
-
-#: panel.c:2538
-msgid "Right edge"
-msgstr ""
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "NeznÃ¡mÃ©"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
 msgstr ""
-"Vá¹ starı soubor s nastavením plochy byl pøeveden do nového XML formátu."
+"VÃ¡Å¡ starÃ½ soubor s nastavenÃ­m plochy byl pÅ™eveden do novÃ©ho XML formÃ¡tu."
 
-#: pinboard.c:635
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
 "the SOAP SetBackdropApp method."
 msgstr ""
-"Ovladaè pro nastavení pozadí musí bıt aplikaèní adresáø. Pøetáhnìte "
-"aplikaèní adresáø na dialog Nastavení pozadí, nebo (pro programátory) jej "
-"pøedejte SOAP metodì SetBackdropApp."
+"OvladaÄ pro nastavenÃ­ pozadÃ­ musÃ­ bÃ½t aplikaÄnÃ­ adresÃ¡Å™. PÅ™etÃ¡hnÄ›te "
+"aplikaÄnÃ­ adresÃ¡Å™ na dialog NastavenÃ­ pozadÃ­, nebo (pro programÃ¡tory) jej "
+"pÅ™edejte SOAP metodÄ› SetBackdropApp."
 
-#: pinboard.c:654
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2686,201 +3059,171 @@ msgid ""
 "Programmers: the application's AppInfo.xml must contain the CanSetBackdrop "
 "element, as described in ROX-Filer's manual."
 msgstr ""
-"Na pozadí mù¾ete nastavit pouze obrázek nebo aplikaci, která ví, jak ovládat "
-"pozadí ROX-Fileru.\n"
+"Na pozadÃ­ mÅ¯Å¾ete nastavit pouze obrÃ¡zek nebo aplikaci, kterÃ¡ vÃ­, jak ovlÃ¡dat "
+"pozadÃ­ ROX-Fileru.\n"
 "\n"
-"Programátorùm: AppInfo.xml aplikace musí obsahovat CanSetBackdrop element, "
-"jak je popsáno v manuálu ROX-Fileru."
+"ProgramÃ¡torÅ¯m: AppInfo.xml aplikace musÃ­ obsahovat CanSetBackdrop element, "
+"jak je popsÃ¡no v manuÃ¡lu ROX-Fileru."
 
-#: pinboard.c:674
+#: pinboard.c:750
 msgid "Set backdrop"
-msgstr "Nastavit pozadí"
+msgstr "Nastavit pozadÃ­"
 
-#: pinboard.c:685
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
-msgstr "Vyberte styl a pøetáhnìte obrázek na:"
+msgstr "Vyberte styl a pÅ™etÃ¡hnÄ›te obrÃ¡zek na:"
 
-#: pinboard.c:698
+#: pinboard.c:774
 msgid "Centre the image without scaling it"
-msgstr "Umístit obrázek do støedu a nemìnit jeho velikost"
+msgstr "UmÃ­stit obrÃ¡zek do stÅ™edu a nemÄ›nit jeho velikost"
 
-#: pinboard.c:699
+#: pinboard.c:775
 msgid "Centre"
-msgstr "Umístit do støedu"
+msgstr "UmÃ­stit do stÅ™edu"
 
-#: pinboard.c:700
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
-msgstr "Zmìnit velikost obrázku na velikost plochy a nezkreslovat ho"
+msgstr "ZmÄ›nit velikost obrÃ¡zku na velikost plochy a nezkreslovat ho"
 
-#: pinboard.c:702
+#: pinboard.c:778
 msgid "Scale"
-msgstr "Zmìnit velikost"
+msgstr "ZmÄ›nit velikost"
 
-#: pinboard.c:703
+#: pinboard.c:779
+#, fuzzy
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr "ZmÄ›nit velikost obrÃ¡zku na velikost plochy a nezkreslovat ho"
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Soubor"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
-msgstr "Roztáhnout obrázek na velikost plochy"
+msgstr "RoztÃ¡hnout obrÃ¡zek na velikost plochy"
 
-#: pinboard.c:704
+#: pinboard.c:783
 msgid "Stretch"
-msgstr "Roztáhnout"
+msgstr "RoztÃ¡hnout"
 
-#: pinboard.c:705
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
-msgstr "Umístit obrázek na plo¹e jako dla¾dice"
+msgstr "UmÃ­stit obrÃ¡zek na ploÅ¡e jako dlaÅ¾dice"
 
-#: pinboard.c:706
+#: pinboard.c:785
 msgid "Tile"
-msgstr "Dla¾dice"
+msgstr "DlaÅ¾dice"
 
-#: pinboard.c:711
+#: pinboard.c:790
 msgid "Drop an image here"
-msgstr "Sem umístìte obrázek"
+msgstr "Sem umÃ­stÄ›te obrÃ¡zek"
 
-#: pinboard.c:772
+#: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
 msgstr ""
-"Nebylo pou¾ito ¾ádné pozadí... 'Default' pozadí bylo vybráno. Pou¾ijte 'rox -"
-"p=Default' pro zapnutí."
+"Nebylo pouÅ¾ito Å¾Ã¡dnÃ© pozadÃ­... 'Default' pozadÃ­ bylo vybrÃ¡no. PouÅ¾ijte 'rox -"
+"p=Default' pro zapnutÃ­."
 
-#: pinboard.c:866
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
 msgstr ""
-"Jen soubory (a nìkteré aplikace) mohou bıt pou¾ity pro nastavení obrázku na "
-"pozadí."
+"Jen soubory (a nÄ›kterÃ© aplikace) mohou bÃ½t pouÅ¾ity pro nastavenÃ­ obrÃ¡zku na "
+"pozadÃ­."
 
-#: pinboard.c:1471
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
-msgstr "Chybí '>' ve jmenovce ikony"
+msgstr "ChybÃ­ '>' ve jmenovce ikony"
 
-#: pinboard.c:1480
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
-msgstr "Chybí ',' za jmenovkou ikony"
+msgstr "ChybÃ­ ',' za jmenovkou ikony"
 
-#: pinboard.c:1565
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
-msgstr "Chyba pøi ukládání pozadí %s: %s"
+msgstr "Chyba pÅ™i uklÃ¡dÃ¡nÃ­ pozadÃ­ %s: %s"
 
-#: pinboard.c:2109
+#: pinboard.c:2247
 msgid "Backdrop..."
-msgstr "Nastavit pozadí..."
+msgstr "Nastavit pozadÃ­..."
 
-#: pinboard.c:2202
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Panely"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
 "%s\n"
 "Backdrop removed."
 msgstr ""
-"Chyba pøi naèítání pozadí:\n"
+"Chyba pÅ™i naÄÃ­tÃ¡nÃ­ pozadÃ­:\n"
 "%s\n"
-"Pozadí odstranìno."
+"PozadÃ­ odstranÄ›no."
 
-#: pixmaps.c:991
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
 "%s"
 msgstr ""
-"Nemohu smazat náhledy v %s:\n"
+"Nemohu smazat nÃ¡hledy v %s:\n"
 "%s"
 
-#: pixmaps.c:1012
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
-msgstr "Nejsou ¾ádné náhledy ke smazání"
+msgstr "Nejsou Å¾Ã¡dnÃ© nÃ¡hledy ke smazÃ¡nÃ­"
 
-#: pixmaps.c:1025
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
-msgstr "Smazat náhledy ulo¾ené v ke¹i"
+msgstr "Smazat nÃ¡hledy uloÅ¾enÃ© v keÅ¡i"
 
-#: remote.c:624
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
-msgstr "Neznámı styl '%s'"
+msgstr "NeznÃ¡mÃ½ styl '%s'"
 
-#: remote.c:646
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
-msgstr "Neznámı typ '%s' podrobností"
+msgstr "NeznÃ¡mÃ½ typ '%s' podrobnostÃ­"
 
-#: remote.c:674
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
-msgstr "Neznámı typ tøídìní '%s'"
+msgstr "NeznÃ¡mÃ½ typ tÅ™Ã­dÄ›nÃ­ '%s'"
 
-#: remote.c:1117
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Attempt to invoke unknown SOAP method '%s'"
 
-#: rox_gettext.c:95
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Neplatnı .gmo soubor pøekladu (pøíli¹ krátkı): %s"
-
-#: rox_gettext.c:108
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Neplatnı .gmo soubor pøekladu (GNU magické èíslo nenalezeno): %s"
-
-#: run.c:96 run.c:141
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
-msgstr "Program %s nenalezen - je smazán?"
+msgstr "Program %s nenalezen - je smazÃ¡n?"
 
-#: run.c:287
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "Soubor neexistuje nebo k ìnu nemám pøístup: %s"
-
-#: run.c:292
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "Nevím, jak otevøít '%s'"
-
-#: run.c:323
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"Aplikace:\n"
-"Toto je aplikaèní adresáø - mù¾ete ho spou¹tìt jako program nebo ho otevøít "
-"(pøi jeho otevírání stidknìte Shift). Vìt¹ina aplikací má na tomto místì "
-"vlastní nápovìdu, tato aplikace ale ne."
-
-#: run.c:407
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "Nemohu poslat data programu: %s"
-
-#: run.c:437
-#, c-format
-msgid "Could not read link: %s"
-msgstr "Nemohu èíst odkaz: %s"
-
-#: run.c:465
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr "Poru¹enı symbolickı odkaz (nebo nemáte práva pro jeho následování): %s"
-
-#: run.c:502
+#: run.c:359
 #, fuzzy, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
 "action by choosing `Set Run Action' from the File menu, or you can just drag "
 "the file to an application.%s"
 msgstr ""
-"Pro soubory typu (%s/%s) nebyla specifikována ¾ádná spou¹tìcí akce - "
-"spou¹tìcí akci mù¾ete nastavit vybráním  `Nastavit spou¹tìcí akci' v menu "
-"souboru, nebo jen pøetáhnìte soubor na aplikaci"
+"Pro soubory typu (%s/%s) nebyla specifikovÃ¡na Å¾Ã¡dnÃ¡ spouÅ¡tÄ›cÃ­ akce - "
+"spouÅ¡tÄ›cÃ­ akci mÅ¯Å¾ete nastavit vybrÃ¡nÃ­m  `Nastavit spouÅ¡tÄ›cÃ­ akci' v menu "
+"souboru, nebo jen pÅ™etÃ¡hnÄ›te soubor na aplikaci"
 
-#: run.c:508
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -2888,195 +3231,64 @@ msgid ""
 "the execute bit by choosing Permissions from the File menu."
 msgstr ""
 
-#: support.c:272
-msgid "B"
-msgstr "B"
-
-#: support.c:351
-msgid "byte"
-msgstr "byte"
-
-#: toolbar.c:115
-msgid "Close"
-msgstr "Zavøít"
-
-#: toolbar.c:115
-msgid "Close filer window"
-msgstr "Zavøít okno správce souborù"
-
-#: toolbar.c:119
-msgid "Up"
-msgstr "Nahoru"
-
-#: toolbar.c:119
-msgid "Change to parent directory"
-msgstr "Pøejít do vy¹¹ího adresáøe"
-
-#: toolbar.c:123
-msgid "Home"
-msgstr "Domù"
-
-#: toolbar.c:123
-msgid "Change to home directory"
-msgstr "Pøejít do domovského adresáøe"
-
-#: toolbar.c:127
-msgid "Bookmarks"
-msgstr "Zálo¾ky"
-
-#: toolbar.c:127
-msgid "Bookmarks menu"
-msgstr "Menu zálo¾ek"
-
-#: toolbar.c:131
-msgid "Scan"
-msgstr "Naèíst"
-
-#: toolbar.c:131
-msgid "Rescan directory contents"
-msgstr "Znovu naèíst obsah adresáøe"
-
-#: toolbar.c:135
-msgid "Change icon size"
-msgstr "Zmìnit velikost ikony"
-
-#: toolbar.c:139
-msgid "Automatic size mode"
-msgstr "Mód Automatická velikost"
-
-#: toolbar.c:143
-msgid "Show extra details"
-msgstr "Zobrazit extra podrobnosti"
-
-#: toolbar.c:147
-#, fuzzy
-msgid "Sort"
-msgstr "Tøídìní"
-
-#: toolbar.c:147
-#, fuzzy
-msgid "Change sort criteria"
-msgstr "Èas zmìny:"
-
-#: toolbar.c:151
-msgid "Hidden"
-msgstr "Skrytı"
-
-#: toolbar.c:151
-msgid "Show/hide hidden files"
-msgstr "Zobrazit/skrıt skryté soubory"
-
-#: toolbar.c:155
-#, fuzzy
-msgid "Select all/invert selection"
-msgstr "Invertovat vıbìr"
-
-#: toolbar.c:159
-msgid "Show ROX-Filer help"
-msgstr "Zobrazit nápovìdu programu ROX-Filer"
-
-#: toolbar.c:220
+#: run.c:373
 #, c-format
-msgid " (%u hidden)"
-msgstr "(%u skrytıch)"
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "Soubor neexistuje nebo k Ä›nu nemÃ¡m pÅ™Ã­stup: %s"
 
-#: toolbar.c:228 tips:80
-msgid "items"
-msgstr "polo¾ek"
-
-#: toolbar.c:228
-msgid "item"
-msgstr "polo¾ka"
-
-#: toolbar.c:231
+#: run.c:378
 #, c-format
-msgid "No items%s"
-msgstr "®ádné polo¾ky%s"
+msgid "I don't know how to open '%s'"
+msgstr "NevÃ­m, jak otevÅ™Ã­t '%s'"
 
-#: toolbar.c:250
-#, c-format
-msgid "%u selected (%s)"
-msgstr "%u vybrán (%s)"
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "!'%s' je symbolickÃ½ odkaz\n"
 
-#: toolbar.c:422
-#, fuzzy
-msgid "Sort by name"
-msgstr "Tøídit podle jména"
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "AdresÃ¡Å™ '%s' nenÃ­ pÅ™Ã­stupnÃ½"
 
-#: toolbar.c:422
-#, fuzzy
-msgid "Sort by type"
-msgstr "Tøídit podle typu"
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "NespustitelnÃ½ %s"
 
-#: toolbar.c:422
-#, fuzzy
-msgid "Sort by date"
-msgstr "Tøídit podle data"
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Chyba v ovladaÄi %s: %s"
 
-#: toolbar.c:423
-#, fuzzy
-msgid "Sort by size"
-msgstr "Tøídit podle velikosti"
-
-#: toolbar.c:423
-#, fuzzy
-msgid "Sort by owner"
-msgstr "Tøídit podle vlastníka"
-
-#: toolbar.c:423
-#, fuzzy
-msgid "Sort by group"
-msgstr "Tøídit podle skupiny"
-
-#: toolbar.c:457
-msgid "ascending"
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
 msgstr ""
+"Aplikace:\n"
+"Toto je aplikaÄnÃ­ adresÃ¡Å™ - mÅ¯Å¾ete ho spouÅ¡tÄ›t jako program nebo ho otevÅ™Ã­t "
+"(pÅ™i jeho otevÃ­rÃ¡nÃ­ stidknÄ›te Shift). VÄ›tÅ¡ina aplikacÃ­ mÃ¡ na tomto mÃ­stÄ› "
+"vlastnÃ­ nÃ¡povÄ›du, tato aplikace ale ne."
 
-#: toolbar.c:457
-msgid "descending"
-msgstr ""
+#: run.c:549
+#, c-format
+msgid "Could not send data to program: %s"
+msgstr "Nemohu poslat data programu: %s"
 
-#: type.c:203
-msgid "Sym link"
-msgstr "Symbolickı odkaz"
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "Nemohu ÄÃ­st odkaz: %s"
 
-#: type.c:205
-msgid "Mount point"
-msgstr "Bod pøipojení"
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
+msgstr "PoruÅ¡enÃ½ symbolickÃ½ odkaz (nebo nemÃ¡te prÃ¡va pro jeho nÃ¡sledovÃ¡nÃ­): %s"
 
-#: type.c:207
-msgid "App dir"
-msgstr "Aplikaèní adresáø"
-
-#: type.c:214
-msgid "Dir"
-msgstr "Adresáø"
-
-#: type.c:216
-msgid "Char dev"
-msgstr "Znakové zaøízení"
-
-#: type.c:218
-msgid "Block dev"
-msgstr "Blokové zaøízení"
-
-#: type.c:220
-msgid "Pipe"
-msgstr "Roura"
-
-#: type.c:222
-msgid "Socket"
-msgstr "Soket"
-
-#: type.c:224
-msgid "Door"
-msgstr "Door"
-
-#: type.c:227
-msgid "Unknown"
-msgstr "Neznámé"
-
-#: type.c:355
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3090,149 +3302,423 @@ msgid ""
 "Otherwise, you should check, or even just delete, all the existing run "
 "actions."
 msgstr ""
-"Spustitelnı '%s' má právo zápisu pro v¹echny! Odmítám spustit. Zmìòte teï "
-"jeho práva (tento problém mù¾e bıt zpùsoben chybou v døívìj¹ích verzích "
-"správce souborù).\n"
+"SpustitelnÃ½ '%s' mÃ¡ prÃ¡vo zÃ¡pisu pro vÅ¡echny! OdmÃ­tÃ¡m spustit. ZmÄ›Åˆte teÄ "
+"jeho prÃ¡va (tento problÃ©m mÅ¯Å¾e bÃ½t zpÅ¯soben chybou v dÅ™Ã­vÄ›jÅ¡Ã­ch verzÃ­ch "
+"sprÃ¡vce souborÅ¯).\n"
 "\n"
-"Právo zápisu (kromì symb. odkazù) u spustitelnıch souborù znamená, ¾e "
-"ostatní lidé, kteøí pou¾ívají Vá¹ poèítaè, mohou nahradit Va¹e programy "
-"¹patnou verzí.\n"
+"PrÃ¡vo zÃ¡pisu (kromÄ› symb. odkazÅ¯) u spustitelnÃ½ch souborÅ¯ znamenÃ¡, Å¾e "
+"ostatnÃ­ lidÃ©, kteÅ™Ã­ pouÅ¾Ã­vajÃ­ VÃ¡Å¡ poÄÃ­taÄ, mohou nahradit VaÅ¡e programy "
+"Å¡patnou verzÃ­.\n"
 "\n"
-"Pokud vìøíte ka¾dému, kdo mù¾e do tìchto souborù zapisovat, pak se nemusíte "
-"obávat. Jinak by jste mìli zkontrolovat, nebo je¹tì lépe smazat, v¹echny "
-"existující programy."
+"Pokud vÄ›Å™Ã­te kaÅ¾dÃ©mu, kdo mÅ¯Å¾e do tÄ›chto souborÅ¯ zapisovat, pak se nemusÃ­te "
+"obÃ¡vat. Jinak by jste mÄ›li zkontrolovat, nebo jeÅ¡tÄ› lÃ©pe smazat, vÅ¡echny "
+"existujÃ­cÃ­ programy."
 
-#: type.c:368
+#: run.c:798
 msgid "go-w (Fix security problem)"
-msgstr "go-w (Opravit bezpeènostní problém)"
+msgstr "go-w (Opravit bezpeÄnostnÃ­ problÃ©m)"
 
-#: type.c:498
+#: support.c:288
+msgid " "
+msgstr ""
+
+#: support.c:381
+msgid "byte"
+msgstr "byte"
+
+#: support.c:1531 support.c:1585
+#, fuzzy, c-format
+msgid "Failed to open and stat file '%s': %s"
+msgstr ""
+"!%s\n"
+"KopÃ­rovÃ¡nÃ­ '%s' selhalo\n"
+
+#: support.c:1542 support.c:1596
+#, fuzzy, c-format
+msgid "Failed to mmap file '%s': %s"
+msgstr ""
+"!%s\n"
+"KopÃ­rovÃ¡nÃ­ '%s' selhalo\n"
+
+#: toolbar.c:116
+msgid "Close"
+msgstr "ZavÅ™Ã­t"
+
+#: toolbar.c:116
+msgid "Close filer window"
+msgstr "ZavÅ™Ã­t okno sprÃ¡vce souborÅ¯"
+
+#: toolbar.c:120
+msgid "Up"
+msgstr "Nahoru"
+
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
+
+#: toolbar.c:126
+msgid "Home"
+msgstr "DomÅ¯"
+
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
+
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
+
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
+
+#: toolbar.c:138
+msgid "Scan"
+msgstr "NaÄÃ­st"
+
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
+
+#: toolbar.c:143
+#, fuzzy
+msgid "Sizeâ”¼"
+msgstr "Velikost"
+
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  â”˜ : Huge\n"
+"  â”¤ : Large\n"
+"  â” : Small\n"
+"  â”Œ, â”œ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automaticky"
+
+#: toolbar.c:155
+msgid "Automatic size mode"
+msgstr "MÃ³d AutomatickÃ¡ velikost"
+
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "SeznamovÃ½ pohled"
+
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
+#, fuzzy
+msgid "Sort"
+msgstr "TÅ™Ã­dÄ›nÃ­"
+
+#: toolbar.c:165
+#, fuzzy
+msgid "Change sort criteria"
+msgstr "ÄŒas zmÄ›ny:"
+
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
+
+#: toolbar.c:169
+msgid ""
+"Left: Show/hide hidden files\n"
+"Right: Show/hide thumbnails"
+msgstr ""
+
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "Invertovat vÃ½bÄ›r"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "â—‹"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  â–½: No settings\n"
+"  â–¼: Own settings\n"
+"  â–¶: Parent settings\n"
+"  â–·: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
+msgid "Show ROX-Filer help"
+msgstr "Zobrazit nÃ¡povÄ›du programu ROX-Filer"
+
+#: toolbar.c:270
+#, c-format
+msgid " (%u hidden)"
+msgstr "(%u skrytÃ½ch)"
+
+#: toolbar.c:276 tips:79
+msgid "items"
+msgstr "poloÅ¾ek"
+
+#: toolbar.c:276
+msgid "item"
+msgstr "poloÅ¾ka"
+
+#: toolbar.c:279
+#, c-format
+msgid "No items%s"
+msgstr "Å½Ã¡dnÃ© poloÅ¾ky%s"
+
+#: toolbar.c:298
+#, c-format
+msgid "%u selected (%s)"
+msgstr "%u vybrÃ¡n (%s)"
+
+#: toolbar.c:535
+#, fuzzy
+msgid "Sort by name"
+msgstr "TÅ™Ã­dit podle jmÃ©na"
+
+#: toolbar.c:535
+#, fuzzy
+msgid "Sort by type"
+msgstr "TÅ™Ã­dit podle typu"
+
+#: toolbar.c:535
+#, fuzzy
+msgid "Sort by date"
+msgstr "TÅ™Ã­dit podle data"
+
+#: toolbar.c:535
+#, fuzzy
+msgid "Sort by size"
+msgstr "TÅ™Ã­dit podle velikosti"
+
+#: toolbar.c:536
+#, fuzzy
+msgid "Sort by owner"
+msgstr "TÅ™Ã­dit podle vlastnÃ­ka"
+
+#: toolbar.c:536
+#, fuzzy
+msgid "Sort by group"
+msgstr "TÅ™Ã­dit podle skupiny"
+
+#: toolbar.c:568
+msgid "ascending"
+msgstr ""
+
+#: toolbar.c:568
+msgid "descending"
+msgstr ""
+
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
+msgid "Sym link"
+msgstr "SymbolickÃ½ odkaz"
+
+#: type.c:223
+msgid "Mount point"
+msgstr "Bod pÅ™ipojenÃ­"
+
+#: type.c:225
+msgid "App dir"
+msgstr "AplikaÄnÃ­ adresÃ¡Å™"
+
+#: type.c:232
+msgid "Dir"
+msgstr "AdresÃ¡Å™"
+
+#: type.c:234
+msgid "Char dev"
+msgstr "ZnakovÃ© zaÅ™Ã­zenÃ­"
+
+#: type.c:236
+msgid "Block dev"
+msgstr "BlokovÃ© zaÅ™Ã­zenÃ­"
+
+#: type.c:238
+msgid "Pipe"
+msgstr "Roura"
+
+#: type.c:240
+msgid "Socket"
+msgstr "Soket"
+
+#: type.c:242
+msgid "Door"
+msgstr "Door"
+
+#: type.c:245
+msgid "Unknown"
+msgstr "NeznÃ¡mÃ©"
+
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
 "gimp \"$@\""
 msgstr ""
-"Zadejte shellovı pøíkaz, kterı otevøe \"$@\" ve vhodném programu. Napø.:\n"
+"Zadejte shellovÃ½ pÅ™Ã­kaz, kterÃ½ otevÅ™e \"$@\" ve vhodnÃ©m programu. NapÅ™.:\n"
 "\n"
 "gimp \"$@\""
 
-#: type.c:679
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
-msgstr "Toto není program! Zadejte aplikaci!"
+msgstr "Toto nenÃ­ program! Zadejte aplikaci!"
 
-#: type.c:740
+#: type.c:839
 msgid "No run action defined"
-msgstr "Není definována ¾ádná spou¹tìcí akce"
+msgstr "NenÃ­ definovÃ¡na Å¾Ã¡dnÃ¡ spouÅ¡tÄ›cÃ­ akce"
 
-#: type.c:766
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
-msgstr "Chyba v ovladaèi %s: %s"
+msgstr "Chyba v ovladaÄi %s: %s"
 
-#: type.c:781
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
-msgstr "Neplatná aplikace %s (¹patnı AppRun)"
+msgstr "NeplatnÃ¡ aplikace %s (Å¡patnÃ½ AppRun)"
 
-#: type.c:792
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
-msgstr "Nespustitelnı %s"
+msgstr "NespustitelnÃ½ %s"
 
-#: type.c:825
+#: type.c:902
 msgid "Set run action"
-msgstr "Nastavit spou¹tìcí akci"
+msgstr "Nastavit spouÅ¡tÄ›cÃ­ akci"
 
-#: type.c:831
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
-"Pokud není nastaven ovladaè pro specifickı typ, pou¾ije se tento jako "
-"defaultní."
+"Pokud nenÃ­ nastaven ovladaÄ pro specifickÃ½ typ, pouÅ¾ije se tento jako "
+"defaultnÃ­."
 
-#: type.c:833
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
-msgstr "Nastavit jako defaultní pro v¹echny typy `%s/<anything>'"
+msgstr "Nastavit jako defaultnÃ­ pro vÅ¡echny typy `%s/<anything>'"
 
-#: type.c:837
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
-msgstr "Pou¾ít tuto aplikaci pro v¹echny soubory s tímto MIME typem."
+msgstr "PouÅ¾Ã­t tuto aplikaci pro vÅ¡echny soubory s tÃ­mto MIME typem."
 
-#: type.c:839
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Pouze pro typ `%s' (%s/%s)"
 
-#: type.c:845
+#: type.c:922
 msgid "Drop a suitable application here"
-msgstr "Pøetáhnìte sem vhodnou aplikaci"
+msgstr "PÅ™etÃ¡hnÄ›te sem vhodnou aplikaci"
 
-#: type.c:860
+#: type.c:963
 msgid "OR"
 msgstr "NEBO"
 
-#: type.c:867
+#: type.c:971
 msgid "Enter a shell command:"
-msgstr "Zadejte shellovı pøíkaz"
+msgstr "Zadejte shellovÃ½ pÅ™Ã­kaz"
 
-#: type.c:896
+#: type.c:1000
 #, fuzzy
 msgid "_Use Command"
-msgstr "Pøíkaz:"
+msgstr "PÅ™Ã­kaz:"
 
-#: type.c:926
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
 msgstr ""
-"Spou¹tìcí akce u¾ existuje a je to celkem velkı program - chcete ji smazat?"
+"SpouÅ¡tÄ›cÃ­ akce uÅ¾ existuje a je to celkem velkÃ½ program - chcete ji smazat?"
 
-#: type.c:937
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Nelze odebrat %s: %s"
 
-#: type.c:974
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
-msgstr "Ulo¾ení Choices je zakázáno promìnnou CHOICESPATH"
+msgstr "UloÅ¾enÃ­ Choices je zakÃ¡zÃ¡no promÄ›nnou CHOICESPATH"
 
-#: type.c:1249
-#, c-format
-msgid ""
-"Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr ""
-
-#: type.c:1263
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason)"
+"%s"
 msgstr ""
+"!%s\n"
+"KopÃ­rovÃ¡nÃ­ '%s' selhalo\n"
 
-#: usericons.c:181
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
-msgstr "Cesta, kterou jste zadali, neexistuje. Ikona nebyla zmìnìna."
+msgstr "Cesta, kterou jste zadali, neexistuje. Ikona nebyla zmÄ›nÄ›na."
 
-#: usericons.c:191 usericons.c:616
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
 "The icon has not been changed."
 msgstr ""
-"Nejde naèíst obrázek -- mo¾ná je ve formátu, kterı neznám, nebo jsou ¹patná "
-"pøístupová práva?\n"
-"Ikona nebyla zmìnìna."
+"Nejde naÄÃ­st obrÃ¡zek -- moÅ¾nÃ¡ je ve formÃ¡tu, kterÃ½ neznÃ¡m, nebo jsou Å¡patnÃ¡ "
+"pÅ™Ã­stupovÃ¡ prÃ¡va?\n"
+"Ikona nebyla zmÄ›nÄ›na."
 
-#: usericons.c:238
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Opravdu smazat ikonu '%s'?"
 
-#: usericons.c:242
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3241,269 +3727,211 @@ msgstr ""
 "Nemohu smazat '%s':\n"
 "%s"
 
-#: usericons.c:270
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Nastavit ikonu"
 
-#: usericons.c:279
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr ""
-"Pou¾ít kopii obrázku jako defaultní pro v¹echny soubory tohoto MIME typu."
+"PouÅ¾Ã­t kopii obrÃ¡zku jako defaultnÃ­ pro vÅ¡echny soubory tohoto MIME typu."
 
-#: usericons.c:281
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
-msgstr "Nastavit ikonu pro v¹echny `%s/<anything>'"
+msgstr "Nastavit ikonu pro vÅ¡echny `%s/<anything>'"
 
-#: usericons.c:286
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
-msgstr "Pou¾ít kopii obrázku pro v¹echny soubory tohoto MIME typu."
+msgstr "PouÅ¾Ã­t kopii obrÃ¡zku pro vÅ¡echny soubory tohoto MIME typu."
 
-#: usericons.c:288
+#: usericons.c:299
 #, fuzzy, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Pouze pro typ `%s' (%s/%s)"
 
-#: usericons.c:294
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
 msgstr ""
-"Pøidat jméno souboru a obrázku do osobního seznamu. Nastavení bude ztraceno, "
-"pokud obrázek nebo soubor bude pøesunut."
+"PÅ™idat jmÃ©no souboru a obrÃ¡zku do osobnÃ­ho seznamu. NastavenÃ­ bude ztraceno, "
+"pokud obrÃ¡zek nebo soubor bude pÅ™esunut."
 
-#: usericons.c:297
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Pouze pro soubor `%s'"
 
-#: usericons.c:305
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
 "This is usually the best option if you can write to the directory."
 msgstr ""
-"Zkopírovat obrázek do adresáøe jako skrytı soubor nazvanı '.DirIcon'. "
-"V¹ichni u¾ivatelé potom uvidí tuto ikonu a Vy mù¾ete bezpeènì pøesunovat "
-"adresáø. Toto je obvykle nejlep¹í volba v pøípadì, ¾e mù¾ete zapisovat do "
-"adresáøe."
+"ZkopÃ­rovat obrÃ¡zek do adresÃ¡Å™e jako skrytÃ½ soubor nazvanÃ½ '.DirIcon'. "
+"VÅ¡ichni uÅ¾ivatelÃ© potom uvidÃ­ tuto ikonu a Vy mÅ¯Å¾ete bezpeÄnÄ› pÅ™esunovat "
+"adresÃ¡Å™. Toto je obvykle nejlepÅ¡Ã­ volba v pÅ™Ã­padÄ›, Å¾e mÅ¯Å¾ete zapisovat do "
+"adresÃ¡Å™e."
 
-#: usericons.c:311
+#: usericons.c:322
 msgid "Copy image into directory"
-msgstr "Zkopírovat obrázek do adresáøe"
+msgstr "ZkopÃ­rovat obrÃ¡zek do adresÃ¡Å™e"
 
-#: usericons.c:317
+#: usericons.c:328
 msgid "Drop an icon file here"
-msgstr "Sem umístìte ikonu"
+msgstr "Sem umÃ­stÄ›te ikonu"
 
-#: usericons.c:587
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
-msgstr "Nastavení ikony zakázáno kvùli CHOICESPATH"
+msgstr "NastavenÃ­ ikony zakÃ¡zÃ¡no kvÅ¯li CHOICESPATH"
 
-#: usericons.c:631
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
 "%s"
 msgstr ""
-"Chyba pøi vytváøení obrázku '%s':\n"
+"Chyba pÅ™i vytvÃ¡Å™enÃ­ obrÃ¡zku '%s':\n"
 "%s"
 
-#: view_details.c:1009
-msgid "_Name"
-msgstr "_Jméno"
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
 
-#: view_details.c:1012
+#: view_details.c:1018
+msgid "Mono font"
+msgstr ""
+
+#: view_details.c:1019
+msgid "Font for displaying mono-spaced text"
+msgstr ""
+
+#: view_details.c:1233
+msgid "_Name"
+msgstr "_JmÃ©no"
+
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Typ"
 
-#: view_details.c:1015
-msgid "_Permissions"
-msgstr "_Práva"
-
-#: view_details.c:1016
-msgid "_Owner"
-msgstr "_Vlastník"
-
-#: view_details.c:1018
-msgid "_Group"
-msgstr "_Skupina"
-
-#: view_details.c:1020
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Velikost"
 
-#: view_details.c:1022
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_PrÃ¡va"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_VlastnÃ­k"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Skupina"
+
+#: view_details.c:1254
 msgid "Last _Modified"
-msgstr "Poslední _Modifikace"
+msgstr "PoslednÃ­ _Modifikace"
+
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr ""
 
 #: tips:1
-msgid "Translation"
-msgstr "Pøeklad"
+msgid "Filer windows"
+msgstr "Okna sprÃ¡vce souborÅ¯"
 
 #: tips:2
-msgid "Language"
-msgstr "Jazyk"
+msgid "Auto-resize filer windows"
+msgstr "Automaticky mÄ›nit velikost oken sprÃ¡vce souborÅ¯"
 
 #: tips:3
-msgid "Use the LANG environment variable"
-msgstr "Pou¾ít promìnnou prostøedí LANG"
+msgid "Never automatically resize"
+msgstr "Nikdy automaticky nÄ›mÄ›nit velikost"
 
 #: tips:4
-msgid "Basque"
-msgstr ""
-
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Èínsky (tradièní)"
-
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Èínsky (zjednodu¹ená)"
-
-#: tips:7
-msgid "Czech"
-msgstr ""
-
-#: tips:8
-msgid "Danish"
-msgstr "Dánsky"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Holandsky"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Anglicky (bez pøekladu)"
-
-#: tips:11
-msgid "Estonian"
-msgstr ""
-
-#: tips:12
-#, fuzzy
-msgid "Finnish"
-msgstr "Dánsky"
-
-#: tips:13
-msgid "French"
-msgstr "Francouzsky"
-
-#: tips:14
-msgid "German"
-msgstr "Nìmecky"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Maïarsky"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Japonsky"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "Norsky"
-
-#: tips:18
-msgid "Italian"
-msgstr "Italsky"
-
-#: tips:19
-msgid "Polish"
-msgstr "Polsky"
-
-#: tips:20
-msgid "Portuguese (Brasil)"
-msgstr ""
-
-#: tips:21
-msgid "Romanian"
-msgstr ""
-
-#: tips:22
-msgid "Russian"
-msgstr "Rusky"
-
-#: tips:23
-msgid "Spanish"
-msgstr "©panìlsky"
-
-#: tips:24
-msgid "Swedish"
-msgstr "©védsky"
-
-#: tips:25
-msgid "Filer windows"
-msgstr "Okna správce souborù"
-
-#: tips:26
-msgid "Auto-resize filer windows"
-msgstr "Automaticky mìnit velikost oken správce souborù"
-
-#: tips:27
-msgid "Never automatically resize"
-msgstr "Nikdy automaticky nìmìnit velikost"
-
-#: tips:28
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
 msgstr ""
-"Budete muset mìnit velikost oken ruènì pomocí správce oken, pomcí nabídky "
-"`Resize Window' v menu nebo pomocí dvojkliku na pozadí okna."
+"Budete muset mÄ›nit velikost oken ruÄnÄ› pomocÃ­ sprÃ¡vce oken, pomcÃ­ nabÃ­dky "
+"`Resize Window' v menu nebo pomocÃ­ dvojkliku na pozadÃ­ okna."
 
-#: tips:29
+#: tips:5
 msgid "Resize when changing the display style"
-msgstr "Zmìnit velikost pøi zmìnì stylu pohledu"
+msgstr "ZmÄ›nit velikost pÅ™i zmÄ›nÄ› stylu pohledu"
 
-#: tips:30
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
 msgstr ""
-"Zmìna velikosti ikon nebo toho, které podrobnosti mají bıt zobrazeny, zmìní "
+"ZmÄ›na velikosti ikon nebo toho, kterÃ© podrobnosti majÃ­ bÃ½t zobrazeny, zmÄ›nÃ­ "
 "velikost okna."
 
-#: tips:31
+#: tips:7
 msgid "Always resize"
-msgstr "V¾dy mìnit velikost"
+msgstr "VÅ¾dy mÄ›nit velikost"
 
-#: tips:32
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
 msgstr ""
-"Správce souborù bude mìnit velikost oken kdykoliv to bude potøeba (pøi zmìnì "
-"adresáøe nebo stylu pohledu)."
+"SprÃ¡vce souborÅ¯ bude mÄ›nit velikost oken kdykoliv to bude potÅ™eba (pÅ™i zmÄ›nÄ› "
+"adresÃ¡Å™e nebo stylu pohledu)."
 
-#: tips:33
+#: tips:9
 msgid "Largest window size:"
-msgstr "Nejvìt¹í velikost okna"
+msgstr "NejvÄ›tÅ¡Ã­ velikost okna"
 
-#: tips:34
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:35
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
 msgstr ""
-"Nejvìt¹í velikost v procentech plochy obrazovky, která mù¾e bıt pou¾ita pøi "
-"automatické zmìnì velikosti."
+"NejvÄ›tÅ¡Ã­ velikost v procentech plochy obrazovky, kterÃ¡ mÅ¯Å¾e bÃ½t pouÅ¾ita pÅ™i "
+"automatickÃ© zmÄ›nÄ› velikosti."
 
-#: tips:36
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "NejvÄ›tÅ¡Ã­ velikost okna"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"NejvÄ›tÅ¡Ã­ velikost v procentech plochy obrazovky, kterÃ¡ mÅ¯Å¾e bÃ½t pouÅ¾ita pÅ™i "
+"automatickÃ© zmÄ›nÄ› velikosti."
+
+#: tips:15
 msgid "Window behaviour"
-msgstr "Chování okna"
+msgstr "ChovÃ¡nÃ­ okna"
 
-#: tips:37
+#: tips:16
 msgid "Short titlebar flags"
-msgstr "Krátké popisky v titulku"
+msgstr "KrÃ¡tkÃ© popisky v titulku"
 
-#: tips:38
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
@@ -3511,549 +3939,875 @@ msgstr ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
 
-#: tips:39
+#: tips:18
 msgid "Unique windows"
-msgstr "Unikátní okna"
+msgstr "UnikÃ¡tnÃ­ okna"
 
-#: tips:40
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
 msgstr ""
-"Pokud otevøete adresáø a tento adresáø je u¾ zobrazen v jimém, oknì, potom "
-"toto nastavení zpùsobí, ¾e jiná okna budou zavøena."
+"Pokud otevÅ™ete adresÃ¡Å™ a tento adresÃ¡Å™ je uÅ¾ zobrazen v jimÃ©m, oknÄ›, potom "
+"toto nastavenÃ­ zpÅ¯sobÃ­, Å¾e jinÃ¡ okna budou zavÅ™ena."
 
-#: tips:41
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Okno"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
-msgstr "Nové okno po stisku tlaèítka 1"
+msgstr "NovÃ© okno po stisku tlaÄÃ­tka 1"
 
-#: tips:42
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
 "reuse the current window."
 msgstr ""
-"Tato volba zpùsobí, ¾e kliknutí tlaèítka 1 na my¹i (obvykle levé tlaèítko) "
-"otevøe adresáø v v novém oknì. Kliknutí tlaèítka 2 na my¹i (prostøední) "
-"pou¾ije souèasné okno."
+"Tato volba zpÅ¯sobÃ­, Å¾e kliknutÃ­ tlaÄÃ­tka 1 na myÅ¡i (obvykle levÃ© tlaÄÃ­tko) "
+"otevÅ™e adresÃ¡Å™ v v novÃ©m oknÄ›. KliknutÃ­ tlaÄÃ­tka 2 na myÅ¡i (prostÅ™ednÃ­) "
+"pouÅ¾ije souÄasnÃ© okno."
 
-#: tips:43
+#: tips:26
 msgid "Single-click navigation"
-msgstr "Procházení pomocí jednoho kliknutí"
+msgstr "ProchÃ¡zenÃ­ pomocÃ­ jednoho kliknutÃ­"
 
-#: tips:44 tips:137
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
 "things."
 msgstr ""
-"Tato volba zpùsobí, ¾e kliknutí na polo¾ku tuto plo¾ku otevøe. Pokud ji "
-"chcete vybrat, musíte pøi kliknutí dr¾et Control. Pokud není tato volba "
-"zapnutá, jedno kliknutí polo¾ku vybere, dvojklik ji otevøe.things."
+"Tato volba zpÅ¯sobÃ­, Å¾e kliknutÃ­ na poloÅ¾ku tuto ploÅ¾ku otevÅ™e. Pokud ji "
+"chcete vybrat, musÃ­te pÅ™i kliknutÃ­ drÅ¾et Control. Pokud nenÃ­ tato volba "
+"zapnutÃ¡, jedno kliknutÃ­ poloÅ¾ku vybere, dvojklik ji otevÅ™e.things."
 
-#: tips:45
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr ""
 
-#: tips:46
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
 msgstr ""
 
-#: tips:47
+#: tips:30
 msgid "Sorting"
-msgstr "Tøídìní"
+msgstr "TÅ™Ã­dÄ›nÃ­"
 
-#: tips:48
+#: tips:31
 msgid "Directories come first (for sort by name)"
-msgstr "Adresáøe jsou zobrazovány první (u tøídìní podle jména)"
+msgstr "AdresÃ¡Å™e jsou zobrazovÃ¡ny prvnÃ­ (u tÅ™Ã­dÄ›nÃ­ podle jmÃ©na)"
 
-#: tips:49
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
 msgstr ""
-"Tato volba zpùsobí, ¾e pokud se tøídí podle jména, adresáøe budou zobrazeny "
-"v¾dy pøed v¹ím ostatním."
+"Tato volba zpÅ¯sobÃ­, Å¾e pokud se tÅ™Ã­dÃ­ podle jmÃ©na, adresÃ¡Å™e budou zobrazeny "
+"vÅ¾dy pÅ™ed vÅ¡Ã­m ostatnÃ­m."
 
-#: tips:50
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
-msgstr "Velká písmena první (u tøídìní podle jména)"
+msgstr "VelkÃ¡ pÃ­smena prvnÃ­ (u tÅ™Ã­dÄ›nÃ­ podle jmÃ©na)"
 
-#: tips:51
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
 msgstr ""
-"Tato volba zpùsobí, ¾e jména souborù zaèínající velkım písmenem mají "
-"pøednost pøed soubory, které zaèínají malım písmenem"
+"Tato volba zpÅ¯sobÃ­, Å¾e jmÃ©na souborÅ¯ zaÄÃ­najÃ­cÃ­ velkÃ½m pÃ­smenem majÃ­ "
+"pÅ™ednost pÅ™ed soubory, kterÃ© zaÄÃ­najÃ­ malÃ½m pÃ­smenem"
 
-#: tips:53
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "AdresÃ¡Å™e jsou zobrazovÃ¡ny prvnÃ­ (u tÅ™Ã­dÄ›nÃ­ podle jmÃ©na)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sec"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "NepouÅ¾Ã­vat jmÃ©na poÄÃ­taÄÅ¯"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
-msgstr "Defaultní nastavení pro nová okna"
+msgstr "DefaultnÃ­ nastavenÃ­ pro novÃ¡ okna"
 
-#: tips:54
+#: tips:46
 msgid "Inherit options from source window"
-msgstr "Zdìdit nastavení ze zdrojového okna"
+msgstr "ZdÄ›dit nastavenÃ­ ze zdrojovÃ©ho okna"
 
-#: tips:55
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
 msgstr ""
-"Tato volba zpùsobí, ¾e nastavení zobrazení pro nové okno je zdìdìno od "
-"zdrojového okna, pokud je to mo¾né, jinak je nastaveno na ní¾e uvedené "
-"defaultní hodnoty."
+"Tato volba zpÅ¯sobÃ­, Å¾e nastavenÃ­ zobrazenÃ­ pro novÃ© okno je zdÄ›dÄ›no od "
+"zdrojovÃ©ho okna, pokud je to moÅ¾nÃ©, jinak je nastaveno na nÃ­Å¾e uvedenÃ© "
+"defaultnÃ­ hodnoty."
 
-#: tips:56
+#: tips:48
 msgid "View type:"
 msgstr "Typ pohledu:"
 
-#: tips:59
+#: tips:51
 msgid "Sort by:"
-msgstr "Tøídit podle:"
+msgstr "TÅ™Ã­dit podle:"
 
-#: tips:61 tips:76
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Typu"
 
-#: tips:62
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Data"
 
-#: tips:64
-msgid "Show hidden files"
-msgstr "Zobrazovat skryté soubory"
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Data"
 
-#: tips:65
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Data"
+
+#: tips:58
+msgid "Show hidden files"
+msgstr "Zobrazovat skrytÃ© soubory"
+
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
 msgstr ""
-"Tato volba zpùsobí, ¾e jsou zobrazovány i soubory, jejich¾ jméno zaèíná "
-"teèkou, jinak jsou tyto soubory skryté."
+"Tato volba zpÅ¯sobÃ­, Å¾e jsou zobrazovÃ¡ny i soubory, jejichÅ¾ jmÃ©no zaÄÃ­nÃ¡ "
+"teÄkou, jinak jsou tyto soubory skrytÃ©."
 
-#: tips:66
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Zobrazovat skrytÃ© soubory"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Tato volba zpÅ¯sobÃ­, Å¾e jsou zobrazovÃ¡ny i soubory, jejichÅ¾ jmÃ©no zaÄÃ­nÃ¡ "
+"teÄkou, jinak jsou tyto soubory skrytÃ©."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "ObrovskÃ© ikony"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "pixelÅ¯"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
-msgstr "Ikonovı pohled"
+msgstr "IkonovÃ½ pohled"
 
 #: tips:67
 msgid "Default size:"
-msgstr "Defaultní velikost"
+msgstr "DefaultnÃ­ velikost"
 
 #: tips:68
 msgid "Huge Icons"
-msgstr "Obrovské ikony"
+msgstr "ObrovskÃ© ikony"
 
-#: tips:69 tips:245
+#: tips:69 tips:296
 msgid "Large Icons"
-msgstr "Velké ikony"
+msgstr "VelkÃ© ikony"
 
-#: tips:70 tips:244
+#: tips:70 tips:295
 msgid "Small Icons"
-msgstr "Malé ikony"
+msgstr "MalÃ© ikony"
 
 #: tips:72
 msgid "Default details:"
-msgstr "Defaultní podrobnosti:"
+msgstr "DefaultnÃ­ podrobnosti:"
 
 #: tips:73
 msgid "No details"
-msgstr "®ádné podrobnosti"
+msgstr "Å½Ã¡dnÃ© podrobnosti"
+
+#: tips:74
+msgid "Sizes"
+msgstr "Velikostmi"
+
+#: tips:77
+msgid "Times"
+msgstr "ÄŒasy"
 
 #: tips:78
-msgid "Automatic small icons:"
-msgstr "Automaticky nastavit malé ikony:"
+#, fuzzy
+msgid "Automatic small icons: Change at:"
+msgstr "Automaticky nastavit malÃ© ikony:"
 
-#: tips:79
-msgid "Change at:"
-msgstr "Zmìnit u:"
-
-#: tips:81
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
 "used."
 msgstr ""
-"Pokud je nastaveno automatické nastavení velikosti ikon: Pokud adresáø "
-"obsahuje alespoò tolik polo¾ek, potom jsou zobrazovány malé ikony, jinak "
-"jsou pou¾ity velké ikony "
+"Pokud je nastaveno automatickÃ© nastavenÃ­ velikosti ikon: Pokud adresÃ¡Å™ "
+"obsahuje alespoÅˆ tolik poloÅ¾ek, potom jsou zobrazovÃ¡ny malÃ© ikony, jinak "
+"jsou pouÅ¾ity velkÃ© ikony "
 
-#: tips:82
-msgid "Max width (Large icons):"
-msgstr "Maximální velikost (Velké ikony):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "VelkÃ© ikony"
 
-#: tips:83 tips:86
-msgid "pixels"
-msgstr "pixelù"
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
+msgstr ""
+"Text, kterÃ½ je Å¡irÅ¡Ã­ je rozdÄ›len na dva Å™Ã¡dky, pokud je pouÅ¾it mÃ³d VelkÃ© "
+"ikony. V mÃ³du ObrovskÃ© ikony je text rozdÄ›len, kdyÅ¾ je Å¡irÅ¡Ã­ o 50%."
 
 #: tips:84
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+msgid "(Wrapped, Details):"
 msgstr ""
-"Text, kterı je ¹ir¹í je rozdìlen na dva øádky, pokud je pou¾it mód Velké "
-"ikony. V módu Obrovské ikony je text rozdìlen, kdy¾ je ¹ir¹í o 50%."
 
-#: tips:85
-msgid "(Small Icons):"
-msgstr "(Malé ikony)"
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
 
 #: tips:87
-msgid "Maximum width for the text beside a Small Icon."
-msgstr "Maximání ¹íøka textu vedle malıch ikon."
+msgid "Wrap by characters"
+msgstr ""
 
 #: tips:88
-msgid "Order small icons vertically"
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
 msgstr ""
 
 #: tips:89
-msgid ""
-"If this option is on, then small icons are ordered vertically, not "
-"horizontally."
-msgstr ""
-
-#: tips:90
-msgid "Order large icons vertically"
-msgstr ""
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "(MalÃ© ikony)"
 
 #: tips:91
-msgid ""
-"If this option is on, then large icons are sorted vertically, not "
-"horizontally."
+msgid "Maximum width for the text beside a Small Icon."
+msgstr "MaximÃ¡nÃ­ Å¡Ã­Å™ka textu vedle malÃ½ch ikon."
+
+#: tips:92
+msgid "Order small icons vertically"
 msgstr ""
 
 #: tips:93
-msgid "Show column headings"
-msgstr "Ukazovat nadpisy sloupcù"
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
+msgstr ""
 
 #: tips:94
-msgid "If this is on then column headings will be shown in the list view."
+msgid "Order large icons vertically"
 msgstr ""
-"Tato volb zpùsobí, ¾e nadpisy sloupcù budou zobrazeny v seznamovém pohledu."
 
 #: tips:95
-#, fuzzy
-msgid "Show full type"
-msgstr "Tøídit podle typu"
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
+msgstr ""
 
 #: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
+msgid "Show column headings"
+msgstr "Ukazovat nadpisy sloupcÅ¯"
+
+#: tips:101
+msgid "If this is on then column headings will be shown in the list view."
+msgstr ""
+"Tato volb zpÅ¯sobÃ­, Å¾e nadpisy sloupcÅ¯ budou zobrazeny v seznamovÃ©m pohledu."
+
+#: tips:102
+#, fuzzy
+msgid "Show full type"
+msgstr "TÅ™Ã­dit podle typu"
+
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr ""
 
-#: tips:97
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "MaximÃ¡nÃ­ Å¡Ã­Å™ka textu vedle malÃ½ch ikon."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Ukazovat nadpisy sloupcÅ¯"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Tato volb zpÅ¯sobÃ­, Å¾e nadpisy sloupcÅ¯ budou zobrazeny v seznamovÃ©m pohledu."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Tato volb zpÅ¯sobÃ­, Å¾e nadpisy sloupcÅ¯ budou zobrazeny v seznamovÃ©m pohledu."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Tato volb zpÅ¯sobÃ­, Å¾e nadpisy sloupcÅ¯ budou zobrazeny v seznamovÃ©m pohledu."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Tato volb zpÅ¯sobÃ­, Å¾e nadpisy sloupcÅ¯ budou zobrazeny v seznamovÃ©m pohledu."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Tato volb zpÅ¯sobÃ­, Å¾e nadpisy sloupcÅ¯ budou zobrazeny v seznamovÃ©m pohledu."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Tato volb zpÅ¯sobÃ­, Å¾e nadpisy sloupcÅ¯ budou zobrazeny v seznamovÃ©m pohledu."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "PoslednÃ­ _Modifikace"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Tato volb zpÅ¯sobÃ­, Å¾e nadpisy sloupcÅ¯ budou zobrazeny v seznamovÃ©m pohledu."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Tato volb zpÅ¯sobÃ­, Å¾e nadpisy sloupcÅ¯ budou zobrazeny v seznamovÃ©m pohledu."
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Tato volb zpÅ¯sobÃ­, Å¾e nadpisy sloupcÅ¯ budou zobrazeny v seznamovÃ©m pohledu."
+
+#: tips:130
 msgid "Tools/Minibuffer"
-msgstr "Nástroje/Minibuffer"
+msgstr "NÃ¡stroje/Minibuffer"
 
-#: tips:98
+#: tips:131
 msgid "Toolbar"
-msgstr "Panel nástrojù"
+msgstr "Panel nÃ¡strojÅ¯"
 
-#: tips:99
+#: tips:132
 msgid "Toolbar type:"
-msgstr "Typ panelu nástrojù:"
+msgstr "Typ panelu nÃ¡strojÅ¯:"
 
-#: tips:100
+#: tips:133
 #, fuzzy
 msgid "No toolbar"
-msgstr "Panel nástrojù"
+msgstr "Panel nÃ¡strojÅ¯"
 
-#: tips:101
+#: tips:134
 msgid "Icons only"
 msgstr "Pouze ikony"
 
-#: tips:102
+#: tips:135
 msgid "Text under icons"
 msgstr "Text pod ikonami"
 
-#: tips:103
+#: tips:136
 msgid "Text beside icons"
 msgstr "Text vedle ikon"
 
-#: tips:104
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Jen obrÃ¡zek"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr ""
-"Zobrazovat souhrnné \n"
-"informace o polo¾kách"
+"Zobrazovat souhrnnÃ© \n"
+"informace o poloÅ¾kÃ¡ch"
 
-#: tips:105
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
 "selected items and their combined size."
 msgstr ""
-"Zobrazuje poèet polo¾ek zobrazenıch v oknì a poèet skrytıch souborù (pokud "
-"existují. Pokud jsou vybrány nìjaké polo¾ky, je zobrazen jejich poèet a "
-"celková velikost."
+"Zobrazuje poÄet poloÅ¾ek zobrazenÃ½ch v oknÄ› a poÄet skrytÃ½ch souborÅ¯ (pokud "
+"existujÃ­. Pokud jsou vybrÃ¡ny nÄ›jakÃ© poloÅ¾ky, je zobrazen jejich poÄet a "
+"celkovÃ¡ velikost."
 
-#: tips:106
+#: tips:140
 msgid "Select the buttons you want on the bar:"
-msgstr "Vyberte tlaèítka, které mají bıt zobrazeny na panelu:"
+msgstr "Vyberte tlaÄÃ­tka, kterÃ© majÃ­ bÃ½t zobrazeny na panelu:"
 
-#: tips:107
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr ""
 
-#: tips:108
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
 msgstr ""
 
-#: tips:109
+#: tips:143
 msgid "Minibuffer"
 msgstr "Minibuffer"
 
-#: tips:110
+#: tips:144
 msgid "Beep if Tab-completion fails"
-msgstr "Pípnout, pokud Tab-doplnìní sel¾e"
+msgstr "PÃ­pnout, pokud Tab-doplnÄ›nÃ­ selÅ¾e"
 
-#: tips:111
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
 "letter varies)."
 msgstr ""
-"Pøi pou¾ívání minibufferu `Zadat cestu...' a pøi stisku Tab pípnout, kdy¾ se "
-"nic nestane (napø. proto¾e existuje více mo¾ností závislıch na dal¹ím znaku)."
+"PÅ™i pouÅ¾Ã­vÃ¡nÃ­ minibufferu `Zadat cestu...' a pÅ™i stisku Tab pÃ­pnout, kdyÅ¾ se "
+"nic nestane (napÅ™. protoÅ¾e existuje vÃ­ce moÅ¾nostÃ­ zÃ¡vislÃ½ch na dalÅ¡Ã­m znaku)."
 
-#: tips:112
+#: tips:146
 msgid "Beep if there are several matches"
-msgstr "Pípnout, kdy¾ existuje více shod"
+msgstr "PÃ­pnout, kdyÅ¾ existuje vÃ­ce shod"
 
-#: tips:113
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
 msgstr ""
-"Pøi pou¾ívání minibufferu `Zadat cestu...' a pøi stisku Tab pípnout, kdy¾ "
-"existuje více odpovídajících souborù, even though some more letters were "
+"PÅ™i pouÅ¾Ã­vÃ¡nÃ­ minibufferu `Zadat cestu...' a pÅ™i stisku Tab pÃ­pnout, kdyÅ¾ "
+"existuje vÃ­ce odpovÃ­dajÃ­cÃ­ch souborÅ¯, even though some more letters were "
 "added."
 
-#: tips:116
+#: tips:148
+msgid "Stdout handler"
+msgstr ""
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Chyba v ovladaÄi %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
 msgstr ""
-"Pokud jsou zapnuty náhledy, ka¾dı obrázek v adresáøi je naèten a je zobrazen "
-"jeho malı náhled."
+"Pokud jsou zapnuty nÃ¡hledy, kaÅ¾dÃ½ obrÃ¡zek v adresÃ¡Å™i je naÄten a je zobrazen "
+"jeho malÃ½ nÃ¡hled."
 
-#: tips:117
+#: tips:155
 msgid "Show image thumbnails"
-msgstr "Zobrazovat náhledy obrázkù"
+msgstr "Zobrazovat nÃ¡hledy obrÃ¡zkÅ¯"
 
-#: tips:118
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
 msgstr ""
-"Toto je dafultní nastavení pro nová okna. Pou¾ijte menu Zobrazit pro "
-"zapnutía vypnutí náhledù v individuálních oknech."
+"Toto je dafultnÃ­ nastavenÃ­ pro novÃ¡ okna. PouÅ¾ijte menu Zobrazit pro "
+"zapnutÃ­a vypnutÃ­ nÃ¡hledÅ¯ v individuÃ¡lnÃ­ch oknech."
 
-#: tips:119
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Zobrazovat nÃ¡hledy obrÃ¡zkÅ¯"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 #, fuzzy
 msgid "Video thumbnails"
-msgstr "Zobrazit náhledy"
+msgstr "Zobrazit nÃ¡hledy"
 
-#: tips:120
+#: tips:160
 msgid "Thumbnails cache"
-msgstr "Ke¹ náhledù"
+msgstr "KeÅ¡ nÃ¡hledÅ¯"
 
-#: tips:121
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
-"Kvùli urychlení jsou vygenerované náhledy ulo¾eny ve skrytém adresáøi ~/."
-"thumbnails. Kliknìte sem pro odtranìní v¹ech ke¹ovanıch náhledù. V pøípadì "
-"potøeby budou znovu vytvoøeny."
+"KvÅ¯li urychlenÃ­ jsou vygenerovanÃ© nÃ¡hledy uloÅ¾eny ve skrytÃ©m adresÃ¡Å™i ~/."
+"thumbnails. KliknÄ›te sem pro odtranÄ›nÃ­ vÅ¡ech keÅ¡ovanÃ½ch nÃ¡hledÅ¯. V pÅ™Ã­padÄ› "
+"potÅ™eby budou znovu vytvoÅ™eny."
 
-#: tips:122 tips:195
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
+#, fuzzy
+msgid "Manage thumbnails"
+msgstr "Zobrazovat nÃ¡hledy obrÃ¡zkÅ¯"
+
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Zobrazit nÃ¡hledy"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sec"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Plocha"
 
-#: tips:123
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
 msgstr ""
-"Pokud pou¾íváte plochu, mù¾ete pøetáhnout soubory a aplikace na plochu a tím "
-"na nì vytvoøíte odkaz."
+"Pokud pouÅ¾Ã­vÃ¡te plochu, mÅ¯Å¾ete pÅ™etÃ¡hnout soubory a aplikace na plochu a tÃ­m "
+"na nÄ› vytvoÅ™Ã­te odkaz."
 
-#: tips:124 tips:241
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Vzhled"
 
-#: tips:125
+#: tips:179
 msgid "Foreground:"
-msgstr "Popøedí"
+msgstr "PopÅ™edÃ­"
 
-#: tips:126
+#: tips:180
 msgid "Text shadow:"
-msgstr "Stín textu:"
+msgstr "StÃ­n textu:"
 
-#: tips:127
+#: tips:181
 msgid "Background:"
-msgstr "Pozadí"
+msgstr "PozadÃ­"
 
-#: tips:128
+#: tips:182
 #, fuzzy
 msgid "No shadow"
-msgstr "Stín textu:"
+msgstr "StÃ­n textu:"
 
-#: tips:129
+#: tips:183
 msgid "Thin"
-msgstr "Tenkı"
+msgstr "TenkÃ½"
 
-#: tips:130
+#: tips:184
 msgid "Thick"
-msgstr "Tlustı"
+msgstr "TlustÃ½"
 
-#: tips:131
+#: tips:185
 msgid "Use custom font:"
-msgstr "Pou¾ít vlastní písmo:"
+msgstr "PouÅ¾Ã­t vlastnÃ­ pÃ­smo:"
 
-#: tips:132
+#: tips:186
 msgid "The font used for the text displayed under the icons"
-msgstr "Písmo pou¾ité pro text zobrazovanı pod ikonami"
+msgstr "PÃ­smo pouÅ¾itÃ© pro text zobrazovanÃ½ pod ikonami"
 
-#: tips:133
+#: tips:187
 msgid "Fast scaling of images"
 msgstr ""
 
-#: tips:134
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
 msgstr ""
 
-#: tips:135
+#: tips:189
 msgid "Pinboard behaviour"
-msgstr "Chování plochy"
+msgstr "ChovÃ¡nÃ­ plochy"
 
-#: tips:136
+#: tips:190
 msgid "Single-click to open"
-msgstr "Jednoduché kliknutí pro otevøení"
+msgstr "JednoduchÃ© kliknutÃ­ pro otevÅ™enÃ­"
 
-#: tips:138
+#: tips:192
 msgid "Keep icons within screen limits"
-msgstr "Dr¾et ikony v mezích obrazovky"
+msgstr "DrÅ¾et ikony v mezÃ­ch obrazovky"
 
-#: tips:139
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
 msgstr ""
-"Tato volba zpùsobí, ¾e ikony na plo¹e jsou v¾dy úplnì umístìny v mezích "
-"obrazovky vèetnì jejich popisku."
+"Tato volba zpÅ¯sobÃ­, Å¾e ikony na ploÅ¡e jsou vÅ¾dy ÃºplnÄ› umÃ­stÄ›ny v mezÃ­ch "
+"obrazovky vÄetnÄ› jejich popisku."
 
-#: tips:140
+#: tips:194
 msgid "Icon grid step:"
-msgstr "Møí¾ka pro umístìní ikon:"
+msgstr "MÅ™Ã­Å¾ka pro umÃ­stÄ›nÃ­ ikon:"
 
-#: tips:141
+#: tips:195
 msgid "Fine"
-msgstr "Jemná"
+msgstr "JemnÃ¡"
 
-#: tips:142
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
-msgstr "Pou¾ije se 2-pixelová møí¾ka pro umís»ování ikon na plo¹e."
+msgstr "PouÅ¾ije se 2-pixelovÃ¡ mÅ™Ã­Å¾ka pro umÃ­sÅ¥ovÃ¡nÃ­ ikon na ploÅ¡e."
 
-#: tips:143
+#: tips:197
 msgid "Medium"
-msgstr "Støední"
+msgstr "StÅ™ednÃ­"
 
-#: tips:144
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
-msgstr "Pou¾ije se 16-pixelová møí¾ka pro umís»ování ikon na plo¹e."
+msgstr "PouÅ¾ije se 16-pixelovÃ¡ mÅ™Ã­Å¾ka pro umÃ­sÅ¥ovÃ¡nÃ­ ikon na ploÅ¡e."
 
-#: tips:145
+#: tips:199
 msgid "Coarse"
-msgstr "Hrubá"
+msgstr "HrubÃ¡"
 
-#: tips:146
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
-msgstr "Pou¾ije se 32-pixelová møí¾ka pro umís»ování ikon na plo¹e."
+msgstr "PouÅ¾ije se 32-pixelovÃ¡ mÅ™Ã­Å¾ka pro umÃ­sÅ¥ovÃ¡nÃ­ ikon na ploÅ¡e."
 
-#: tips:147 tips:149
+#: tips:201 tips:203
 msgid "Iconified windows"
-msgstr "Ikonifikovaná okna"
+msgstr "IkonifikovanÃ¡ okna"
 
-#: tips:148
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
 "windows."
 msgstr ""
-"Vìt¹ina správcù oken umo¾òuje ikonifikovat (nebo 'minimalizovat') okna, a "
-"rùzné programy, vèetnì ROX-Fileru, mohou bıt pou¾ity ke zobrazování "
-"ikonifikovanıch oken."
+"VÄ›tÅ¡ina sprÃ¡vcÅ¯ oken umoÅ¾Åˆuje ikonifikovat (nebo 'minimalizovat') okna, a "
+"rÅ¯znÃ© programy, vÄetnÄ› ROX-Fileru, mohou bÃ½t pouÅ¾ity ke zobrazovÃ¡nÃ­ "
+"ikonifikovanÃ½ch oken."
 
-#: tips:150
+#: tips:204
 msgid "Show iconified windows"
-msgstr "Zobrazovat ikonifikovaná okna"
+msgstr "Zobrazovat ikonifikovanÃ¡ okna"
 
-#: tips:151
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
 "pinboard must be in use."
 msgstr ""
-"Tato volba zpùsobí, ¾e správce souborù zobrazí ka¾dé ikonifikované okno jako "
-"malé tlaèítko na plo¹e. Je potøeba kompatibilní správce oken a musí bıt "
-"pou¾ívána plocha."
+"Tato volba zpÅ¯sobÃ­, Å¾e sprÃ¡vce souborÅ¯ zobrazÃ­ kaÅ¾dÃ© ikonifikovanÃ© okno jako "
+"malÃ© tlaÄÃ­tko na ploÅ¡e. Je potÅ™eba kompatibilnÃ­ sprÃ¡vce oken a musÃ­ bÃ½t "
+"pouÅ¾Ã­vÃ¡na plocha."
 
-#: tips:152
+#: tips:206
 msgid "Show per workspace"
 msgstr ""
 
-#: tips:153
+#: tips:207
 #, fuzzy
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
 msgstr ""
-"Tato volba zpùsobí, ¾e správce souborù zobrazí ka¾dé ikonifikované okno jako "
-"malé tlaèítko na plo¹e. Je potøeba kompatibilní správce oken a musí bıt "
-"pou¾ívána plocha."
+"Tato volba zpÅ¯sobÃ­, Å¾e sprÃ¡vce souborÅ¯ zobrazÃ­ kaÅ¾dÃ© ikonifikovanÃ© okno jako "
+"malÃ© tlaÄÃ­tko na ploÅ¡e. Je potÅ™eba kompatibilnÃ­ sprÃ¡vce oken a musÃ­ bÃ½t "
+"pouÅ¾Ã­vÃ¡na plocha."
 
-#: tips:154
+#: tips:208
 msgid "Iconify to the"
 msgstr "Ikonifikovat "
 
-#: tips:155
+#: tips:209
 msgid "top-left"
-msgstr "nahoøe-vlevo"
+msgstr "nahoÅ™e-vlevo"
 
-#: tips:156
+#: tips:210
 msgid "top-right"
-msgstr "nahoøe-vpravo"
+msgstr "nahoÅ™e-vpravo"
 
-#: tips:157
+#: tips:211
 msgid "bottom-left"
 msgstr "dole-vlevo"
 
-#: tips:158
+#: tips:212
 msgid "bottom-right"
 msgstr "dole-vpravo"
 
-#: tips:159
+#: tips:213
 msgid ", going"
-msgstr ", smìrem"
+msgstr ", smÄ›rem"
 
-#: tips:160
+#: tips:214
 msgid "horizontally"
-msgstr "horizontálním"
+msgstr "horizontÃ¡lnÃ­m"
 
-#: tips:161
+#: tips:215
 msgid "vertically"
-msgstr "vertikálním"
+msgstr "vertikÃ¡lnÃ­m"
 
-#: tips:162
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4061,317 +4815,287 @@ msgid ""
 "about its own panel."
 msgstr ""
 
-#: tips:163
+#: tips:217
 msgid "Top margin"
 msgstr ""
 
-#: tips:164
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr ""
 
-#: tips:165
+#: tips:219
 msgid "Bottom margin"
 msgstr ""
 
-#: tips:166
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr ""
 
-#: tips:167
-msgid "Panels"
-msgstr "Panely"
-
-#: tips:168
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr ""
-"Panely jsou pásy ikon umístìné podél okraje obrazovky. Více informací o "
-"pu¾ití panelù je v manuálu."
-
-#: tips:169
-msgid "Panel style"
-msgstr "Styl panelu"
-
-#: tips:170
-msgid "Image and text"
-msgstr "Obrázek a text"
-
-#: tips:171
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Ka¾dá ikona panelu je zobrazena s obrázkem a nìjakım textem."
-
-#: tips:172
-msgid "Image only for applications"
-msgstr "Obrázek pouze pro aplikace"
-
-#: tips:173
-msgid ""
-"Applications have just an image, everything else has both an image and text."
-msgstr "Aplikace mají pouze obrázek, v¹echno ostatní má orázek i text."
-
-#: tips:174
-msgid "Image only"
-msgstr "Jen obrázek"
-
-#: tips:175
-msgid "Only the image is shown."
-msgstr "Je zobrazen pouze obrázek."
-
-#: tips:176
-msgid "Panel width (thin)"
-msgstr "©íøka panelu (úzkı)"
-
-#: tips:177
-msgid "(thick)"
-msgstr "(¹irokı)"
-
-#: tips:178
-msgid "The size of the panels."
-msgstr "Velikost panelù."
-
-#: tips:179
-msgid "Do not cover panel"
+#: tips:221
+msgid "Left margin"
 msgstr ""
 
-#: tips:180
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
+#: tips:222
+msgid "Width of no-go area at left of screen."
 msgstr ""
 
-#: tips:181
-msgid "Xinerama"
+#: tips:223
+msgid "Right margin"
 msgstr ""
 
-#: tips:182
-msgid "Confine to Xinerama monitor"
+#: tips:224
+msgid "Width of no-go area at right of screen."
 msgstr ""
 
-#: tips:183
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
-msgstr ""
-
-#: tips:184
-msgid ""
-"The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr ""
-
-#: tips:185
+#: tips:225
 msgid "Desktop"
 msgstr ""
 
-#: tips:186
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
 msgstr ""
 
-#: tips:187
+#: tips:227
 #, fuzzy
 msgid "Panel only"
-msgstr "Jen obrázek"
+msgstr "Jen obrÃ¡zek"
 
-#: tips:188
+#: tips:228
 #, fuzzy
 msgid "Only a panel is shown."
-msgstr "Je zobrazen pouze obrázek."
+msgstr "Je zobrazen pouze obrÃ¡zek."
 
-#: tips:189
+#: tips:229
 #, fuzzy
 msgid "Pinboard only"
 msgstr "Plocha"
 
-#: tips:190
+#: tips:230
 #, fuzzy
 msgid "Only the pinboard is shown."
-msgstr "Je zobrazen pouze obrázek."
+msgstr "Je zobrazen pouze obrÃ¡zek."
 
-#: tips:191
+#: tips:231
 #, fuzzy
 msgid "Panel and pinboard"
 msgstr "Plocha"
 
-#: tips:192
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr ""
 
-#: tips:193
-#, fuzzy
-msgid "Panel"
-msgstr "Panely"
-
-#: tips:194
-msgid "Enter the name of the panel to show here."
-msgstr ""
-
-#: tips:196
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr ""
 
-#: tips:197
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr ""
 
-#: tips:198
+#: tips:236
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 
-#: tips:199
+#: tips:237
 msgid "Action windows"
-msgstr "Okna akcí"
+msgstr "Okna akcÃ­"
 
-#: tips:200
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
 msgstr ""
-"Okna akcí se zobrazí, kdy¾ spustíte nìjakou operaci\n"
-"na pozadí, napøíklad kopírování nebo mazání souborù."
+"Okna akcÃ­ se zobrazÃ­, kdyÅ¾ spustÃ­te nÄ›jakou operaci\n"
+"na pozadÃ­, napÅ™Ã­klad kopÃ­rovÃ¡nÃ­ nebo mazÃ¡nÃ­ souborÅ¯."
 
-#: tips:201
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
-msgstr "Automaticky (bez upozornìní) provést tyto operace"
+msgstr "Automaticky (bez upozornÄ›nÃ­) provÃ©st tyto operace"
 
-#: tips:203
+#: tips:241
 msgid "Copy files without confirming first."
-msgstr "Kopírovat soubory bez upozornìní."
+msgstr "KopÃ­rovat soubory bez upozornÄ›nÃ­."
 
-#: tips:205
+#: tips:243
 msgid "Move files without confirming first."
-msgstr "Pøesunout soubory bez upozornìní."
+msgstr "PÅ™esunout soubory bez upozornÄ›nÃ­."
 
-#: tips:207
+#: tips:245
 msgid "Create links to files without confirming first."
-msgstr "Vytváøet symbolické odkazy na soubory bez upozornìní."
+msgstr "VytvÃ¡Å™et symbolickÃ© odkazy na soubory bez upozornÄ›nÃ­."
 
-#: tips:209
+#: tips:247
 msgid "Delete files without confirming first."
-msgstr "Smazat soubory bez upozornìní."
+msgstr "Smazat soubory bez upozornÄ›nÃ­."
 
-#: tips:210
+#: tips:248
 msgid "Mount"
-msgstr "Pøipojit"
+msgstr "PÅ™ipojit"
 
-#: tips:211
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
-msgstr "Pøipojit a odpojit soubory bez upozornìní."
+msgstr "PÅ™ipojit a odpojit soubory bez upozornÄ›nÃ­."
 
-#: tips:212
+#: tips:250
 msgid "Default settings"
-msgstr "Defaultní nastavení"
+msgstr "DefaultnÃ­ nastavenÃ­"
 
-#: tips:214
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Bez potvrzenÃ­"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
-msgstr "Nepotvrzovat smazání polo¾ek, které nemají právo zápisu."
+msgstr "Nepotvrzovat smazÃ¡nÃ­ poloÅ¾ek, kterÃ© nemajÃ­ prÃ¡vo zÃ¡pisu."
 
-#: tips:216
+#: tips:254
 msgid "Don't display so much information in the message area."
-msgstr "Nezobrazovat moc informací v oknì zpráv."
+msgstr "Nezobrazovat moc informacÃ­ v oknÄ› zprÃ¡v."
 
-#: tips:218
+#: tips:256
 msgid "Also change contents of subdirectories."
-msgstr "Mìnit také obsah podadresáøù."
+msgstr "MÄ›nit takÃ© obsah podadresÃ¡Å™Å¯."
 
-#: tips:221
+#: tips:263
+#, fuzzy
+msgid "Mount commands"
+msgstr "Bod pÅ™ipojenÃ­"
+
+#: tips:264
+#, fuzzy
+msgid "Mount command"
+msgstr "Bod pÅ™ipojenÃ­"
+
+#: tips:265
+msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
+msgstr ""
+
+#: tips:266
+#, fuzzy
+msgid "Unmount command"
+msgstr "Odpojit"
+
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "PÅ™Ã­kaz:"
+
+#: tips:269
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
-msgstr "Táhni a pus»"
+msgstr "TÃ¡hni a pusÅ¥"
 
-#: tips:222
+#: tips:273
 msgid "Dragging to icons"
-msgstr "Pøetáhnutí na ikony"
+msgstr "PÅ™etÃ¡hnutÃ­ na ikony"
 
-#: tips:223
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
-msgstr "Povolit pøetahování na ikony ve správci souborù"
+msgstr "Povolit pÅ™etahovÃ¡nÃ­ na ikony ve sprÃ¡vci souborÅ¯"
 
-#: tips:224
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
 "will put it into that directory, or load it into the program."
 msgstr ""
-"Tato volba zpùsobí, ¾e pøetahovat soubor pøes podadresáøe nebo programy ve "
-"správci oken. Polo¾ka pøi tom bude zvıraznìna a upu¹tìní souboru ho umístí "
-"do tohoto adresáøe nebo v pøípadì programu bude do tohoto programu naèten."
+"Tato volba zpÅ¯sobÃ­, Å¾e pÅ™etahovat soubor pÅ™es podadresÃ¡Å™e nebo programy ve "
+"sprÃ¡vci oken. PoloÅ¾ka pÅ™i tom bude zvÃ½raznÄ›na a upuÅ¡tÄ›nÃ­ souboru ho umÃ­stÃ­ "
+"do tohoto adresÃ¡Å™e nebo v pÅ™Ã­padÄ› programu bude do tohoto programu naÄten."
 
-#: tips:225
+#: tips:276
 msgid "Directories spring open"
-msgstr "Pru¾né otvírání adresáøù"
+msgstr "PruÅ¾nÃ© otvÃ­rÃ¡nÃ­ adresÃ¡Å™Å¯"
 
-#: tips:226
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
 "short while."
 msgstr ""
-"Tato volba, která vy¾aduje zapnutou i pøedchozí volbu, zpùsobí, ¾e adresáø "
-"je 'pru¾nì otevøen', kdy¾ je nad nimi soubor podr¾en po urèitou dobu."
+"Tato volba, kterÃ¡ vyÅ¾aduje zapnutou i pÅ™edchozÃ­ volbu, zpÅ¯sobÃ­, Å¾e adresÃ¡Å™ "
+"je 'pruÅ¾nÄ› otevÅ™en', kdyÅ¾ je nad nimi soubor podrÅ¾en po urÄitou dobu."
 
-#: tips:227
+#: tips:278
 msgid "Spring delay:"
-msgstr "Zpo¾dìní pro pru¾né otevøení:"
+msgstr "ZpoÅ¾dÄ›nÃ­ pro pruÅ¾nÃ© otevÅ™enÃ­:"
 
-#: tips:228
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:229
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
 "have any effect."
 msgstr ""
-"Tato volba nastavuje, jak dlouho v ms musíte podr¾et soubor nad adresáøem "
-"pøedtím, ne¾ bude otevøen. Pøedchozí volba musí bıt zapnuta, aby mìla tado "
-"volba nìjakı efekt."
+"Tato volba nastavuje, jak dlouho v ms musÃ­te podrÅ¾et soubor nad adresÃ¡Å™em "
+"pÅ™edtÃ­m, neÅ¾ bude otevÅ™en. PÅ™edchozÃ­ volba musÃ­ bÃ½t zapnuta, aby mÄ›la tado "
+"volba nÄ›jakÃ½ efekt."
 
-#: tips:230
+#: tips:281
 msgid "When dragging files with the left mouse button"
-msgstr "Pøi pøetahování souborù levım tlaèítkem my¹i"
+msgstr "PÅ™i pÅ™etahovÃ¡nÃ­ souborÅ¯ levÃ½m tlaÄÃ­tkem myÅ¡i"
 
-#: tips:231 tips:235
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
-msgstr "Zobrazit nabídku mo¾nıch akcí"
+msgstr "Zobrazit nabÃ­dku moÅ¾nÃ½ch akcÃ­"
 
-#: tips:232
+#: tips:283
 msgid "Copy the files"
-msgstr "Kopírovat soubory"
+msgstr "KopÃ­rovat soubory"
 
-#: tips:233
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
 msgstr ""
-"Zobrazit nabídku mù¾ete také v pøípadì, ¾e pøi pøetahování byl stisknut Alt."
+"Zobrazit nabÃ­dku mÅ¯Å¾ete takÃ© v pÅ™Ã­padÄ›, Å¾e pÅ™i pÅ™etahovÃ¡nÃ­ byl stisknut Alt."
 
-#: tips:234
+#: tips:285
 msgid "When dragging files with the middle mouse button"
-msgstr "Pøi pøetahování souborù prostøedním tlaèítkem my¹i"
+msgstr "PÅ™i pÅ™etahovÃ¡nÃ­ souborÅ¯ prostÅ™ednÃ­m tlaÄÃ­tkem myÅ¡i"
 
-#: tips:236
+#: tips:287
 msgid "Move the files"
-msgstr "Pøesunout soubory"
+msgstr "PÅ™esunout soubory"
 
-#: tips:237
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
 msgstr ""
-"Zobrazit nabídku mù¾ete také v pøípadì, ¾e pøi pøetahování lev7m tlaèítkem "
+"Zobrazit nabÃ­dku mÅ¯Å¾ete takÃ© v pÅ™Ã­padÄ›, Å¾e pÅ™i pÅ™etahovÃ¡nÃ­ lev7m tlaÄÃ­tkem "
 "byl stisknut Alt."
 
-#: tips:238
+#: tips:289
 msgid "Download handler"
 msgstr ""
 
-#: tips:239
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4379,180 +5103,214 @@ msgid ""
 "xterm -e wget $1"
 msgstr ""
 
-#: tips:240
+#: tips:291
 msgid "Menus"
-msgstr "Nabídky"
+msgstr "NabÃ­dky"
 
-#: tips:242
+#: tips:293
 msgid "Size of icons in menus:"
-msgstr "Velikost ikon v nabídkách:"
+msgstr "Velikost ikon v nabÃ­dkÃ¡ch:"
 
-#: tips:243
+#: tips:294
 msgid "No Icons"
-msgstr "®ádné ikony"
+msgstr "Å½Ã¡dnÃ© ikony"
 
-#: tips:246
+#: tips:297
 msgid "Same as current window"
-msgstr "Stejná jako v souèasném oknì"
+msgstr "StejnÃ¡ jako v souÄasnÃ©m oknÄ›"
 
-#: tips:247
+#: tips:298
 msgid "Same as default"
-msgstr "Stajná jako defaultní"
+msgstr "StajnÃ¡ jako defaultnÃ­"
 
-#: tips:248
+#: tips:299
 msgid "Behaviour"
-msgstr "Chování"
+msgstr "ChovÃ¡nÃ­"
 
-#: tips:249
+#: tips:300
 msgid "File menu on right-click"
 msgstr ""
 
-#: tips:250
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
 msgstr ""
 
-#: tips:251
-msgid "`Xterm Here' program"
-msgstr "`Xterm v tomto adresáøi' program"
+#: tips:302
+#, fuzzy
+msgid "Terminal emulator program"
+msgstr "`Xterm v tomto adresÃ¡Å™i' program"
 
-#: tips:252
-msgid "The program to launch when you choose `Xterm Here' from the menu."
+#: tips:303
+#, fuzzy
+msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr ""
-"Program, kterı je spu¹tìn, kdy¾ vyberete `Xterm v tomto adresáøi' z nabídky"
+"Program, kterÃ½ je spuÅ¡tÄ›n, kdyÅ¾ vyberete `Xterm v tomto adresÃ¡Å™i' z nabÃ­dky"
 
-#: tips:253
+#: tips:304
 msgid "Keyboard shortcuts"
-msgstr "Klávesové zkratky"
+msgstr "KlÃ¡vesovÃ© zkratky"
 
-#: tips:255
+#: tips:305
+msgid "Types"
+msgstr "Typy"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME typy"
 
-#: tips:256
+#: tips:307
 #, fuzzy
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
 msgstr ""
-"Správce souborù pou¾ívá sadu pravidel k urèení správného MIME typu pro ka¾dı "
-"soubor, potom vybírá vhodnou ikonu pro tento typ. Pou¾ijte aplikaci MIME-"
-"Editor pro zmìnu pøiøazení souborù k typùm:\n"
+"SprÃ¡vce souborÅ¯ pouÅ¾Ã­vÃ¡ sadu pravidel k urÄenÃ­ sprÃ¡vnÃ©ho MIME typu pro kaÅ¾dÃ½ "
+"soubor, potom vybÃ­rÃ¡ vhodnou ikonu pro tento typ. PouÅ¾ijte aplikaci MIME-"
+"Editor pro zmÄ›nu pÅ™iÅ™azenÃ­ souborÅ¯ k typÅ¯m:\n"
 "\n"
 "http://rox.sourceforge.net/mime_editor.html"
 
-#: tips:257
+#: tips:308
 msgid "Edit MIME rules"
 msgstr ""
 
-#: tips:258
+#: tips:309
 #, fuzzy
 msgid "Themes"
-msgstr "Èasy"
+msgstr "ÄŒasy"
 
-#: tips:259
+#: tips:310
 #, fuzzy
 msgid "Icon theme"
 msgstr "Ikonifikovat "
 
-#: tips:260
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr ""
 
-#: tips:261
+#: tips:312
 #, fuzzy
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
 msgstr ""
-"Pou¾ijte dialogové okno 'Nastavit ikonu...' k nastavení pro ka¾dı MIME typ"
+"PouÅ¾ijte dialogovÃ© okno 'Nastavit ikonu...' k nastavenÃ­ pro kaÅ¾dÃ½ MIME typ"
 
-#: tips:262
+#: tips:313
 msgid "Colours"
 msgstr "Barvy"
 
-#: tips:263
+#: tips:314
 msgid "File type colours"
-msgstr "Barvy typù souborù"
+msgstr "Barvy typÅ¯ souborÅ¯"
 
-#: tips:264
+#: tips:315
 msgid "Colour files based on their types"
-msgstr "Barvy souborù zavisí na jejich typech"
+msgstr "Barvy souborÅ¯ zavisÃ­ na jejich typech"
 
-#: tips:265
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr ""
-"Jména souborù (a podrobnosti) mají barvu, která patøí k danému typu souboru."
+"JmÃ©na souborÅ¯ (a podrobnosti) majÃ­ barvu, kterÃ¡ patÅ™Ã­ k danÃ©mu typu souboru."
 
-#: tips:266
+#: tips:317
 msgid "Directory:"
-msgstr "Adresáø"
+msgstr "AdresÃ¡Å™"
 
-#: tips:267
+#: tips:318
 msgid "Regular file:"
-msgstr "Bì¾nı soubor"
+msgstr "BÄ›Å¾nÃ½ soubor"
 
-#: tips:268
+#: tips:319
 msgid "Pipe:"
 msgstr "Roura"
 
-#: tips:269
+#: tips:320
 msgid "Socket:"
 msgstr "Soket"
 
-#: tips:271
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
 msgstr ""
-"Chyba, jako napøíklad symbolickı odkaz na neexistující soubor nebo soubor "
-"nebo soubor u kterého nemá spravce souborù práva k prozkoumání."
+"Chyba, jako napÅ™Ã­klad symbolickÃ½ odkaz na neexistujÃ­cÃ­ soubor nebo soubor "
+"nebo soubor u kterÃ©ho nemÃ¡ spravce souborÅ¯ prÃ¡va k prozkoumÃ¡nÃ­."
 
-#: tips:272
+#: tips:323
 msgid "Character device:"
-msgstr "Znakové zaøízení:"
+msgstr "ZnakovÃ© zaÅ™Ã­zenÃ­:"
 
-#: tips:273
+#: tips:324
 msgid "Block device:"
-msgstr "Blokové zaøízení:"
+msgstr "BlokovÃ© zaÅ™Ã­zenÃ­:"
 
-#: tips:274
+#: tips:325
 msgid "Door:"
 msgstr "DOOR:"
 
-#: tips:275
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
 msgstr ""
 "Door soubory jsou trochu jako sokety a roury a jsou pou69v8ny na Solarisu."
 
-#: tips:276
+#: tips:327
 msgid "Executable file:"
-msgstr "Spustitelnı soubor:"
+msgstr "SpustitelnÃ½ soubor:"
 
-#: tips:277
+#: tips:328
 msgid "Application directory:"
-msgstr "Aplikaèní adresáø:"
+msgstr "AplikaÄnÃ­ adresÃ¡Å™:"
 
-#: tips:278
+#: tips:329
 msgid "Unknown type:"
-msgstr "Neznámı typ:"
+msgstr "NeznÃ¡mÃ½ typ:"
 
-#: tips:279
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "PozadÃ­"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "PouÅ¾Ã­t vlastnÃ­ pÃ­smo:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Kompatibilita"
 
-#: tips:280
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
-msgstr "Problémy se správcem oken"
+msgstr "ProblÃ©my se sprÃ¡vcem oken"
 
-#: tips:281
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
-msgstr "Pøebít kontrolu správce oken nad pozadím a panely "
+msgstr "PÅ™ebÃ­t kontrolu sprÃ¡vce oken nad pozadÃ­m a panely "
 
-#: tips:282
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4560,78 +5318,97 @@ msgid ""
 "on it, titlebars and other decorations appearing around windows, or having "
 "them appear in window-select lists."
 msgstr ""
-"Nìkteøí správci oken nepodporují Extended Window Manager Hints system "
-"zachází s pozadím a panely jako s normálními okny. Pou¾ijte, pro vyøe¹ení "
-"problémù jako: pozadí vyskoèí dopøedu pøi kliknutí na nìj, titulky a jiné "
-"dekorace se objevují u tìchto oken nebo se objevují v seznamu oken."
+"NÄ›kteÅ™Ã­ sprÃ¡vci oken nepodporujÃ­ Extended Window Manager Hints system "
+"zachÃ¡zÃ­ s pozadÃ­m a panely jako s normÃ¡lnÃ­mi okny. PouÅ¾ijte, pro vyÅ™eÅ¡enÃ­ "
+"problÃ©mÅ¯ jako: pozadÃ­ vyskoÄÃ­ dopÅ™edu pÅ™i kliknutÃ­ na nÄ›j, titulky a jinÃ© "
+"dekorace se objevujÃ­ u tÄ›chto oken nebo se objevujÃ­ v seznamu oken."
 
-#: tips:283
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
-msgstr "Pøedat v¹echny kliknutí my¹í na pozadí správci oken"
+msgstr "PÅ™edat vÅ¡echny kliknutÃ­ myÅ¡Ã­ na pozadÃ­ sprÃ¡vci oken"
 
-#: tips:284
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
 "events to your window manager instead. Clicks on icons will not be forwarded."
 msgstr ""
-"Normálnì pravé kliknutí na plo¹e otevøe nabídku plochy a levé kliknutí "
-"vyma¾e vıbìr. Pokud je zapnuto, pøedjí se v¹echny události správci oken. "
-"Kliknutí na ikony nebude pøedáno."
+"NormÃ¡lnÄ› pravÃ© kliknutÃ­ na ploÅ¡e otevÅ™e nabÃ­dku plochy a levÃ© kliknutÃ­ "
+"vymaÅ¾e vÃ½bÄ›r. Pokud je zapnuto, pÅ™edjÃ­ se vÅ¡echny udÃ¡losti sprÃ¡vci oken. "
+"KliknutÃ­ na ikony nebude pÅ™edÃ¡no."
 
-#: tips:285
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Blackbox root menus hack"
 
-#: tips:286
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
 "managers are expected to change their behaviour in new versions so that this "
 "isn't necessary."
 msgstr ""
-"Blackbox, Fluxbox a podobní správci oken zatím nepracují dobøe s pozadím ROX-"
-"Fileru. Tato volba èásteènì øe¹í problémy. Tito správcioken pravdìpodbnì "
-"opraví chování ve svıch novıch verzích, tak¾e toto není nutné."
+"Blackbox, Fluxbox a podobnÃ­ sprÃ¡vci oken zatÃ­m nepracujÃ­ dobÅ™e s pozadÃ­m ROX-"
+"Fileru. Tato volba ÄÃ¡steÄnÄ› Å™eÅ¡Ã­ problÃ©my. Tito sprÃ¡vcioken pravdÄ›podbnÄ› "
+"opravÃ­ chovÃ¡nÃ­ ve svÃ½ch novÃ½ch verzÃ­ch, takÅ¾e toto nenÃ­ nutnÃ©."
 
-#: tips:287
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr ""
 
-#: tips:288
+#: tips:346
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 
-#: tips:289
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Styl panelu"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
-msgstr "Táhni a pus»"
+msgstr "TÃ¡hni a pusÅ¥"
 
-#: tips:290
+#: tips:352
 msgid "Don't use hostnames"
-msgstr "Nepou¾ívat jména poèítaèù"
+msgstr "NepouÅ¾Ã­vat jmÃ©na poÄÃ­taÄÅ¯"
 
-#: tips:291
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
 "sign on the pointer but the drop doesn't work."
 msgstr ""
-"Nìkteré star¹í aplikace plnì nepodporují XDND a mohou potøebovat mít "
-"zapnutoututo volbu. Pou¾ijte, pokud pøetáhnutí souborù na aplikaci zobrazí "
-"znak +, ale pu¹tìní souborù nefunguje."
+"NÄ›kterÃ© starÅ¡Ã­ aplikace plnÄ› nepodporujÃ­ XDND a mohou potÅ™ebovat mÃ­t "
+"zapnutoututo volbu. PouÅ¾ijte, pokud pÅ™etÃ¡hnutÃ­ souborÅ¯ na aplikaci zobrazÃ­ "
+"znak +, ale puÅ¡tÄ›nÃ­ souborÅ¯ nefunguje."
 
-#: tips:292
-msgid "Extended attributes"
-msgstr ""
-
-#: tips:293
+#: tips:355
 #, fuzzy
 msgid "Don't use extended attributes"
-msgstr "Nepou¾ívat jména poèítaèù"
+msgstr "NepouÅ¾Ã­vat jmÃ©na poÄÃ­taÄÅ¯"
 
-#: tips:294
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4639,24 +5416,364 @@ msgid ""
 "the properties window does not report extended attributes."
 msgstr ""
 
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+msgid "Bottom gap:"
+msgstr ""
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+msgid "Right gap:"
+msgstr ""
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "DomovskÃ½ adresÃ¡Å™"
+
+#: ../Templates.ui.h:4
+#, fuzzy
+msgid "Panel Options"
+msgstr "MoÅ¾nosti"
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "ObrÃ¡zek a text"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "KaÅ¾dÃ¡ ikona panelu je zobrazena s obrÃ¡zkem a nÄ›jakÃ½m textem."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "ObrÃ¡zek pouze pro aplikace"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr "Aplikace majÃ­ pouze obrÃ¡zek, vÅ¡echno ostatnÃ­ mÃ¡ orÃ¡zek i text."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Jen obrÃ¡zek"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Je zobrazen pouze obrÃ¡zek."
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Å Ã­Å™ka panelu (ÃºzkÃ½)"
+
+#: ../Templates.ui.h:12
+#, fuzzy
+msgid "The size of this panel."
+msgstr "Velikost panelÅ¯."
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "PÅ™eklad"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr ""
+
+#: ../Templates.ui.h:19
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Styl panelu"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr ""
+
+#: ../Templates.ui.h:22
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+
+#: ../Templates.ui.h:23
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "PÅ™Ã­stupovÃ¡ prÃ¡va"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr ""
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr ""
+
+#: ../Templates.ui.h:27
+msgid "Bottom edge"
+msgstr ""
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr ""
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "PÅ™Ã­stupovÃ¡ prÃ¡va"
+
+#~ msgid "<dir>"
+#~ msgstr "<adresÃ¡Å™>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' uÅ¾ existuje - pÅ™epsat?"
+
+#, fuzzy
+#~ msgid "Choices migration"
+#~ msgstr "ÄŒÃ­nsky (tradiÄnÃ­)"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Chyba pÅ™i prozkoumÃ¡vÃ¡nÃ­ '%s':\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "AdresÃ¡Å™ chybÃ­/je smazÃ¡n"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "AdresÃ¡Å™ '%s' nenalezen."
+
+#~ msgid "Cancel"
+#~ msgstr "ZavÅ™Ã­t"
+
+#~ msgid "GNOME-VFS library"
+#~ msgstr "GNOME-VFS knihovna"
+
+#~ msgid "Dnotify support"
+#~ msgstr "Dnotify support"
+
+#~ msgid "Open AVFS"
+#~ msgstr "OtevÅ™Ã­t AFVS"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "MÄ›li by jste stisknout Shift a menu tlaÄÃ­tko nad souborem, abyste jej "
+#~ "nÄ›kam poslali"
+
+#~ msgid "Look inside ... ?"
+#~ msgstr "PodÃ­vat se do ... ?"
+
+#, fuzzy
+#~ msgid "Panel: %s"
+#~ msgstr "Panely"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "NeplatnÃ½ .gmo soubor pÅ™ekladu (pÅ™Ã­liÅ¡ krÃ¡tkÃ½): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr "NeplatnÃ½ .gmo soubor pÅ™ekladu (GNU magickÃ© ÄÃ­slo nenalezeno): %s"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "PÅ™ejÃ­t do vyÅ¡Å¡Ã­ho adresÃ¡Å™e"
+
+#~ msgid "Change to home directory"
+#~ msgstr "PÅ™ejÃ­t do domovskÃ©ho adresÃ¡Å™e"
+
+#~ msgid "Bookmarks"
+#~ msgstr "ZÃ¡loÅ¾ky"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Menu zÃ¡loÅ¾ek"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Znovu naÄÃ­st obsah adresÃ¡Å™e"
+
+#~ msgid "Change icon size"
+#~ msgstr "ZmÄ›nit velikost ikony"
+
+#~ msgid "Show extra details"
+#~ msgstr "Zobrazit extra podrobnosti"
+
+#~ msgid "Hidden"
+#~ msgstr "SkrytÃ½"
+
+#~ msgid "Show/hide hidden files"
+#~ msgstr "Zobrazit/skrÃ½t skrytÃ© soubory"
+
+#~ msgid "Language"
+#~ msgstr "Jazyk"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "PouÅ¾Ã­t promÄ›nnou prostÅ™edÃ­ LANG"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "ÄŒÃ­nsky (tradiÄnÃ­)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "ÄŒÃ­nsky (zjednoduÅ¡enÃ¡)"
+
+#~ msgid "Danish"
+#~ msgstr "DÃ¡nsky"
+
+#~ msgid "Dutch"
+#~ msgstr "Holandsky"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Anglicky (bez pÅ™ekladu)"
+
+#, fuzzy
+#~ msgid "Finnish"
+#~ msgstr "DÃ¡nsky"
+
+#~ msgid "French"
+#~ msgstr "Francouzsky"
+
+#~ msgid "German"
+#~ msgstr "NÄ›mecky"
+
+#~ msgid "Hungarian"
+#~ msgstr "MaÄarsky"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonsky"
+
+#~ msgid "Norwegian"
+#~ msgstr "Norsky"
+
+#~ msgid "Italian"
+#~ msgstr "Italsky"
+
+#~ msgid "Polish"
+#~ msgstr "Polsky"
+
+#~ msgid "Russian"
+#~ msgstr "Rusky"
+
+#~ msgid "Spanish"
+#~ msgstr "Å panÄ›lsky"
+
+#~ msgid "Swedish"
+#~ msgstr "Å vÃ©dsky"
+
+#~ msgid "Change at:"
+#~ msgstr "ZmÄ›nit u:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "MaximÃ¡lnÃ­ velikost (VelkÃ© ikony):"
+
+#~ msgid "Panels"
+#~ msgstr "Panely"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Panely jsou pÃ¡sy ikon umÃ­stÄ›nÃ© podÃ©l okraje obrazovky. VÃ­ce informacÃ­ o "
+#~ "puÅ¾itÃ­ panelÅ¯ je v manuÃ¡lu."
+
+#~ msgid "(thick)"
+#~ msgstr "(Å¡irokÃ½)"
+
 #~ msgid ""
 #~ "Error loading MIME database:\n"
 #~ "%s"
 #~ msgstr ""
-#~ "Chyba pøi ètení MIME databáze:\n"
+#~ "Chyba pÅ™i ÄtenÃ­ MIME databÃ¡ze:\n"
 #~ "%s"
 
 #~ msgid "File '%s' corrupted!"
-#~ msgstr "Soubor '%s' je poru¹en!"
+#~ msgstr "Soubor '%s' je poruÅ¡en!"
 
 #~ msgid ""
 #~ "The ~/.mime directory has moved. It should now be ~/.local/share/mime. "
 #~ "You should move it there (and make a symlink from ~/.mime to it for older "
 #~ "applications)."
 #~ msgstr ""
-#~ "~/.mime adresáø byl pøesunut. Nyní by mìl bıt ~/.local/share/mime. Mìli "
-#~ "by jste ho tampøesunout (a vytvoøit na nìj symbolickı odkaz ~/.mime kvùli "
-#~ "star¹ím aplikacím)."
+#~ "~/.mime adresÃ¡Å™ byl pÅ™esunut. NynÃ­ by mÄ›l bÃ½t ~/.local/share/mime. MÄ›li "
+#~ "by jste ho tampÅ™esunout (a vytvoÅ™it na nÄ›j symbolickÃ½ odkaz ~/.mime kvÅ¯li "
+#~ "starÅ¡Ã­m aplikacÃ­m)."
 
 #, fuzzy
 #~ msgid ""
@@ -4670,52 +5787,49 @@ msgstr ""
 #~ "allow the files to be read (check /usr/local/share/mime/globs or /usr/"
 #~ "share/mime/globs)."
 #~ msgstr ""
-#~ "Standardní MIME databáze typù  (verze 0.9 nebo vy¹¹í) nebyla nalezena. "
-#~ "Správce souborù pravdìpodobnì nezobrazí korektnì typy pro rùzné soubory. "
-#~ "Mìli by jste stáhnout a nainstalovat balíèek'shared-mime-info-0.9' z:\n"
+#~ "StandardnÃ­ MIME databÃ¡ze typÅ¯  (verze 0.9 nebo vyÅ¡Å¡Ã­) nebyla nalezena. "
+#~ "SprÃ¡vce souborÅ¯ pravdÄ›podobnÄ› nezobrazÃ­ korektnÄ› typy pro rÅ¯znÃ© soubory. "
+#~ "MÄ›li by jste stÃ¡hnout a nainstalovat balÃ­Äek'shared-mime-info-0.9' z:\n"
 #~ "http://www.freedesktop.org/standards/shared-mime-info.html\n"
 #~ "\n"
-#~ "Pokud u¾ tento balíèek máte nainstalován, zkontrolujte pøístupová práva, "
-#~ "zda je mo¾né soubory èíst (zkontrolujte /usr/local/share/mime/globs nebo /"
+#~ "Pokud uÅ¾ tento balÃ­Äek mÃ¡te nainstalovÃ¡n, zkontrolujte pÅ™Ã­stupovÃ¡ prÃ¡va, "
+#~ "zda je moÅ¾nÃ© soubory ÄÃ­st (zkontrolujte /usr/local/share/mime/globs nebo /"
 #~ "usr/share/mime/globs)."
 
 #~ msgid "Executable files"
-#~ msgstr "Spustitelné soubory"
+#~ msgstr "SpustitelnÃ© soubory"
 
 #~ msgid "Ignore eXecutable bit for known extensions"
-#~ msgstr "Ignorovat spou¹tìcí bit pro známé pøípony"
+#~ msgstr "Ignorovat spouÅ¡tÄ›cÃ­ bit pro znÃ¡mÃ© pÅ™Ã­pony"
 
 #~ msgid ""
 #~ "If a file has a known extension (eg '.gif') then ignore the executable "
 #~ "bit. This is useful if you have files on a Windows-type filesystem which "
 #~ "are being shown as executable programs."
 #~ msgstr ""
-#~ "Pokud má soubor známou pøíponu (napø. '.gif'), je ignorován spustitelnı "
-#~ "bit. To je vhodné, pokud máte soubory na systému souborù typu Windows, "
-#~ "které jsou zobrazovány jako spustitelné programy."
+#~ "Pokud mÃ¡ soubor znÃ¡mou pÅ™Ã­ponu (napÅ™. '.gif'), je ignorovÃ¡n spustitelnÃ½ "
+#~ "bit. To je vhodnÃ©, pokud mÃ¡te soubory na systÃ©mu souborÅ¯ typu Windows, "
+#~ "kterÃ© jsou zobrazovÃ¡ny jako spustitelnÃ© programy."
 
 #, fuzzy
 #~ msgid "Umount"
 #~ msgstr "Odpojit"
 
-#~ msgid "A"
-#~ msgstr "A"
-
 #~ msgid "All, "
-#~ msgstr "V¹e, "
+#~ msgstr "VÅ¡e, "
 
 #~ msgid ""
 #~ "Pinboard icons cannot be drawn because ROX-Filer was compiled against GTK"
 #~ "+-2.0 but is running with GTK+-2.2. Please recompile it."
 #~ msgstr ""
-#~ "Ikony na plo¹e nemohou bıt zobrazeny, proto¾e ROX-Filer byl pøelo¾en s GTK"
-#~ "+-2.0, ale je spu¹tìn s GTK+-2.2. Znovu jej, prosím, pøelo¾te."
+#~ "Ikony na ploÅ¡e nemohou bÃ½t zobrazeny, protoÅ¾e ROX-Filer byl pÅ™eloÅ¾en s GTK"
+#~ "+-2.0, ale je spuÅ¡tÄ›n s GTK+-2.2. Znovu jej, prosÃ­m, pÅ™eloÅ¾te."
 
 #~ msgid "Info"
 #~ msgstr "Info"
 
 #~ msgid "Symbolic link to %s"
-#~ msgstr "Symbolickı odkaz na %s"
+#~ msgstr "SymbolickÃ½ odkaz na %s"
 
 #~ msgid "No (gnome-vfs-config not found)"
 #~ msgstr "Ne (gnome-vfs-config nenalezena)"
@@ -4724,20 +5838,20 @@ msgstr ""
 #~ msgstr "Prozkoumat ... ?"
 
 #~ msgid "Permissions:"
-#~ msgstr "Práva:"
+#~ msgstr "PrÃ¡va:"
 
 #~ msgid "file(1) says..."
-#~ msgstr "file(1) øíká..."
+#~ msgstr "file(1) Å™Ã­kÃ¡..."
 
 #~ msgid "Help about ... ?"
-#~ msgstr "Nápovìda k ... ?"
+#~ msgstr "NÃ¡povÄ›da k ... ?"
 
 #~ msgid ""
 #~ "Executable file:\n"
 #~ "This is a file with an eXecute bit set - it can be run as a program."
 #~ msgstr ""
-#~ "Spustitelnı soubor:\n"
-#~ "Tento soubor má nastaven bit pro spou¹tìní - mù¾e bıt spu¹tìn jako "
+#~ "SpustitelnÃ½ soubor:\n"
+#~ "Tento soubor mÃ¡ nastaven bit pro spouÅ¡tÄ›nÃ­ - mÅ¯Å¾e bÃ½t spuÅ¡tÄ›n jako "
 #~ "program."
 
 #~ msgid ""
@@ -4745,8 +5859,8 @@ msgstr ""
 #~ "This is a data file. Try using the Info menu item to find out more..."
 #~ msgstr ""
 #~ "Soubor:\n"
-#~ "Toto je datovı soubor. Zkuste pou¾ít nabídku Info v menu pro zji¹tìní "
-#~ "podrobností..."
+#~ "Toto je datovÃ½ soubor. Zkuste pouÅ¾Ã­t nabÃ­dku Info v menu pro zjiÅ¡tÄ›nÃ­ "
+#~ "podrobnostÃ­..."
 
 #~ msgid ""
 #~ "Mount point:\n"
@@ -4754,35 +5868,35 @@ msgstr ""
 #~ "on. Everything on the mounted filesystem then appears to be inside the "
 #~ "directory."
 #~ msgstr ""
-#~ "Bod pøipojení:\n"
-#~ "Bod pøipojení je adresáø, na kterı mù¾e bıt pøipojen jinı systém souborù. "
-#~ "V¹echno na pøipojeném systému souborù potom vypadá, ¾e je to uvnitø toho "
-#~ "adresáøe."
+#~ "Bod pÅ™ipojenÃ­:\n"
+#~ "Bod pÅ™ipojenÃ­ je adresÃ¡Å™, na kterÃ½ mÅ¯Å¾e bÃ½t pÅ™ipojen jinÃ½ systÃ©m souborÅ¯. "
+#~ "VÅ¡echno na pÅ™ipojenÃ©m systÃ©mu souborÅ¯ potom vypadÃ¡, Å¾e je to uvnitÅ™ toho "
+#~ "adresÃ¡Å™e."
 
 #~ msgid ""
 #~ "Device file:\n"
 #~ "Device files allow you to read from or write to a device driver as though "
 #~ "it was an ordinary file."
 #~ msgstr ""
-#~ "Soubor zaøízení:\n"
-#~ "Soubory zaøízení umo¾òují èíst a zapisovat na z/na zaøízení tak, jako by "
-#~ "to byl obyèejnı soubor."
+#~ "Soubor zaÅ™Ã­zenÃ­:\n"
+#~ "Soubory zaÅ™Ã­zenÃ­ umoÅ¾ÅˆujÃ­ ÄÃ­st a zapisovat na z/na zaÅ™Ã­zenÃ­ tak, jako by "
+#~ "to byl obyÄejnÃ½ soubor."
 
 #~ msgid ""
 #~ "Named pipe:\n"
 #~ "Pipes allow different programs to communicate. One program writes data to "
 #~ "the pipe while another one reads it out again."
 #~ msgstr ""
-#~ "Pojmenovaná roura:\n"
-#~ "Roury umo¾òují procesùm komunikovat. Jeden program zapisuje data do "
-#~ "roury, zatímco jinı program je ète."
+#~ "PojmenovanÃ¡ roura:\n"
+#~ "Roury umoÅ¾ÅˆujÃ­ procesÅ¯m komunikovat. Jeden program zapisuje data do "
+#~ "roury, zatÃ­mco jinÃ½ program je Äte."
 
 #~ msgid ""
 #~ "Socket:\n"
 #~ "Sockets allow processes to communicate."
 #~ msgstr ""
 #~ "Soket:\n"
-#~ "Sokety umo¾òují procesùm komunikovat mezi sebou."
+#~ "Sokety umoÅ¾ÅˆujÃ­ procesÅ¯m komunikovat mezi sebou."
 
 #~ msgid ""
 #~ "Door:\n"
@@ -4796,26 +5910,26 @@ msgstr ""
 #~ "I couldn't find out what kind of file this is. Maybe it doesn't exist "
 #~ "anymore or you don't have search permission on the directory it's in?"
 #~ msgstr ""
-#~ "Neznámı typ:\n"
-#~ "Jemohu urèit typ souboru. Mo¾ná u¾ neexistuje nebo nemáte právo pøístupu "
-#~ "do adresáøe, ve kterém se nachází?"
+#~ "NeznÃ¡mÃ½ typ:\n"
+#~ "Jemohu urÄit typ souboru. MoÅ¾nÃ¡ uÅ¾ neexistuje nebo nemÃ¡te prÃ¡vo pÅ™Ã­stupu "
+#~ "do adresÃ¡Å™e, ve kterÃ©m se nachÃ¡zÃ­?"
 
 #~ msgid ""
 #~ "Directory:\n"
 #~ "This is a directory. It contains an index to other items - open it to see "
 #~ "the list."
 #~ msgstr ""
-#~ "Adresáø:\n"
-#~ "Toto je adresáø. Obsahuje index jinıch polo¾ek - pokud chcete vidìt "
-#~ "seznam, tak jej otevøete."
+#~ "AdresÃ¡Å™:\n"
+#~ "Toto je adresÃ¡Å™. Obsahuje index jinÃ½ch poloÅ¾ek - pokud chcete vidÄ›t "
+#~ "seznam, tak jej otevÅ™ete."
 
 #~ msgid "Menu on button 2 (RISC OS style)"
-#~ msgstr "Zobrazit nabídku pøi stisku tlaèítka 2 (RISC OS styl)"
+#~ msgstr "Zobrazit nabÃ­dku pÅ™i stisku tlaÄÃ­tka 2 (RISC OS styl)"
 
 #~ msgid ""
 #~ "Use button 2, the middle button (click both buttons at once on two button "
 #~ "mice), to pop up the menu. If off, use button 3 (right) instead."
 #~ msgstr ""
-#~ "Pou¾ijte tlaèítko 2, prostøední tlaèítko (stisknìte obì tlaèítka na "
-#~ "dvotlaèítkové my¹i), k zobrazení nabídky. Pokud je tato volba vypnutá, "
-#~ "pu¾ijte tlaèítko 3 (pravé)."
+#~ "PouÅ¾ijte tlaÄÃ­tko 2, prostÅ™ednÃ­ tlaÄÃ­tko (stisknÄ›te obÄ› tlaÄÃ­tka na "
+#~ "dvotlaÄÃ­tkovÃ© myÅ¡i), k zobrazenÃ­ nabÃ­dky. Pokud je tato volba vypnutÃ¡, "
+#~ "puÅ¾ijte tlaÄÃ­tko 3 (pravÃ©)."

--- a/ROX-Filer/src/po/da.po
+++ b/ROX-Filer/src/po/da.po
@@ -1,67 +1,72 @@
 # Danish messages for ROX-Filer.
 # Copyright (C) 2002 Free Software Foundation, Inc.
 # Christian Storgaard <dannieglitter@gmail.com>, 2002-2005.
-# 
-# 
+#
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: ROX-Filer 2.1.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-08-09 14:02+0100\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2005-02-23 17:11+0100\n"
 "Last-Translator: Christan D. Storgaard <dannieglitter@gmail.com>\n"
 "Language-Team: Danish <dansk@klid.dk>\n"
+"Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: abox.c:127
-msgid "<dir>"
-msgstr "<mappe>"
+msgid "<src>"
+msgstr ""
 
-#: abox.c:219
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Stille"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Quiet"
 msgstr "Stille"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Kræv ikke bekræftelse for hver handling"
 
-#: abox.c:455 tips:60
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Navn"
 
-#: abox.c:461 menu.c:232
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Mappe"
 
-#: abox.c:550
+#: abox.c:546
 msgid "Expression:"
 msgstr "Udtryk:"
 
-#: action.c:58
+#: action.c:57
 #, fuzzy
 msgid "See the attr(5) man page for full details."
 msgstr "Se ROX-Filer manualen for detaljer."
 
-#: action.c:60
+#: action.c:59
 #, fuzzy
 msgid "See the fsattr(5) man page for full details."
 msgstr "Se ROX-Filer manualen for detaljer."
 
-#: action.c:62
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr ""
 
-#: action.c:188
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Find udtryks-reference"
 
-#: action.c:199
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -138,12 +143,12 @@ msgstr ""
 "a % i 'kommando' bliver erstattet med stien til den valgte fil)\n"
 "<b>beskær</b> (falsk, og forhindrer en mappe i at blive gennemsøgt)."
 
-#: action.c:246
+#: action.c:256
 #, fuzzy
 msgid "Change permissions reference"
 msgstr "Find udtryks-reference"
 
-#: action.c:257
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -202,11 +207,11 @@ msgstr ""
 "\n"
 "Se chmod(1) man-siden for detaljer."
 
-#: action.c:298
+#: action.c:308
 msgid "Set type reference"
 msgstr "Find udtryks reference"
 
-#: action.c:309
+#: action.c:319
 #, fuzzy
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
@@ -237,48 +242,55 @@ msgstr ""
 "filsystemer og hvor styresystemet understøtter dem.\n"
 "\n"
 
-#: action.c:416
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Processen er blevet afsluttet.\n"
 
-#: action.c:432
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Der skete 1 fejl.\n"
 
-#: action.c:434
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Der var %d fejl.\n"
 
-#: action.c:458
+#: action.c:516
 msgid "ERROR reading"
 msgstr "FEJL under læsning"
 
-#: action.c:501
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Færdig\n"
 
-#: action.c:557 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "FEJL"
 
-#: action.c:711 main.c:674 main.c:681 main.c:688
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Ja"
 
-#: action.c:714 main.c:676 main.c:690
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Nej"
 
-#: action.c:732
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -286,7 +298,7 @@ msgstr ""
 "\n"
 "Beder børne-processen om at afslutte...\n"
 
-#: action.c:739
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -294,41 +306,41 @@ msgstr ""
 "\n"
 "Prøver at lukke (KILL) den bortløbne proces...\n"
 
-#: action.c:892
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Tæl indehold af %s?"
 
-#: action.c:928
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Slet %s'%s'?"
 
-#: action.c:929
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "SKRIVE-BESKYTTET "
 
-#: action.c:936
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'Sletter '%s'\n"
 
-#: action.c:949
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'Mappen '%s' slettet\n"
 
-#: action.c:982
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?Skub '%s' ud?"
 
-#: action.c:989
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Skub '%s' ud\n"
 
-#: action.c:1008
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -337,80 +349,95 @@ msgstr ""
 "!%s\n"
 "skubben ud mislykkedes\n"
 
-#: action.c:1027 action.c:1046
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Check '%s'?"
 
-#: action.c:1043
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Ugyldige søge-parametre - ret dem og prøv igen\n"
 
-#: action.c:1053
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(imens '%s' bliver checket)\n"
 
-#: action.c:1127 action.c:1152
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Ændre tilladelserne på '%s'?"
 
-#: action.c:1133
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Ændrer tilladelserne på '%s'\n"
 
-#: action.c:1150
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Ugyldig mode kommando - ret den og prøv igen\n"
 
-#: action.c:1207 action.c:1227
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?Ændr typen på '%s'?"
+
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Ændr typen på '%s'?"
 
-#: action.c:1224
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Ugyldig type - ændr den og prøv igen\n"
 
-#: action.c:1246
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Ændrer typen på '%s' til '%s'\n"
 
-#: action.c:1325
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'Ændrer typen på '%s' til '%s'\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' findes allerede - %s?"
 
-#: action.c:1327
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "sammensmelt indehold"
 
-#: action.c:1328
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "overskriv"
 
-#: action.c:1344
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Prøver at kopiere alligevel...\n"
 
-#: action.c:1353
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Kopier %s som %s?"
 
-#: action.c:1357
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Kopierer %s som %s\n"
 
-#: action.c:1372
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!FEJL: Destinationen findes allerede, men er ikke en mappe\n"
 
-#: action.c:1444
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -419,26 +446,7 @@ msgstr ""
 "!%s\n"
 "Kopiering af '%s' mislykkedes\n"
 
-#: action.c:1488
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' findes allerede - overskriv?"
-
-#: action.c:1503
-msgid "'Trying move anyway...\n"
-msgstr "'Prøver at flytte alligevel...\n"
-
-#: action.c:1511
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Flyt %s som %s?"
-
-#: action.c:1515
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Flytter %s som %s\n"
-
-#: action.c:1523
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -447,45 +455,59 @@ msgstr ""
 "!%s\n"
 "!FEJL: Mislykkedes i at flytte %s som %s\n"
 
-#: action.c:1544
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Prøver at flytte alligevel...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Flyt %s som %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Flytter %s som %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!FEJL: Kan ikke kopiere object til sig selv\n"
 
-#: action.c:1559
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!FEJL: Kan ikke flytte/omdøbe objekt til sig selv\n"
 
-#: action.c:1571
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Opretter lænke til %s som %s\n"
 
-#: action.c:1576
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Opret lænke til %s som %s?"
 
-#: action.c:1618
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Monterer %s\n"
 
-#: action.c:1619
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Afmonterer %s\n"
 
-#: action.c:1622
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?Montér %s?"
 
-#: action.c:1623
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?Afmontér %s?"
 
-#: action.c:1643
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -494,7 +516,7 @@ msgstr ""
 "!%s\n"
 "Monteringen mislykkedes\n"
 
-#: action.c:1644
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -503,11 +525,11 @@ msgstr ""
 "!%s\n"
 "Afmontering mislykkedes\n"
 
-#: action.c:1652
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(lader til at være monteret nu alligevel)\n"
 
-#: action.c:1698
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -516,211 +538,235 @@ msgstr ""
 "'\n"
 "Total: %s ("
 
-#: action.c:1704
+#: action.c:2108
 msgid "file"
 msgstr "fil"
 
-#: action.c:1704
+#: action.c:2108
 msgid "files"
 msgstr "filer"
 
-#: action.c:1708
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "ingen mapper)\n"
 
-#: action.c:1712
+#: action.c:2116
 msgid "directory"
 msgstr "mappe"
 
-#: action.c:1713
+#: action.c:2117
 msgid "directories"
 msgstr "mapper"
 
-#: action.c:1754
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Der er ikke valgt nogen monterings-punkter!\n"
 
-#: action.c:1839
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?En søgning til?"
 
-#: action.c:1869 action.c:1900
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' er en symbolsk lænke\n"
 
-#: action.c:1940
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "Du skal vælge nogle ting at gennemsøge"
 
-#: action.c:1950 menu.c:223
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Find"
 
-#: action.c:1983
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Du skal vælge nogle ting at tælle"
 
-#: action.c:1987
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Disk Brug"
 
-#: action.c:2021
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Montér / Afmontér"
 
-#: action.c:2034
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr ""
 "ROX-Filer understøtter desværre endnu ikke monterings-punkter under dit "
 "system."
 
-#: action.c:2048 menu.c:210 tips:208
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Slet"
 
-#: action.c:2058 tips:213
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Tving"
 
-#: action.c:2058
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Spørg ikke igen omkring sletning af ikke-skrivbare objekter."
 
-#: action.c:2061 action.c:2116 action.c:2175 action.c:2228 action.c:2264
-#: tips:215
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Kort"
 
-#: action.c:2061
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Lav kun log over sletning af mapper"
 
-#: action.c:2078
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "Du skal vælge hvilke objekter du vil ændre tilladelser på"
 
-#: action.c:2086
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Gør udførbar/søgelig)"
 
-#: action.c:2088
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (Gør ikke-udførbar/ikke-søgelig)"
 
-#: action.c:2090
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Giv ejer læs+skriv)"
 
-#: action.c:2092
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Privat - kun ejer adgang)"
 
-#: action.c:2094
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Offentlig adgang, ikke skrivbar)"
 
-#: action.c:2105 menu.c:184 menu.c:221 tips:75
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Tilladdelser"
 
-#: action.c:2116 action.c:2175
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Oprems ikke bearbejdede filer "
 
-#: action.c:2119 action.c:2178 tips:217
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Rekursivt"
 
-#: action.c:2119
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Indholdet af undermapper skal også ændres."
 
-#: action.c:2123
+#: action.c:2547
 msgid "Command:"
 msgstr "Kommando:"
 
-#: action.c:2151
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Du skal vælge hvilke objekter du vil ændre typen af"
 
-#: action.c:2164
+#: action.c:2590
 msgid "Set type"
 msgstr "Sæt type"
 
-#: action.c:2178
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Ændr indholdet af undermapper"
 
-#: action.c:2185 infobox.c:615
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Type:"
 
-#: action.c:2214 dnd.c:124 menu.c:1999 tips:202
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Kopier"
 
-#: action.c:2224 action.c:2260 tips:219
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Kræv ikke bekræftelse for hver handling"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Overskriv kun hvis kilden er nyere end destinationen."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Nyere"
 
-#: action.c:2225 action.c:2261 tips:220
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Overskriv kun hvis kilden er nyere end destinationen."
 
-#: action.c:2228
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "mapper"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Lav kun log over mapper efterhånden som de bliver kopieret"
 
-#: action.c:2250 dnd.c:125 tips:204
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Flyt"
 
-#: action.c:2264
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Lav ikke log over filer der bliver flyttet"
 
-#: action.c:2284 tips:206
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Lav Lænke"
 
-#: action.c:2303 appmenu.c:113
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Skub ud"
 
-#: action.c:2360
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Sletter objekter som f.eks. "
 
-#: action.c:2364
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Sletter objektet "
 
-#: action.c:2366
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Sletter objekterne "
 
-#: action.c:2385
+#: action.c:2900
 msgid " and "
 msgstr " og "
 
-#: action.c:2394
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr ""
 " vil påvirke nogle objekter på opslagstavlen eller panelet - virkelig slette "
 "den?"
 
-#: action.c:2401
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr ""
 " vil påvirke nogle objekter på opslagstavlen eller panelet - virkelig slette "
 "dem?"
 
-#: appmenu.c:198
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<manglende titel>"
 
-#: appmenu.c:295
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
@@ -729,86 +775,86 @@ msgstr ""
 "Lav symbolske lænker, til ethvert program du ønsker, i denne mappe. De vil "
 "være at finde i menuen for alle objekter af denne type (%s/%s)."
 
-#: appmenu.c:339 menu.c:234
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Indstil Menu..."
 
-#: appmenu.c:396 menu.c:251 toolbar.c:159
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Hjælp"
 
-#: bookmarks.c:147
-msgid "Path"
-msgstr "Sti"
-
-#: bookmarks.c:155
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Tittel"
 
-#: bookmarks.c:304
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Sti"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Kan ikke lave et bogmærke til den ikke-lokale resource '%s'\n"
 
-#: bookmarks.c:312 bookmarks.c:630
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' er ikke en mappe"
 
-#: bookmarks.c:518
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Du skal først vælge nogle linjer at fjerne"
 
-#: bookmarks.c:542
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Placér markøren på det objekt i listen du vil flytte"
 
-#: bookmarks.c:562
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Dette objekt er allerede i slutningen"
 
-#: bookmarks.c:636
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Kan ikke lave bogmærker til ikke-lokale mapper som '%s'"
 
-#: bookmarks.c:778
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Tilføj Nyt Bogmærke"
 
-#: bookmarks.c:785
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Redigér Bogmærker"
 
-#: bookmarks.c:790
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "For Nyligt Besøgte"
 
-#: bulk_rename.c:68
+#: bulk_rename.c:69
 #, fuzzy
 msgid "Bulk rename files"
 msgstr "Genlæs filer"
 
-#: bulk_rename.c:71
+#: bulk_rename.c:72
 #, fuzzy
 msgid "Reset"
 msgstr "_Fortryd ændringer"
 
-#: bulk_rename.c:76
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr ""
 
-#: bulk_rename.c:81
+#: bulk_rename.c:82
 #, fuzzy
 msgid "_Rename"
 msgstr "Omdøb"
 
-#: bulk_rename.c:94
+#: bulk_rename.c:95
 #, fuzzy
 msgid "Replace:"
 msgstr "_Erstat"
 
-#: bulk_rename.c:101
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -824,58 +870,59 @@ msgstr "Skriv"
 
 #: bulk_rename.c:116
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Slå til"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
 msgstr ""
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr ""
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 #, fuzzy
 msgid "New name"
 msgstr "Omdøb"
 
-#: bulk_rename.c:259
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr ""
 
-#: bulk_rename.c:264
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr ""
 
-#: bulk_rename.c:267
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr ""
 
-#: bulk_rename.c:293
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr ""
 
-#: bulk_rename.c:310
+#: bulk_rename.c:347
 #, fuzzy, c-format
 msgid "%s (for '%s')"
 msgstr "%s-'%s'"
 
-#: bulk_rename.c:343
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr ""
 
-#: bulk_rename.c:348
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -883,65 +930,81 @@ msgid ""
 "Aborting bulk rename."
 msgstr ""
 
-#: bulk_rename.c:410
+#: bulk_rename.c:447
 #, fuzzy, c-format
 msgid "A file called '%s' already exists"
 msgstr "?'%s' findes allerede - %s?"
 
-#: bulk_rename.c:421
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
 "files to end up in different directories. Continue?"
 msgstr ""
 
-#: bulk_rename.c:436
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr ""
 
-#: choices.c:428
-#, fuzzy
-msgid "Choices migration"
-msgstr "Kinesisk (traditionel)"
+#: choices.c:434
+#, c-format
+msgid "%d directories could not be migrated"
+msgstr ""
 
 #: choices.c:436
 #, c-format
 msgid ""
 "Choices have been moved from \n"
-"<b>%s</b>\n"
+"%s\n"
 " to the new location \n"
-"<b>%s</b>\n"
+"%s\n"
+"%s"
 msgstr ""
 
-#: choices.c:447
-#, c-format
-msgid "%d directories could not be migrated"
-msgstr ""
-
-#: dir.c:982
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Kan ikke få info om mappen: %s"
 
-#: dir.c:991
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Kan ikke åbne mappen: %s"
 
-#: display.c:588
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Størrelse"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) mislykkedes: %s"
 
-#: dnd.c:126
-msgid "Link (relative)"
-msgstr ""
-
-#: dnd.c:127
-msgid "Link (absolute)"
-msgstr ""
-
-#: dnd.c:426
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Intern fejl - dårlig info type"
 
@@ -1024,14 +1087,14 @@ msgid ""
 msgstr ""
 "Kan ikke få dataen fra anden maskine (application/octet-stream ikke givet)"
 
-#: dnd.c:1016
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
 "Nogle af disse filer er på en anden maskine - de vil blive ignoreret - "
 "desværre"
 
-#: dnd.c:1023
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
@@ -1039,28 +1102,44 @@ msgstr ""
 "Ingen af disse filer er på denne maskine - Jeg kan ikke arbejde på netwærks-"
 "filer - desværre."
 
-#: dnd.c:1036
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Ukendt handling anmodet"
 
-#: dnd.c:1044
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Fejl uder hentning af fil-liste: %s"
 
-#: dropbox.c:114
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr ""
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr ""
+
+#: dnd.c:1109
+msgid "Link (relative, sym path)"
+msgstr ""
+
+#: dnd.c:1110
+msgid "Link (absolute, sym path)"
+msgstr ""
+
+#: dropbox.c:112
 msgid "Show"
 msgstr "Vis"
 
-#: dropbox.c:120
+#: dropbox.c:118
 msgid "Show the current choice in a filer window"
 msgstr "Vis the nuværende valg i et 'filer' vindue"
 
-#: dropbox.c:174
+#: dropbox.c:172
 msgid "<nothing>"
 msgstr "<intet>"
 
-#: dropbox.c:239
+#: dropbox.c:237
 msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
@@ -1068,16 +1147,16 @@ msgstr ""
 "Jeg kan ikke vise dig det nuværende valgte objekt da intet er valgt. Træk "
 "noget hen på mig!"
 
-#: dropbox.c:263
+#: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
 msgstr "Desværre; du kan kun slippe én fil oven på slip-området."
 
-#: dropbox.c:273
+#: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr "Jeg kan desværre ikke bruge '%s', da det ikke er en lokal fil."
 
-#: dropbox.c:280 pinboard.c:853
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1086,7 +1165,7 @@ msgstr ""
 "Kan ikke få adgang til '%s':\n"
 "%s"
 
-#: filer.c:453
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1095,16 +1174,7 @@ msgstr ""
 "Fejl under scanning af '%s':\n"
 "%s\n"
 
-#: filer.c:457
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Fejl under scanning af '%s:\n"
-"%s"
-
-#: filer.c:562
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1114,20 +1184,20 @@ msgstr ""
 "\n"
 "Ved at afmontere en enhed er det sikkert at fjerne disken."
 
-#: filer.c:566
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 #, fuzzy
 msgid "No change"
 msgstr "Intet"
 
-#: filer.c:572 menu.c:862
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Afmontér"
 
-#: filer.c:669
-msgid "Directory missing/deleted"
-msgstr "Mappe mangler/slettet"
-
-#: filer.c:1031
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
@@ -1137,314 +1207,373 @@ msgstr ""
 "Gruppen %s er ikke sat. Vælg nogle filer og tryk Ctrl+%s for at huske "
 "gruppen. Tryk %s alene for at genvælge filerne senere."
 
-#: filer.c:1267
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Mappen '%s' er ikke tilgænglig"
+#: filer.c:2655
+msgid "A"
+msgstr ""
 
-#: filer.c:1419
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Mappen '%s' kan ikke findes."
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
 
-#: filer.c:1713
-msgid "Cancel"
-msgstr "Fortryd"
+#: filer.c:2659 find.c:923
+msgid "G"
+msgstr ""
 
-#: filer.c:2002
+#: filer.c:2664
 msgid "S"
 msgstr "K"
 
-#: filer.c:2004
+#: filer.c:2669
 msgid "T"
 msgstr "M"
 
-#: filer.c:2026
+#: filer.c:2670
+msgid "D"
+msgstr ""
+
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
+#, c-format
+msgid "Glob (%s), "
+msgstr ""
+
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Scanner, "
 
-#: filer.c:2028
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Thumbs, "
 
-#: filer.c:2304
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Thumbs, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Symbolsk lænke til "
 
-#: filer.c:2335
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "Dette filnavn er ikke i korrekt UTF-8. Du bør omdøbe den.\n"
 
-#: filer.c:2643 menu.c:1989
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "Objektet eksisterer ikke længere!"
 
-#: filer.c:3327
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Vælg hvilke visnings-indstillinger der skal gemmes"
 
-#: filer.c:3334
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Vælg hvilke visnings-indstillinger der skal gemmes"
+
+#: filer.c:4727
 msgid "Position"
 msgstr "Position"
 
-#: filer.c:3339 toolbar.c:135 toolbar.c:139 tips:63
-msgid "Size"
-msgstr "Størrelse"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Vindues-størrelse grænse"
 
-#: filer.c:3344
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Vis skjulte"
 
-#: filer.c:3350
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Visnings-stil"
 
-#: filer.c:3356
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Sorterings-type og rækkefølge"
 
-#: filer.c:3361 toolbar.c:143
+#: filer.c:4754
 msgid "Details"
 msgstr "Detaljer"
 
-#: filer.c:3366 tips:114 tips:115
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Miniature"
 
-#: filer.c:3372
+#: filer.c:4765
 msgid "Filter"
 msgstr "Filter"
 
-#: find.c:487
+#: find.c:485
 msgid "And"
 msgstr "Og"
 
-#: find.c:511
+#: find.c:509
 msgid "Not"
 msgstr "Ikke"
 
-#: find.c:554
+#: find.c:552
 msgid "system"
 msgstr "system"
 
-#: find.c:562
+#: find.c:560
 msgid "prune"
 msgstr "beskær"
 
-#: find.c:650
+#: find.c:648
 msgid "After"
 msgstr "Efter"
 
-#: find.c:652
+#: find.c:650
 msgid "Before"
 msgstr "Før"
 
-#: find.c:746
+#: find.c:744
 msgid "IsReg"
 msgstr "ErNorm"
 
-#: find.c:748
+#: find.c:746
 msgid "IsLink"
 msgstr "ErLænke"
 
-#: find.c:750
+#: find.c:748
 msgid "IsDir"
 msgstr "ErMappe"
 
-#: find.c:752
+#: find.c:750
 msgid "IsChar"
 msgstr "ErKar"
 
-#: find.c:754
+#: find.c:752
 msgid "IsBlock"
 msgstr "ErBlok"
 
-#: find.c:756
+#: find.c:754
 msgid "IsDev"
 msgstr "ErEnhed"
 
-#: find.c:758
+#: find.c:756
 msgid "IsPipe"
 msgstr "ErRør"
 
-#: find.c:760
+#: find.c:758
 msgid "IsSocket"
 msgstr "ErStik"
 
-#: find.c:762
+#: find.c:760
 msgid "IsDoor"
 msgstr "ErDør"
 
-#: find.c:764
+#: find.c:762
 msgid "IsSUID"
 msgstr "ErSUID"
 
-#: find.c:766
+#: find.c:764
 msgid "IsSGID"
 msgstr "ErSGID"
 
-#: find.c:768
+#: find.c:766
 msgid "IsSticky"
 msgstr "ErKlæbrig"
 
-#: find.c:770
+#: find.c:768
 msgid "IsReadable"
 msgstr "ErLæselig"
 
-#: find.c:772
+#: find.c:770
 msgid "IsWriteable"
 msgstr "ErSkrivbar"
 
-#: find.c:774
+#: find.c:772
 msgid "IsExecutable"
 msgstr "ErUdførbar"
 
-#: find.c:776
+#: find.c:774
 msgid "IsEmpty"
 msgstr "ErTom"
 
-#: find.c:778
+#: find.c:776
 msgid "IsMine"
 msgstr "ErMin"
 
-#: find.c:906
+#: find.c:904
 msgid "Now"
 msgstr "Nu"
 
-#: find.c:919
+#: find.c:917
 msgid "Byte"
 msgstr "Byte"
 
-#: find.c:919
+#: find.c:917
 msgid "Bytes"
 msgstr "Byte"
 
-#: find.c:921
+#: find.c:919
 msgid "Kb"
 msgstr ""
 
-#: find.c:921
+#: find.c:919
 #, fuzzy
 msgid "K"
 msgstr "OK"
 
-#: find.c:923
+#: find.c:921
 msgid "Mb"
 msgstr ""
 
-#: find.c:923
+#: find.c:921
 msgid "M"
 msgstr ""
 
-#: find.c:925
+#: find.c:923
 msgid "Gb"
 msgstr ""
 
 #: find.c:925
-msgid "G"
-msgstr ""
-
-#: find.c:927
 msgid "Sec"
 msgstr "Sek"
 
-#: find.c:927
+#: find.c:925
 msgid "Secs"
 msgstr "Sekunder"
 
-#: find.c:929
+#: find.c:927
 msgid "Min"
 msgstr "Min"
 
-#: find.c:929
+#: find.c:927
 msgid "Mins"
 msgstr "Minutter"
 
-#: find.c:931
+#: find.c:929
 msgid "Hour"
 msgstr "Time"
 
-#: find.c:931
+#: find.c:929
 msgid "Hours"
 msgstr "Timer"
 
-#: find.c:933
+#: find.c:931
 msgid "Day"
 msgstr "Dag"
 
-#: find.c:933
+#: find.c:931
 msgid "Days"
 msgstr "Dage"
 
-#: find.c:935
+#: find.c:933
 msgid "Week"
 msgstr "Uge"
 
-#: find.c:935
+#: find.c:933
 msgid "Weeks"
 msgstr "Uger"
 
-#: find.c:937
+#: find.c:935
 msgid "Year"
 msgstr "År"
 
-#: find.c:937
+#: find.c:935
 msgid "Years"
 msgstr "År"
 
-#: find.c:946
+#: find.c:944
 msgid "Ago"
 msgstr "Siden"
 
-#: find.c:948
+#: find.c:946
 msgid "Hence"
 msgstr "Fra nu"
 
-#: find.c:963
+#: find.c:961
 msgid "atime"
 msgstr "atid"
 
-#: find.c:965
+#: find.c:963
 msgid "ctime"
 msgstr "ctid"
 
-#: find.c:967
+#: find.c:965
 msgid "mtime"
 msgstr "mtid"
 
-#: find.c:969
+#: find.c:967
 msgid "size"
 msgstr "størrelse"
 
-#: find.c:971
+#: find.c:969
 msgid "inode"
 msgstr "inode"
 
-#: find.c:973
+#: find.c:971
 msgid "nlinks"
 msgstr "nlænke"
 
-#: find.c:975
+#: find.c:973
 msgid "uid"
 msgstr "uid"
 
-#: find.c:977
+#: find.c:975
 msgid "gid"
 msgstr "gid"
 
-#: find.c:979
+#: find.c:977
 msgid "blocks"
 msgstr "blokke"
 
-#: gtksavebox.c:251
+#: gtksavebox.c:249
 msgid "Save As:"
 msgstr "Gem som:"
 
-#: gtksavebox.c:397
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Unavngivet"
 
-#: gtksavebox.c:473
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
@@ -1452,7 +1581,7 @@ msgstr ""
 "Det andet program vil gerne bruge Direct Save, men jeg kan ikke læse "
 "XdndDirectSave0 (type text/plain) delen.\n"
 
-#: gtksavebox.c:598
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1460,7 +1589,7 @@ msgstr ""
 "Træk ikonet til en mappe-oversigt\n"
 "(eller skriv den fulde sti)"
 
-#: gui_support.c:331
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1468,19 +1597,20 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:400
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr ""
 "Forsøg på at læse en XML fil som en tekst fil. Filen '%s' er måske ødelagt."
 
-#: gui_support.c:417
-#, c-format
+#: gui_support.c:542
+#, fuzzy, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
 "This may be due to upgrading from a previous version of ROX-Filer. Open the "
-"Options window and click on Save.\n"
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
 "Fejl i '%s' filen på linie %d: \n"
@@ -1489,32 +1619,33 @@ msgstr ""
 "Åben Indstillinger-vinduet og klik på Gem.\n"
 "Flere fejl vil blive ignorerede."
 
-#: gui_support.c:1000
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Ukorrekt eller manglende linje-afslutning i tekst/uri-liste data"
 
-#: gui_support.c:1332
+#: gui_support.c:1473
 #, fuzzy, c-format
 msgid "Failed to open file '%s': %s"
 msgstr ""
 "Det lykkedes ikke at aflænke '%s':\n"
 "%s"
 
-#: gui_support.c:1376
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
 msgstr ""
 
-#: gui_support.c:1427
+#: gui_support.c:1583
+#, c-format
 msgid ""
-"This program cannot be run, as the 0launch command is not available. It can "
-"be downloaded from here:\n"
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
 
-#: i18n.c:38
+#: i18n.c:39
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
@@ -1522,154 +1653,177 @@ msgstr ""
 "Bemærk at du skal gemme dine valg og genstarte programmet før den nye sprog "
 "indstillling tager fuld effekt."
 
-#: icon.c:78
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(klik for at sætte)"
 
-#: icon.c:133
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:134 menu.c:252
-msgid "About ROX-Filer..."
-msgstr "Om ROX-Filer..."
-
-#: icon.c:135 menu.c:253
-msgid "Show Help Files"
-msgstr "Vis Hjælpe-filer"
-
-#: icon.c:136 menu.c:254
-msgid "Manual"
-msgstr "Manual"
-
-#: icon.c:138 menu.c:230
-msgid "Options..."
-msgstr "Indstillinger..."
-
-#: icon.c:139 menu.c:239
-msgid "Home Directory"
-msgstr "Hjemme-mappen"
-
-#: icon.c:140 icon.c:1340 menu.c:206 type.c:212
-msgid "File"
-msgstr "Fil"
-
-#: icon.c:141 menu.c:212 menu.c:875
-msgid "Shift Open"
-msgstr "Shift Åben"
-
-#: icon.c:142 menu.c:218
-msgid "Properties"
-msgstr "Egenskaber"
-
-#: icon.c:143 menu.c:216
-msgid "Set Run Action..."
-msgstr "Sæt Kør Hændelse..."
-
-#: icon.c:144 menu.c:217
-msgid "Set Icon..."
-msgstr "Definer Ikon..."
-
-#: icon.c:145 icon.c:806
-msgid "Edit Item"
-msgstr "Rediger Objekt"
-
-#: icon.c:146
-msgid "Show Location"
-msgstr "Vis Oprindelse"
-
-#: icon.c:147
-msgid "Remove Item(s)"
-msgstr "Fjern Objekt(er)"
-
-#: icon.c:278 menu.c:764
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s-'%s'"
 
-#: icon.c:291
+#: icon.c:311
 msgid "Nothing"
 msgstr "Intet"
 
-#: icon.c:547
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "Stien skal indeholde i hvertfald et tegn!"
 
-#: icon.c:613
+#: icon.c:641
+#, c-format
+msgid "You must unlock '%s' before removing it"
+msgstr ""
+
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Du skal først vælge nogle objekter at fjerne"
 
-#: icon.c:627
+#: icon.c:657
+msgid "An item must be unlocked before it can be removed."
+msgstr ""
+
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Du skal åbne menuen over et objekt"
 
-#: icon.c:652 menu.c:1260
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "Du kan kun sætte kør hændelsen for en normal fil"
 
-#: icon.c:738
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Tryk den ønskede genvej (f.eks. Control+F1)"
 
-#: icon.c:760
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Kunne ikke få fat i tastaturet!"
 
-#: icon.c:809
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Rediger Objekt"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Et klik på ikonet åbner:"
 
-#: icon.c:819
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Argumenter der skal videregives (for udførbare filer):"
 
-#: icon.c:833
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "Teksten der bliver vist under ikonet er:"
 
-#: icon.c:846
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "Tastatur-genvejen er:"
 
-#: infobox.c:112
+#: icon.c:910
+#, fuzzy
+msgid "Locked"
+msgstr "Socket"
+
+#: icon.c:915
+msgid "Locking an item prevents it from being accidentally removed"
+msgstr ""
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Om ROX-Filer..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Vis Hjælpe-filer"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Manual"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Indstillinger..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Hjemme-mappen"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Fil"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Shift Åben"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Egenskaber"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Sæt Kør Hændelse..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Definer Ikon..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Vis Oprindelse"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Fjern Objekt(er)"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
 msgstr "Er du sikker på at du vil åbne %d vinduer?"
 
-#: infobox.c:113
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Vis Info"
 
-#: infobox.c:135 menu.c:769
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(ukorrekt uft-8)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Vis _Hjælpe-filer"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Tilladdelser</b>"
 
-#: infobox.c:286
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>Lader til at være...</b>"
 
-#: infobox.c:423 infobox.c:560 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Lav kun log over mapper efterhånden som de bliver kopieret"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "byte"
 
-#: infobox.c:446
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Det lykkedes ikke at læse størrelsen"
 
-#: infobox.c:504
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' er ikke længere en symbolsk lænke"
 
-#: infobox.c:511
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1678,7 +1832,7 @@ msgstr ""
 "Det lykkedes ikke at aflænke '%s':\n"
 "%s"
 
-#: infobox.c:516
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1689,146 +1843,195 @@ msgstr ""
 "%s\n"
 "(bemærk: den gamle lænke er blevet fjernet)"
 
-#: infobox.c:539 tips:270
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Fejl:"
 
-#: infobox.c:546
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Rigtige mappe:"
 
-#: infobox.c:549
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Ejer, Gruppe:"
 
-#: infobox.c:556 infobox.c:571 infobox.c:580
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Størrelse:"
 
-#: infobox.c:581
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Scanner"
 
-#: infobox.c:602
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Det lykkedes ikke at skanne"
 
-#: infobox.c:609
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Ændre tid:"
 
-#: infobox.c:611
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Modificer tid:"
 
-#: infobox.c:613
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Ændrings tid:"
 
-#: infobox.c:621
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr ""
 
-#: infobox.c:623
+#: infobox.c:667
 msgid "Present"
 msgstr ""
 
-#: infobox.c:624
+#: infobox.c:668
 msgid "None"
 msgstr "Ingen"
 
-#: infobox.c:625
+#: infobox.c:669
 #, fuzzy
 msgid "Not supported"
 msgstr "Dnotify-understøttelse"
 
-#: infobox.c:637
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Lænke-mål:"
 
-#: infobox.c:649 infobox.c:652
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Kør handling:"
 
-#: infobox.c:649
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Kørbar fil"
 
-#: infobox.c:744
+#: infobox.c:805
+#, fuzzy
+msgid "Comment"
+msgstr "Kommando:"
+
+#: infobox.c:807
+#, fuzzy
+msgid "Execute"
+msgstr "Kørbar fil"
+
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<intet endnu>"
 
-#: infobox.c:814
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "file(1) siger... %s"
 
-#: infobox.c:871
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Kunne ikke ændre indstillingerne: %s"
 
-#: infobox.c:889
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Ejer"
 
-#: infobox.c:891
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Gruppe"
 
-#: infobox.c:893
+#: infobox.c:974
 msgid "World"
 msgstr "Andre"
 
-#: infobox.c:896
+#: infobox.c:977
 msgid "Read"
 msgstr "Læs"
 
-#: infobox.c:898
+#: infobox.c:980
 msgid "Write"
 msgstr "Skriv"
 
-#: infobox.c:900
+#: infobox.c:983
 msgid "Exec"
 msgstr "Udfør"
 
-#: infobox.c:917
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:924
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:931
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Klæbrig"
 
-#: infobox.c:953
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<intet>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Symbolsk lænke"
 
-#: infobox.c:956
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX programmet"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "mounted"
 msgstr "monteret"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "ikke monteret"
 
-#: infobox.c:968
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Monteringspunktet for %s (%s)"
 
-#: infobox.c:971
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Monteringspunkt (%s)"
+
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d objekter"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Kopier..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "objekt"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Tider"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Program"
 
 #: main.c:95
 #, fuzzy
@@ -1865,7 +2068,7 @@ msgstr ""
 "du bliver nød til at bruge de korte istedet.\n"
 
 #: main.c:115
-#, fuzzy
+#, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Open each directory or file listed, or the current working\n"
@@ -1887,10 +2090,12 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
-"Report bugs to "
+"Report bugs to %s.\n"
+"Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
 "Anvendelse: ROX-Filer/AppRun [VALGMULIGHEDER]... [FIL]...\n"
 "Åbn hver mappe eller fil givet, eller den nuværende arbejds\n"
@@ -1916,15 +2121,7 @@ msgstr ""
 "\n"
 "Rapporter fejl til "
 
-#: main.c:136
-msgid ""
-".\n"
-"Home page (including updated versions): http://rox.sourceforge.net/\n"
-msgstr ""
-".\n"
-"Hjemmeside (med nyere udgaver): http://rox.sourceforge.net/\n"
-
-#: main.c:234
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1932,7 +2129,7 @@ msgid ""
 "Trying to continue..."
 msgstr ""
 
-#: main.c:382
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
@@ -1940,279 +2137,378 @@ msgstr ""
 "Argumentet -o bliver ikke længere brugt. Du kan slå tilsidesættelse til i "
 "Indstillings-vinduet i stedet."
 
-#: main.c:489
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Kører som bruger '%s'"
 
-#: main.c:666
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Kompileret med GTK version %s\n"
 
-#: main.c:667
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Kører med GTK version %d.%d.%d\n"
 
-#: main.c:671
+#: main.c:693
 msgid "features set at compile time"
 msgstr "funktioner sat ved kompilerings tid"
 
-#: main.c:672
+#: main.c:694
 msgid "Large File Support"
 msgstr "Understøttelse af Store Filer"
 
-#: main.c:679
-msgid "GNOME-VFS library"
-msgstr "GNOME-VFS-bibliotek"
-
-#: main.c:683
-msgid "No (need 2.8.0 or later)"
-msgstr "Nej (kræver 2.8.0 eller nyere)"
-
-#: main.c:686
-msgid "Dnotify support"
-msgstr "Dnotify-understøttelse"
-
-#: main.c:693
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Binær kompatibel"
 
-#: main.c:695
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Ja (kan køre med ældre udgaver af glibc)"
 
-#: main.c:697
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Nej (apsymbols.h er ikke fundet)"
 
-#: menu.c:180 tips:52
+#: main.c:709
+#, fuzzy
+msgid "Extended attribute support"
+msgstr "Bug ikke værtsnavn"
+
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr ""
+"Det lykkedes ikke at aflænke '%s':\n"
+"%s"
+
+#: main.c:895
+#, c-format
+msgid ""
+"Left-click to run %s.\n"
+"Right-click for a list of versions."
+msgstr ""
+
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Fejl under skabning af: '%s': %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Gem som:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Vis"
 
-#: menu.c:181 tips:57
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "Ikon-visning"
 
-#: menu.c:182
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "Ikoner, Med..."
 
-#: menu.c:183 tips:74
-msgid "Sizes"
-msgstr "Størrelser"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Ikon-tema"
 
-#: menu.c:185 tips:254
-msgid "Types"
-msgstr "Typer"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Tilladdelser"
 
-#: menu.c:186 tips:77
-msgid "Times"
-msgstr "Tider"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Ikoner, Med..."
 
-#: menu.c:187 tips:58 tips:92
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "Liste-visning"
 
-#: menu.c:189
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "Størrere Ikoner"
 
-#: menu.c:190
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "Mindre Ikoner"
 
-#: menu.c:191 tips:71
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Automatisk"
 
-#: menu.c:193
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Sortér efter Navn"
 
-#: menu.c:194
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Sortér efter Type"
 
-#: menu.c:195
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Sortér efter Dato"
 
-#: menu.c:196
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Sortér efter Dato"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Sortér efter Dato"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Sortér efter Størrelse"
 
-#: menu.c:197
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Tilladdelser"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "Sortér efter Ejer"
 
-#: menu.c:198
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "Sortér efter Gruppe"
 
-#: menu.c:199
+#: menu.c:671
 msgid "Reversed"
 msgstr "Omvendt"
 
-#: menu.c:201
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "Vis Skjulte"
 
-#: menu.c:202
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Vis Hjælpe-filer"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "ingen mapper)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "Filtrér Filer..."
 
-#: menu.c:203
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Filtrér Filer..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "Vis Thumbnails"
 
-#: menu.c:204
+#: menu.c:683
 msgid "Refresh"
 msgstr "Opdater"
 
-#: menu.c:205
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Opdater"
+
+#: menu.c:686
 msgid "Save Display Settings..."
 msgstr "Gem Visnings-indstillinger..."
 
-#: menu.c:207
-msgid "Copy..."
-msgstr "Kopier..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Gem Visnings-indstillinger..."
 
-#: menu.c:208
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Tæl"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "Omdøb..."
 
-#: menu.c:209
+#: menu.c:700
 msgid "Link..."
 msgstr "Lav Lænke..."
 
-#: menu.c:213
-msgid "Open AVFS"
-msgstr "Open med AVFS"
-
-#: menu.c:214
+#: menu.c:708
 msgid "Send To..."
 msgstr "Send til..."
 
-#: menu.c:219
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Bug ikke værtsnavn"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Tæl"
 
-#: menu.c:220
+#: menu.c:723
 msgid "Set Type..."
 msgstr "Sæt Type..."
 
-#: menu.c:224 toolbar.c:155
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Vælg"
 
-#: menu.c:225
+#: menu.c:733
 msgid "Select All"
 msgstr "Vælg Alle"
 
-#: menu.c:226
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "Vælg Ingen"
 
-#: menu.c:227
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "Vend Valg Om"
 
-#: menu.c:228
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "Vælg efter Navn..."
 
-#: menu.c:229
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Vælg Hvis..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Vælg Hvis..."
 
-#: menu.c:231
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Ny"
 
-#: menu.c:233
+#: menu.c:752
 msgid "Blank file"
 msgstr "Tom fil"
 
-#: menu.c:235 tasklist.c:308
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Vindue"
 
-#: menu.c:236
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "Overmappe, Nyt Vindue"
 
-#: menu.c:237
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "Overmappe, Samme Vindue"
 
-#: menu.c:238
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "Nyt Vindue"
 
-#: menu.c:240
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "Vis Bogmærker"
 
-#: menu.c:241
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Vis Info"
+
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "Følg Symbolske Lænker"
 
-#: menu.c:242
+#: menu.c:769
 msgid "Resize Window"
 msgstr "Tilpas størrelse på Vindue"
 
-#: menu.c:245
+#: menu.c:771
 msgid "Close Window"
 msgstr "Luk Vindue"
 
-#: menu.c:247
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Skriv Sti..."
 
-#: menu.c:248
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Shell kommando..."
 
-#: menu.c:249
-msgid "Xterm Here"
+#: menu.c:780
+#, fuzzy
+msgid "Terminal Here"
 msgstr "Xterm Her"
 
-#: menu.c:250
-msgid "Switch to xterm"
+#: menu.c:782
+#, fuzzy
+msgid "Switch to Terminal"
 msgstr "Skift til xterm"
 
-#: menu.c:718
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "Du burde Shift-klikke på en fil for at sende den til noget"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Indstil Menu..."
 
-#: menu.c:754
+#: menu.c:976
 msgid "Next Click"
 msgstr "Næste Klik"
 
-#: menu.c:776
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d objekter"
 
-#: menu.c:864
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "Åbn umonteret"
 
-#: menu.c:867
+#: menu.c:1097
 msgid "Show Target"
 msgstr "Hvis Mål"
 
-#: menu.c:869
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "Kig Indeni"
 
-#: menu.c:871
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "Åben Som Tekst"
 
-#: menu.c:1031
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2221,15 +2517,15 @@ msgid ""
 "mount option ('user_xattr' on Linux)."
 msgstr ""
 
-#: menu.c:1037
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr ""
 
-#: menu.c:1072
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "_Relativ lænke"
 
-#: menu.c:1078
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2241,45 +2537,58 @@ msgstr ""
 "Hvis dette er slået fra vil den fulde sti til målet blive gemt - brug dette "
 "hvis lænke måske bliver flyttet, men målet altid vil være samme sted."
 
-#: menu.c:1148
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "Nyt mappenavn er ikke absolut"
 
-#: menu.c:1214
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr ""
 "Der findes allerede en symbolsk lænke fra '%s'. Skal den erstattes med en "
 "lænke til '%s'?"
 
-#: menu.c:1220
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Erstat"
 
-#: menu.c:1351 menu.c:1392 menu.c:1452
-msgid "Create"
-msgstr "Lav"
-
-#: menu.c:1352
+#: menu.c:1704
 msgid "NewDir"
 msgstr "Ny Mappe"
 
-#: menu.c:1366 menu.c:1372
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Fejl under skabning af: '%s': %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Lav"
 
-#: menu.c:1393
+#: menu.c:1755
 msgid "NewFile"
 msgstr "Ny Fil"
 
-#: menu.c:1411
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "Fejl under skabning af fil: kunne ikke finde skabelonen for %s"
 
-#: menu.c:1482
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Lav symbolske lænker, til ethvert program du ønsker, i denne mappe. De vil "
+"være at finde i menuen for alle objekter af denne type (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2291,8 +2600,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "'Send Til' menuen er en hurtig måde at sende filer til et program. "
 "Programmerne på listen er i de følgende mapper:\n"
@@ -2306,7 +2616,7 @@ msgstr ""
 "vil blive vist for filer af den type. '.group' bliver kun vist når flere "
 "filer er valgt."
 
-#: menu.c:1493
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
@@ -2314,11 +2624,11 @@ msgstr ""
 "Jeg viser dig nu din 'Send Til' mappe; du bør lave symbolske lænker (Ctrl"
 "+Shift træk) til ethvert program du vil have i den."
 
-#: menu.c:1496 menu.c:1536
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr "Din CHOICESPATH variabel indstilling umuliggør ændringer - desværre."
 
-#: menu.c:1529
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2330,7 +2640,7 @@ msgid ""
 "%s\n"
 msgstr ""
 
-#: menu.c:1534
+#: menu.c:1936
 #, fuzzy
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
@@ -2339,15 +2649,21 @@ msgstr ""
 "Jeg viser dig nu din 'Send Til' mappe; du bør lave symbolske lænker (Ctrl"
 "+Shift træk) til ethvert program du vil have i den."
 
-#: menu.c:1651
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Indstil"
 
-#: menu.c:1717
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Indstil Menu..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Dette er allerede det korteste navn for denne mappe."
 
-#: menu.c:1748
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2355,75 +2671,104 @@ msgstr ""
 "Du kan ikke åbne en til oversigt over denne mappe fordi 'Unikke Vinduer' "
 "insdstillingen er slået til i Indstillinger vinduet."
 
-#: menu.c:1869
-msgid "Copy ... ?"
-msgstr "Kopier ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1872
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Kopier %s som %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Kopier %s som %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Omdøb ... ?"
 
-#: menu.c:1875
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Lav en symbolsk lænke ... ?"
 
-#: menu.c:1878
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Shift Åben ... ?"
 
-#: menu.c:1881
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Egenskaber af ... ?"
 
-#: menu.c:1884
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Bug ikke værtsnavn"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Definer typen på ... ?"
 
-#: menu.c:1887
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Sæt kør handlingen for ... ?"
 
-#: menu.c:1890
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Definer ikonet for ... ?"
 
-#: menu.c:1893
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Send ... til ... ?"
 
-#: menu.c:1896
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "SLET ... ?"
 
-#: menu.c:1899
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Udregn størrelsen af ... ?"
 
-#: menu.c:1902
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Sæt tilladelserne på ... ?"
 
-#: menu.c:1905
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Søg indeni ... ?"
 
-#: menu.c:1908
-msgid "Look inside ... ?"
-msgstr "Kig indendi ... ?"
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Kopier ... ?"
 
-#: menu.c:1972
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Du kan ikke gøre dette ved mere end et objekt ad gangen"
 
-#: menu.c:2004
+#: menu.c:2609
+#, fuzzy
+msgid "Duplicate"
+msgstr "Program"
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Omdøb"
 
-#: menu.c:2009
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Lav symbolsk lænke"
 
-#: menu.c:2041
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2445,7 +2790,7 @@ msgstr ""
 "\tgtk-can-change-accels·=·1\n"
 "\t(dette virker kun hvis XSettings IKKE bliver brugt)"
 
-#: menu.c:2052
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2465,31 +2810,40 @@ msgstr ""
 "Tasten vil vise sig ved siden af funktionen og du kan bare presse den tast "
 "uden at åbne menuen for fremtiden."
 
-#: menu.c:2067
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Indstil tastatur-genveje"
 
-#: minibuffer.c:131
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Gå til:"
 
-#: minibuffer.c:132
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Shell:"
 
-#: minibuffer.c:133
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Væg Hvis:"
 
-#: minibuffer.c:134
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Vælg Navngivede:"
 
-#: minibuffer.c:135
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Væg Hvis:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Mønster:"
 
-#: minibuffer.c:264
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
@@ -2497,14 +2851,34 @@ msgstr ""
 "Skriv navnet på en fil og jeg vil vise den til dig. Tryk på Tab for at "
 "udfylde den længste match. Escape-tasten lukker minibufferen."
 
-#: minibuffer.c:270
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
 "Skriv en shell kommando der skal udføres. Klik på en fil for at tilføje den "
 "til bufferen."
 
-#: minibuffer.c:275
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Skriv et filnavns-mønster for at vælge alle matchende filer:\n"
+"\n"
+"? betyder ethvert tegn\n"
+"* betyder nul eller flere tegn\n"
+"[aA] betyder 'a' eller 'A'\n"
+"[a-z] betyder ethvert tegn fra a til z (små bogstaver)\n"
+"*.png betyder ethvert navn der slutter på '.png'"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2522,7 +2896,7 @@ msgstr ""
 "[a-z] betyder ethvert tegn fra a til z (små bogstaver)\n"
 "*.png betyder ethvert navn der slutter på '.png'"
 
-#: minibuffer.c:287
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
@@ -2530,42 +2904,56 @@ msgstr ""
 "Skriv et mønster for hvilke filer der skal vises. Et tomt mønster slår "
 "filteret fra."
 
-#: minibuffer.c:895
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Skriv et mønster for hvilke filer der skal vises. Et tomt mønster slår "
+"filteret fra."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Ugyldinge find parametre"
 
-#: mount.c:374
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s i alt, %s brugt, %s ledig (%.1f %%)"
 
-#: options.c:277
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr ""
 "Din gamle Indstillings-fil er blevet konverteret til det nye XML format"
 
-#: options.c:535 options.c:1258
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(brug standard)"
 
-#: options.c:806
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Intern fejl: %s kan ikke læses"
 
-#: options.c:917
+#: options.c:929
 msgid "Options"
 msgstr "Indstillinger"
 
-#: options.c:962
+#: options.c:974
 msgid "_Revert"
 msgstr "_Fortryd ændringer"
 
-#: options.c:968
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr "Gendan alle valg så de er som da Indstillings-vinduet blev åbnet."
 
-#: options.c:983
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2574,24 +2962,36 @@ msgstr ""
 "Valg vil blive gemt som:\n"
 "%s"
 
-#: options.c:991
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(gemning er slået fra af CHOICESPATH variablen)"
 
-#: options.c:1164 usericons.c:450
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Fejl under gemning af %s: %s"
 
-#: options.c:1794
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Mangler '='"
 
-#: panel.c:439
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr ""
+"Det lykkedes ikke at aflænke '%s':\n"
+"%s"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "Din gamle panel-fil er blevet konverteret til det nye XML format."
 
-#: panel.c:546
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
@@ -2599,20 +2999,20 @@ msgstr ""
 "Du har prøvet at lukke et panel via window manageren - Jeg plejer at opfatte "
 "det som et uheld... vil du rent faktisk lukke det?"
 
-#: panel.c:639
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Mangler < eller > i panel configurations filen"
 
-#: panel.c:1519
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Fejl under gemning af panel %s: %s"
 
-#: panel.c:1835
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "Applet afsluttede uden overhovedet at lave et widget!"
 
-#: panel.c:1934
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2621,70 +3021,59 @@ msgstr ""
 "Fejl under udførelse af panelprogram:\n"
 "%s"
 
-#: panel.c:2335
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "Er du sikker på at du vil åbne %d vinduer?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Fjern"
+
+#: panel.c:2777
 #, fuzzy
 msgid "Panel Options..."
 msgstr "Indstillinger..."
 
-#: panel.c:2427
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Xinerama-skærm %d er ikke tilgængelig"
 
-#: panel.c:2502
-#, fuzzy
-msgid "Panel Options"
-msgstr "Indstillinger"
-
-#: panel.c:2517
-#, fuzzy, c-format
-msgid "Panel: %s"
-msgstr "Paneler"
-
-#: panel.c:2525
-msgid "Select the panel's position:"
+#: panel.c:2897
+msgid "Top"
 msgstr ""
 
-#: panel.c:2531
+#: panel.c:2899
 #, fuzzy
-msgid "Top-edge panel"
-msgstr "Luk panel?"
-
-#: panel.c:2532
-msgid "Top edge"
-msgstr ""
-
-#: panel.c:2533
-msgid "Bottom edge panel"
-msgstr ""
-
-#: panel.c:2534
-#, fuzzy
-msgid "Bottom edge"
+msgid "Bottom"
 msgstr "Bund-margen"
 
-#: panel.c:2535
-msgid "Left edge panel"
+#: panel.c:2901
+msgid "Left"
 msgstr ""
 
-#: panel.c:2536
-msgid "Left edge"
+#: panel.c:2903
+msgid "Right"
 msgstr ""
 
-#: panel.c:2537
-msgid "Right-edge panel"
-msgstr ""
+#: panel.c:2905
+#, fuzzy
+msgid "Default"
+msgstr "Standard størrelse:"
 
-#: panel.c:2538
-msgid "Right edge"
-msgstr ""
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "Ukendt"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
 msgstr ""
 "Din gamle opslagstavle-fil er blevet konverteret til det nye XML format."
 
-#: pinboard.c:635
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
@@ -2694,7 +3083,7 @@ msgstr ""
 "mappe ind i \"Indstil Baggrund\"-dialogboksen, eller (for programører) "
 "videregiv den til SOAP SetBackdropApp-metoden."
 
-#: pinboard.c:654
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2708,52 +3097,65 @@ msgstr ""
 "Programmører: programmets AppInfo.xml skal indeholde CanSetBackdrop-"
 "elementet,som beskrevet i ROX-Filer-manualen."
 
-#: pinboard.c:674
+#: pinboard.c:750
 msgid "Set backdrop"
 msgstr "Indstil baggrund"
 
-#: pinboard.c:685
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
 msgstr "Vælg en stil og træk et billede til:"
 
-#: pinboard.c:698
+#: pinboard.c:774
 msgid "Centre the image without scaling it"
 msgstr "Centrér billedet uden at skalere det"
 
-#: pinboard.c:699
+#: pinboard.c:775
 msgid "Centre"
 msgstr "Centrér"
 
-#: pinboard.c:700
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr ""
 "Skalér billedet til at passe på baggrundsarealet, uden at forvrænge det"
 
-#: pinboard.c:702
+#: pinboard.c:778
 msgid "Scale"
 msgstr "Skalér"
 
-#: pinboard.c:703
+#: pinboard.c:779
+#, fuzzy
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr ""
+"Skalér billedet til at passe på baggrundsarealet, uden at forvrænge det"
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Filter"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
 msgstr "Stræk billedet så det fylder baggrundsarealet"
 
-#: pinboard.c:704
+#: pinboard.c:783
 msgid "Stretch"
 msgstr "Udstræk"
 
-#: pinboard.c:705
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr "Læg billedet som fliser hen over baggrunden"
 
-#: pinboard.c:706
+#: pinboard.c:785
 msgid "Tile"
 msgstr "Læg som fliser"
 
-#: pinboard.c:711
+#: pinboard.c:790
 msgid "Drop an image here"
 msgstr "Træk et billede-hertil"
 
-#: pinboard.c:772
+#: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
@@ -2761,31 +3163,36 @@ msgstr ""
 "Der var ikke nogen opslagstavle i brug, derfor er opslagstavlen 'Default' "
 "blevet valgt. Brug 'rox -p=Default' for at slå den til fremover."
 
-#: pinboard.c:866
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
 msgstr ""
 "Kun filer (og visse programmer) kan bruges til at sætte baggrunds-billedet."
 
-#: pinboard.c:1471
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Mangler '>' i ikon titlen"
 
-#: pinboard.c:1480
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Mangler ',' efter ikon titlen"
 
-#: pinboard.c:1565
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Fejl under gemning af opslagstavlen %s: %s"
 
-#: pinboard.c:2109
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Indstil baggrunden"
 
-#: pinboard.c:2202
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Paneler"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2796,7 +3203,7 @@ msgstr ""
 "%s\n"
 "Baggrunden er blevet fjernet."
 
-#: pixmaps.c:991
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2805,60 +3212,89 @@ msgstr ""
 "Kan ikke slette miniature i %s:\n"
 "%s"
 
-#: pixmaps.c:1012
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Der er ikke nogle miniature at slette"
 
-#: pixmaps.c:1025
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Rens miniature disk-mellemlageret"
 
-#: remote.c:624
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Ukendt stil '%s'"
 
-#: remote.c:646
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Ukendt detalje-type '%s'"
 
-#: remote.c:674
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Ukendt sorterings-type '%s'"
 
-#: remote.c:1117
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Forsøg på at starte ukendt SOAP metode '%s'"
 
-#: rox_gettext.c:95
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Ugyldig .gmo oversættelses-fil (for kort): %s"
-
-#: rox_gettext.c:108
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Ugyldig .gmo oversættelses-fil (GNU magic number ikke fundet): %s"
-
-#: run.c:96 run.c:141
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "Programmet %s ikke fundet - slettet?"
 
-#: run.c:287
+#: run.c:359
+#, fuzzy, c-format
+msgid ""
+"No run action specified for files of this type (%s/%s) - you can set a run "
+"action by choosing `Set Run Action' from the File menu, or you can just drag "
+"the file to an application.%s"
+msgstr ""
+"Der er ikke sat nogen kør handling for filer af denne type (%s/%s) - du kan "
+"sætte dens handling ved at vælge 'Set Kør Handling' fra fil-menuen, eller du "
+"kan også bare trække filen til et program"
+
+#: run.c:365
+msgid ""
+"\n"
+"\n"
+"Note: If this is a computer program which you want to run, you need to set "
+"the execute bit by choosing Permissions from the File menu."
+msgstr ""
+
+#: run.c:373
 #, c-format
 msgid "File doesn't exist, or I can't access it: %s"
 msgstr "Filen eksisterer ikke, eller jeg har ikke adgang til den: %s"
 
-#: run.c:292
+#: run.c:378
 #, c-format
 msgid "I don't know how to open '%s'"
 msgstr "Jeg ved ikke hvordan man åbner '%s'"
 
-#: run.c:323
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' er ikke længere en symbolsk lænke"
+
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "Mappen '%s' er ikke tilgænglig"
+
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "Ikke-kørbar fil %s"
+
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Fejl i behandler %s: %s"
+
+#: run.c:465
 msgid ""
 "Application:\n"
 "This is an application directory - you can run it as a program, or open it "
@@ -2870,222 +3306,24 @@ msgstr ""
 "(hold Shift nede mens du åbner den). De fleste programmer har deres egen "
 "hjælp der, men denne har ikke."
 
-#: run.c:407
+#: run.c:549
 #, c-format
 msgid "Could not send data to program: %s"
 msgstr "Kunne ikke sende data til programmet %s"
 
-#: run.c:437
+#: run.c:578
 #, c-format
 msgid "Could not read link: %s"
 msgstr "Kunne ikke læse lænken: %s"
 
-#: run.c:465
+#: run.c:606
 #, c-format
 msgid "Broken symlink (or you don't have permission to follow it): %s"
 msgstr ""
 "Knækket symbolsk lænke (eller også har du ikke tilladelse til at følge den): "
 "%s"
 
-#: run.c:502
-#, fuzzy, c-format
-msgid ""
-"No run action specified for files of this type (%s/%s) - you can set a run "
-"action by choosing `Set Run Action' from the File menu, or you can just drag "
-"the file to an application.%s"
-msgstr ""
-"Der er ikke sat nogen kør handling for filer af denne type (%s/%s) - du kan "
-"sætte dens handling ved at vælge 'Set Kør Handling' fra fil-menuen, eller du "
-"kan også bare trække filen til et program"
-
-#: run.c:508
-msgid ""
-"\n"
-"\n"
-"Note: If this is a computer program which you want to run, you need to set "
-"the execute bit by choosing Permissions from the File menu."
-msgstr ""
-
-#: support.c:272
-msgid "B"
-msgstr "B"
-
-#: support.c:351
-msgid "byte"
-msgstr "byte"
-
-#: toolbar.c:115
-msgid "Close"
-msgstr "Luk"
-
-#: toolbar.c:115
-msgid "Close filer window"
-msgstr "Luk 'filer' vinduet"
-
-#: toolbar.c:119
-msgid "Up"
-msgstr "Op"
-
-#: toolbar.c:119
-msgid "Change to parent directory"
-msgstr "Gå til overmappen"
-
-#: toolbar.c:123
-msgid "Home"
-msgstr "Hjem"
-
-#: toolbar.c:123
-msgid "Change to home directory"
-msgstr "Gå til hjemme-mappen"
-
-#: toolbar.c:127
-msgid "Bookmarks"
-msgstr "Bogmærker"
-
-#: toolbar.c:127
-msgid "Bookmarks menu"
-msgstr "Bogmærke-menu"
-
-#: toolbar.c:131
-msgid "Scan"
-msgstr "Scan"
-
-#: toolbar.c:131
-msgid "Rescan directory contents"
-msgstr "Genscan mappens indhold"
-
-#: toolbar.c:135
-msgid "Change icon size"
-msgstr "Indstil ikon størrelsen"
-
-#: toolbar.c:139
-msgid "Automatic size mode"
-msgstr "Automatisk-størrelse-tilstand"
-
-#: toolbar.c:143
-msgid "Show extra details"
-msgstr "Vis ekstra detaljer"
-
-#: toolbar.c:147
-msgid "Sort"
-msgstr "Sortér"
-
-#: toolbar.c:147
-msgid "Change sort criteria"
-msgstr "Skift sorterings-kriterie"
-
-#: toolbar.c:151
-msgid "Hidden"
-msgstr "Skjult"
-
-#: toolbar.c:151
-msgid "Show/hide hidden files"
-msgstr "Vis/Skjul skjulte filer"
-
-#: toolbar.c:155
-msgid "Select all/invert selection"
-msgstr "Vælg alt/vend valg om"
-
-#: toolbar.c:159
-msgid "Show ROX-Filer help"
-msgstr "Vis ROX-Filers hjælp"
-
-#: toolbar.c:220
-#, c-format
-msgid " (%u hidden)"
-msgstr " (%u skjult)"
-
-#: toolbar.c:228 tips:80
-msgid "items"
-msgstr "objekter"
-
-#: toolbar.c:228
-msgid "item"
-msgstr "objekt"
-
-#: toolbar.c:231
-#, c-format
-msgid "No items%s"
-msgstr "Ingen objekter%s"
-
-#: toolbar.c:250
-#, c-format
-msgid "%u selected (%s)"
-msgstr "%u valgt (%s)"
-
-#: toolbar.c:422
-msgid "Sort by name"
-msgstr "Sortér efter navn"
-
-#: toolbar.c:422
-msgid "Sort by type"
-msgstr "Sortér efter type"
-
-#: toolbar.c:422
-msgid "Sort by date"
-msgstr "Sortér efter dato"
-
-#: toolbar.c:423
-msgid "Sort by size"
-msgstr "Sortér efter størrelse"
-
-#: toolbar.c:423
-msgid "Sort by owner"
-msgstr "Sortér efter ejer"
-
-#: toolbar.c:423
-msgid "Sort by group"
-msgstr "Sortér efter gruppe"
-
-#: toolbar.c:457
-msgid "ascending"
-msgstr "stigende"
-
-#: toolbar.c:457
-msgid "descending"
-msgstr "faldende"
-
-#: type.c:203
-msgid "Sym link"
-msgstr "Symbolsk lænke"
-
-#: type.c:205
-msgid "Mount point"
-msgstr "Monterings-punkt"
-
-#: type.c:207
-msgid "App dir"
-msgstr "Program mappe"
-
-#: type.c:214
-msgid "Dir"
-msgstr "Mappe"
-
-#: type.c:216
-msgid "Char dev"
-msgstr "Char dev"
-
-#: type.c:218
-msgid "Block dev"
-msgstr "Black dev"
-
-#: type.c:220
-msgid "Pipe"
-msgstr "Pipe"
-
-#: type.c:222
-msgid "Socket"
-msgstr "Socket"
-
-#: type.c:224
-msgid "Door"
-msgstr "Dør"
-
-#: type.c:227
-msgid "Unknown"
-msgstr "Ukendt"
-
-#: type.c:355
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3111,11 +3349,284 @@ msgstr ""
 "har du intet at bekymre dig om. Hvis ikke, bør du checke, eller enda slette, "
 "alle de eksisterende handlinger."
 
-#: type.c:368
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Ret sikkerheds-problemmet)"
 
-#: type.c:498
+#: support.c:288
+msgid " "
+msgstr ""
+
+#: support.c:381
+msgid "byte"
+msgstr "byte"
+
+#: support.c:1531 support.c:1585
+#, fuzzy, c-format
+msgid "Failed to open and stat file '%s': %s"
+msgstr ""
+"Det lykkedes ikke at aflænke '%s':\n"
+"%s"
+
+#: support.c:1542 support.c:1596
+#, fuzzy, c-format
+msgid "Failed to mmap file '%s': %s"
+msgstr ""
+"Det lykkedes ikke at aflænke '%s':\n"
+"%s"
+
+#: toolbar.c:116
+msgid "Close"
+msgstr "Luk"
+
+#: toolbar.c:116
+msgid "Close filer window"
+msgstr "Luk 'filer' vinduet"
+
+#: toolbar.c:120
+msgid "Up"
+msgstr "Op"
+
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
+
+#: toolbar.c:126
+msgid "Home"
+msgstr "Hjem"
+
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
+
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
+
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
+
+#: toolbar.c:138
+msgid "Scan"
+msgstr "Scan"
+
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
+
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Størrelse"
+
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automatisk"
+
+#: toolbar.c:155
+msgid "Automatic size mode"
+msgstr "Automatisk-størrelse-tilstand"
+
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Liste-visning"
+
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
+msgid "Sort"
+msgstr "Sortér"
+
+#: toolbar.c:165
+msgid "Change sort criteria"
+msgstr "Skift sorterings-kriterie"
+
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
+
+#: toolbar.c:169
+msgid ""
+"Left: Show/hide hidden files\n"
+"Right: Show/hide thumbnails"
+msgstr ""
+
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "Vælg alt/vend valg om"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
+msgid "Show ROX-Filer help"
+msgstr "Vis ROX-Filers hjælp"
+
+#: toolbar.c:270
+#, c-format
+msgid " (%u hidden)"
+msgstr " (%u skjult)"
+
+#: toolbar.c:276 tips:79
+msgid "items"
+msgstr "objekter"
+
+#: toolbar.c:276
+msgid "item"
+msgstr "objekt"
+
+#: toolbar.c:279
+#, c-format
+msgid "No items%s"
+msgstr "Ingen objekter%s"
+
+#: toolbar.c:298
+#, c-format
+msgid "%u selected (%s)"
+msgstr "%u valgt (%s)"
+
+#: toolbar.c:535
+msgid "Sort by name"
+msgstr "Sortér efter navn"
+
+#: toolbar.c:535
+msgid "Sort by type"
+msgstr "Sortér efter type"
+
+#: toolbar.c:535
+msgid "Sort by date"
+msgstr "Sortér efter dato"
+
+#: toolbar.c:535
+msgid "Sort by size"
+msgstr "Sortér efter størrelse"
+
+#: toolbar.c:536
+msgid "Sort by owner"
+msgstr "Sortér efter ejer"
+
+#: toolbar.c:536
+msgid "Sort by group"
+msgstr "Sortér efter gruppe"
+
+#: toolbar.c:568
+msgid "ascending"
+msgstr "stigende"
+
+#: toolbar.c:568
+msgid "descending"
+msgstr "faldende"
+
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
+msgid "Sym link"
+msgstr "Symbolsk lænke"
+
+#: type.c:223
+msgid "Mount point"
+msgstr "Monterings-punkt"
+
+#: type.c:225
+msgid "App dir"
+msgstr "Program mappe"
+
+#: type.c:232
+msgid "Dir"
+msgstr "Mappe"
+
+#: type.c:234
+msgid "Char dev"
+msgstr "Char dev"
+
+#: type.c:236
+msgid "Block dev"
+msgstr "Black dev"
+
+#: type.c:238
+msgid "Pipe"
+msgstr "Pipe"
+
+#: type.c:240
+msgid "Socket"
+msgstr "Socket"
+
+#: type.c:242
+msgid "Door"
+msgstr "Dør"
+
+#: type.c:245
+msgid "Unknown"
+msgstr "Ukendt"
+
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3126,72 +3637,72 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:679
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Dette er ikke et prgram! Giv mig et program istedet!"
 
-#: type.c:740
+#: type.c:839
 msgid "No run action defined"
 msgstr "Ingen kør handling defineret"
 
-#: type.c:766
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Fejl i behandler %s: %s"
 
-#: type.c:781
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Ugyldingt program %s (dårlig AppRun)"
 
-#: type.c:792
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "Ikke-kørbar fil %s"
 
-#: type.c:825
+#: type.c:902
 msgid "Set run action"
 msgstr "Sæt kør handling"
 
-#: type.c:831
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 "Hvis der ikke er sat en handling for den specifikke type, så brug denne som "
 "standard."
 
-#: type.c:833
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Sæt som normalt for alle `%s/<hvad som helst>'"
 
-#: type.c:837
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Brug dette program til alle filer med denne MIME-type."
 
-#: type.c:839
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Kun for typen `%s' (%s/%s)"
 
-#: type.c:845
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Træk et passende program hertil"
 
-#: type.c:860
+#: type.c:963
 msgid "OR"
 msgstr "ELLER"
 
-#: type.c:867
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Skriv en shell kommando:"
 
-#: type.c:896
+#: type.c:1000
 #, fuzzy
 msgid "_Use Command"
 msgstr "Kommando:"
 
-#: type.c:926
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
@@ -3199,43 +3710,29 @@ msgstr ""
 "Der findes allerede en kør handling og den er et ret stort program - er du "
 "sikker på at du vil slette den?"
 
-#: type.c:937
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Kan ikke fjerne %s: %s"
 
-#: type.c:974
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "Gemning af Choices er slået fra af CHOICESPATH variablen"
 
-#: type.c:1249
-#, c-format
-msgid ""
-"Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr ""
-"Da ikon-temaet '%s' ikke indeholder nogen MIME-ikoner, bliver standard-ROX-"
-"temaet anvendt."
-
-#: type.c:1263
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason)"
+"%s"
 msgstr ""
-"Det lykkedes ikke at lave den symbolske lænke '%s':\n"
-"%s\n"
-"\n"
-"(dette kan betyde at ROX-temaet allerede findes dér, men at 'mime-"
-"application:postscript'-ikonet ikke kunne indlæses)"
+"Det lykkedes ikke at aflænke '%s':\n"
+"%s"
 
-#: usericons.c:181
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "Sti-navnet du gav findes ikke. Ikonet er ikke blevet ændret."
 
-#: usericons.c:191 usericons.c:616
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3245,12 +3742,12 @@ msgstr ""
 "elle også er tilladelserne ikke i orden?\n"
 "Ikonet er ikke blevet ændret."
 
-#: usericons.c:238
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Vil du virkelig slette ikonet '%s'?"
 
-#: usericons.c:242
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3259,32 +3756,32 @@ msgstr ""
 "Kan ikke slette '%s'\n"
 "%s"
 
-#: usericons.c:270
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Definer ikon"
 
-#: usericons.c:279
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr ""
 "Anvend en kopi af billedet som standard for alle filer af denne MIME-type."
 
-#: usericons.c:281
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Sæt som ikon for alle `%s/<hvad som helst>'"
 
-#: usericons.c:286
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr ""
 "Anvend en kopi af billedet som standard for alle filer af denne MIME-type."
 
-#: usericons.c:288
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "For alle filer af typen `%s (%s/%s)"
 
-#: usericons.c:294
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
@@ -3292,12 +3789,12 @@ msgstr ""
 "Tilføj filen og billede-filnavnene til din personlige liste. Valget vil "
 "blive glemt hvis billedet eller filen bliver flyttet."
 
-#: usericons.c:297
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Kun for filen `%s'"
 
-#: usericons.c:305
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
@@ -3307,19 +3804,19 @@ msgstr ""
 "brugerne vil kunne se ikonet, og du kan flytte mappen rundt uden problemer. "
 "Dette er som regel den bedste løsning, hvis du kan skrive til mappen."
 
-#: usericons.c:311
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Kopiér billedet til mappen"
 
-#: usericons.c:317
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Træk en ikon-fil her hen"
 
-#: usericons.c:587
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "Gemning af Choices er slået fra af CHOICESPATH variablen"
 
-#: usericons.c:631
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3328,147 +3825,71 @@ msgstr ""
 "Fejl under generering af billedet '%s':\n"
 "%s"
 
-#: view_details.c:1009
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
+msgid "Mono font"
+msgstr ""
+
+#: view_details.c:1019
+msgid "Font for displaying mono-spaced text"
+msgstr ""
+
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Navn"
 
-#: view_details.c:1012
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Type"
 
-#: view_details.c:1015
-msgid "_Permissions"
-msgstr "_Tilladdelser"
-
-#: view_details.c:1016
-msgid "_Owner"
-msgstr "_Ejer"
-
-#: view_details.c:1018
-msgid "_Group"
-msgstr "_Gruppe"
-
-#: view_details.c:1020
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Størrelse"
 
-#: view_details.c:1022
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Tilladdelser"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_Ejer"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Gruppe"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "Sidst _Ændret"
 
-#: tips:1
-msgid "Translation"
-msgstr "Oversættelse"
-
-#: tips:2
-msgid "Language"
-msgstr "Sprog"
-
-#: tips:3
-msgid "Use the LANG environment variable"
-msgstr "Brug LANG miljø variabel"
-
-#: tips:4
-msgid "Basque"
+#: view_details.c:1260
+msgid "Last _Changed"
 msgstr ""
 
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Kinesisk (traditionel)"
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
 
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Kinesisk (simplificeret)"
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr ""
 
-#: tips:7
-msgid "Czech"
-msgstr "Tjekkisk"
-
-# tips=x
-#: tips:8
-msgid "Danish"
-msgstr "Dansk"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Hollandsk"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Engelsk (ingen oversættelse)"
-
-#: tips:11
-#, fuzzy
-msgid "Estonian"
-msgstr "Rumænsk"
-
-# tips=x
-#: tips:12
-#, fuzzy
-msgid "Finnish"
-msgstr "Dansk"
-
-#: tips:13
-msgid "French"
-msgstr "Fransk"
-
-#: tips:14
-msgid "German"
-msgstr "Tysk"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Ungarnsk"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Japansk"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "Norsk"
-
-#: tips:18
-msgid "Italian"
-msgstr "Italiensk"
-
-#: tips:19
-msgid "Polish"
-msgstr "Polsk"
-
-#: tips:20
-msgid "Portuguese (Brasil)"
-msgstr "Portugisisk (Braziliansk)"
-
-#: tips:21
-msgid "Romanian"
-msgstr "Rumænsk"
-
-#: tips:22
-msgid "Russian"
-msgstr "Russisk"
-
-#: tips:23
-msgid "Spanish"
-msgstr "Spansk"
-
-#: tips:24
-msgid "Swedish"
-msgstr "Svensk"
-
-#: tips:25
+#: tips:1
 msgid "Filer windows"
 msgstr "'Filer' vinduer"
 
-#: tips:26
+#: tips:2
 msgid "Auto-resize filer windows"
 msgstr "Tilpas automatisk størrelsen på 'filer' vinduer"
 
-#: tips:27
+#: tips:3
 msgid "Never automatically resize"
 msgstr "Tilpas aldrig størrelsen automatisk"
 
-#: tips:28
+#: tips:4
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
@@ -3477,11 +3898,11 @@ msgstr ""
 "brug af 'Tilpas størrelse på Vindue' i menuen eller ved at dobbelt-klikke på "
 "vindue-baggrunden."
 
-#: tips:29
+#: tips:5
 msgid "Resize when changing the display style"
 msgstr "Ændr størrelsen ved ændring af visnings-stil"
 
-#: tips:30
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
@@ -3489,11 +3910,11 @@ msgstr ""
 "Ved ændring af størrelsen på ikoner eller hvilke detaljer der bliver vist "
 "vil vinduet tilpasse sin størrelse automatisk."
 
-#: tips:31
+#: tips:7
 msgid "Always resize"
 msgstr "Ændr altid størrelse"
 
-#: tips:32
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
@@ -3501,15 +3922,16 @@ msgstr ""
 "Vinduet vil tilpasse sin størrelse hver gang det virker nyttigt (det vil "
 "sige, ved skift af mappe eller ændring af visnings-stil)."
 
-#: tips:33
+#: tips:9
 msgid "Largest window size:"
 msgstr "Største vinduesstørrelse:"
 
-#: tips:34
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:35
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
@@ -3517,15 +3939,29 @@ msgstr ""
 "Den største største, som en procentdel af skærm-størrelsen, som vinduet vil "
 "tilpasse sig til."
 
-#: tips:36
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Største vinduesstørrelse:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Den største største, som en procentdel af skærm-størrelsen, som vinduet vil "
+"tilpasse sig til."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Vindues-opførsel"
 
-#: tips:37
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Korte titelbjælke-flag"
 
-#: tips:38
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
@@ -3533,11 +3969,11 @@ msgstr ""
 "Brug enkelte bogstaver i stedet for ord til Skanner-, Alle- og Miniature-"
 "indikatorenepå tittelbjælken."
 
-#: tips:39
+#: tips:18
 msgid "Unique windows"
 msgstr "Unikke vinduer"
 
-#: tips:40
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3545,11 +3981,34 @@ msgstr ""
 "Hvis du åbner et vindue med en mappe der allerede bliver vist i et andet "
 "vindue, vil denne indstilling tvinge det andet vindue til at lukke."
 
-#: tips:41
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Vindue"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Nyt vindue på knap 1"
 
-#: tips:42
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3559,11 +4018,11 @@ msgstr ""
 "med denne indstilling slået til. Et klik med knap 2 (midterste) vil genbruge "
 "det nuværende vindue."
 
-#: tips:43
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Et-kliks navigation"
 
-#: tips:44 tips:137
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
@@ -3573,11 +4032,11 @@ msgstr ""
 "nede for at vælge det istedet. Hvis slået fra: Et klik vælger et objekt; "
 "dobbelt-klik åbner det."
 
-#: tips:45
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Dobbelt-klik på tilpasser vinduet"
 
-#: tips:46
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
@@ -3586,15 +4045,15 @@ msgstr ""
 "vinduets størrelse - fuldstændigt som havde man klikket på Automatisk "
 "størrelse-tilstands-knappen på værktøjslinjen."
 
-#: tips:47
+#: tips:30
 msgid "Sorting"
 msgstr "Sortering"
 
-#: tips:48
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Mapper kommer først (sortér efter navn)"
 
-#: tips:49
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
@@ -3602,11 +4061,11 @@ msgstr ""
 "Hvis dette er slået til vil mapper altid vises først i listen, når der "
 "sorteresefter navn."
 
-#: tips:50
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Navne med stort kommer først (ved sortér efter navn)"
 
-#: tips:51
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
@@ -3614,15 +4073,58 @@ msgstr ""
 "Hvis dette er slået til, vil filnavne der starter med stort, komme før navne "
 "der ikke gør."
 
-#: tips:53
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Mapper kommer først (sortér efter navn)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sek"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "Bug ikke værtsnavn"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "Standard-indstilling for nye vinduer"
 
-#: tips:54
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "Arv indstillinger fra kilde vinduet"
 
-#: tips:55
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
@@ -3631,27 +4133,38 @@ msgstr ""
 "kilde vinduet, hvis muligt; ellers bliver de sat til hvad der er valgt "
 "nedenfor."
 
-#: tips:56
+#: tips:48
 msgid "View type:"
 msgstr "Vis type:"
 
-#: tips:59
+#: tips:51
 msgid "Sort by:"
 msgstr "Sortér efter:"
 
-#: tips:61 tips:76
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Type"
 
-#: tips:62
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Dato"
 
-#: tips:64
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Dato"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Dato"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Vis skjulte filer"
 
-#: tips:65
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
@@ -3659,7 +4172,34 @@ msgstr ""
 "Hvis dette er slået til så bliver filer hvis navner der starter med et "
 "punktum også vist, ellers er de skjult."
 
-#: tips:66
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Vis skjulte filer"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Hvis dette er slået til så bliver filer hvis navner der starter med et "
+"punktum også vist, ellers er de skjult."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Kæmpe Ikoner"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "billedpunkter"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "Ikon Visning"
 
@@ -3671,11 +4211,11 @@ msgstr "Standard størrelse:"
 msgid "Huge Icons"
 msgstr "Kæmpe Ikoner"
 
-#: tips:69 tips:245
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Store Ikoner"
 
-#: tips:70 tips:244
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "Små Ikoner"
 
@@ -3687,15 +4227,20 @@ msgstr "Standard detaljer:"
 msgid "No details"
 msgstr "Ingen detaljer"
 
+#: tips:74
+msgid "Sizes"
+msgstr "Størrelser"
+
+#: tips:77
+msgid "Times"
+msgstr "Tider"
+
 #: tips:78
-msgid "Automatic small icons:"
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "Automatisk små ikoner:"
 
-#: tips:79
-msgid "Change at:"
-msgstr "Ændre tid:"
-
-#: tips:81
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3705,105 +4250,229 @@ msgstr ""
 "blive vist med små ikoner, og mapper med få objekter blive vist med store "
 "ikoner."
 
-#: tips:82
-msgid "Max width (Large icons):"
-msgstr "Største bredde (Store ikoner):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Stor ombrydnings-bredde"
 
-#: tips:83 tips:86
-msgid "pixels"
-msgstr "billedpunkter"
-
-#: tips:84
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "Tekst der er bredere end dette bliver brudt i to linjer når vist som Store "
 "Ikoner. Vist som Kæmpe Ikoner bliver tekstet brudt hvis deb er størrere end "
 "50% ad dette."
 
-#: tips:85
-msgid "(Small Icons):"
-msgstr "(Små Ikoner):"
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
 
 #: tips:87
-msgid "Maximum width for the text beside a Small Icon."
-msgstr "Maksimal bredde for tekst ved siden af et lille ikon."
+msgid "Wrap by characters"
+msgstr ""
 
 #: tips:88
-msgid "Order small icons vertically"
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
 msgstr ""
 
 #: tips:89
-msgid ""
-"If this option is on, then small icons are ordered vertically, not "
-"horizontally."
-msgstr ""
-
-#: tips:90
-msgid "Order large icons vertically"
-msgstr ""
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "Maks Små Ikoner bredde"
 
 #: tips:91
-msgid ""
-"If this option is on, then large icons are sorted vertically, not "
-"horizontally."
+msgid "Maximum width for the text beside a Small Icon."
+msgstr "Maksimal bredde for tekst ved siden af et lille ikon."
+
+#: tips:92
+msgid "Order small icons vertically"
 msgstr ""
 
 #: tips:93
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
+msgstr ""
+
+#: tips:94
+msgid "Order large icons vertically"
+msgstr ""
+
+#: tips:95
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
+msgstr ""
+
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Vis kolonne-titler"
 
-#: tips:94
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr ""
 "Hvis dette er valgt, vil kolonne-titler blive vist under liste-visning."
 
-#: tips:95
+#: tips:102
 #, fuzzy
 msgid "Show full type"
 msgstr "Sortér efter type"
 
-#: tips:96
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr ""
 
-#: tips:97
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Maksimal bredde for tekst ved siden af et lille ikon."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Vis kolonne-titler"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Hvis dette er valgt, vil kolonne-titler blive vist under liste-visning."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Hvis dette er valgt, vil kolonne-titler blive vist under liste-visning."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Hvis dette er valgt, vil kolonne-titler blive vist under liste-visning."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Hvis dette er valgt, vil kolonne-titler blive vist under liste-visning."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Hvis dette er valgt, vil kolonne-titler blive vist under liste-visning."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Hvis dette er valgt, vil kolonne-titler blive vist under liste-visning."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "Sidst _Ændret"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Hvis dette er valgt, vil kolonne-titler blive vist under liste-visning."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Hvis dette er valgt, vil kolonne-titler blive vist under liste-visning."
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Hvis dette er valgt, vil kolonne-titler blive vist under liste-visning."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Værktøjer/Minibuffer"
 
-#: tips:98
+#: tips:131
 msgid "Toolbar"
 msgstr "Værktøjslinje"
 
-#: tips:99
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Værktøjslinje type:"
 
-#: tips:100
+#: tips:133
 #, fuzzy
 msgid "No toolbar"
 msgstr "Værktøjslinje"
 
-#: tips:101
+#: tips:134
 msgid "Icons only"
 msgstr "Kun ikoner"
 
-#: tips:102
+#: tips:135
 msgid "Text under icons"
 msgstr "Tekst under ikoner"
 
-#: tips:103
+#: tips:136
 msgid "Text beside icons"
 msgstr "Tekst ved siden af ikoner"
 
-#: tips:104
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Kun billede"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Vis totaler af objekter"
 
-#: tips:105
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3813,16 +4482,16 @@ msgstr ""
 "skjulte objekter (hvis nogen). Når noget er valgt vises antallet af valgte "
 "objekter og deres sammenlagte størrelse."
 
-#: tips:106
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Vælg hvilke knapper du ønsker at have på bjælken:"
 
-#: tips:107
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr ""
 "Bredden på værktøjsbjælken sætter den mindst mulige størrelse af vinduet"
 
-#: tips:108
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
@@ -3830,15 +4499,15 @@ msgstr ""
 "Hver 'filer'-vindue bliver tvunget til at være stort nok til at kunne vise "
 "hele værktøjsbjælken."
 
-#: tips:109
+#: tips:143
 msgid "Minibuffer"
 msgstr "Minibuffer"
 
-#: tips:110
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Bip hvis Tab-fuldførelse slå fejl"
 
-#: tips:111
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
@@ -3848,11 +4517,11 @@ msgstr ""
 "bippet vis intet sker (f.eks. fordi der er flere muligheder og det næste "
 "bogstavet varierer)."
 
-#: tips:112
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Bip hvis der er flere muligheder"
 
-#: tips:113
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
@@ -3861,7 +4530,27 @@ msgstr ""
 "bippet hvis der er mere end en matchende fil, også selvom der er blevet "
 "tilføjet flere bogstaver."
 
-#: tips:116
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Hentnings-håndterer"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Fejl i behandler %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
@@ -3870,11 +4559,11 @@ msgstr ""
 "lille miniature-udgave af billedet vil blive vist i stedet for det normale "
 "ikon."
 
-#: tips:117
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Vis thumbnails af billeder"
 
-#: tips:118
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
@@ -3882,30 +4571,104 @@ msgstr ""
 "Dette er standard-indstillingen for nye vinduer. Brug Vis-menuen til at slå "
 "miniature fra og til for individuelle vinduer."
 
-#: tips:119
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Vis thumbnails af billeder"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 #, fuzzy
 msgid "Video thumbnails"
 msgstr "Gem thumbnails"
 
-#: tips:120
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Miniature mellemlager"
 
-#: tips:121
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "For at gøre det hurtigere, bliver genererede miniature gemt i den skjulte "
 "mappe ~/.thumbnails. Klik her for at fjerne alle de mellemlagrede miniature. "
 "De vil blive skabt igen når de skal bruges."
 
-#: tips:122 tips:195
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
+#, fuzzy
+msgid "Manage thumbnails"
+msgstr "Vis thumbnails af billeder"
+
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Gem thumbnails"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sek"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Opslagstavle"
 
-#: tips:123
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
@@ -3913,66 +4676,66 @@ msgstr ""
 "Når opslagstavlen er i brug kan du trække filer og programmer hen på "
 "skrivebords-baggrunden for at skabe genveje til dem."
 
-#: tips:124 tips:241
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Udseende"
 
-#: tips:125
+#: tips:179
 msgid "Foreground:"
 msgstr "Forgrund:"
 
-#: tips:126
+#: tips:180
 msgid "Text shadow:"
 msgstr "Tekst-skygge:"
 
-#: tips:127
+#: tips:181
 msgid "Background:"
 msgstr "Baggrund:"
 
-#: tips:128
+#: tips:182
 #, fuzzy
 msgid "No shadow"
 msgstr "Tekst-skygge:"
 
-#: tips:129
+#: tips:183
 msgid "Thin"
 msgstr "Tynd"
 
-#: tips:130
+#: tips:184
 msgid "Thick"
 msgstr "Tyk"
 
-#: tips:131
+#: tips:185
 msgid "Use custom font:"
 msgstr "Brug udvalgt skrifttype:"
 
-#: tips:132
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Skrifttypen der bliver brugt til teksten vist under ikonerne"
 
-#: tips:133
+#: tips:187
 msgid "Fast scaling of images"
 msgstr ""
 
-#: tips:134
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
 msgstr ""
 
-#: tips:135
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Opslagstavlens opførsel"
 
-#: tips:136
+#: tips:190
 msgid "Single-click to open"
 msgstr "Et-klik for at åbne"
 
-#: tips:138
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Hold ikoner indenfor skærm-arealet"
 
-#: tips:139
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
@@ -3980,39 +4743,39 @@ msgstr ""
 "Hvis dette er på bliver ikoner på opslagstavlen altid holdt fuldstændig "
 "indenfor skærmens areal, også titlen."
 
-#: tips:140
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Ikon gitter-finhed:"
 
-#: tips:141
+#: tips:195
 msgid "Fine"
 msgstr "Fin"
 
-#: tips:142
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "Bruger et 2-pixel gitter til at placere ikoner på desktoppen."
 
-#: tips:143
+#: tips:197
 msgid "Medium"
 msgstr "Medium"
 
-#: tips:144
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "Bruger et 16-pixel gitter til at placere ikoner på desktoppen."
 
-#: tips:145
+#: tips:199
 msgid "Coarse"
 msgstr "Groft"
 
-#: tips:146
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "Bruger et 32-pixel gitter til at placere ikoner på desktoppen."
 
-#: tips:147 tips:149
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Skjulte vinduer"
 
-#: tips:148
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
@@ -4022,11 +4785,11 @@ msgstr ""
 "'minimere') vinduer, og diverse programmer, der i blandt ROX-Filer, kan "
 "bruges til at vise disse skjulte vinduer."
 
-#: tips:150
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Vis skjulte vinduer"
 
-#: tips:151
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
@@ -4036,11 +4799,11 @@ msgstr ""
 "knapper på opslagstavlen. Dette kræver en kompatibel vindues-håndtering, og "
 "at opslagstavlen er i brug."
 
-#: tips:152
+#: tips:206
 msgid "Show per workspace"
 msgstr ""
 
-#: tips:153
+#: tips:207
 #, fuzzy
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
@@ -4050,39 +4813,39 @@ msgstr ""
 "knapper på opslagstavlen. Dette kræver en kompatibel vindues-håndtering, og "
 "at opslagstavlen er i brug."
 
-#: tips:154
+#: tips:208
 msgid "Iconify to the"
 msgstr "Vis skjulte vinduer"
 
-#: tips:155
+#: tips:209
 msgid "top-left"
 msgstr "øverst til venstre"
 
-#: tips:156
+#: tips:210
 msgid "top-right"
 msgstr "øverst til højre"
 
-#: tips:157
+#: tips:211
 msgid "bottom-left"
 msgstr "nederst til venstre"
 
-#: tips:158
+#: tips:212
 msgid "bottom-right"
 msgstr "nederst til højre"
 
-#: tips:159
+#: tips:213
 msgid ", going"
 msgstr " på en"
 
-#: tips:160
+#: tips:214
 msgid "horizontally"
 msgstr "vandret linje"
 
-#: tips:161
+#: tips:215
 msgid "vertically"
 msgstr "lodret linje"
 
-#: tips:162
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4094,181 +4857,100 @@ msgstr ""
 "definere en top og/eller bund margen for at undgå at ikonerne bliver "
 "placeret dér. 'Fileren' kender allerede til sine egne paneler."
 
-#: tips:163
+#: tips:217
 msgid "Top margin"
 msgstr "Top-margen"
 
-#: tips:164
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Højden på arealet, der ikke skal benyttes, i toppen af skærmen-"
 
-#: tips:165
+#: tips:219
 msgid "Bottom margin"
 msgstr "Bund-margen"
 
-#: tips:166
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "Højden på arealet, der ikke skal benyttes, i bunden af skærmen-"
 
-#: tips:167
-msgid "Panels"
-msgstr "Paneler"
+#: tips:221
+#, fuzzy
+msgid "Left margin"
+msgstr "Top-margen"
 
-#: tips:168
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr ""
-"Paneler er rækker af ikoner der løber langs siden af skærmen. Se manualen "
-"for mere information omkring paneler og deres brug."
+#: tips:222
+#, fuzzy
+msgid "Width of no-go area at left of screen."
+msgstr "Højden på arealet, der ikke skal benyttes, i toppen af skærmen-"
 
-#: tips:169
-msgid "Panel style"
-msgstr "Panel-stil"
+#: tips:223
+#, fuzzy
+msgid "Right margin"
+msgstr "Bund-margen"
 
-#: tips:170
-msgid "Image and text"
-msgstr "Billeder og tekst"
+#: tips:224
+#, fuzzy
+msgid "Width of no-go area at right of screen."
+msgstr "Højden på arealet, der ikke skal benyttes, i toppen af skærmen-"
 
-#: tips:171
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Ethvert panel-ikon bliver vist med et billede og noget tekst."
-
-#: tips:172
-msgid "Image only for applications"
-msgstr "Kun billeder for programmer"
-
-#: tips:173
-msgid ""
-"Applications have just an image, everything else has both an image and text."
-msgstr "Programmer har kun et billede, alt andet har både et billede og tekst."
-
-#: tips:174
-msgid "Image only"
-msgstr "Kun billede"
-
-#: tips:175
-msgid "Only the image is shown."
-msgstr "Kun billedet bliver vist"
-
-#: tips:176
-msgid "Panel width (thin)"
-msgstr "Panel-tykkelse (tynd)"
-
-#: tips:177
-msgid "(thick)"
-msgstr "(tyk)"
-
-#: tips:178
-msgid "The size of the panels."
-msgstr "Størrelsen af paneler."
-
-#: tips:179
-msgid "Do not cover panel"
-msgstr "Dæk ikke paneler"
-
-#: tips:180
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
-msgstr ""
-"Bed vindues-håndteringen om ikke at dække paneler, når den maksimerer et "
-"vindue. Nogle vindues-håndterere overholder muligvis ikke dette. Hvis det "
-"ikke slået til, vil 'fileren' bede om at få holdt blot et par billedpunkter "
-"frie, i kanten af skærmen, så auto-hævning virker."
-
-#: tips:181
-msgid "Xinerama"
-msgstr "Xinerama"
-
-#: tips:182
-msgid "Confine to Xinerama monitor"
-msgstr "Begræns til Xinerama-skærm"
-
-#: tips:183
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
-msgstr ""
-"Hvis du har en Xinerama flerskærms-opsætning, kan du slå dette til for at "
-"begrænse paneler til én skærm, i stedet for at bredde sig over flere."
-
-#: tips:184
-msgid ""
-"The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr ""
-"Den skærm som paneler begrænser sig til i Xinerama-tilstand (nummereret fra "
-"0)"
-
-#: tips:185
+#: tips:225
 msgid "Desktop"
 msgstr ""
 
-#: tips:186
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
 msgstr ""
 
-#: tips:187
+#: tips:227
 #, fuzzy
 msgid "Panel only"
 msgstr "Kun billede"
 
-#: tips:188
+#: tips:228
 #, fuzzy
 msgid "Only a panel is shown."
 msgstr "Kun billedet bliver vist"
 
-#: tips:189
+#: tips:229
 #, fuzzy
 msgid "Pinboard only"
 msgstr "Opslagstavle"
 
-#: tips:190
+#: tips:230
 #, fuzzy
 msgid "Only the pinboard is shown."
 msgstr "Kun billedet bliver vist"
 
-#: tips:191
+#: tips:231
 #, fuzzy
 msgid "Panel and pinboard"
 msgstr "Opslagstavle"
 
-#: tips:192
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr ""
 
-#: tips:193
-#, fuzzy
-msgid "Panel"
-msgstr "Paneler"
-
-#: tips:194
-msgid "Enter the name of the panel to show here."
-msgstr ""
-
-#: tips:196
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr ""
 
-#: tips:197
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr ""
 
-#: tips:198
+#: tips:236
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 
-#: tips:199
+#: tips:237
 msgid "Action windows"
 msgstr "Handlings vinduer"
 
-#: tips:200
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4276,63 +4958,110 @@ msgstr ""
 "Handlings vinduer dukker op når du starter en baggrunds-\n"
 "handling, som f.eks. at kopiere eller slette nogle filer."
 
-#: tips:201
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Auto-start (Stille) disse handlinger"
 
-#: tips:203
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Kopier filer uden at spørge igen først."
 
-#: tips:205
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Flyt filer uden at spørge igen først."
 
-#: tips:207
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Lav lænker til filer uden at spørge først."
 
-#: tips:209
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Slet filer uden at spørge igen først."
 
-#: tips:210
+#: tips:248
 msgid "Mount"
 msgstr "Montér"
 
-#: tips:211
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Montér og afmontér filsystemer uden at spørge først."
 
-#: tips:212
+#: tips:250
 msgid "Default settings"
 msgstr "Standard-indstillinger"
 
-#: tips:214
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Tving"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "Spørg ikke igen omkring sletning af ikke-skrivbare objekter."
 
-#: tips:216
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Vis ikke så meget information i besked området."
 
-#: tips:218
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Indholdet af undermapper skal også ændres."
 
-#: tips:221
+#: tips:263
+#, fuzzy
+msgid "Mount commands"
+msgstr "Monterings-punkt"
+
+#: tips:264
+#, fuzzy
+msgid "Mount command"
+msgstr "Monterings-punkt"
+
+#: tips:265
+msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
+msgstr ""
+
+#: tips:266
+#, fuzzy
+msgid "Unmount command"
+msgstr "Afmontér"
+
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "Kommando:"
+
+#: tips:269
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Træk og Slip"
 
-#: tips:222
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Træk til ikoner"
 
-#: tips:223
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Tillad træk til ikoner i 'filer' vinduer"
 
-#: tips:224
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
@@ -4342,11 +5071,11 @@ msgstr ""
 "i et vindue. Objektet vil blive markeret nå du gør dette, og et slip af "
 "filen vil putte den i den mappe, eller hente det ind i programmet."
 
-#: tips:225
+#: tips:276
 msgid "Directories spring open"
 msgstr "Mapper springer åbne"
 
-#: tips:226
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
@@ -4356,15 +5085,15 @@ msgstr ""
 "markerede mappe til at 'springe' åben efter at filen har været holdt over "
 "den i et kort stykke tid."
 
-#: tips:227
+#: tips:278
 msgid "Spring delay:"
 msgstr "Spring forsinkelse:"
 
-#: tips:228
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:229
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
@@ -4374,19 +5103,19 @@ msgstr ""
 "en fil over en mappe før den springer åben. Indstillingen ovenover skal slås "
 "til før denne har nogen effekt."
 
-#: tips:230
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Når man trækker filer med venstre muse-knap"
 
-#: tips:231 tips:235
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Vis en menu over mulige handlinger"
 
-#: tips:232
+#: tips:283
 msgid "Copy the files"
 msgstr "Kopiér filerne"
 
-#: tips:233
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
@@ -4394,15 +5123,15 @@ msgstr ""
 "Bemærk at du stadig kan få menuen frem ved at trække med Alt-knappen holdt "
 "nede."
 
-#: tips:234
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Når man trækker filer med den midterste muse-knap"
 
-#: tips:236
+#: tips:287
 msgid "Move the files"
 msgstr "Flyt filerne"
 
-#: tips:237
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
@@ -4410,11 +5139,11 @@ msgstr ""
 "Bemærk at du stadig kan få menuen frem ved at trække med venstre museknap, "
 "mens du holder Alt-knappen nede."
 
-#: tips:238
+#: tips:289
 msgid "Download handler"
 msgstr "Hentnings-håndterer"
 
-#: tips:239
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4426,35 +5155,35 @@ msgstr ""
 "'fileren', og den nuværende mappe er destinationen. F.eks.\n"
 "xterm -e wget $1"
 
-#: tips:240
+#: tips:291
 msgid "Menus"
 msgstr "Menuer"
 
-#: tips:242
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Størrelsen af ikonerne i menuen:"
 
-#: tips:243
+#: tips:294
 msgid "No Icons"
 msgstr "Ingen ikoner"
 
-#: tips:246
+#: tips:297
 msgid "Same as current window"
 msgstr "Det samme som det nuværende vindue"
 
-#: tips:247
+#: tips:298
 msgid "Same as default"
 msgstr "Det samme som standard"
 
-#: tips:248
+#: tips:299
 msgid "Behaviour"
 msgstr "Opførsel"
 
-#: tips:249
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Fil-menu ved højreklik"
 
-#: tips:250
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
@@ -4462,23 +5191,29 @@ msgstr ""
 "Vis fil-menuen i stedet for hovedmenuen, ved højreklik, hvis der er valgte "
 "filer (hovedmenuen bliver vist hvis Control holdes nede)."
 
-#: tips:251
-msgid "`Xterm Here' program"
+#: tips:302
+#, fuzzy
+msgid "Terminal emulator program"
 msgstr "'Xterm Her' program"
 
-#: tips:252
-msgid "The program to launch when you choose `Xterm Here' from the menu."
+#: tips:303
+#, fuzzy
+msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr "Programmet der bliver startet når du vælger 'Xterm Her' fra menuen."
 
-#: tips:253
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Tastatur-genveje"
 
-#: tips:255
+#: tips:305
+msgid "Types"
+msgstr "Typer"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME-typer"
 
-#: tips:256
+#: tips:307
 #, fuzzy
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
@@ -4491,24 +5226,24 @@ msgstr ""
 "\n"
 "http://rox.sourceforge.net/mime_editor.html"
 
-#: tips:257
+#: tips:308
 msgid "Edit MIME rules"
 msgstr ""
 
-#: tips:258
+#: tips:309
 #, fuzzy
 msgid "Themes"
 msgstr "Tider"
 
-#: tips:259
+#: tips:310
 msgid "Icon theme"
 msgstr "Ikon-tema"
 
-#: tips:260
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "Temaer bør placeres i mappen ~/.icons."
 
-#: tips:261
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
@@ -4517,39 +5252,39 @@ msgstr ""
 "type.Bemærk at ikoner der er defineret på denne måde vil blive valgt fremfor "
 "det valgte temas ikoner."
 
-#: tips:262
+#: tips:313
 msgid "Colours"
 msgstr "Farver"
 
-#: tips:263
+#: tips:314
 msgid "File type colours"
 msgstr "Fil-type farver"
 
-#: tips:264
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Farv filer baseret på deres type"
 
-#: tips:265
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr "Filnavne (og detaljer) skal farves efter deres fils type."
 
-#: tips:266
+#: tips:317
 msgid "Directory:"
 msgstr "Mappe:"
 
-#: tips:267
+#: tips:318
 msgid "Regular file:"
 msgstr "Normal fil:"
 
-#: tips:268
+#: tips:319
 msgid "Pipe:"
 msgstr "Rør:"
 
-#: tips:269
+#: tips:320
 msgid "Socket:"
 msgstr "Stik:"
 
-#: tips:271
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
@@ -4557,19 +5292,19 @@ msgstr ""
 "Fejl, som f.eks. en symbolsk lænke der peger mod en ikke-eksisterende fil, "
 "eller en fil som der er problemer med at undersøge."
 
-#: tips:272
+#: tips:323
 msgid "Character device:"
 msgstr "Karakter-enhed:"
 
-#: tips:273
+#: tips:324
 msgid "Block device:"
 msgstr "Blok-enhed:"
 
-#: tips:274
+#: tips:325
 msgid "Door:"
 msgstr "Dør:"
 
-#: tips:275
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
@@ -4577,31 +5312,59 @@ msgstr ""
 "Dør-filer er lidt ligesom stik eller rør, og findes (indtil videre) kun "
 "under Solaris."
 
-#: tips:276
+#: tips:327
 msgid "Executable file:"
 msgstr "Udførbar fil:"
 
-#: tips:277
+#: tips:328
 msgid "Application directory:"
 msgstr "Program-mappe:"
 
-#: tips:278
+#: tips:329
 msgid "Unknown type:"
 msgstr "Ukendt type:"
 
-#: tips:279
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Baggrund:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Baggrund:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Kompatibilitet"
 
-#: tips:280
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Vindues-håndterings-problemer"
 
-#: tips:281
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "Tilsidesæt vindues-behanderens kontrol af opslagstavlen og paneler"
 
-#: tips:282
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4616,11 +5379,11 @@ msgstr ""
 "tittelbjælker og andre dekorationer på paneler, eller at begge dele er at "
 "finde i vindues-listen."
 
-#: tips:283
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "Videresend alle museklik på baggrunden til vindues-håndteringen"
 
-#: tips:284
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
@@ -4631,11 +5394,11 @@ msgstr ""
 "slået til, vil alle klik blive sendt videre til vindues-håndteringen i "
 "stedet. Klik på ikoner vil ikke blive videresendt."
 
-#: tips:285
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Blackbox rod-menu-rettelse"
 
-#: tips:286
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4647,27 +5410,51 @@ msgstr ""
 "lapninger for dette. Disse vindues-håndterere forventes at ændre deres "
 "opførsel i nyere udgaver, så dette ikke bliver nødvendigt."
 
-#: tips:287
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "Panelet er en 'dok'"
 
-#: tips:288
+#: tips:346
+#, fuzzy
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 "Slå denne funktion fra, hvis du ikke ønsker at paneler ligger ovenover andre "
 "vinduer. Dette kræver en genstart af programmet for at virke."
 
-#: tips:289
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Panel-stil"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Træk og slip"
 
-#: tips:290
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Bug ikke værtsnavn"
 
-#: tips:291
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4677,22 +5464,421 @@ msgstr ""
 "at denne indstilling er slået til. Slå denne til hvis træk af filer til et "
 "program viser et + tegn på muse-pointeren men trækket ikke virker."
 
-#: tips:292
-msgid "Extended attributes"
-msgstr ""
-
-#: tips:293
+#: tips:355
 #, fuzzy
 msgid "Don't use extended attributes"
 msgstr "Bug ikke værtsnavn"
 
-#: tips:294
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
 "disabled, the MIME type of the file is only derived from the file name and "
 "the properties window does not report extended attributes."
 msgstr ""
+
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Bund-margen"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+msgid "Right gap:"
+msgstr ""
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "Ny Mappe"
+
+#: ../Templates.ui.h:4
+#, fuzzy
+msgid "Panel Options"
+msgstr "Indstillinger"
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Billeder og tekst"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Ethvert panel-ikon bliver vist med et billede og noget tekst."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Kun billeder for programmer"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr "Programmer har kun et billede, alt andet har både et billede og tekst."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Kun billede"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Kun billedet bliver vist"
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Panel-tykkelse (tynd)"
+
+#: ../Templates.ui.h:12
+#, fuzzy
+msgid "The size of this panel."
+msgstr "Størrelsen af paneler."
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Oversættelse"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "Dæk ikke paneler"
+
+#: ../Templates.ui.h:19
+#, fuzzy
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Bed vindues-håndteringen om ikke at dække paneler, når den maksimerer et "
+"vindue. Nogle vindues-håndterere overholder muligvis ikke dette. Hvis det "
+"ikke slået til, vil 'fileren' bede om at få holdt blot et par billedpunkter "
+"frie, i kanten af skærmen, så auto-hævning virker."
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Panel-stil"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Begræns til Xinerama-skærm"
+
+#: ../Templates.ui.h:22
+#, fuzzy
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Hvis du har en Xinerama flerskærms-opsætning, kan du slå dette til for at "
+"begrænse paneler til én skærm, i stedet for at bredde sig over flere."
+
+#: ../Templates.ui.h:23
+#, fuzzy
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+"Den skærm som paneler begrænser sig til i Xinerama-tilstand (nummereret fra "
+"0)"
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "Xinerama"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr ""
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr ""
+
+#: ../Templates.ui.h:27
+#, fuzzy
+msgid "Bottom edge"
+msgstr "Bund-margen"
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr ""
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "<b>Tilladdelser</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<mappe>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' findes allerede - overskriv?"
+
+#, fuzzy
+#~ msgid "Choices migration"
+#~ msgstr "Kinesisk (traditionel)"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Fejl under scanning af '%s:\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Mappe mangler/slettet"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Mappen '%s' kan ikke findes."
+
+#~ msgid "Cancel"
+#~ msgstr "Fortryd"
+
+#~ msgid ""
+#~ ".\n"
+#~ "Home page (including updated versions): http://rox.sourceforge.net/\n"
+#~ msgstr ""
+#~ ".\n"
+#~ "Hjemmeside (med nyere udgaver): http://rox.sourceforge.net/\n"
+
+#~ msgid "GNOME-VFS library"
+#~ msgstr "GNOME-VFS-bibliotek"
+
+#~ msgid "No (need 2.8.0 or later)"
+#~ msgstr "Nej (kræver 2.8.0 eller nyere)"
+
+#~ msgid "Dnotify support"
+#~ msgstr "Dnotify-understøttelse"
+
+#~ msgid "Open AVFS"
+#~ msgstr "Open med AVFS"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr "Du burde Shift-klikke på en fil for at sende den til noget"
+
+#~ msgid "Look inside ... ?"
+#~ msgstr "Kig indendi ... ?"
+
+#, fuzzy
+#~ msgid "Panel: %s"
+#~ msgstr "Paneler"
+
+#, fuzzy
+#~ msgid "Top-edge panel"
+#~ msgstr "Luk panel?"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Ugyldig .gmo oversættelses-fil (for kort): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr "Ugyldig .gmo oversættelses-fil (GNU magic number ikke fundet): %s"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Gå til overmappen"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Gå til hjemme-mappen"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Bogmærker"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Bogmærke-menu"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Genscan mappens indhold"
+
+#~ msgid "Change icon size"
+#~ msgstr "Indstil ikon størrelsen"
+
+#~ msgid "Show extra details"
+#~ msgstr "Vis ekstra detaljer"
+
+#~ msgid "Hidden"
+#~ msgstr "Skjult"
+
+#~ msgid "Show/hide hidden files"
+#~ msgstr "Vis/Skjul skjulte filer"
+
+#~ msgid ""
+#~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
+#~ "instead."
+#~ msgstr ""
+#~ "Da ikon-temaet '%s' ikke indeholder nogen MIME-ikoner, bliver standard-"
+#~ "ROX-temaet anvendt."
+
+#~ msgid ""
+#~ "Failed to create symlink '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(this may mean that the ROX theme already exists there, but the 'mime-"
+#~ "application:postscript' icon couldn't be loaded for some reason)"
+#~ msgstr ""
+#~ "Det lykkedes ikke at lave den symbolske lænke '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(dette kan betyde at ROX-temaet allerede findes dér, men at 'mime-"
+#~ "application:postscript'-ikonet ikke kunne indlæses)"
+
+#~ msgid "Language"
+#~ msgstr "Sprog"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "Brug LANG miljø variabel"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Kinesisk (traditionel)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Kinesisk (simplificeret)"
+
+#~ msgid "Czech"
+#~ msgstr "Tjekkisk"
+
+# tips=x
+#~ msgid "Danish"
+#~ msgstr "Dansk"
+
+#~ msgid "Dutch"
+#~ msgstr "Hollandsk"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Engelsk (ingen oversættelse)"
+
+#, fuzzy
+#~ msgid "Estonian"
+#~ msgstr "Rumænsk"
+
+# tips=x
+#, fuzzy
+#~ msgid "Finnish"
+#~ msgstr "Dansk"
+
+#~ msgid "French"
+#~ msgstr "Fransk"
+
+#~ msgid "German"
+#~ msgstr "Tysk"
+
+#~ msgid "Hungarian"
+#~ msgstr "Ungarnsk"
+
+#~ msgid "Japanese"
+#~ msgstr "Japansk"
+
+#~ msgid "Norwegian"
+#~ msgstr "Norsk"
+
+#~ msgid "Italian"
+#~ msgstr "Italiensk"
+
+#~ msgid "Polish"
+#~ msgstr "Polsk"
+
+#~ msgid "Portuguese (Brasil)"
+#~ msgstr "Portugisisk (Braziliansk)"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumænsk"
+
+#~ msgid "Russian"
+#~ msgstr "Russisk"
+
+#~ msgid "Spanish"
+#~ msgstr "Spansk"
+
+#~ msgid "Swedish"
+#~ msgstr "Svensk"
+
+#~ msgid "Change at:"
+#~ msgstr "Ændre tid:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Største bredde (Store ikoner):"
+
+#~ msgid "(Small Icons):"
+#~ msgstr "(Små Ikoner):"
+
+#~ msgid "Panels"
+#~ msgstr "Paneler"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Paneler er rækker af ikoner der løber langs siden af skærmen. Se manualen "
+#~ "for mere information omkring paneler og deres brug."
+
+#~ msgid "(thick)"
+#~ msgstr "(tyk)"
 
 #~ msgid ""
 #~ "Error loading MIME database:\n"
@@ -4857,14 +6043,6 @@ msgstr ""
 #~ msgid "Show name-to-type rules"
 #~ msgstr "Vis navn-til-type regler"
 
-#, fuzzy
-#~ msgid "DirItem"
-#~ msgstr "objekt"
-
-#, fuzzy
-#~ msgid "Background color"
-#~ msgstr "Baggrund:"
-
 #~ msgid "Set Icon"
 #~ msgstr "Definer Ikon"
 
@@ -4929,14 +6107,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Du har ikke defineret nogle specielle ikoner; derfor har jeg ingen mapper "
 #~ "vise dig"
-
-#, fuzzy
-#~ msgid "Large wrap width:"
-#~ msgstr "Stor ombrydnings-bredde"
-
-#, fuzzy
-#~ msgid "Max Small Icons width:"
-#~ msgstr "Maks Små Ikoner bredde"
 
 #, fuzzy
 #~ msgid ""
@@ -5090,9 +6260,6 @@ msgstr ""
 #~ msgid "File Information"
 #~ msgstr "ROX-Filer indstillinger"
 
-#~ msgid "Remove"
-#~ msgstr "Fjern"
-
 #, fuzzy
 #~ msgid "Intelligent sorting"
 #~ msgstr "Ignorer store og små bogstaver under sortering"
@@ -5187,9 +6354,6 @@ msgstr ""
 #~ msgid "RPM"
 #~ msgstr "RPM"
 
-#~ msgid "New Directory"
-#~ msgstr "Ny Mappe"
-
 #~ msgid "New File"
 #~ msgstr "Ny Fil"
 
@@ -5226,9 +6390,6 @@ msgstr ""
 
 #~ msgid "...always"
 #~ msgstr "...altid"
-
-#~ msgid "Window size limit"
-#~ msgstr "Vindues-størrelse grænse"
 
 #~ msgid "Error"
 #~ msgstr "Fejl"
@@ -5269,9 +6430,6 @@ msgstr ""
 
 #~ msgid "Named pipe"
 #~ msgstr "Navngivet pipe"
-
-#~ msgid "Application"
-#~ msgstr "Program"
 
 #~ msgid "Copy failed"
 #~ msgstr "Kopiering mislykkedes"

--- a/ROX-Filer/src/po/de.po
+++ b/ROX-Filer/src/po/de.po
@@ -2,61 +2,66 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ROX-Filer 2.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-08-09 14:02+0100\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2005-07-31 22:36+0100\n"
 "Last-Translator: Guido Schimmels <__guido__@web.de>\n"
 "Language-Team: ROX Mailing List <rox-devel@lists.sourceforge.net>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-Language: German\n"
 "X-Poedit-Country: GERMANY\n"
 
 #: abox.c:127
-msgid "<dir>"
-msgstr "<ver>"
+msgid "<src>"
+msgstr ""
 
-#: abox.c:219
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Still"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Quiet"
 msgstr "Still"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Nicht jede Operation bestätigen"
 
-#: abox.c:455 tips:60
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Name"
 
-#: abox.c:461 menu.c:232
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Verzeichnis"
 
-#: abox.c:550
+#: abox.c:546
 msgid "Expression:"
 msgstr "Ausdruck:"
 
-#: action.c:58
+#: action.c:57
 msgid "See the attr(5) man page for full details."
 msgstr "Siehe die Handbuchseite attr(5) für Einzelheiten."
 
-#: action.c:60
+#: action.c:59
 msgid "See the fsattr(5) man page for full details."
 msgstr "Siehe die Handbuchseite fsattr(5) für Einzelheiten."
 
-#: action.c:62
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr "Das Betriebssystem scheint dies nicht zu unterstützen."
 
-#: action.c:188
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Hilfe zur Suchfunktion"
 
-#: action.c:199
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -134,11 +139,11 @@ msgstr ""
 "ein % in 'Befehl' wird ersetzt mit dem Pfad der aktuellen Datei)\n"
 "<b>prune</b> (falsch, und verhindert das Durchsuchen von Verzeichnissen)."
 
-#: action.c:246
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Hilfe zum Ändern der Zugriffsrechte"
 
-#: action.c:257
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -200,11 +205,11 @@ msgstr ""
 "\n"
 "Lesen Sie die chmod(1) Manpage für weitere Informationen."
 
-#: action.c:298
+#: action.c:308
 msgid "Set type reference"
 msgstr "Typreferenz zuordnen"
 
-#: action.c:309
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -232,48 +237,55 @@ msgstr ""
 "für Verzeichnisse, Geräte, Pipes oder Sockets, und dann\n"
 "auch nur für bestimmte Dateisysteme und Betriebssysteme.\n"
 
-#: action.c:416
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Prozess beendet..\n"
 
-#: action.c:432
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Es gab genau einen Fehler.\n"
 
-#: action.c:434
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Es gab %d Fehler.\n"
 
-#: action.c:458
+#: action.c:516
 msgid "ERROR reading"
 msgstr "FEHLER beim Lesen"
 
-#: action.c:501
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Fertig\n"
 
-#: action.c:557 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "FEHLER"
 
-#: action.c:711 main.c:674 main.c:681 main.c:688
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Ja"
 
-#: action.c:714 main.c:676 main.c:690
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Nein"
 
-#: action.c:732
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -281,7 +293,7 @@ msgstr ""
 "\n"
 "Fordere Kindprozess auf, sich zu beenden...\n"
 
-#: action.c:739
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -289,41 +301,41 @@ msgstr ""
 "\n"
 "Versuche KILL auf Wildläuferprozess ...\n"
 
-#: action.c:892
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Inhalt von %s zählen?"
 
-#: action.c:928
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?%s'%s' löschen?"
 
-#: action.c:929
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "SCHREIBGESCHÜTZT"
 
-#: action.c:936
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "Lösche '%s'\n"
 
-#: action.c:949
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'Verzeichnis '%s' gelöscht\n"
 
-#: action.c:982
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?'%s auswerfen'?"
 
-#: action.c:989
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'%s' auswerfen\n"
 
-#: action.c:1008
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -332,80 +344,95 @@ msgstr ""
 "!%s\n"
 "Einhängen fehlgeschlagen\n"
 
-#: action.c:1027 action.c:1046
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?'%s' prüfen?"
 
-#: action.c:1043
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Ungültiges Suchmuster - ändern Sie es und versuchen Sie es erneut\n"
 
-#: action.c:1053
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(beim prüfen von '%s')\n"
 
-#: action.c:1127 action.c:1152
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Zugriffsrechte für '%s' ändern?"
 
-#: action.c:1133
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Ändere Zugriffsrechte für '%s'\n"
 
-#: action.c:1150
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Ungültiger Befehl - ändern Sie es und versuchen Sie es nocheinmal\n"
 
-#: action.c:1207 action.c:1227
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?Typ von '%s' ändern?"
+
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Typ von '%s' ändern?"
 
-#: action.c:1224
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Ungültiger Typ - ändern Sie ihn und versuchen es erneut\n"
 
-#: action.c:1246
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Typ ändern von '%s' zu '%s'\n"
 
-#: action.c:1325
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'Typ ändern von '%s' zu '%s'\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' existiert bereits - %s?"
 
-#: action.c:1327
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "Inhalte zusammenführen"
 
-#: action.c:1328
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "überschreiben"
 
-#: action.c:1344
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Versuche trotzdem zu kopieren...\n"
 
-#: action.c:1353
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?%s nach %s kopieren?"
 
-#: action.c:1357
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Kopiere %s nach %s\n"
 
-#: action.c:1372
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!FEHLER: Das Ziel existiert bereits, ist aber kein Verzeichnis\n"
 
-#: action.c:1444
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -414,26 +441,7 @@ msgstr ""
 "!%s\n"
 "Kopieren von '%s' fehlgeschlagen\n"
 
-#: action.c:1488
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' existiert bereits - überschreiben?"
-
-#: action.c:1503
-msgid "'Trying move anyway...\n"
-msgstr "'Versuche trotzdem zu verschieben...\n"
-
-#: action.c:1511
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?%s nach %s verschieben?"
-
-#: action.c:1515
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Verschiebe %s nach %s\n"
-
-#: action.c:1523
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -442,45 +450,59 @@ msgstr ""
 "!%s\n"
 "Kann %s nicht nach %s verschieben\n"
 
-#: action.c:1544
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Versuche trotzdem zu verschieben...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?%s nach %s verschieben?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Verschiebe %s nach %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!FEHLER: Kopieren eines Objekts auf sich selbst nicht möglich\n"
 
-#: action.c:1559
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!FEHLER: Verschieben eines Objekts auf sich selbst nicht möglich\n"
 
-#: action.c:1571
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Erstelle Verknüpfung von %s nach %s\n"
 
-#: action.c:1576
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Verknüpfung von %s nach %s erstellen?"
 
-#: action.c:1618
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Hänge %s ein\n"
 
-#: action.c:1619
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Hänge %s aus\n"
 
-#: action.c:1622
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?%s einhängen?"
 
-#: action.c:1623
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?%s aushängen?"
 
-#: action.c:1643
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -489,7 +511,7 @@ msgstr ""
 "!%s\n"
 "Einhängen fehlgeschlagen\n"
 
-#: action.c:1644
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -498,11 +520,11 @@ msgstr ""
 "!%s\n"
 "Aushängen fehlgeschlagen\n"
 
-#: action.c:1652
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(scheint bereits eingehängt zu sein)\n"
 
-#: action.c:1698
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -511,209 +533,233 @@ msgstr ""
 "'\n"
 "Gesamt: %s ("
 
-#: action.c:1704
+#: action.c:2108
 msgid "file"
 msgstr "Datei"
 
-#: action.c:1704
+#: action.c:2108
 msgid "files"
 msgstr "Dateien"
 
-#: action.c:1708
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "keine Verzeichnisse)\n"
 
-#: action.c:1712
+#: action.c:2116
 msgid "directory"
 msgstr "Verzeichnis"
 
-#: action.c:1713
+#: action.c:2117
 msgid "directories"
 msgstr "Verzeichnisse"
 
-#: action.c:1754
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Kein Mount-Punkt angewählt!\n"
 
-#: action.c:1839
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Weitere Suche?"
 
-#: action.c:1869 action.c:1900
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' ist eine Verknüpfung\n"
 
-#: action.c:1940
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "Bitte wählen Sie erst einige zu durchsuchende Verzeichnisse aus"
 
-#: action.c:1950 menu.c:223
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Suchen"
 
-#: action.c:1983
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Bitte wählen Sie erst einige zu zählende Einträge aus"
 
-#: action.c:1987
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Speicherverbrauch"
 
-#: action.c:2021
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Einhängen / Aushängen"
 
-#: action.c:2034
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr ""
 "ROX-Filer unterstützt noch keine Mount-Punkte auf Ihrem System. "
 "'tschuldigung."
 
-#: action.c:2048 menu.c:210 tips:208
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Löschen"
 
-#: action.c:2058 tips:213
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Erzwingen"
 
-#: action.c:2058
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Löschen von nicht-schreibbaren Einträgen nicht bestätigen"
 
-#: action.c:2061 action.c:2116 action.c:2175 action.c:2228 action.c:2264
-#: tips:215
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Knapp"
 
-#: action.c:2061
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Nur gelöschte Verzeichnisse auflisten"
 
-#: action.c:2078
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr ""
 "Bitte wählen Sie erst einige Einträge aus, deren Zugriffsrechte Sie ändern "
 "wollen"
 
-#: action.c:2086
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Mache ausführbar/durchsuchbar)"
 
-#: action.c:2088
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (Mache nicht-ausführbar/nicht-durchsuchbar)"
 
-#: action.c:2090
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Gib Besitzer Lese+Schreib-Rechte)"
 
-#: action.c:2092
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Privat - Zugriff nur für Besitzer)"
 
-#: action.c:2094
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Öffentlicher Zugriff ohne Schreiben)"
 
-#: action.c:2105 menu.c:184 menu.c:221 tips:75
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Zugriffsrechte"
 
-#: action.c:2116 action.c:2175
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Bearbeitete Dateien nicht auflisten"
 
-#: action.c:2119 action.c:2178 tips:217
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Rekursiv"
 
-#: action.c:2119
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Auch den Inhalt von Unterverzeichnissen ändern"
 
-#: action.c:2123
+#: action.c:2547
 msgid "Command:"
 msgstr "Befehl:"
 
-#: action.c:2151
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Bitte wählen Sie erst die Dateien aus, deren Typ Sie ändern wollen"
 
-#: action.c:2164
+#: action.c:2590
 msgid "Set type"
 msgstr "Typ zuordnen"
 
-#: action.c:2178
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Inhalt von Unterverzeichnissen ändern"
 
-#: action.c:2185 infobox.c:615
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Typ:"
 
-#: action.c:2214 dnd.c:124 menu.c:1999 tips:202
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Kopieren"
 
-#: action.c:2224 action.c:2260 tips:219
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Nicht jede Operation bestätigen"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Dateien dürfen nur von neuerer Version überschrieben werden."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Neuere"
 
-#: action.c:2225 action.c:2261 tips:220
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Dateien dürfen nur von neuerer Version überschrieben werden."
 
-#: action.c:2228
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "Verzeichnisse"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Nur Verzeichnisse beim Kopieren listen"
 
-#: action.c:2250 dnd.c:125 tips:204
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Verschieben"
 
-#: action.c:2264
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Dateien beim Verschieben nicht einzeln listen"
 
-#: action.c:2284 tips:206
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Verknüpfen"
 
-#: action.c:2303 appmenu.c:113
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Auswerfen"
 
-#: action.c:2360
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Lösche Einträge wie "
 
-#: action.c:2364
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Lösche den Eintrag "
 
-#: action.c:2366
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Lösche die Einträge "
 
-#: action.c:2385
+#: action.c:2900
 msgid " and "
 msgstr " und "
 
-#: action.c:2394
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr " betrifft Datei auf Pinwand oder Leiste - trotzdem löschen? "
 
-#: action.c:2401
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr " betrifft Dateien auf Pinwand oder Leiste - trotzdem löschen?"
 
-#: appmenu.c:198
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<Bezeichnung fehlt>"
 
-#: appmenu.c:295
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
@@ -722,82 +768,82 @@ msgstr ""
 "Erstelle Verknüpfungen zu den gewünschten Programmen in diesem Verzeichnis. "
 "Diese erscheinen im Menü für diesen Typ (%s/%s)."
 
-#: appmenu.c:339 menu.c:234
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Menü anpassen..."
 
-#: appmenu.c:396 menu.c:251 toolbar.c:159
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Hilfe"
 
-#: bookmarks.c:147
-msgid "Path"
-msgstr "Pfad"
-
-#: bookmarks.c:155
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Title"
 
-#: bookmarks.c:304
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Pfad"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Lesezeichen für Netzwerkresource '%s' nicht anlegbar\n"
 
-#: bookmarks.c:312 bookmarks.c:630
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' ist kein Verzeichnis"
 
-#: bookmarks.c:518
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Kein Lesezeichen markiert"
 
-#: bookmarks.c:542
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Zum Verschieben, Cursor auf gewünschtes Lesezeichen setzen"
 
-#: bookmarks.c:562
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Das Ende der Liste ist schon erreicht"
 
-#: bookmarks.c:636
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Lesezeichen für Netzwerkverzeichnisse wie '%s' nicht anlegbar"
 
-#: bookmarks.c:778
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Lesezeichen anlegen"
 
-#: bookmarks.c:785
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Lesezeichen bearbeiten"
 
-#: bookmarks.c:790
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Zuletzt besucht"
 
-#: bulk_rename.c:68
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Massenhafte Dateiumbenennung"
 
-#: bulk_rename.c:71
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Rückgängig"
 
-#: bulk_rename.c:76
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "Mache die Spalte 'Neu' zur Kopie von 'Alt'"
 
-#: bulk_rename.c:81
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "_Umbenennen"
 
-#: bulk_rename.c:94
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Ersetzen:"
 
-#: bulk_rename.c:101
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -816,18 +862,20 @@ msgid "With:"
 msgstr "Mit:"
 
 #: bulk_rename.c:116
+#, fuzzy
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 "Die erste Übereinstimmung in jedem Dateinamen wird ersetzt mit dieser "
 "Zeichenkette.Es gibt keine Sonderzeichen."
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Anwenden"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
@@ -835,47 +883,47 @@ msgstr ""
 "Suchen-und-Ersetzen in der Spalte 'Neu'. Die Dateien werden erst nach "
 "Drücken des Umbenennen-Schalters tatsächlich umbenannt."
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Alter Name"
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Neuer Name"
 
-#: bulk_rename.c:259
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr "Keine Übereinstimmung (in der Spalte 'Neu') mit diesem Ausdruck"
 
-#: bulk_rename.c:264
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Eine Namensübereinstimmung, aber das Ergebnis war das selbe."
 
-#: bulk_rename.c:267
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr ""
 "%d Namensübereinstimmungen, aber die Ergebnisse waren jeweils identisch"
 
-#: bulk_rename.c:293
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr ""
 "Geben Sie einen regulären Suchausdruck an, und eine Zeichenkette mit der der "
 "Suchtext ersetzt werden soll."
 
-#: bulk_rename.c:310
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (für '%s')"
 
-#: bulk_rename.c:343
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr ""
 "Eine Datei mit Namen '%s' gibt es schon. Massenumbenennung abgebrochen."
 
-#: bulk_rename.c:348
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -886,12 +934,12 @@ msgstr ""
 "%s\n"
 "Massenumbenennung abgebrochen."
 
-#: bulk_rename.c:410
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "Eine Datei namens '%s' ist bereits vorhanden"
 
-#: bulk_rename.c:421
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
@@ -900,56 +948,73 @@ msgstr ""
 "Einige der 'Neu'-Namen enthalten / Zeichen (z.B. `%s`). Dadurch landen die "
 "Dateien in verschiedenen Verzeichnissen. Fortsetzen?"
 
-#: bulk_rename.c:436
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Kein Name geändert. Nichts zu tun!"
 
-#: choices.c:428
-msgid "Choices migration"
-msgstr "Einstellungen konvertieren"
+#: choices.c:434
+#, c-format
+msgid "%d directories could not be migrated"
+msgstr "%d Verzeichnisse konnten nicht konvertiert werden"
 
 #: choices.c:436
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Choices have been moved from \n"
-"<b>%s</b>\n"
+"%s\n"
 " to the new location \n"
-"<b>%s</b>\n"
+"%s\n"
+"%s"
 msgstr ""
 "Einstellungen wurden verschoben von \n"
 "<b>%s</b>\n"
 " zum neuen Ort \n"
 "<b>%s</b>\n"
 
-#: choices.c:447
-#, c-format
-msgid "%d directories could not be migrated"
-msgstr "%d Verzeichnisse konnten nicht konvertiert werden"
-
-#: dir.c:982
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Kann Verzeichnis %s nicht auswerten "
 
-#: dir.c:991
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Kann Verzeichnis %s nicht öffnen"
 
-#: display.c:588
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Größe"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) fehlgeschlagen: %s"
 
-#: dnd.c:126
-msgid "Link (relative)"
-msgstr "Verknüpfung (relative)"
-
-#: dnd.c:127
-msgid "Link (absolute)"
-msgstr "Verknüpfung (absolute)"
-
-#: dnd.c:426
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Interner Fehler - Fehlerhafter Info-Typ"
 
@@ -1034,14 +1099,14 @@ msgstr ""
 "Kann keine Daten vom Netzwerkrechner bekommen (application/octet-stream "
 "nicht verfügbar)"
 
-#: dnd.c:1016
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
 "Einige dieser Dateien sind auf einem anderen Rechner - sie werden ignoriert "
 "- 'tschuldigung"
 
-#: dnd.c:1023
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
@@ -1049,43 +1114,61 @@ msgstr ""
 "Keine dieser Dateien sind auf dem lokalen Rechner - Ich kann nicht mehrere "
 "Dateien vom Netzwerk bearbeiten - 'tschuldigung"
 
-#: dnd.c:1036
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Unbekannter Aktionsaufruf"
 
-#: dnd.c:1044
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Fehler beim Holen der Dateiliste: %s"
 
-#: dropbox.c:114
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Verknüpfung (relative)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Verknüpfung (absolute)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Verknüpfung (relative)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Verknüpfung (absolute)"
+
+#: dropbox.c:112
 msgid "Show"
 msgstr "Zeige"
 
-#: dropbox.c:120
+#: dropbox.c:118
 msgid "Show the current choice in a filer window"
 msgstr "Zeige aktuelle Einstellung in Dateifenster"
 
-#: dropbox.c:174
+#: dropbox.c:172
 msgid "<nothing>"
 msgstr "<nichts>"
 
-#: dropbox.c:239
+#: dropbox.c:237
 msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
 msgstr "Es gibt nichts zu zeigen. Ziehe etwas auf mich!"
 
-#: dropbox.c:263
+#: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
 msgstr "Nur immer genau eine Datei auf diese Zone bewegen."
 
-#: dropbox.c:273
+#: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr "Kann '%s' nicht verwenden, da es keine lokale Datei ist."
 
-#: dropbox.c:280 pinboard.c:853
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1094,7 +1177,7 @@ msgstr ""
 "Kein Zugriff möglich auf '%s':\n"
 "%s"
 
-#: filer.c:453
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1103,16 +1186,7 @@ msgstr ""
 "Fehler beim Durchsuchen von '%s':\n"
 "%s\n"
 
-#: filer.c:457
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Fehler beim Durchsuchen von '%s':\n"
-"%s"
-
-#: filer.c:562
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1122,337 +1196,396 @@ msgstr ""
 "\n"
 "Nach Aushängen kann Medium gefahrlos entnommen werden."
 
-#: filer.c:566
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 msgid "No change"
 msgstr "Keine Änderung"
 
-#: filer.c:572 menu.c:862
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Aushängen"
 
-#: filer.c:669
-msgid "Directory missing/deleted"
-msgstr "Verzeichnis nicht vorhanden/gelöscht"
-
-#: filer.c:1031
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
 "Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"Gruppe %s nicht definiert. Wählen Sie ein paar Dateien und drücken Sie Ctrl+%"
-"s, um die Gruppe zu definieren. Drücken Sie nur %s, um die Dateien später "
+"Gruppe %s nicht definiert. Wählen Sie ein paar Dateien und drücken Sie Ctrl+"
+"%s, um die Gruppe zu definieren. Drücken Sie nur %s, um die Dateien später "
 "noch einmal auszuwählen. Falls sie den Zahlenblock benutzen, achten Sie "
 "darauf, dass NumLock an ist."
 
-#: filer.c:1267
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Kann nicht auf Verzeichnis '%s' zugreifen"
+#: filer.c:2655
+msgid "A"
+msgstr ""
 
-#: filer.c:1419
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Verzeichnis '%s' nicht gefunden."
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
 
-#: filer.c:1713
-msgid "Cancel"
-msgstr "Abbruch"
+#: filer.c:2659 find.c:923
+msgid "G"
+msgstr "G"
 
-#: filer.c:2002
+#: filer.c:2664
 msgid "S"
 msgstr "S"
 
-#: filer.c:2004
+#: filer.c:2669
 msgid "T"
 msgstr "T"
 
-#: filer.c:2026
+#: filer.c:2670
+msgid "D"
+msgstr ""
+
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
+#, c-format
+msgid "Glob (%s), "
+msgstr ""
+
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Durchsuche, "
 
-#: filer.c:2028
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Miniaturen, "
 
-#: filer.c:2304
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Miniaturen, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Verknüpfung zu "
 
-#: filer.c:2335
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "Dies ist kein gültiger UTF-8 Dateiname. Sie sollten ihn ändern.\n"
 
-#: filer.c:2643 menu.c:1989
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "Das Symbol existiert nicht mehr!"
 
-#: filer.c:3327
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Wähle zu speichernde Ansichtseigenschaften"
 
-#: filer.c:3334
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Wähle zu speichernde Ansichtseigenschaften"
+
+#: filer.c:4727
 msgid "Position"
 msgstr "Position"
 
-#: filer.c:3339 toolbar.c:135 toolbar.c:139 tips:63
-msgid "Size"
-msgstr "Größe"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Fenster"
 
-#: filer.c:3344
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Versteckte zeigen"
 
-#: filer.c:3350
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Ansicht"
 
-#: filer.c:3356
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Sortierung"
 
-#: filer.c:3361 toolbar.c:143
+#: filer.c:4754
 msgid "Details"
 msgstr "Details"
 
-#: filer.c:3366 tips:114 tips:115
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Miniaturen"
 
-#: filer.c:3372
+#: filer.c:4765
 msgid "Filter"
 msgstr "Filter"
 
-#: find.c:487
+#: find.c:485
 msgid "And"
 msgstr "Und"
 
-#: find.c:511
+#: find.c:509
 msgid "Not"
 msgstr "Nicht"
 
-#: find.c:554
+#: find.c:552
 msgid "system"
 msgstr "System"
 
-#: find.c:562
+#: find.c:560
 msgid "prune"
 msgstr "abschneiden"
 
-#: find.c:650
+#: find.c:648
 msgid "After"
 msgstr "Nach"
 
-#: find.c:652
+#: find.c:650
 msgid "Before"
 msgstr "Bevor"
 
-#: find.c:746
+#: find.c:744
 msgid "IsReg"
 msgstr "IsReg"
 
-#: find.c:748
+#: find.c:746
 msgid "IsLink"
 msgstr "IsLink"
 
-#: find.c:750
+#: find.c:748
 msgid "IsDir"
 msgstr "IsDir"
 
-#: find.c:752
+#: find.c:750
 msgid "IsChar"
 msgstr "IsChar"
 
-#: find.c:754
+#: find.c:752
 msgid "IsBlock"
 msgstr "IsBlock"
 
-#: find.c:756
+#: find.c:754
 msgid "IsDev"
 msgstr "IsDev"
 
-#: find.c:758
+#: find.c:756
 msgid "IsPipe"
 msgstr "IsPipe"
 
-#: find.c:760
+#: find.c:758
 msgid "IsSocket"
 msgstr "IsSocket"
 
-#: find.c:762
+#: find.c:760
 msgid "IsDoor"
 msgstr "IsDoor"
 
-#: find.c:764
+#: find.c:762
 msgid "IsSUID"
 msgstr "IsSUID"
 
-#: find.c:766
+#: find.c:764
 msgid "IsSGID"
 msgstr "IsSGID"
 
-#: find.c:768
+#: find.c:766
 msgid "IsSticky"
 msgstr "IsSticky"
 
-#: find.c:770
+#: find.c:768
 msgid "IsReadable"
 msgstr "IsReadable"
 
-#: find.c:772
+#: find.c:770
 msgid "IsWriteable"
 msgstr "IsWritable"
 
-#: find.c:774
+#: find.c:772
 msgid "IsExecutable"
 msgstr "IsExecutable"
 
-#: find.c:776
+#: find.c:774
 msgid "IsEmpty"
 msgstr "IsEmpty"
 
-#: find.c:778
+#: find.c:776
 msgid "IsMine"
 msgstr "IsMine"
 
-#: find.c:906
+#: find.c:904
 msgid "Now"
 msgstr "Jetzt"
 
-#: find.c:919
+#: find.c:917
 msgid "Byte"
 msgstr "Byte"
 
-#: find.c:919
+#: find.c:917
 msgid "Bytes"
 msgstr "Bytes"
 
-#: find.c:921
+#: find.c:919
 msgid "Kb"
 msgstr "Kb"
 
-#: find.c:921
+#: find.c:919
 msgid "K"
 msgstr "K"
 
-#: find.c:923
+#: find.c:921
 msgid "Mb"
 msgstr "Mb"
 
-#: find.c:923
+#: find.c:921
 msgid "M"
 msgstr "M"
 
-#: find.c:925
+#: find.c:923
 msgid "Gb"
 msgstr "Gb"
 
 #: find.c:925
-msgid "G"
-msgstr "G"
-
-#: find.c:927
 msgid "Sec"
 msgstr "Sek"
 
-#: find.c:927
+#: find.c:925
 msgid "Secs"
 msgstr "Seks"
 
-#: find.c:929
+#: find.c:927
 msgid "Min"
 msgstr "Min"
 
-#: find.c:929
+#: find.c:927
 msgid "Mins"
 msgstr "Mins"
 
-#: find.c:931
+#: find.c:929
 msgid "Hour"
 msgstr "Stunde"
 
-#: find.c:931
+#: find.c:929
 msgid "Hours"
 msgstr "Stunden"
 
-#: find.c:933
+#: find.c:931
 msgid "Day"
 msgstr "Tag"
 
-#: find.c:933
+#: find.c:931
 msgid "Days"
 msgstr "Tage"
 
-#: find.c:935
+#: find.c:933
 msgid "Week"
 msgstr "Woche"
 
-#: find.c:935
+#: find.c:933
 msgid "Weeks"
 msgstr "Wochen"
 
-#: find.c:937
+#: find.c:935
 msgid "Year"
 msgstr "Jahr"
 
-#: find.c:937
+#: find.c:935
 msgid "Years"
 msgstr "Jahre"
 
-#: find.c:946
+#: find.c:944
 msgid "Ago"
 msgstr "Zurück"
 
-#: find.c:948
+#: find.c:946
 msgid "Hence"
 msgstr "Deshalb"
 
-#: find.c:963
+#: find.c:961
 msgid "atime"
 msgstr "atime"
 
-#: find.c:965
+#: find.c:963
 msgid "ctime"
 msgstr "ctime"
 
-#: find.c:967
+#: find.c:965
 msgid "mtime"
 msgstr "mtime"
 
-#: find.c:969
+#: find.c:967
 msgid "size"
 msgstr "Größe"
 
-#: find.c:971
+#: find.c:969
 msgid "inode"
 msgstr "inode"
 
-#: find.c:973
+#: find.c:971
 msgid "nlinks"
 msgstr "nlinks"
 
-#: find.c:975
+#: find.c:973
 msgid "uid"
 msgstr "uid"
 
-#: find.c:977
+#: find.c:975
 msgid "gid"
 msgstr "gid"
 
-#: find.c:979
+#: find.c:977
 msgid "blocks"
 msgstr "Blöcke"
 
-#: gtksavebox.c:251
+#: gtksavebox.c:249
 msgid "Save As:"
 msgstr "Speichere unter:"
 
-#: gtksavebox.c:397
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Unbenannt"
 
-#: gtksavebox.c:473
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
@@ -1460,7 +1593,7 @@ msgstr ""
 "Programm von Netzwerk will Direct Save benutzen, aber ich kann die "
 "XdndDirectSave0-Einstellung (type text/plain) nicht lesen.\n"
 
-#: gtksavebox.c:598
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1468,7 +1601,7 @@ msgstr ""
 "Ziehen Sie das Symbol auf einen Verzeichnisanzeiger\n"
 "(oder geben Sie einen vollen Pfadnamen an)"
 
-#: gui_support.c:331
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1476,20 +1609,21 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:400
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr ""
 "Versuche, eine XML-Datei als Textdatei zu lesen. Die Datei '%s' ist "
 "vielleicht fehlerhaft."
 
-#: gui_support.c:417
-#, c-format
+#: gui_support.c:542
+#, fuzzy, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
 "This may be due to upgrading from a previous version of ROX-Filer. Open the "
-"Options window and click on Save.\n"
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
 "Fehler in Datei '%s' bei Zeile %d: \n"
@@ -1498,16 +1632,16 @@ msgstr ""
 "Öffnen Sie das Options-Fenster und klicken Sie auf Speichern.\n"
 "Weitere Fehler werden ignoriert."
 
-#: gui_support.c:1000
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Fehlerhafter oder fehlender Zeilenumbruch in den text/uri-list Daten"
 
-#: gui_support.c:1332
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "Fehler beim öffnen von Datei '%s': %s"
 
-#: gui_support.c:1376
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
@@ -1515,10 +1649,11 @@ msgstr ""
 "Konnte Bild '%s' nicht laden: Ursache unbekannt, wahrscheinlich eine defekte "
 "Bilddatei"
 
-#: gui_support.c:1427
+#: gui_support.c:1583
+#, fuzzy, c-format
 msgid ""
-"This program cannot be run, as the 0launch command is not available. It can "
-"be downloaded from here:\n"
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
@@ -1527,7 +1662,7 @@ msgstr ""
 "\n"
 "http://0install.net/injector.html"
 
-#: i18n.c:38
+#: i18n.c:39
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
@@ -1535,154 +1670,177 @@ msgstr ""
 "Sie müssen den Dateimanager neu starten, bevor die neue Sprache voll aktiv "
 "wird"
 
-#: icon.c:78
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(Auswählen durch Anklicken)"
 
-#: icon.c:133
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:134 menu.c:252
-msgid "About ROX-Filer..."
-msgstr "Über ROX-Filer..."
-
-#: icon.c:135 menu.c:253
-msgid "Show Help Files"
-msgstr "Hilfedateien"
-
-#: icon.c:136 menu.c:254
-msgid "Manual"
-msgstr "Manual"
-
-#: icon.c:138 menu.c:230
-msgid "Options..."
-msgstr "Optionen..."
-
-#: icon.c:139 menu.c:239
-msgid "Home Directory"
-msgstr "Heimatverzeichnis"
-
-#: icon.c:140 icon.c:1340 menu.c:206 type.c:212
-msgid "File"
-msgstr "Datei"
-
-#: icon.c:141 menu.c:212 menu.c:875
-msgid "Shift Open"
-msgstr "Öffnen als Text"
-
-#: icon.c:142 menu.c:218
-msgid "Properties"
-msgstr "Eigenschaften"
-
-#: icon.c:143 menu.c:216
-msgid "Set Run Action..."
-msgstr "Startaktion ändern..."
-
-#: icon.c:144 menu.c:217
-msgid "Set Icon..."
-msgstr "Symbol ändern..."
-
-#: icon.c:145 icon.c:806
-msgid "Edit Item"
-msgstr "Eintrag ändern"
-
-#: icon.c:146
-msgid "Show Location"
-msgstr "Ursprung zeigen"
-
-#: icon.c:147
-msgid "Remove Item(s)"
-msgstr "Eintrag entfernen"
-
-#: icon.c:278 menu.c:764
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:291
+#: icon.c:311
 msgid "Nothing"
 msgstr "Nichts"
 
-#: icon.c:547
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "Der Ort muß mindestens ein Zeichen enthalten!"
 
-#: icon.c:613
+#: icon.c:641
+#, c-format
+msgid "You must unlock '%s' before removing it"
+msgstr ""
+
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Bitten wählen Sie erst einige Einträge zum Löschen aus"
 
-#: icon.c:627
+#: icon.c:657
+msgid "An item must be unlocked before it can be removed."
+msgstr ""
+
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Bitte öffnen Sie das Menü über einem Eintrag"
 
-#: icon.c:652 menu.c:1260
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "Sie können Startaktionen nur für normale Dateien setzen"
 
-#: icon.c:738
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Drücken Sie die gewünschte Tastenkombination (z.B. Strg+F1)"
 
-#: icon.c:760
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Kann Taste nicht zuordnen!"
 
-#: icon.c:809
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Eintrag ändern"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Klick auf das Symbol öffnet:"
 
-#: icon.c:819
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Zu übergebende Parameter (für Programme):"
 
-#: icon.c:833
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "Der Text unter dem Symbol ist:"
 
-#: icon.c:846
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "Das Tastaturkürzel ist:"
 
-#: infobox.c:112
+#: icon.c:910
+#, fuzzy
+msgid "Locked"
+msgstr "Socket"
+
+#: icon.c:915
+msgid "Locking an item prevents it from being accidentally removed"
+msgstr ""
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Über ROX-Filer..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Hilfedateien"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Manual"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Optionen..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Heimatverzeichnis"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Datei"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Öffnen als Text"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Eigenschaften"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Startaktion ändern..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Symbol ändern..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Ursprung zeigen"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Eintrag entfernen"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
 msgstr "Wollen Sie wirklich %d Fenster öffnen?"
 
-#: infobox.c:113
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Zeige Info"
 
-#: infobox.c:135 menu.c:769
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "ungültiges utf-8"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Zeige _Hilfedateien"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Zugriffsrechte</b>"
 
-#: infobox.c:286
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>Sieht aus nach...</b>"
 
-#: infobox.c:423 infobox.c:560 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Nur Verzeichnisse beim Kopieren listen"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "bytes"
 
-#: infobox.c:446
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Kann Dateigröße nicht lesen"
 
-#: infobox.c:504
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "!'%s' ist nicht weiter eine Verknüpfung"
 
-#: infobox.c:511
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1691,7 +1849,7 @@ msgstr ""
 "Verknüpfung konnte nicht entfernt werden '%s':\n"
 "%s"
 
-#: infobox.c:516
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1702,145 +1860,194 @@ msgstr ""
 "%s\n"
 "(bisherige Verknüpfung wurde entfernt)"
 
-#: infobox.c:539 tips:270
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Fehler:"
 
-#: infobox.c:546
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Wahres Verzeichnis"
 
-#: infobox.c:549
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Besitzer, Gruppe:"
 
-#: infobox.c:556 infobox.c:571 infobox.c:580
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Größe:"
 
-#: infobox.c:581
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Durchsuche"
 
-#: infobox.c:602
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Fehler beim Einlesen"
 
-#: infobox.c:609
+#: infobox.c:653
 msgid "Change time:"
 msgstr "letzte Änderung:"
 
-#: infobox.c:611
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Erstellt:"
 
-#: infobox.c:613
+#: infobox.c:657
 msgid "Access time:"
 msgstr "letzter Zugriff:"
 
-#: infobox.c:621
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Erweiterte Attribute:"
 
-#: infobox.c:623
+#: infobox.c:667
 msgid "Present"
 msgstr "Vorhanden"
 
-#: infobox.c:624
+#: infobox.c:668
 msgid "None"
 msgstr "Keine"
 
-#: infobox.c:625
+#: infobox.c:669
 msgid "Not supported"
 msgstr "Nicht unterstützt"
 
-#: infobox.c:637
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Verknüpfungsziel:"
 
-#: infobox.c:649 infobox.c:652
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Startaktion:"
 
-#: infobox.c:649
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Datei ausführen"
 
-#: infobox.c:744
+#: infobox.c:805
+#, fuzzy
+msgid "Comment"
+msgstr "Befehl:"
+
+#: infobox.c:807
+#, fuzzy
+msgid "Execute"
+msgstr "Datei ausführen"
+
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<nichts bisher>"
 
-#: infobox.c:814
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "file(1) sagt... %s"
 
-#: infobox.c:871
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Konnte Rechte nicht ändern: %s"
 
-#: infobox.c:889
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Besitzer"
 
-#: infobox.c:891
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Gruppe"
 
-#: infobox.c:893
+#: infobox.c:974
 msgid "World"
 msgstr "Welt"
 
-#: infobox.c:896
+#: infobox.c:977
 msgid "Read"
 msgstr "Lesen"
 
-#: infobox.c:898
+#: infobox.c:980
 msgid "Write"
 msgstr "Schreiben"
 
-#: infobox.c:900
+#: infobox.c:983
 msgid "Exec"
 msgstr "Ausführen"
 
-#: infobox.c:917
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:924
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:931
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky"
 
-#: infobox.c:953
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<nichts>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Verknüpfung"
 
-#: infobox.c:956
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX Applikation"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "mounted"
 msgstr "eingehängt"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "augehängt"
 
-#: infobox.c:968
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Mount-Punkt für %s (%s)"
 
-#: infobox.c:971
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Mount-Punkt (%s) "
+
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d Einträge"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Kopieren..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "Eintrag ändern"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Zeitangaben"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Optionen"
 
 #: main.c:95
 msgid ""
@@ -1877,6 +2084,7 @@ msgstr ""
 "\n"
 
 #: main.c:115
+#, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Open each directory or file listed, or the current working\n"
@@ -1898,10 +2106,12 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
-"Report bugs to "
+"Report bugs to %s.\n"
+"Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
 "Benutzung: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Öffne jedes angegebene Verzeichnis oder jede angegebene Datei, oder das\n"
@@ -1928,15 +2138,7 @@ msgstr ""
 "\n"
 "Bug-Reports bitte an "
 
-#: main.c:136
-msgid ""
-".\n"
-"Home page (including updated versions): http://rox.sourceforge.net/\n"
-msgstr ""
-".\n"
-"Homepage (inklusive neuer Versionen): http://rox.sourceforge.net/\n"
-
-#: main.c:234
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1948,7 +2150,7 @@ msgstr ""
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Versuche weiterzumachen..."
 
-#: main.c:382
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
@@ -1956,279 +2158,376 @@ msgstr ""
 "Die -o Option wird nicht mehr benutzt. Nehmen Sie diese Einstellung über "
 "Optionen->Kompatibilität vor."
 
-#: main.c:489
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Gestartet als Benutzter '%s'"
 
-#: main.c:666
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Kompiliert mit GTK Version %s\n"
 
-#: main.c:667
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Läuft mit GTK Version %d.%d.%d\n"
 
-#: main.c:671
+#: main.c:693
 msgid "features set at compile time"
 msgstr "Eigenschaften, die beim Kompilieren festgelegt wurden"
 
-#: main.c:672
+#: main.c:694
 msgid "Large File Support"
 msgstr "Unterstützung für große Dateien"
 
-#: main.c:679
-msgid "GNOME-VFS library"
-msgstr "GNOME-VFS-Bibliothek"
-
-#: main.c:683
-msgid "No (need 2.8.0 or later)"
-msgstr "Nein (benötigt 2.8.0 oder neuer)"
-
-#: main.c:686
-msgid "Dnotify support"
-msgstr "Dnotify-Ünterstützung"
-
-#: main.c:693
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Binärkompatibilität"
 
-#: main.c:695
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Ja (funktioniert auch mit älterer Glibc-Version)"
 
-#: main.c:697
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Nein (apsymbols.h nicht gefunden)"
 
-#: menu.c:180 tips:52
+#: main.c:709
+#, fuzzy
+msgid "Extended attribute support"
+msgstr "Erweiterte Attribute"
+
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr "Fehler beim öffnen von Datei '%s': %s"
+
+#: main.c:895
+#, c-format
+msgid ""
+"Left-click to run %s.\n"
+"Right-click for a list of versions."
+msgstr ""
+
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Fehler beim Erstellen der Datei '%s': %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Speichere unter:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Ansicht"
 
-#: menu.c:181 tips:57
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "Symbolansicht"
 
-#: menu.c:182
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "Symbole, mit..."
 
-#: menu.c:183 tips:74
-msgid "Sizes"
-msgstr "Größenangaben"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Symbolthema"
 
-#: menu.c:185 tips:254
-msgid "Types"
-msgstr "Typen"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Zugriffsrechte"
 
-#: menu.c:186 tips:77
-msgid "Times"
-msgstr "Zeitangaben"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Symbole, mit..."
 
-#: menu.c:187 tips:58 tips:92
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "Listenansicht"
 
-#: menu.c:189
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "Größere Symbole"
 
-#: menu.c:190
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "Kleinere Symbole"
 
-#: menu.c:191 tips:71
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: menu.c:193
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Nach Name sortieren"
 
-#: menu.c:194
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Nach Typ sortieren"
 
-#: menu.c:195
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Nach Datum sortieren"
 
-#: menu.c:196
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Nach Datum sortieren"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Nach Datum sortieren"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Nach Größe sortieren"
 
-#: menu.c:197
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Zugriffsrechte"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "Nach Benutzer sortieren"
 
-#: menu.c:198
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "Nach Gruppe sortieren"
 
-#: menu.c:199
+#: menu.c:671
 msgid "Reversed"
 msgstr "Umgekehrt"
 
-#: menu.c:201
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "Versteckte zeigen"
 
-#: menu.c:202
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Hilfedateien"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "keine Verzeichnisse)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "Dateien filtern..."
 
-#: menu.c:203
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Dateien filtern..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "Miniaturen zeigen"
 
-#: menu.c:204
+#: menu.c:683
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: menu.c:205
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Aktualisieren"
+
+#: menu.c:686
 msgid "Save Display Settings..."
 msgstr "Ansichtseinstellungen speichern..."
 
-#: menu.c:207
-msgid "Copy..."
-msgstr "Kopieren..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Ansichtseinstellungen speichern..."
 
-#: menu.c:208
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Speicherbedarf"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "Umbenennen..."
 
-#: menu.c:209
+#: menu.c:700
 msgid "Link..."
 msgstr "Verknüpfen..."
 
-#: menu.c:213
-msgid "Open AVFS"
-msgstr "Öffnen mit AVFS"
-
-#: menu.c:214
+#: menu.c:708
 msgid "Send To..."
 msgstr "Öffnen mit..."
 
-#: menu.c:219
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Erweiterte Attribute"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Speicherbedarf"
 
-#: menu.c:220
+#: menu.c:723
 msgid "Set Type..."
 msgstr "Typ zuordnen..."
 
-#: menu.c:224 toolbar.c:155
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Auswählen"
 
-#: menu.c:225
+#: menu.c:733
 msgid "Select All"
 msgstr "Alles auswählen"
 
-#: menu.c:226
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "Auswahl löschen"
 
-#: menu.c:227
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "Auswahl umkehren"
 
-#: menu.c:228
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "Nach Name sortieren..."
 
-#: menu.c:229
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Auswahlkriterium..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Auswahlkriterium..."
 
-#: menu.c:231
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Neu"
 
-#: menu.c:233
+#: menu.c:752
 msgid "Blank file"
 msgstr "Leere Datei"
 
-#: menu.c:235 tasklist.c:308
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Fenster"
 
-#: menu.c:236
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "Übergeordnetes Verzeichnis, neues Fenster"
 
-#: menu.c:237
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "Übergeordnetes Verzeichnis, selbes Fenster"
 
-#: menu.c:238
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "Neues Fenster"
 
-#: menu.c:240
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "Zeige Lesezeichen"
 
-#: menu.c:241
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Zeige Info"
+
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "Verknüpfungen folgen"
 
-#: menu.c:242
+#: menu.c:769
 msgid "Resize Window"
 msgstr "Fenstergröße anpassen"
 
-#: menu.c:245
+#: menu.c:771
 msgid "Close Window"
 msgstr "Fenster schließen"
 
-#: menu.c:247
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Pfad eingeben..."
 
-#: menu.c:248
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Shell-Befehl..."
 
-#: menu.c:249
-msgid "Xterm Here"
+#: menu.c:780
+#, fuzzy
+msgid "Terminal Here"
 msgstr "Terminal hier"
 
-#: menu.c:250
-msgid "Switch to xterm"
+#: menu.c:782
+#, fuzzy
+msgid "Switch to Terminal"
 msgstr "Zu Terminal wechseln"
 
-#: menu.c:718
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "Drücken Sie Shift+Menü-Taste über einer Datei, um sie zu senden"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Menü anpassen..."
 
-#: menu.c:754
+#: menu.c:976
 msgid "Next Click"
 msgstr "Nächster Klick"
 
-#: menu.c:776
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d Einträge"
 
-#: menu.c:864
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "Öffnen ohne einzuhängen"
 
-#: menu.c:867
+#: menu.c:1097
 msgid "Show Target"
 msgstr "Ziel zeigen"
 
-#: menu.c:869
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "Inhalt zeigen"
 
-#: menu.c:871
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "Als Text öffnen"
 
-#: menu.c:1031
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2236,21 +2535,21 @@ msgid ""
 "it may simply be that the filesystem needs to be mounted with the right "
 "mount option ('user_xattr' on Linux)."
 msgstr ""
-"Erweiterte Attribute, zur Speicherung des Dateityps, werden für diese Datei"
-"(en) nicht unterstützt.\n"
+"Erweiterte Attribute, zur Speicherung des Dateityps, werden für diese "
+"Datei(en) nicht unterstützt.\n"
 "Das könnte an fehlender Unterstützung durch das Dateisystems oder der "
 "Systembibiliothek liegen; oder vielleicht muss das Dateisystem mit den "
 "Richtigen Optionen eingebunden werden ('user _xattr in Linux')."
 
-#: menu.c:1037
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr "Typzuweisung für einige der Dateien nicht unterstützt."
 
-#: menu.c:1072
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "_Relative Verknüpfung"
 
-#: menu.c:1078
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2263,44 +2562,57 @@ msgstr ""
 "Wenn aus, wird der Pfad vom Wurzelverzeichnis gespeichert - benutzen Sie "
 "dies, wenn die Verknüpfung verschoben wird, aber das Ziel fest bleibt."
 
-#: menu.c:1148
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "Neuer Pfadname ist nicht absolut"
 
-#: menu.c:1214
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr ""
 "Die Bestehende Verknüpfung zu '%s' mit einer Verknüpfung zu '%s' ersetzen?"
 
-#: menu.c:1220
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Ersetzen"
 
-#: menu.c:1351 menu.c:1392 menu.c:1452
-msgid "Create"
-msgstr "Erzeugen"
-
-#: menu.c:1352
+#: menu.c:1704
 msgid "NewDir"
 msgstr "NeuesVerzeichnis"
 
-#: menu.c:1366 menu.c:1372
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Fehler beim Erstellen der Datei '%s': %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Erzeugen"
 
-#: menu.c:1393
+#: menu.c:1755
 msgid "NewFile"
 msgstr "NeueDatei"
 
-#: menu.c:1411
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "Fehler beim Erstellen der Datei: konnte Vorlage für %s nicht finden"
 
-#: menu.c:1482
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Erstelle Verknüpfungen zu den gewünschten Programmen in diesem Verzeichnis. "
+"Diese erscheinen im Menü für diesen Typ (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2312,8 +2624,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "Über das `Öffnen mit'-Menü können Dateien bequem mit einer definierbaren "
 "Auswahl an Programmen geöffnet werden. Um Programme in dieses Menü "
@@ -2324,7 +2637,7 @@ msgstr ""
 "Das `Öffnen mit'-Menü kann durch Drücken von Shift+Menü-Taste über einer "
 "Datei geöffnet werden."
 
-#: menu.c:1493
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
@@ -2333,12 +2646,12 @@ msgstr ""
 "Verknüpfung zu jeder Anwendung, an die sie Dateien übergeben wollen, dort "
 "erstellen (Ctrl+Shift und Ziehen)."
 
-#: menu.c:1496 menu.c:1536
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr ""
 "Ihre CHOICESPATH Variable erlaubt nur Root die Einstellungen zu ändern."
 
-#: menu.c:1529
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2357,7 +2670,7 @@ msgstr ""
 "%s\n"
 "%s\n"
 
-#: menu.c:1534
+#: menu.c:1936
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
@@ -2365,15 +2678,21 @@ msgstr ""
 "Ich werden Ihnen Ihr Vorlagenverzeichnis nun zeigen; dort sollten alle "
 "gewünschten Vorlagen abgelegt werden."
 
-#: menu.c:1651
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Anpassen"
 
-#: menu.c:1717
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Menü anpassen..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Das Verzeichnis besitzt bereits den vorgesehenen Namen."
 
-#: menu.c:1748
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2381,75 +2700,103 @@ msgstr ""
 "Sie können keine zweite Ansicht dieses Verzeichnisses öffnen, da die "
 "'Einzigartige Fenster'-Option im Options-Fenster aktiviert ist."
 
-#: menu.c:1869
-msgid "Copy ... ?"
-msgstr "Kopiere ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1872
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?%s nach %s kopieren?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?%s nach %s kopieren?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Benenne ... um?"
 
-#: menu.c:1875
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Verknüpfe ... ?"
 
-#: menu.c:1878
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Als Text Öffnen ... ?"
 
-#: menu.c:1881
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Eigenschaften von ... ?"
 
-#: menu.c:1884
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Erweiterte Attribute"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Typ zuordnen von ... ?"
 
-#: menu.c:1887
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Setze Startaktion für ... ?"
 
-#: menu.c:1890
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Setze Symbol für ... ?"
 
-#: menu.c:1893
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Öffne ... mit ... ?"
 
-#: menu.c:1896
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "LÖSCHEN ... ?"
 
-#: menu.c:1899
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Zähle die Größe von ... ?"
 
-#: menu.c:1902
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Setze Zugriffsrechte von ... ?"
 
-#: menu.c:1905
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Suche in ... ?"
 
-#: menu.c:1908
-msgid "Look inside ... ?"
-msgstr "Zeige Inhalt von ... ?"
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Kopiere ... ?"
 
-#: menu.c:1972
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Sie können dies nicht mit mehr als einem Eintrag auf einmal tun"
 
-#: menu.c:2004
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Umbenennen"
 
-#: menu.c:2009
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Verknüpfen"
 
-#: menu.c:2041
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2471,7 +2818,7 @@ msgstr ""
 "\tgtk-can-change-accels = 1\n"
 "\t(das funktioniert nur, wenn XSETTINGS nicht benutzt werden)"
 
-#: menu.c:2052
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2491,31 +2838,40 @@ msgstr ""
 " Die Taste erscheint dann neben dem Menüeintrag und Sie können nun einfach "
 "diese Taste drücken, ohne das Menü zu öffnen."
 
-#: menu.c:2067
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Tastaturkürzel festlegen"
 
-#: minibuffer.c:131
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Gehe zu:"
 
-#: minibuffer.c:132
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Shell:"
 
-#: minibuffer.c:133
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Wähle Wenn:"
 
-#: minibuffer.c:134
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Wähle nach Name:"
 
-#: minibuffer.c:135
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Wähle Wenn:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Muster:"
 
-#: minibuffer.c:264
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
@@ -2523,14 +2879,33 @@ msgstr ""
 "Geben Sie den Namen einer Datei ein und ich zeige sie an. Drücken Sie Tab um "
 "den längsten Treffer einzusetzen. ESC zum Schließen der Befehlszeile."
 
-#: minibuffer.c:270
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
 "Geben Sie einen auszuführenden Shell-Befehl an. Klicken Sie auf eine Datei, "
 "um sie zum Puffer hinzuzufügen."
 
-#: minibuffer.c:275
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Ein Dateinamensmuster eingeben, um alle zutreffenden Dateien zu wählen:\n"
+"\n"
+"? steht für exakt ein beliebiges Zeichen\n"
+"[aA] steht für 'a' oder 'A'\n"
+"[a-z] steht für einen beliebigen Buchstaben von a bis z (kleingeschrieben)\n"
+"*.png steht für Dateien, die auf '.png' enden"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2547,7 +2922,7 @@ msgstr ""
 "[a-z] steht für einen beliebigen Buchstaben von a bis z (kleingeschrieben)\n"
 "*.png steht für Dateien, die auf '.png' enden"
 
-#: minibuffer.c:287
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
@@ -2555,41 +2930,55 @@ msgstr ""
 "Ein Muster für anzuzeigende Dateien eingeben. Ein leeres Muster schaltetden "
 "Filter aus."
 
-#: minibuffer.c:895
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Ein Muster für anzuzeigende Dateien eingeben. Ein leeres Muster schaltetden "
+"Filter aus."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Ungültiger Such-Parameter"
 
-#: mount.c:374
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s gesamt, %s benutzt, %s frei (%.1f %%)"
 
-#: options.c:277
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "Ihre alten Einstellungen wurden ins neue XML-Format konvertiert."
 
-#: options.c:535 options.c:1258
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(wie Voreinstellung)"
 
-#: options.c:806
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Interner Fehler - %s nicht lesbar"
 
-#: options.c:917
+#: options.c:929
 msgid "Options"
 msgstr "Optionen"
 
-#: options.c:962
+#: options.c:974
 msgid "_Revert"
 msgstr "_Rückgängig"
 
-#: options.c:968
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr "Alle Änderungen seit Öffnen des Optionsfensters rückgängig machen."
 
-#: options.c:983
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2598,25 +2987,35 @@ msgstr ""
 "Einstellungen werden gespeichert als:\n"
 "%s"
 
-#: options.c:991
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(Nur Administrator darf Änderungen speichern)"
 
-#: options.c:1164 usericons.c:450
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Fehler beim Speichern von %s: %s"
 
-#: options.c:1794
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Fehlendes '='"
 
-#: panel.c:439
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr "Fehler beim öffnen von Datei '%s': %s"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr ""
 "Ihre alten Leisten-Einstellungen wurden ins neue XML-Format konvertiert."
 
-#: panel.c:546
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
@@ -2624,20 +3023,20 @@ msgstr ""
 "Sie haben versucht, das Leiste per Fenstermanager zu schließen - ich denke, "
 "daß das normalerweise versehentlich passiert ... wirklich schließen?"
 
-#: panel.c:639
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Fehlendes < oder > in Leisten-Konfigurationsdatei"
 
-#: panel.c:1519
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Fehler beim Speichern der Leiste %s: %s"
 
-#: panel.c:1835
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "Applet endete, ohne ein Widget zu erzeugen!"
 
-#: panel.c:1934
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2646,66 +3045,60 @@ msgstr ""
 "Fehler beim Starten von Applet:\n"
 "%s"
 
-#: panel.c:2335
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "Wollen Sie wirklich %d Fenster öffnen?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Eintrag entfernen"
+
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Leisten-Einstellungen..."
 
-#: panel.c:2427
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Xinerama-Monitor %d nicht verfügbar"
 
-#: panel.c:2502
-msgid "Panel Options"
-msgstr "Leisten-Einstellungen"
+#: panel.c:2897
+msgid "Top"
+msgstr ""
 
-#: panel.c:2517
-#, c-format
-msgid "Panel: %s"
-msgstr "Leisten: %s"
-
-#: panel.c:2525
-msgid "Select the panel's position:"
-msgstr "Wahl der Leistenposition:"
-
-#: panel.c:2531
-msgid "Top-edge panel"
-msgstr "Leiste am oberen Rand"
-
-#: panel.c:2532
-msgid "Top edge"
-msgstr "Oberer Rand"
-
-#: panel.c:2533
-msgid "Bottom edge panel"
-msgstr "Oberer Rand"
-
-#: panel.c:2534
-msgid "Bottom edge"
+#: panel.c:2899
+#, fuzzy
+msgid "Bottom"
 msgstr "Unterer Rand"
 
-#: panel.c:2535
-msgid "Left edge panel"
-msgstr "Leiste am linken Rand"
-
-#: panel.c:2536
-msgid "Left edge"
+#: panel.c:2901
+#, fuzzy
+msgid "Left"
 msgstr "Linker Rand"
 
-#: panel.c:2537
-msgid "Right-edge panel"
-msgstr "Leiste am rechten Rand"
-
-#: panel.c:2538
-msgid "Right edge"
+#: panel.c:2903
+#, fuzzy
+msgid "Right"
 msgstr "Rechter Rand"
+
+#: panel.c:2905
+#, fuzzy
+msgid "Default"
+msgstr "Standardgröße:"
+
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "Unbekannt"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
 msgstr ""
 "Ihre alten Pinwand-Einstellungen wurden ins neue XML-Format konvertiert."
 
-#: pinboard.c:635
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
@@ -2715,7 +3108,7 @@ msgstr ""
 "Programmverzeichnis auf den 'Hintergrund einstellen'-Dialog oder (für "
 "Programmierer) übergeben Sie es an die SOAP SetBackdropApp Methode."
 
-#: pinboard.c:654
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2729,51 +3122,63 @@ msgstr ""
 "Programmierer: Die Appinfo.xml des Programmes muss das CanSetBackdrop "
 "Element enthalten, wie im ROX-Filer Manual beschrieben."
 
-#: pinboard.c:674
+#: pinboard.c:750
 msgid "Set backdrop"
 msgstr "Hintergrund ändern"
 
-#: pinboard.c:685
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
 msgstr "Stil wählen und Bild hineinziehen:"
 
-#: pinboard.c:698
+#: pinboard.c:774
 msgid "Centre the image without scaling it"
 msgstr "Bild unskaliert zentrieren"
 
-#: pinboard.c:699
+#: pinboard.c:775
 msgid "Centre"
 msgstr "Zentrieren"
 
-#: pinboard.c:700
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr "Bild auf Hintergrundgröße skalieren, ohne es zu verzerren"
 
-#: pinboard.c:702
+#: pinboard.c:778
 msgid "Scale"
 msgstr "Skalieren"
 
-#: pinboard.c:703
+#: pinboard.c:779
+#, fuzzy
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr "Bild auf Hintergrundgröße skalieren, ohne es zu verzerren"
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Filter"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
 msgstr "Bild strecken, um den Hintergrund auszufüllen"
 
-#: pinboard.c:704
+#: pinboard.c:783
 msgid "Stretch"
 msgstr "Strecken"
 
-#: pinboard.c:705
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr "Fliese Hintergrund mit dem Bild"
 
-#: pinboard.c:706
+#: pinboard.c:785
 msgid "Tile"
 msgstr "Fliesen"
 
-#: pinboard.c:711
+#: pinboard.c:790
 msgid "Drop an image here"
 msgstr "Ziehen Sie ein Bild hierher"
 
-#: pinboard.c:772
+#: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
@@ -2781,7 +3186,7 @@ msgstr ""
 "Die Pinwand wurde noch nicht benutzt... stelle Standardhintergrund ein. "
 "Starten sie ROX-Filer mit 'rox -p=Default', um die Pinwand zu aktivieren."
 
-#: pinboard.c:866
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
@@ -2789,24 +3194,29 @@ msgstr ""
 "Nur Bilddateien (und bestimmte Programme) können das  Hintergrundbild "
 "liefern."
 
-#: pinboard.c:1471
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Fehlendes '>' im Icon-Label"
 
-#: pinboard.c:1480
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Fehlendes ',' nach dem Symbolnamen"
 
-#: pinboard.c:1565
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Fehler beim Speichern der Pinwand %s: %s"
 
-#: pinboard.c:2109
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Hintergrund..."
 
-#: pinboard.c:2202
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Leiste"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2817,7 +3227,7 @@ msgstr ""
 "%s\n"
 "Hintergrundbild entfernt."
 
-#: pixmaps.c:991
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2826,60 +3236,93 @@ msgstr ""
 "Kann Miniaturen in %s nicht entfernen:\n"
 "%s"
 
-#: pixmaps.c:1012
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Es gibt keine Miniaturem zum Entfernen"
 
-#: pixmaps.c:1025
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Zwischenspeicher für Miniaturen leeren"
 
-#: remote.c:624
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Unbekannter Stil '%s'"
 
-#: remote.c:646
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Unbekannter Detailtyp '%s'"
 
-#: remote.c:674
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Unbekannter Sortiertyp '%s'"
 
-#: remote.c:1117
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Versuch, eine unbekannte SOAP-Methode aufzurufen '%s'"
 
-#: rox_gettext.c:95
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Ungültige .gmo Übersetzungsdatei (zu kurz): %s"
-
-#: rox_gettext.c:108
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Ungültige .gmo Übersetzungsdatei (GNU magic number nicht gefunden): %s"
-
-#: run.c:96 run.c:141
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "Programm %s nicht gefunden - gelöscht?"
 
-#: run.c:287
+#: run.c:359
+#, c-format
+msgid ""
+"No run action specified for files of this type (%s/%s) - you can set a run "
+"action by choosing `Set Run Action' from the File menu, or you can just drag "
+"the file to an application.%s"
+msgstr ""
+"Es ist keine Startaktion für Dateien dieses Typs (%s/%s) definiert - Sie "
+"können sie setzen, indem sie 'Startaktion setzen' aus dem Dateimenü wählen, "
+"oder sie ziehen die Datei einfach auf eine Applikation.%s"
+
+#: run.c:365
+msgid ""
+"\n"
+"\n"
+"Note: If this is a computer program which you want to run, you need to set "
+"the execute bit by choosing Permissions from the File menu."
+msgstr ""
+"\n"
+"\n"
+"Hinweis: Wenn es sich hier um ein auszuführendes Computerprogramm handelt, "
+"muss das Ausführbit gesetzt werden (Dateimenü->Zugriffsrechte)."
+
+#: run.c:373
 #, c-format
 msgid "File doesn't exist, or I can't access it: %s"
 msgstr "Datei existiert nicht oder ich kann nicht auf sie zugreifen: %s"
 
-#: run.c:292
+#: run.c:378
 #, c-format
 msgid "I don't know how to open '%s'"
 msgstr "Ich weiß nicht, wie ich '%s' öffnen soll"
 
-#: run.c:323
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "!'%s' ist nicht weiter eine Verknüpfung"
+
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "Kann nicht auf Verzeichnis '%s' zugreifen"
+
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "Nicht-Ausführbare Datei %s"
+
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Fehler im Handler %s: %s"
+
+#: run.c:465
 msgid ""
 "Application:\n"
 "This is an application directory - you can run it as a program, or open it "
@@ -2892,224 +3335,22 @@ msgstr ""
 "Applikationen stellen ihre eigene Hilfe hier bereit, aber diese tut das "
 "nicht."
 
-#: run.c:407
+#: run.c:549
 #, c-format
 msgid "Could not send data to program: %s"
 msgstr "Konnte Daten nicht senden an Programm: %s"
 
-#: run.c:437
+#: run.c:578
 #, c-format
 msgid "Could not read link: %s"
 msgstr "Konnte Verknüpfung nicht lesen: %s"
 
-#: run.c:465
+#: run.c:606
 #, c-format
 msgid "Broken symlink (or you don't have permission to follow it): %s"
 msgstr "Leere Verknüpfung (oder Sie haben kein Recht, ihr zu folgen): %s"
 
-#: run.c:502
-#, c-format
-msgid ""
-"No run action specified for files of this type (%s/%s) - you can set a run "
-"action by choosing `Set Run Action' from the File menu, or you can just drag "
-"the file to an application.%s"
-msgstr ""
-"Es ist keine Startaktion für Dateien dieses Typs (%s/%s) definiert - Sie "
-"können sie setzen, indem sie 'Startaktion setzen' aus dem Dateimenü wählen, "
-"oder sie ziehen die Datei einfach auf eine Applikation.%s"
-
-#: run.c:508
-msgid ""
-"\n"
-"\n"
-"Note: If this is a computer program which you want to run, you need to set "
-"the execute bit by choosing Permissions from the File menu."
-msgstr ""
-"\n"
-"\n"
-"Hinweis: Wenn es sich hier um ein auszuführendes Computerprogramm handelt, "
-"muss das Ausführbit gesetzt werden (Dateimenü->Zugriffsrechte)."
-
-#: support.c:272
-msgid "B"
-msgstr "B"
-
-#: support.c:351
-msgid "byte"
-msgstr "Byte"
-
-#: toolbar.c:115
-msgid "Close"
-msgstr "Schließen"
-
-#: toolbar.c:115
-msgid "Close filer window"
-msgstr "Dateimanager-Fenster schließen"
-
-#: toolbar.c:119
-msgid "Up"
-msgstr "Hoch"
-
-#: toolbar.c:119
-msgid "Change to parent directory"
-msgstr "Zum übergeordneten Verzeichnis wechseln"
-
-#: toolbar.c:123
-msgid "Home"
-msgstr "Heimat"
-
-#: toolbar.c:123
-msgid "Change to home directory"
-msgstr "Zum Heimatverzeichnis wechseln"
-
-#: toolbar.c:127
-msgid "Bookmarks"
-msgstr "Lesezeichen"
-
-#: toolbar.c:127
-msgid "Bookmarks menu"
-msgstr "Lesezeichen-Menü"
-
-#: toolbar.c:131
-msgid "Scan"
-msgstr "Aktualisieren"
-
-#: toolbar.c:131
-msgid "Rescan directory contents"
-msgstr "Verzeichnisinhalt neu einlesen"
-
-#: toolbar.c:135
-msgid "Change icon size"
-msgstr "Wechseln der Symbolgröße"
-
-#: toolbar.c:139
-msgid "Automatic size mode"
-msgstr "Automatische Größenanpassung"
-
-#: toolbar.c:143
-msgid "Show extra details"
-msgstr "Dateieigenschaften zeigen"
-
-#: toolbar.c:147
-msgid "Sort"
-msgstr "Sortieren"
-
-#: toolbar.c:147
-msgid "Change sort criteria"
-msgstr "Sortierkriterium ändern"
-
-#: toolbar.c:151
-msgid "Hidden"
-msgstr "Versteckt"
-
-#: toolbar.c:151
-msgid "Show/hide hidden files"
-msgstr "Versteckte Dateien zeigen/ausblenden"
-
-#: toolbar.c:155
-msgid "Select all/invert selection"
-msgstr "Alles wählen/Auswahl umkehren"
-
-#: toolbar.c:159
-msgid "Show ROX-Filer help"
-msgstr "ROX-Filer-Hilfe anzeigen"
-
-#: toolbar.c:220
-#, c-format
-msgid " (%u hidden)"
-msgstr " (%u versteckte)"
-
-#: toolbar.c:228 tips:80
-msgid "items"
-msgstr "Dateien"
-
-#: toolbar.c:228
-msgid "item"
-msgstr "Datei"
-
-#: toolbar.c:231
-#, c-format
-msgid "No items%s"
-msgstr "Keine Dateien%s"
-
-#: toolbar.c:250
-#, c-format
-msgid "%u selected (%s)"
-msgstr "%u ausgewählt (%s)"
-
-#: toolbar.c:422
-msgid "Sort by name"
-msgstr "Nach Name sortieren"
-
-#: toolbar.c:422
-msgid "Sort by type"
-msgstr "Nach Typ sortieren"
-
-#: toolbar.c:422
-msgid "Sort by date"
-msgstr "Nach Datum sortieren"
-
-#: toolbar.c:423
-msgid "Sort by size"
-msgstr "Nach Größe sortieren"
-
-#: toolbar.c:423
-msgid "Sort by owner"
-msgstr "Nach Benutzer sortieren"
-
-#: toolbar.c:423
-msgid "Sort by group"
-msgstr "Nach Gruppe sortieren"
-
-#: toolbar.c:457
-msgid "ascending"
-msgstr "aufsteigend"
-
-#: toolbar.c:457
-msgid "descending"
-msgstr "absteigend"
-
-#: type.c:203
-msgid "Sym link"
-msgstr "Verkn."
-
-#: type.c:205
-msgid "Mount point"
-msgstr "Mount-Punkt"
-
-#: type.c:207
-msgid "App dir"
-msgstr "App-Verz."
-
-#: type.c:214
-msgid "Dir"
-msgstr "Verz."
-
-#: type.c:216
-msgid "Char dev"
-msgstr "Char-Dev."
-
-#: type.c:218
-msgid "Block dev"
-msgstr "Block-Dev."
-
-#: type.c:220
-msgid "Pipe"
-msgstr "Pipe"
-
-#: type.c:222
-msgid "Socket"
-msgstr "Socket"
-
-#: type.c:224
-msgid "Door"
-msgstr "Door"
-
-#: type.c:227
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#: type.c:355
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3135,11 +3376,280 @@ msgstr ""
 "sich nicht kümmern. Sonst sollten Sie alle bestehenden Startaktionen "
 "überprüfen oder einfach gerade löschen."
 
-#: type.c:368
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Sicherheitsproblem beheben)"
 
-#: type.c:498
+#: support.c:288
+msgid " "
+msgstr ""
+
+#: support.c:381
+msgid "byte"
+msgstr "Byte"
+
+#: support.c:1531 support.c:1585
+#, fuzzy, c-format
+msgid "Failed to open and stat file '%s': %s"
+msgstr "Fehler beim öffnen von Datei '%s': %s"
+
+#: support.c:1542 support.c:1596
+#, fuzzy, c-format
+msgid "Failed to mmap file '%s': %s"
+msgstr "Fehler beim öffnen von Datei '%s': %s"
+
+#: toolbar.c:116
+msgid "Close"
+msgstr "Schließen"
+
+#: toolbar.c:116
+msgid "Close filer window"
+msgstr "Dateimanager-Fenster schließen"
+
+#: toolbar.c:120
+msgid "Up"
+msgstr "Hoch"
+
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
+
+#: toolbar.c:126
+msgid "Home"
+msgstr "Heimat"
+
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
+
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
+
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
+
+#: toolbar.c:138
+msgid "Scan"
+msgstr "Aktualisieren"
+
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
+
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Größe"
+
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automatisch"
+
+#: toolbar.c:155
+msgid "Automatic size mode"
+msgstr "Automatische Größenanpassung"
+
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Listenansicht"
+
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
+msgid "Sort"
+msgstr "Sortieren"
+
+#: toolbar.c:165
+msgid "Change sort criteria"
+msgstr "Sortierkriterium ändern"
+
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
+
+#: toolbar.c:169
+msgid ""
+"Left: Show/hide hidden files\n"
+"Right: Show/hide thumbnails"
+msgstr ""
+
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "Alles wählen/Auswahl umkehren"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
+msgid "Show ROX-Filer help"
+msgstr "ROX-Filer-Hilfe anzeigen"
+
+#: toolbar.c:270
+#, c-format
+msgid " (%u hidden)"
+msgstr " (%u versteckte)"
+
+#: toolbar.c:276 tips:79
+msgid "items"
+msgstr "Dateien"
+
+#: toolbar.c:276
+msgid "item"
+msgstr "Datei"
+
+#: toolbar.c:279
+#, c-format
+msgid "No items%s"
+msgstr "Keine Dateien%s"
+
+#: toolbar.c:298
+#, c-format
+msgid "%u selected (%s)"
+msgstr "%u ausgewählt (%s)"
+
+#: toolbar.c:535
+msgid "Sort by name"
+msgstr "Nach Name sortieren"
+
+#: toolbar.c:535
+msgid "Sort by type"
+msgstr "Nach Typ sortieren"
+
+#: toolbar.c:535
+msgid "Sort by date"
+msgstr "Nach Datum sortieren"
+
+#: toolbar.c:535
+msgid "Sort by size"
+msgstr "Nach Größe sortieren"
+
+#: toolbar.c:536
+msgid "Sort by owner"
+msgstr "Nach Benutzer sortieren"
+
+#: toolbar.c:536
+msgid "Sort by group"
+msgstr "Nach Gruppe sortieren"
+
+#: toolbar.c:568
+msgid "ascending"
+msgstr "aufsteigend"
+
+#: toolbar.c:568
+msgid "descending"
+msgstr "absteigend"
+
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
+msgid "Sym link"
+msgstr "Verkn."
+
+#: type.c:223
+msgid "Mount point"
+msgstr "Mount-Punkt"
+
+#: type.c:225
+msgid "App dir"
+msgstr "App-Verz."
+
+#: type.c:232
+msgid "Dir"
+msgstr "Verz."
+
+#: type.c:234
+msgid "Char dev"
+msgstr "Char-Dev."
+
+#: type.c:236
+msgid "Block dev"
+msgstr "Block-Dev."
+
+#: type.c:238
+msgid "Pipe"
+msgstr "Pipe"
+
+#: type.c:240
+msgid "Socket"
+msgstr "Socket"
+
+#: type.c:242
+msgid "Door"
+msgstr "Door"
+
+#: type.c:245
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3150,69 +3660,69 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:679
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Das ist kein Programm! Geben Sie mir stattdessen eine Applikation!"
 
-#: type.c:740
+#: type.c:839
 msgid "No run action defined"
 msgstr "Keine Startaktion definiert"
 
-#: type.c:766
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Fehler im Handler %s: %s"
 
-#: type.c:781
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Ungültige Applikation %s (fehlerhaftes AppRun)"
 
-#: type.c:792
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "Nicht-Ausführbare Datei %s"
 
-#: type.c:825
+#: type.c:902
 msgid "Set run action"
 msgstr "Startaktion festlegen"
 
-#: type.c:831
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr "Voreinstellung, falls dem Typ noch keine Applikation zugeordnet wurde."
 
-#: type.c:833
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Standard für alle '%s/<irgendwas>' festlegen"
 
-#: type.c:837
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Diese Applikation verwenden für alle Dateien von diesem MIME-Typ."
 
-#: type.c:839
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Nur für den Typ `%s' (%s/%s)"
 
-#: type.c:845
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Ziehen Sie eine passende Applikation hierher"
 
-#: type.c:860
+#: type.c:963
 msgid "OR"
 msgstr "ODER"
 
-#: type.c:867
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Geben Sie einen Shell-Befehl ein:"
 
-#: type.c:896
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Verwende Befehl"
 
-#: type.c:926
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
@@ -3220,46 +3730,31 @@ msgstr ""
 "Eine Startaktion existiert bereits und ist ein recht großes Programm - sind "
 "Sie sicher, daß Sie es löschen wollen?"
 
-#: type.c:937
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Kann %s:%s nicht entfernen"
 
-#: type.c:974
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "Choices speichern ist durch CHOICESPATH-Variable unterbunden"
 
-#: type.c:1249
-#, c-format
-msgid ""
-"Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr ""
-"Symbolthema '%s' enthält keine MIME-Symbole. Das ROX-Standardthema wird "
-"daher verwendet."
-
-#: type.c:1263
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason)"
+"%s"
 msgstr ""
-"Konnte Verknüpfung '%s' nicht erzeugen:\n"
-"%s\n"
-"\n"
-"(dies könnte bedeuten, dass das ROX-Thema dort bereits installiert ist, aber "
-"das Symbol 'mime-application:postscript' aus irgend einem Grund nicht "
-"geladen werden konnte)"
+"Verknüpfung konnte nicht entfernt werden '%s':\n"
+"%s"
 
-#: usericons.c:181
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr ""
 "Der Pfadname, den Sie angegeben haben, existiert nicht. Das Symbol wurde "
 "nicht geändert."
 
-#: usericons.c:191 usericons.c:616
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3269,12 +3764,12 @@ msgstr ""
 "nicht, oder vielleicht sind die Zugriffsrechte falsch gesetzt?\n"
 "Das Symbol wurde nicht geändert."
 
-#: usericons.c:238
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Symbol '%s' wirklich entfernen?"
 
-#: usericons.c:242
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3283,30 +3778,30 @@ msgstr ""
 "Kann nicht entfernen '%s':\n"
 "%s"
 
-#: usericons.c:270
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Symbol ändern"
 
-#: usericons.c:279
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr "Eine Kopie des Bildes als Standard für diesen MIME-Typ verwenden."
 
-#: usericons.c:281
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Symbol für alle `%s/<irgendwas>' festlegen"
 
-#: usericons.c:286
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "Eine Kopie des Bildes für diesen MIME-Typ verwenden."
 
-#: usericons.c:288
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Für alle Dateien vom Typ `%s' (%s/%s)"
 
-#: usericons.c:294
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
@@ -3314,12 +3809,12 @@ msgstr ""
 "Fügen Sie die Datei und die Bilddateinamen ihrer perönlichen Liste zu. Die "
 "Einstellung geht verloren, wenn das Bild oder die Datei verschoben wird."
 
-#: usericons.c:297
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Nur für die Datei `%s'"
 
-#: usericons.c:305
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
@@ -3330,19 +3825,19 @@ msgstr ""
 "verschoben werden. Das ist meistens die beste Variante, wenn Sie "
 "Schreibrechte für das Verzeichnis besitzen."
 
-#: usericons.c:311
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Bild in das Verzeichnis kopieren"
 
-#: usericons.c:317
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Ziehen Sie ein Symbol hierher"
 
-#: usericons.c:587
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "Definieren des Symbols ist per CHOICESPATH-Variable unterbunden"
 
-#: usericons.c:631
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3351,143 +3846,71 @@ msgstr ""
 "Fehler beim kopieren des Bildes '%s':\n"
 "%s"
 
-#: view_details.c:1009
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
+msgid "Mono font"
+msgstr ""
+
+#: view_details.c:1019
+msgid "Font for displaying mono-spaced text"
+msgstr ""
+
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Name"
 
-#: view_details.c:1012
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Typ"
 
-#: view_details.c:1015
-msgid "_Permissions"
-msgstr "_Zugriffsrechte"
-
-#: view_details.c:1016
-msgid "_Owner"
-msgstr "_Besitzer"
-
-#: view_details.c:1018
-msgid "_Group"
-msgstr "_Gruppe"
-
-#: view_details.c:1020
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Größe"
 
-#: view_details.c:1022
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Zugriffsrechte"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_Besitzer"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Gruppe"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "Letzte Änderung"
 
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Erweiterte Attribute"
+
 #: tips:1
-msgid "Translation"
-msgstr "Übersetzung"
-
-#: tips:2
-msgid "Language"
-msgstr "Sprache"
-
-#: tips:3
-msgid "Use the LANG environment variable"
-msgstr "LANG Environment-Variable benutzen"
-
-#: tips:4
-msgid "Basque"
-msgstr "Baskisch"
-
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Chinesisch (traditionell)"
-
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Chinesisch (vereinfacht)"
-
-#: tips:7
-msgid "Czech"
-msgstr "Tchechisch"
-
-#: tips:8
-msgid "Danish"
-msgstr "Dänisch"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Niederländisch"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Englisch (keine Übersetzung)"
-
-#: tips:11
-msgid "Estonian"
-msgstr "Estnisch"
-
-#: tips:12
-msgid "Finnish"
-msgstr "Finnisch"
-
-#: tips:13
-msgid "French"
-msgstr "Französisch"
-
-#: tips:14
-msgid "German"
-msgstr "Deutsch"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Ungarisch"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Japanisch"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "Norwegisch"
-
-#: tips:18
-msgid "Italian"
-msgstr "Italienisch"
-
-#: tips:19
-msgid "Polish"
-msgstr "Polnisch"
-
-#: tips:20
-msgid "Portuguese (Brasil)"
-msgstr "Portugiesisch (Brasilien)"
-
-#: tips:21
-msgid "Romanian"
-msgstr "Rumänisch"
-
-#: tips:22
-msgid "Russian"
-msgstr "Russisch"
-
-#: tips:23
-msgid "Spanish"
-msgstr "Spanisch"
-
-#: tips:24
-msgid "Swedish"
-msgstr "Schwedisch"
-
-#: tips:25
 msgid "Filer windows"
 msgstr "Dateimanager-Fenster"
 
-#: tips:26
+#: tips:2
 msgid "Auto-resize filer windows"
 msgstr "Fenstergröße automatisch anpassen"
 
-#: tips:27
+#: tips:3
 msgid "Never automatically resize"
 msgstr "Nie automatisch anpassen"
 
-#: tips:28
+#: tips:4
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
@@ -3496,11 +3919,11 @@ msgstr ""
 "oder den `Fenstergröße anpassen'-Menüpunkt benutzen oder durch Doppelklick "
 "auf den Fensterhintergrund."
 
-#: tips:29
+#: tips:5
 msgid "Resize when changing the display style"
 msgstr "Größe beim Ändern des Anzeigemodus anpassen"
 
-#: tips:30
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
@@ -3508,11 +3931,11 @@ msgstr ""
 "Beim Verändern der Symbolgröße oder der angezeigten Details wird die "
 "Fenstergröße automatisch neu angepaßt."
 
-#: tips:31
+#: tips:7
 msgid "Always resize"
 msgstr "Immer anpassen"
 
-#: tips:32
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
@@ -3520,15 +3943,16 @@ msgstr ""
 "Der Dateimanager wird jedesmal, wenn es sinnvoll erscheint (wenn Sie das "
 "Verzeichnis wechseln oder die Anzeigeart), die Fenstergröße anpassen."
 
-#: tips:33
+#: tips:9
 msgid "Largest window size:"
 msgstr "Maximale Fenstergröße:"
 
-#: tips:34
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:35
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
@@ -3536,15 +3960,29 @@ msgstr ""
 "Die maximale Größe, prozentual zum Bildschirm, auf die die automatische "
 "Größenanpassung das Fenster vergrößern darf."
 
-#: tips:36
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Maximale Fenstergröße:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Die maximale Größe, prozentual zum Bildschirm, auf die die automatische "
+"Größenanpassung das Fenster vergrößern darf."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Fensterverhalten"
 
-#: tips:37
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Kurze Titelzeilenflags"
 
-#: tips:38
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
@@ -3552,11 +3990,11 @@ msgstr ""
 "Benutze nur Einzelbuchstaben statt Worten für 'Durchsuche', 'Alle' und "
 "'Miniaturen' in der Titelzeile."
 
-#: tips:39
+#: tips:18
 msgid "Unique windows"
 msgstr "Einmalige Fenster"
 
-#: tips:40
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3565,11 +4003,34 @@ msgstr ""
 "anderen Fenster angezeigt wird, dann veranlaßt diese Option ein Schließen "
 "des anderen Fensters."
 
-#: tips:41
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Fenster"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Neues Fenster auf Taste 1"
 
-#: tips:42
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3579,11 +4040,11 @@ msgstr ""
 "Verzeichnis in einem neuen Fenster, wenn dies aktiviert ist. Ein Klick mit "
 "Taste 2 (mittlere) benutzt dafür das aktuelle Fenster."
 
-#: tips:43
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Öffnen durch einfachen Klick"
 
-#: tips:44 tips:137
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
@@ -3593,11 +4054,11 @@ msgstr ""
 "stattdessen den Eintrag auszuwählen. Falls aus, wählt ein einfacher Klick "
 "den Eintrag an, ein doppelter öffnet ihn."
 
-#: tips:45
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Doppelklick auf Hintergrund ändert Fenstergröße"
 
-#: tips:46
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
@@ -3606,15 +4067,15 @@ msgstr ""
 "anpaßt. Der Werkzeugleistenknopf \"Automatische Größenanpassung\" bewirkt "
 "das gleiche."
 
-#: tips:47
+#: tips:30
 msgid "Sorting"
 msgstr "Sortieren"
 
-#: tips:48
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Verzeichnisse immer zuerst (für Sortieren nach Name)"
 
-#: tips:49
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
@@ -3622,11 +4083,11 @@ msgstr ""
 "Mit dieser Option werden Verzeichnisse beim Sortieren nach Name immer als "
 "erstes angezeigt."
 
-#: tips:50
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Großgeschriebene Namen zuerst (für Sortieren nach Name)"
 
-#: tips:51
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
@@ -3634,15 +4095,58 @@ msgstr ""
 "Wenn Haken gesetzt, werden Dateien mit großem Anfangsbuchstaben zuerst "
 "gelistet."
 
-#: tips:53
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Verzeichnisse immer zuerst (für Sortieren nach Name)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sek"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "Erweiterte Attribute"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "Einstellung für neue Fenster"
 
-#: tips:54
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "Optionen vom Ursprungsfenster übernehmen"
 
-#: tips:55
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
@@ -3651,27 +4155,38 @@ msgstr ""
 "seinem Ursprungsfenster übernommen, sofern möglich, andernfalls werden sie "
 "auf die untenstehenden Voreinstellungen gesetzt."
 
-#: tips:56
+#: tips:48
 msgid "View type:"
 msgstr "Ansichtsart:"
 
-#: tips:59
+#: tips:51
 msgid "Sort by:"
 msgstr "Sortieren nach:"
 
-#: tips:61 tips:76
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Typ"
 
-#: tips:62
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Datum"
 
-#: tips:64
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Datum"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Datum"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Versteckte Dateien zeigen"
 
-#: tips:65
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
@@ -3679,7 +4194,34 @@ msgstr ""
 "Ist dies an, werden auch Dateien deren Name mit einem Punkt beginnt "
 "angezeigt, sonst werden sie versteckt."
 
-#: tips:66
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Versteckte Dateien zeigen"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Ist dies an, werden auch Dateien deren Name mit einem Punkt beginnt "
+"angezeigt, sonst werden sie versteckt."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Riesige Symbole"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "Pixel"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "Symbolansicht"
 
@@ -3691,11 +4233,11 @@ msgstr "Standardgröße:"
 msgid "Huge Icons"
 msgstr "Riesige Symbole"
 
-#: tips:69 tips:245
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Große Symbole"
 
-#: tips:70 tips:244
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "Kleine Symbole"
 
@@ -3707,15 +4249,20 @@ msgstr "Standarddetails:"
 msgid "No details"
 msgstr "Keine Details"
 
+#: tips:74
+msgid "Sizes"
+msgstr "Größenangaben"
+
+#: tips:77
+msgid "Times"
+msgstr "Zeitangaben"
+
 #: tips:78
-msgid "Automatic small icons:"
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "Automatisch kleine Symbole:"
 
-#: tips:79
-msgid "Change at:"
-msgstr "Ändern ab:"
-
-#: tips:81
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3724,67 +4271,91 @@ msgstr ""
 "Wenn das Verzeichnis diese Anzahl von Dateien enthält, wird es mit Kleinen "
 "Symbolen dargestellt, sonst werden Große Symbole verwendet."
 
-#: tips:82
-msgid "Max width (Large icons):"
-msgstr "Max. Breite (Große Symbole):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Große Symbole"
 
-#: tips:83 tips:86
-msgid "pixels"
-msgstr "Pixel"
-
-#: tips:84
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "Text, der breiter als dieser Wert ist, wird im 'Große Icons'-Modus in eine "
 "zweite Zeile umgebrochen. Im 'Riesige Symbole'-Modus wird der Text "
 "umgebrochen, wenn er 50% breiter als dieser Wert ist."
 
-#: tips:85
-msgid "(Small Icons):"
-msgstr "(Kleine Symbole):"
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
 
 #: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
+#: tips:88
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr ""
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "(Kleine Symbole):"
+
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "Maximale Breite für den Text neben Kleinen Symbolen."
 
-#: tips:88
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "Kleine Symbole vertikal ordnen"
 
-#: tips:89
+#: tips:93
+#, fuzzy
 msgid ""
-"If this option is on, then small icons are ordered vertically, not "
-"horizontally."
+"If this option is on, then small icons are arranged in columns, not rows."
 msgstr ""
 "Mit dieser Option aktiv, werden kleine Symbole vertikal geordnet, nicht "
 "horizontal."
 
-#: tips:90
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "Große Symbole vertikal ordnen"
 
-#: tips:91
+#: tips:95
+#, fuzzy
 msgid ""
-"If this option is on, then large icons are sorted vertically, not "
-"horizontally."
+"If this option is on, then large icons are arranged in columns, not rows."
 msgstr ""
 "Wählen Sie dies, um große Symbole vertikal zu sortieren, nicht horizontal."
 
-#: tips:93
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Zeige Spaltenüberschriften"
 
-#: tips:94
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr "Haken setzen für Spaltenüberschriften in der Listenansicht."
 
-#: tips:95
+#: tips:102
 msgid "Show full type"
 msgstr "Zeige vollständigen Typ"
 
-#: tips:96
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
@@ -3792,39 +4363,132 @@ msgstr ""
 "Wenn aktiv, wird die vollständige Beschreibung jedes Objekttyps gezeigt, "
 "statt einer kurzen Zusammenfassung des Basistyps."
 
-#: tips:97
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Maximale Breite für den Text neben Kleinen Symbolen."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Zeige Spaltenüberschriften"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr "Haken setzen für Spaltenüberschriften in der Listenansicht."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr "Haken setzen für Spaltenüberschriften in der Listenansicht."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr "Haken setzen für Spaltenüberschriften in der Listenansicht."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr "Haken setzen für Spaltenüberschriften in der Listenansicht."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr "Haken setzen für Spaltenüberschriften in der Listenansicht."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr "Haken setzen für Spaltenüberschriften in der Listenansicht."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "Letzte Änderung"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr "Haken setzen für Spaltenüberschriften in der Listenansicht."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr "Haken setzen für Spaltenüberschriften in der Listenansicht."
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr "Haken setzen für Spaltenüberschriften in der Listenansicht."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Werkzeuge/Befehlszeile"
 
-#: tips:98
+#: tips:131
 msgid "Toolbar"
 msgstr "Werkzeugleiste"
 
-#: tips:99
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Typ der Werkzeugleiste"
 
-#: tips:100
+#: tips:133
 msgid "No toolbar"
 msgstr "Keine Werkzeugleiste"
 
-#: tips:101
+#: tips:134
 msgid "Icons only"
 msgstr "Nur Symbole"
 
-#: tips:102
+#: tips:135
 msgid "Text under icons"
 msgstr "Text unter Symbolen"
 
-#: tips:103
+#: tips:136
 msgid "Text beside icons"
 msgstr "Text neben Symbolen"
 
-#: tips:104
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Nur Bild"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Zusammenfassung für Einträge zeigen"
 
-#: tips:105
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3835,15 +4499,15 @@ msgstr ""
 "eine Auswahl getroffen wurde, zeige Zahl und Gesamtgröße der ausgewählten "
 "Einträge."
 
-#: tips:106
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Wählen Sie die Werkzeuge, die Sie auf der Leiste wünschen:"
 
-#: tips:107
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "Breite der Werkzeugleiste bestimmt Minimalbreite des Fensters"
 
-#: tips:108
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
@@ -3851,15 +4515,15 @@ msgstr ""
 "Dateifenster mindestens so breit machen, dass die Werkzeugeleiste "
 "vollständig sichtbar ist."
 
-#: tips:109
+#: tips:143
 msgid "Minibuffer"
 msgstr "Befehlszeile"
 
-#: tips:110
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Piepton wenn Tab-Namenergänzung fehlschlägt"
 
-#: tips:111
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
@@ -3869,11 +4533,11 @@ msgstr ""
 "ausgegeben, falls nichts passiert (z.B. weil es mehrere Möglichkeiten gibt "
 "und der nächste Buchstabe variiert)."
 
-#: tips:112
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Piepton bei mehreren Treffern"
 
-#: tips:113
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
@@ -3882,7 +4546,27 @@ msgstr ""
 "ausgegeben, falls mehr als eine passende Datei gefunden wird, auch wenn "
 "weitere Buchstaben hinzugefügt wurden."
 
-#: tips:116
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Programm für Internet-Downloads"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Fehler im Handler %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
@@ -3890,11 +4574,11 @@ msgstr ""
 "Wenn Miniaturen eingeschaltet sind, wird jedes Bild verkleinert im "
 "Verzeichnisfenster dargestellt."
 
-#: tips:117
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Bildminiaturen zeigen"
 
-#: tips:118
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
@@ -3902,29 +4586,103 @@ msgstr ""
 "Das ist die Standardeinstellung für neue Fenster. Über das Menu 'Ansicht' "
 "können Miniaturen für jedes Fenster an- und abgeschaltet werden."
 
-#: tips:119
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Bildminiaturen zeigen"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "Videovorschaubilder"
 
-#: tips:120
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Miniaturenspeicher"
 
-#: tips:121
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "Zur Beschleunigung werden die erzeugten Miniaturen im versteckten "
 "Verzeichnis ~/.thumbnails gespeichert. Klicken Sie hier, um diesen Speicher "
 "zu löschen. Die Miniaturen werden neu erstellt, sobald nötig."
 
-#: tips:122 tips:195
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
+#, fuzzy
+msgid "Manage thumbnails"
+msgstr "Bildminiaturen zeigen"
+
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Videovorschaubilder"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sek"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Pinwand"
 
-#: tips:123
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
@@ -3932,47 +4690,47 @@ msgstr ""
 "Wenn Sie die Pinwand verwenden, können Sie Dateien und Programme auf den "
 "Hintergrund ziehen und dort für schnellen Zugriff ablegen."
 
-#: tips:124 tips:241
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Aussehen"
 
-#: tips:125
+#: tips:179
 msgid "Foreground:"
 msgstr "Vordergrund:"
 
-#: tips:126
+#: tips:180
 msgid "Text shadow:"
 msgstr "Textschatten:"
 
-#: tips:127
+#: tips:181
 msgid "Background:"
 msgstr "Hintergrund:"
 
-#: tips:128
+#: tips:182
 msgid "No shadow"
 msgstr "Kein Schatten"
 
-#: tips:129
+#: tips:183
 msgid "Thin"
 msgstr "Dünn"
 
-#: tips:130
+#: tips:184
 msgid "Thick"
 msgstr "Dick"
 
-#: tips:131
+#: tips:185
 msgid "Use custom font:"
 msgstr "Zeichensatz:"
 
-#: tips:132
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Der Zeichensatz, der für den Text unter Symbolen verwendet wird"
 
-#: tips:133
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Schnelle Bildskalierung"
 
-#: tips:134
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
@@ -3981,19 +4739,19 @@ msgstr ""
 "Größenanpassung der Hintegrundbilder. Die langsame Methode gibt gelegentlich "
 "bessere Ergebnisse."
 
-#: tips:135
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Pinwandverhalten"
 
-#: tips:136
+#: tips:190
 msgid "Single-click to open"
 msgstr "Öffnen durch einfachen Click"
 
-#: tips:138
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Halte Symbole innerhalb der Bildschirmgrenzen"
 
-#: tips:139
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
@@ -4001,45 +4759,45 @@ msgstr ""
 "Wenn aktiviert, werden Symbole immer komplett innerhalb des Bildschirms "
 "gehalten, incl. des Textes"
 
-#: tips:140
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Rastergröße für Symbole:"
 
-#: tips:141
+#: tips:195
 msgid "Fine"
 msgstr "Fein"
 
-#: tips:142
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr ""
 "Benutze ein Raster mit 2 Pixeln Abstand, um Symbole auf der Arbeitsfläche zu "
 "positionieren."
 
-#: tips:143
+#: tips:197
 msgid "Medium"
 msgstr "Mittel"
 
-#: tips:144
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr ""
 "Benutze ein Raster mit 16 Pixeln Abstand, um Symbole auf der Arbeitsfläche "
 "zu positionieren."
 
-#: tips:145
+#: tips:199
 msgid "Coarse"
 msgstr "Grob"
 
-#: tips:146
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr ""
 "Benutze ein Raster mit 32 Pixeln Abstand, um Symbole auf der Arbeitsfläche "
 "zu positionieren."
 
-#: tips:147 tips:149
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Minimierte Fenster"
 
-#: tips:148
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
@@ -4049,11 +4807,11 @@ msgstr ""
 "(iconifizieren)  und manche Programme, wie der ROX Dateimanager, können "
 "minimierte Fenster anzeigen. "
 
-#: tips:150
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Zeige minimierte Fenster"
 
-#: tips:151
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
@@ -4063,11 +4821,11 @@ msgstr ""
 "Pinwand als Symbol. Benötigt einen kompatiblen Fenstermanager und die "
 "Pinwand muss verwendet werden."
 
-#: tips:152
+#: tips:206
 msgid "Show per workspace"
 msgstr "Zeige per Arbeitsfläche"
 
-#: tips:153
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
@@ -4075,39 +4833,39 @@ msgstr ""
 "Wenn diese Option gewählt ist, werden nur minimierte Fenster gezeigt, die "
 "zur aktuellen Arbeitsfläche gehören."
 
-#: tips:154
+#: tips:208
 msgid "Iconify to the"
 msgstr "Minimieren nach"
 
-#: tips:155
+#: tips:209
 msgid "top-left"
 msgstr "oben-links"
 
-#: tips:156
+#: tips:210
 msgid "top-right"
 msgstr "oben-rechts"
 
-#: tips:157
+#: tips:211
 msgid "bottom-left"
 msgstr "unten-links"
 
-#: tips:158
+#: tips:212
 msgid "bottom-right"
 msgstr "unten-rechts"
 
-#: tips:159
+#: tips:213
 msgid ", going"
 msgstr ", aufgereiht"
 
-#: tips:160
+#: tips:214
 msgid "horizontally"
 msgstr "waagerecht"
 
-#: tips:161
+#: tips:215
 msgid "vertically"
 msgstr "senkrecht"
 
-#: tips:162
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4120,120 +4878,47 @@ msgstr ""
 "minimierte Fenster definiert werden. ROX-Filer Leiste verursachen keine "
 "Probleme."
 
-#: tips:163
+#: tips:217
 msgid "Top margin"
 msgstr "Obere Tabuzone"
 
-#: tips:164
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Höhe der Tabuzone am oberen Bildschirmrand."
 
-#: tips:165
+#: tips:219
 msgid "Bottom margin"
 msgstr "Untere Tabuzone"
 
-#: tips:166
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "Höhe der Tabuzone am unteren Bildschirmrand"
 
-#: tips:167
-msgid "Panels"
-msgstr "Leisten"
+#: tips:221
+#, fuzzy
+msgid "Left margin"
+msgstr "Obere Tabuzone"
 
-#: tips:168
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr ""
-"Leisten sind Streifen, die entlang der Bildschirmkanten verlaufen.\n"
-"Lesen sie das Handbuch, um mehr über Leisten zu erfahren."
+#: tips:222
+#, fuzzy
+msgid "Width of no-go area at left of screen."
+msgstr "Höhe der Tabuzone am oberen Bildschirmrand."
 
-#: tips:169
-msgid "Panel style"
-msgstr "Leistenstil"
+#: tips:223
+#, fuzzy
+msgid "Right margin"
+msgstr "Untere Tabuzone"
 
-#: tips:170
-msgid "Image and text"
-msgstr "Bild und Text"
+#: tips:224
+#, fuzzy
+msgid "Width of no-go area at right of screen."
+msgstr "Höhe der Tabuzone am oberen Bildschirmrand."
 
-#: tips:171
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Jedes Leisten-Symbol wird mit Bild und Text angezeigt."
-
-#: tips:172
-msgid "Image only for applications"
-msgstr "Nur Bild für Applikationen"
-
-#: tips:173
-msgid ""
-"Applications have just an image, everything else has both an image and text."
-msgstr ""
-"Applikationen haben nur ein Bild, alles andere hat beides, Bild und Text."
-
-#: tips:174
-msgid "Image only"
-msgstr "Nur Bild"
-
-#: tips:175
-msgid "Only the image is shown."
-msgstr "Nur das Bild wird angezeigt."
-
-#: tips:176
-msgid "Panel width (thin)"
-msgstr "Leistenbreite (schmal)"
-
-#: tips:177
-msgid "(thick)"
-msgstr "(breit)"
-
-#: tips:178
-msgid "The size of the panels."
-msgstr "Die Größe der Leisten."
-
-#: tips:179
-msgid "Do not cover panel"
-msgstr "Leisten nicht überdecken"
-
-#: tips:180
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
-msgstr ""
-"Den Fenster-Manager anweisen, Leisten niemals beim Maximieren von Fenstern "
-"zu überdecken. Nicht alle Fenster-Manager beachten diese Einstellung. "
-"Normalerweise werden nur einige Pixel am Bildschirmrand reserviert, um das "
-"automatische Anheben zu ermöglichen."
-
-#: tips:181
-msgid "Xinerama"
-msgstr "Xinerama"
-
-#: tips:182
-msgid "Confine to Xinerama monitor"
-msgstr "Eingrenzen in Xinerama-Monitor"
-
-#: tips:183
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
-msgstr ""
-"Für eine Xinerama Multimonitor-Konfiguration, mit dieser Option die Leisten "
-"in einen Monitor eingrenzen, statt auf alle auszudehnen."
-
-#: tips:184
-msgid ""
-"The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr ""
-"Der Monitor in die Leisten im Xinerama-Modus eingegrenzt werden (gezählt von "
-"0)."
-
-#: tips:185
+#: tips:225
 msgid "Desktop"
 msgstr "Arbeitsplatz"
 
-#: tips:186
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
@@ -4242,59 +4927,52 @@ msgstr ""
 "Dateimanager eine Liste und/oder die Pinwand öffnen. Hier kann eingestellt "
 "werden, welche."
 
-#: tips:187
+#: tips:227
 msgid "Panel only"
 msgstr "Nur Leiste"
 
-#: tips:188
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Zeige nur die Leiste."
 
-#: tips:189
+#: tips:229
 msgid "Pinboard only"
 msgstr "Nur Pinwand"
 
-#: tips:190
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "Zeige nur die Pinwand."
 
-#: tips:191
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "Leiste und Pinwand"
 
-#: tips:192
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "Sowohl eine Leiste, als auch die Pinwand werden gezeigt."
 
-#: tips:193
-msgid "Panel"
-msgstr "Leiste"
-
-#: tips:194
-msgid "Enter the name of the panel to show here."
-msgstr "Eingabe des Namens der Leiste"
-
-#: tips:196
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "Eingabe des Namens der Pinwand"
 
-#: tips:197
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr "Änderungen treten in Kraft beim nächsten Start des Dateimanagers."
 
-#: tips:198
+#: tips:236
+#, fuzzy
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 "Der Sitzungsmanager wendet diese Einstellungen an durch -S oder --rox-"
 "session als Aufrufparameter beim Start des Dateimanagers."
 
-#: tips:199
+#: tips:237
 msgid "Action windows"
 msgstr "Aktions-Fenster"
 
-#: tips:200
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4302,63 +4980,110 @@ msgstr ""
 "Aktions-Fenster öffnen sich, wenn Sie eine Hintergrund-\n"
 "Operation starten, wie das Kopieren oder Löschen von Dateien."
 
-#: tips:201
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Starte diese Aktionen automatisch (still):"
 
-#: tips:203
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Vor dem Kopieren nicht nachfragen."
 
-#: tips:205
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Vor dem Verschieben nicht nachfragen."
 
-#: tips:207
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Vor dem Erstellen von Verknüpfungen nicht nachfragen."
 
-#: tips:209
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Vor dem Löschen nicht nachfragen."
 
-#: tips:210
+#: tips:248
 msgid "Mount"
 msgstr "Einhängen"
 
-#: tips:211
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Vor dem Ein- und Aushängen von Dateisystemen nicht nachfragen."
 
-#: tips:212
+#: tips:250
 msgid "Default settings"
 msgstr "Voreinstellungen"
 
-#: tips:214
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Erzwingen"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "Löschen von nicht-schreibbaren Einträgen ohne Rückfragen"
 
-#: tips:216
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Weniger Informationen im Mitteilungsfenster anzeigen."
 
-#: tips:218
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Ändere auch den Inhalt von Unterverzeichnissen"
 
-#: tips:221
+#: tips:263
+#, fuzzy
+msgid "Mount commands"
+msgstr "Mount-Punkt"
+
+#: tips:264
+#, fuzzy
+msgid "Mount command"
+msgstr "Mount-Punkt"
+
+#: tips:265
+msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
+msgstr ""
+
+#: tips:266
+#, fuzzy
+msgid "Unmount command"
+msgstr "Aushängen"
+
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "_Verwende Befehl"
+
+#: tips:269
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Drag & Drop"
 
-#: tips:222
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Ziehen auf Symbole"
 
-#: tips:223
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Ziehen auf Symbole in Verzeichnisfenster erlauben"
 
-#: tips:224
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
@@ -4369,11 +5094,11 @@ msgstr ""
 "Eintrag wird hervorgehoben und ein Loslassen der Datei führt dazu, daß diese "
 "in das Verzeichnis gelegt oder in das Programm geladen wird."
 
-#: tips:225
+#: tips:276
 msgid "Directories spring open"
 msgstr "Aufspringende Verzeichnisse"
 
-#: tips:226
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
@@ -4383,15 +5108,15 @@ msgstr ""
 "Verzeichnis aufspringt, nachdem eine Datei für eine Weile darübergehalten "
 "wurde."
 
-#: tips:227
+#: tips:278
 msgid "Spring delay:"
 msgstr "Sprungverzögerung:"
 
-#: tips:228
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:229
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
@@ -4401,34 +5126,34 @@ msgstr ""
 "Datei über ein Verzeichnis halten müssen, bevor es aufspringt. Sie benötigt "
 "die vorherige Option, um eine Wirkung zu haben."
 
-#: tips:230
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Beim Ziehen von Dateien mit der linken Maustaste"
 
-#: tips:231 tips:235
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Zeige ein Menü der möglichen Aktionen"
 
-#: tips:232
+#: tips:283
 msgid "Copy the files"
 msgstr "Kopiere die Dateien"
 
-#: tips:233
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
 msgstr ""
 "Das Menü ist weiterhin erreichbar durch Ziehen bei gedrückter Alt-Taste."
 
-#: tips:234
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Beim Ziehen von Dateien mit der mittleren Maustaste"
 
-#: tips:236
+#: tips:287
 msgid "Move the files"
 msgstr "Verschiebe die Dateien"
 
-#: tips:237
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
@@ -4436,11 +5161,11 @@ msgstr ""
 "Das Menü ist weiterhin erreichbar, durch Ziehen mit der linken Maustaste bei "
 "gedrückter Alt-Taste."
 
-#: tips:238
+#: tips:289
 msgid "Download handler"
 msgstr "Programm für Internet-Downloads"
 
-#: tips:239
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4452,35 +5177,35 @@ msgstr ""
 "URI (Netzadresse), und Ziel ist das aktuelle Verzeichnis. Beispiel:\n"
 "xterm -e wget $1"
 
-#: tips:240
+#: tips:291
 msgid "Menus"
 msgstr "Menüs"
 
-#: tips:242
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Größe der Symbole in Menüs:"
 
-#: tips:243
+#: tips:294
 msgid "No Icons"
 msgstr "Keine Symbole"
 
-#: tips:246
+#: tips:297
 msgid "Same as current window"
 msgstr "Wie aktuelles Fenster"
 
-#: tips:247
+#: tips:298
 msgid "Same as default"
 msgstr "Wie Voreinstellung"
 
-#: tips:248
+#: tips:299
 msgid "Behaviour"
 msgstr "Verhalten"
 
-#: tips:249
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Dateimenü auf Rechtsklick"
 
-#: tips:250
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
@@ -4488,25 +5213,31 @@ msgstr ""
 "Zeige das Dateimenü anstelle des Hauptmenüs beim Rechtsklick auf markierte "
 "Dateien (das Hauptmenü ist Erreichbar durch Niederhalten der Strg-Taste)."
 
-#: tips:251
-msgid "`Xterm Here' program"
+#: tips:302
+#, fuzzy
+msgid "Terminal emulator program"
 msgstr "Terminalprogramm:"
 
-#: tips:252
-msgid "The program to launch when you choose `Xterm Here' from the menu."
+#: tips:303
+#, fuzzy
+msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr ""
 "Das Programm, das gestart wird, wenn Sie 'Terminal hier' aus dem Menü "
 "aufrufen."
 
-#: tips:253
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Tastaturkürzel"
 
-#: tips:255
+#: tips:305
+msgid "Types"
+msgstr "Typen"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME-Typen"
 
-#: tips:256
+#: tips:307
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
@@ -4515,23 +5246,23 @@ msgstr ""
 "für jede reguläre Datei herauszufinden, um dann nach einem passenden Symbol "
 "für diesen Typ zu suchen."
 
-#: tips:257
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "MIME-Regeln bearbeiten"
 
-#: tips:258
+#: tips:309
 msgid "Themes"
 msgstr "Themen"
 
-#: tips:259
+#: tips:310
 msgid "Icon theme"
 msgstr "Symbolthema"
 
-#: tips:260
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "Symbol-Themen gehören nach ~/.icons."
 
-#: tips:261
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
@@ -4540,39 +5271,39 @@ msgstr ""
 "setzen. Beachte, daß so zugewiesene Symbol Vorrang vor Themensymbole "
 "genießen."
 
-#: tips:262
+#: tips:313
 msgid "Colours"
 msgstr "Farben"
 
-#: tips:263
+#: tips:314
 msgid "File type colours"
 msgstr "Farbe für Dateitypen"
 
-#: tips:264
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Dateien entsprechend ihres Typs einfärben"
 
-#: tips:265
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr "Dateinamen (und Details) werden entsprechend des Dateityps eingefärbt."
 
-#: tips:266
+#: tips:317
 msgid "Directory:"
 msgstr "Verzeichnis:"
 
-#: tips:267
+#: tips:318
 msgid "Regular file:"
 msgstr "Reguläre Datei:"
 
-#: tips:268
+#: tips:319
 msgid "Pipe:"
 msgstr "Pipe:"
 
-#: tips:269
+#: tips:320
 msgid "Socket:"
 msgstr "Socket:"
 
-#: tips:271
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
@@ -4580,19 +5311,19 @@ msgstr ""
 "Fehler, z.B. eine Verknüpfung mit einer nicht-existenten Datei, oder eine "
 "Datei, zu deren Untersuchung der Dateimanager keine Berechtigung hat."
 
-#: tips:272
+#: tips:323
 msgid "Character device:"
 msgstr "Zeichengerät:"
 
-#: tips:273
+#: tips:324
 msgid "Block device:"
 msgstr "Blockgerät:"
 
-#: tips:274
+#: tips:325
 msgid "Door:"
 msgstr "Door:"
 
-#: tips:275
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
@@ -4600,31 +5331,59 @@ msgstr ""
 "Door-Dateien sind Sockets oder Pipes ähnlich, und sind nur auf Solaris "
 "bekannt."
 
-#: tips:276
+#: tips:327
 msgid "Executable file:"
 msgstr "Ausführbare Datei:"
 
-#: tips:277
+#: tips:328
 msgid "Application directory:"
 msgstr "Programmverzeichnis:"
 
-#: tips:278
+#: tips:329
 msgid "Unknown type:"
 msgstr "Unbekannter Typ:"
 
-#: tips:279
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Hintergrund:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Zeichensatz:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Kompatibilität"
 
-#: tips:280
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Fenstermanagerprobleme"
 
-#: tips:281
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "Ignoriere Fenstermanagerkontrolle über Pinwand und Leisten"
 
-#: tips:282
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4639,11 +5398,11 @@ msgstr ""
 "Pinwand oder Pane, oder wenn die Pinwand durch Mausklick in den Vordergrund "
 "kommt."
 
-#: tips:283
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "Alle Mausklicks auf den Hintergrund an Fenstermanager durchreichen"
 
-#: tips:284
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
@@ -4654,11 +5413,11 @@ msgstr ""
 "Klicks an den Fenstermanager zu übergeben. Klick auf Symbole werden nicht "
 "übergeben."
 
-#: tips:285
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Hack für das Blackbox Hintergrundmenü"
 
-#: tips:286
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4670,27 +5429,51 @@ msgstr ""
 "zukünftigen Versionen dieser Windowmanager dürfte sich dieses Problem "
 "erledigen. "
 
-#: tips:287
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "Leiste ist 'Dock'"
 
-#: tips:288
+#: tips:346
+#, fuzzy
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 "Diese Einstellung deaktivieren, falls die Leiste unerwünscht über anderen "
 "Fenstern verharrt. Wirkt sich erst nach Neustart des Dateimanagers aus."
 
-#: tips:289
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Leistenstil"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Ziehen & Ablegen"
 
-#: tips:290
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Hostnamen nicht benutzen"
 
-#: tips:291
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4701,15 +5484,11 @@ msgstr ""
 "Ziehen einer Datei über eine Applikation ein + auf dem Mauszeiger erscheint, "
 "aber nichts passiert."
 
-#: tips:292
-msgid "Extended attributes"
-msgstr "Erweiterte Attribute"
-
-#: tips:293
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Erweiterte Attribute nicht verwenden"
 
-#: tips:294
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4721,6 +5500,419 @@ msgstr ""
 "'Typ zuweisen' deaktiviert. Der Dateityp (MIME-Typ) wird nur aus dem "
 "Dateinamen abgeleitet und das Eigenschaftenfenster zeigt keine erweiterten "
 "Attribute an."
+
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Unterer Rand"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "Rechter Rand"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "Heimatverzeichnis"
+
+#: ../Templates.ui.h:4
+msgid "Panel Options"
+msgstr "Leisten-Einstellungen"
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Bild und Text"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Jedes Leisten-Symbol wird mit Bild und Text angezeigt."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Nur Bild für Applikationen"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"Applikationen haben nur ein Bild, alles andere hat beides, Bild und Text."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Nur Bild"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Nur das Bild wird angezeigt."
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Leistenbreite (schmal)"
+
+#: ../Templates.ui.h:12
+#, fuzzy
+msgid "The size of this panel."
+msgstr "Die Größe der Leisten."
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Übersetzung"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "Leisten nicht überdecken"
+
+#: ../Templates.ui.h:19
+#, fuzzy
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Den Fenster-Manager anweisen, Leisten niemals beim Maximieren von Fenstern "
+"zu überdecken. Nicht alle Fenster-Manager beachten diese Einstellung. "
+"Normalerweise werden nur einige Pixel am Bildschirmrand reserviert, um das "
+"automatische Anheben zu ermöglichen."
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Leistenstil"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Eingrenzen in Xinerama-Monitor"
+
+#: ../Templates.ui.h:22
+#, fuzzy
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Für eine Xinerama Multimonitor-Konfiguration, mit dieser Option die Leisten "
+"in einen Monitor eingrenzen, statt auf alle auszudehnen."
+
+#: ../Templates.ui.h:23
+#, fuzzy
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+"Der Monitor in die Leisten im Xinerama-Modus eingegrenzt werden (gezählt von "
+"0)."
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "Xinerama"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr "Rechter Rand"
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr "Linker Rand"
+
+#: ../Templates.ui.h:27
+msgid "Bottom edge"
+msgstr "Unterer Rand"
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr "Oberer Rand"
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "<b>Zugriffsrechte</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<ver>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' existiert bereits - überschreiben?"
+
+#~ msgid "Choices migration"
+#~ msgstr "Einstellungen konvertieren"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Fehler beim Durchsuchen von '%s':\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Verzeichnis nicht vorhanden/gelöscht"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Verzeichnis '%s' nicht gefunden."
+
+#~ msgid "Cancel"
+#~ msgstr "Abbruch"
+
+#~ msgid ""
+#~ ".\n"
+#~ "Home page (including updated versions): http://rox.sourceforge.net/\n"
+#~ msgstr ""
+#~ ".\n"
+#~ "Homepage (inklusive neuer Versionen): http://rox.sourceforge.net/\n"
+
+#~ msgid "GNOME-VFS library"
+#~ msgstr "GNOME-VFS-Bibliothek"
+
+#~ msgid "No (need 2.8.0 or later)"
+#~ msgstr "Nein (benötigt 2.8.0 oder neuer)"
+
+#~ msgid "Dnotify support"
+#~ msgstr "Dnotify-Ünterstützung"
+
+#~ msgid "Open AVFS"
+#~ msgstr "Öffnen mit AVFS"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr "Drücken Sie Shift+Menü-Taste über einer Datei, um sie zu senden"
+
+#~ msgid "Look inside ... ?"
+#~ msgstr "Zeige Inhalt von ... ?"
+
+#~ msgid "Panel: %s"
+#~ msgstr "Leisten: %s"
+
+#~ msgid "Select the panel's position:"
+#~ msgstr "Wahl der Leistenposition:"
+
+#~ msgid "Top-edge panel"
+#~ msgstr "Leiste am oberen Rand"
+
+#~ msgid "Bottom edge panel"
+#~ msgstr "Oberer Rand"
+
+#~ msgid "Left edge panel"
+#~ msgstr "Leiste am linken Rand"
+
+#~ msgid "Right-edge panel"
+#~ msgstr "Leiste am rechten Rand"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Ungültige .gmo Übersetzungsdatei (zu kurz): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr ""
+#~ "Ungültige .gmo Übersetzungsdatei (GNU magic number nicht gefunden): %s"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Zum übergeordneten Verzeichnis wechseln"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Zum Heimatverzeichnis wechseln"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Lesezeichen"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Lesezeichen-Menü"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Verzeichnisinhalt neu einlesen"
+
+#~ msgid "Change icon size"
+#~ msgstr "Wechseln der Symbolgröße"
+
+#~ msgid "Show extra details"
+#~ msgstr "Dateieigenschaften zeigen"
+
+#~ msgid "Hidden"
+#~ msgstr "Versteckt"
+
+#~ msgid "Show/hide hidden files"
+#~ msgstr "Versteckte Dateien zeigen/ausblenden"
+
+#~ msgid ""
+#~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
+#~ "instead."
+#~ msgstr ""
+#~ "Symbolthema '%s' enthält keine MIME-Symbole. Das ROX-Standardthema wird "
+#~ "daher verwendet."
+
+#~ msgid ""
+#~ "Failed to create symlink '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(this may mean that the ROX theme already exists there, but the 'mime-"
+#~ "application:postscript' icon couldn't be loaded for some reason)"
+#~ msgstr ""
+#~ "Konnte Verknüpfung '%s' nicht erzeugen:\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(dies könnte bedeuten, dass das ROX-Thema dort bereits installiert ist, "
+#~ "aber das Symbol 'mime-application:postscript' aus irgend einem Grund "
+#~ "nicht geladen werden konnte)"
+
+#~ msgid "Language"
+#~ msgstr "Sprache"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "LANG Environment-Variable benutzen"
+
+#~ msgid "Basque"
+#~ msgstr "Baskisch"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Chinesisch (traditionell)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Chinesisch (vereinfacht)"
+
+#~ msgid "Czech"
+#~ msgstr "Tchechisch"
+
+#~ msgid "Danish"
+#~ msgstr "Dänisch"
+
+#~ msgid "Dutch"
+#~ msgstr "Niederländisch"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Englisch (keine Übersetzung)"
+
+#~ msgid "Estonian"
+#~ msgstr "Estnisch"
+
+#~ msgid "Finnish"
+#~ msgstr "Finnisch"
+
+#~ msgid "French"
+#~ msgstr "Französisch"
+
+#~ msgid "German"
+#~ msgstr "Deutsch"
+
+#~ msgid "Hungarian"
+#~ msgstr "Ungarisch"
+
+#~ msgid "Japanese"
+#~ msgstr "Japanisch"
+
+#~ msgid "Norwegian"
+#~ msgstr "Norwegisch"
+
+#~ msgid "Italian"
+#~ msgstr "Italienisch"
+
+#~ msgid "Polish"
+#~ msgstr "Polnisch"
+
+#~ msgid "Portuguese (Brasil)"
+#~ msgstr "Portugiesisch (Brasilien)"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumänisch"
+
+#~ msgid "Russian"
+#~ msgstr "Russisch"
+
+#~ msgid "Spanish"
+#~ msgstr "Spanisch"
+
+#~ msgid "Swedish"
+#~ msgstr "Schwedisch"
+
+#~ msgid "Change at:"
+#~ msgstr "Ändern ab:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Max. Breite (Große Symbole):"
+
+#~ msgid "Panels"
+#~ msgstr "Leisten"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Leisten sind Streifen, die entlang der Bildschirmkanten verlaufen.\n"
+#~ "Lesen sie das Handbuch, um mehr über Leisten zu erfahren."
+
+#~ msgid "(thick)"
+#~ msgstr "(breit)"
+
+#~ msgid "Enter the name of the panel to show here."
+#~ msgstr "Eingabe des Namens der Leiste"
 
 #~ msgid ""
 #~ "Error loading MIME database:\n"

--- a/ROX-Filer/src/po/es.po
+++ b/ROX-Filer/src/po/es.po
@@ -2,44 +2,46 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rox-filer-2.9 spanish\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-09-16 08:51+0200\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2009-10-18 18:45+0100\n"
 "Last-Translator: Miguel Anxo Bouzada <mbouzada@gmail.com>\n"
 "Language-Team: GALPon MiniNo <mbouzada@gmail.com>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-Language: Spanish\n"
 "X-Poedit-Country: SPAIN\n"
 
-#: abox.c:125
-msgid "<dir>"
-msgstr "<dir>"
+#: abox.c:127
+msgid "<src>"
+msgstr ""
 
-#: abox.c:218
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Silencioso"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Quiet"
 msgstr "Silencioso"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "No confirme cada operación"
 
-#: abox.c:454
-#: infobox.c:782
-#: tips:36
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Nombre"
 
-#: abox.c:460
-#: menu.c:237
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Directorio"
 
-#: abox.c:549
+#: abox.c:546
 msgid "Expression:"
 msgstr "Expresión:"
 
@@ -55,11 +57,11 @@ msgstr "Vea la página del manual fsattr(5) para más detalles."
 msgid "You do not appear to have OS support."
 msgstr "Parece que no tiene soporte OS."
 
-#: action.c:191
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Referencia para expresiones de búsqueda"
 
-#: action.c:202
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -75,10 +77,13 @@ msgid ""
 "<b>IsReg system(grep -q fred \"%\")</b> (contains the word 'fred')\n"
 "\n"
 "<u>Simple Tests</u>\n"
-"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</b> (types)\n"
-"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> (permissions)\n"
+"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
+"b> (types)\n"
+"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
+"(permissions)\n"
 "<b>IsEmpty, IsMine</b>\n"
-"A pattern in single quotes is a shell-style wildcard pattern to match. If it\n"
+"A pattern in single quotes is a shell-style wildcard pattern to match. If "
+"it\n"
 "contains a slash then the match is against the full path; otherwise it is\n"
 "against the leafname only.\n"
 "\n"
@@ -86,7 +91,8 @@ msgid ""
 "<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (compare two values)\n"
 "<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (file sizes)\n"
 "<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (times)\n"
-"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> (values)\n"
+"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
+"(values)\n"
 "\n"
 "<u>Specials</u>\n"
 "<b>system(command)</b> (true if 'command' returns with a zero exit status;\n"
@@ -102,13 +108,16 @@ msgstr ""
 "<b>IsDIr 'lib'</b> (Encuentra directorios 'lib')\n"
 "<b>IsReg 'core'</b> (encuentra un archivo regular llamado 'core')\n"
 "<b>! (IsDir, IsReg)</b> (No es un directorio o archivo regular)\n"
-"<b>mtime after 1 day ago and size > 1Mb</b> (Con 1 mb y modificado recientemente)\n"
+"<b>mtime after 1 day ago and size > 1Mb</b> (Con 1 mb y modificado "
+"recientemente)\n"
 "<b>'CVS' prune, isreg</b> (archivo regular no está en CVS)\n"
 "<b>IsReg system(grep -q fred \"%\")</b> (contiene la palabra 'fred')\n"
 "\n"
 "<u>Probas sinxelas</u>\n"
-"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</b> (tipos)\n"
-"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> (permisos)\n"
+"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
+"b> (tipos)\n"
+"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
+"(permisos)\n"
 "<b>IsEmpty, IsMine</b>\n"
 "Un patrón entre comillas simples es un patrón comodín estilo terminal.\n"
 "Si contiene una barra después del espacio rompe la ruta completa, por el\n"
@@ -118,27 +127,30 @@ msgstr ""
 "<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (compara dos valores)\n"
 "<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (tamaños de archivos)\n"
 "<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (veces)\n"
-"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> (valores)\n"
+"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
+"(valores)\n"
 "\n"
 "<u>Especiales</u>\n"
 "<b>system(command)</b> (verdadero si «comando» devuelve un cero de salida;\n"
 "un % en el «comando» es substituido por la ruta del archivo actual)\n"
 "<b>prune</b> (falso, impide la búsqueda de contenido en un directorio)."
 
-#: action.c:249
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Referencia para el cambio de permisos"
 
-#: action.c:260
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
 "\n"
 "The format of a command is: <b>CHANGE, CHANGE, ...</b>\n"
 "Each <b>CHANGE</b> is: <b>WHO HOW PERMISSIONS</b>\n"
-"<b>WHO</b> is some combination of <b>u</b>, <b>g</b> and <b>o</b> which determines whether to\n"
+"<b>WHO</b> is some combination of <b>u</b>, <b>g</b> and <b>o</b> which "
+"determines whether to\n"
 "change the permissions for the User (owner), Group or Others.\n"
-"<b>HOW</b> is <b>+</b>, <b>-</b> or <b>=</b> to add, remove or set exactly the permissions.\n"
+"<b>HOW</b> is <b>+</b>, <b>-</b> or <b>=</b> to add, remove or set exactly "
+"the permissions.\n"
 "<b>PERMISSIONS</b> is some combination of the letters <b>rwxXstugo</b>\n"
 "\n"
 "Bracketed text and spaces are ignored.\n"
@@ -146,7 +158,8 @@ msgid ""
 "<u>Examples</u>\n"
 "<b>u+rw</b>: the file owner gains read and write permission\n"
 "<b>g=u</b>: the group permissions are set to be the same as the user's\n"
-"<b>o=u-w</b>: others get the same permissions as the owner, but without write permission\n"
+"<b>o=u-w</b>: others get the same permissions as the owner, but without "
+"write permission\n"
 "<b>a+x</b>: <b>a</b>ll get execute/access permission - same as <b>ugo+x</b>\n"
 "<b>a+X</b>: directories become accessable by everyone; files which were\n"
 "executable by anyone become executable by everyone\n"
@@ -161,29 +174,35 @@ msgstr ""
 "\n"
 "El formato de una orden es <b>CAMBIO,CAMBIO,...</b>\n"
 "Cada <b>CAMBIO</b> es: <b>QUIÉN CÓMO PERMISOS</b>\n"
-"<b>QUIÉN</b> es alguna combinación de <b>u</b>, <b>g</b>, <b>o</b> que determina si se van a\n"
+"<b>QUIÉN</b> es alguna combinación de <b>u</b>, <b>g</b>, <b>o</b> que "
+"determina si se van a\n"
 "cambiar los permisos para el Usuario (propietario), Grupo u Otros.\n"
-"<b>CÓMO</b> es <b>+</b>,<b>-</b> o <b>-</b> para añadir, quitar o mantener permisos.\n"
+"<b>CÓMO</b> es <b>+</b>,<b>-</b> o <b>-</b> para añadir, quitar o mantener "
+"permisos.\n"
 "<b>PERMISOS</b> son combinaciones de las letras <b>rwxXstugo</b>\n"
 "\n"
 "Los textos entre paréntesis y los espacios son ignorados\n"
 "<u>Ejemplos</u>\n"
 "<b>u+rw</b>: concede permisos de lectura y escritura al propietario\n"
 "<b>g=u</b>: los permisos para grupo son los mismos que los de usuario(s)\n"
-"<b>o=u-w</b>: otros tienen los mismos permisos que el propietario menos el de escritura\n"
-"<b>a+x</b>: <b>a</b>Permisos de acceso/ejecución - lo mismo que <b>ugo+x</b>\n"
-"<b>a+X</b>: los directorios se hacen accesibles para todos; los archivos se hacen ejecutables para todos\n"
+"<b>o=u-w</b>: otros tienen los mismos permisos que el propietario menos el "
+"de escritura\n"
+"<b>a+x</b>: <b>a</b>Permisos de acceso/ejecución - lo mismo que <b>ugo+x</"
+"b>\n"
+"<b>a+X</b>: los directorios se hacen accesibles para todos; los archivos se "
+"hacen ejecutables para todos\n"
 "<b>u+rw, go+r</b>: ¡dos órdenes a la vez!\n"
-"<b>u+s</b>: poner el bit SetUID - normalmente no tiene efecto en archivos de escritura\n"
+"<b>u+s</b>: poner el bit SetUID - normalmente no tiene efecto en archivos de "
+"escritura\n"
 "<b>755</b>: configura permisos directamente\n"
 "\n"
 "Vea la página de ayuda (man) chmod(1) para ver más detalles."
 
-#: action.c:301
+#: action.c:308
 msgid "Set type reference"
 msgstr "Referencia para la definición de tipo"
 
-#: action.c:312
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -208,60 +227,59 @@ msgstr ""
 "«user.mime_type» para guardar los tipos de archivo.\n"
 "\n"
 "Los tipos de archivo sólo son soportados para archivos regulares, y\n"
-"no para directorios, dispositivos, tuberías (pipes) o «sockets», por lo tanto sólo\n"
+"no para directorios, dispositivos, tuberías (pipes) o «sockets», por lo "
+"tanto sólo\n"
 "en ciertos sistemas de archivos es cuando el S.O. los implementa.\n"
 
-#: action.c:419
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Proceso terminado.\n"
 
-#: action.c:435
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Había un error.\n"
 
-#: action.c:437
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Había %d errores.\n"
 
-#: action.c:461
+#: action.c:516
 msgid "ERROR reading"
 msgstr "ERROR al leer"
 
-#: action.c:504
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Hecho\n"
 
-#: action.c:560
-#: support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "ERROR"
 
-#: action.c:714
-#: main.c:698
-#: main.c:705
-#: main.c:712
-#: main.c:726
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Sí"
 
-#: action.c:717
-#: main.c:700
-#: main.c:707
-#: main.c:714
-#: main.c:726
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "No"
 
-#: action.c:735
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -269,7 +287,7 @@ msgstr ""
 "\n"
 "Solicitando al proceso hijo que termine...\n"
 
-#: action.c:742
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -277,41 +295,41 @@ msgstr ""
 "\n"
 "Intentando MATAR un proceso desbocado...\n"
 
-#: action.c:895
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?¿Calcular el contenido de %s?"
 
-#: action.c:931
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?¿Eliminar %s'%s'?"
 
-#: action.c:932
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "PROTEGIDO CONTRA ESCRITURA"
 
-#: action.c:939
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'Borrando '%s'\n"
 
-#: action.c:952
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'El directorio '%s' fue borrado\n"
 
-#: action.c:985
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?¿Expulsar '%s'?"
 
-#: action.c:992
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Expulsar '%s'\n"
 
-#: action.c:1011
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -320,98 +338,96 @@ msgstr ""
 "!%s\n"
 "falló la expulsión\n"
 
-#: action.c:1030
-#: action.c:1049
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?¿Verificar '%s'?"
 
-#: action.c:1046
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
-msgstr "!La condición de búsqueda no es válida - debe cambiarla y probar de nuevo\n"
+msgstr ""
+"!La condición de búsqueda no es válida - debe cambiarla y probar de nuevo\n"
 
-#: action.c:1056
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(al verificar '%s')\n"
 
-#: action.c:1130
-#: action.c:1155
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?¿Cambiar permisos de '%s'?"
 
-#: action.c:1136
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Cambiando permisos de '%s'\n"
 
-#: action.c:1153
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Orden de modo no válida - debe cambiarla y probar de nuevo\n"
 
-#: action.c:1211
+#: action.c:1332
 #, c-format
 msgid "?Change contents of '%s'?"
 msgstr "?¿Cambiar el contenido de '%s'?"
 
-#: action.c:1214
-#: action.c:1234
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?¿Cambiar el tipo de '%s'?"
 
-#: action.c:1231
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Tipo no válido - debe cambiarlo y probar de nuevo\n"
 
-#: action.c:1253
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Cambiando el tipo de '%s' a '%s'\n"
 
-#: action.c:1276
+#: action.c:1397
 #, c-format
 msgid "'Not changing type of directory '%s'\n"
 msgstr "'El tipo de directorio '%s no se cambia'\n"
 
-#: action.c:1282
+#: action.c:1403
 #, c-format
 msgid "'Non-regular file '%s' not changed\n"
 msgstr "'Archivo no regular '%s' no se cambia\n"
 
-#: action.c:1342
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?¿'%s' ya existe - %s?"
 
-#: action.c:1344
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "mezclar contenidos"
 
-#: action.c:1345
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "sobreescribir"
 
-#: action.c:1361
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Intentando copiar de todas formas...\n"
 
-#: action.c:1370
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?¿Copiar %s en %s?"
 
-#: action.c:1374
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Copiando %s en %s\n"
 
-#: action.c:1389
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!ERROR: El destino ya existe pero no es un directorio\n"
 
-#: action.c:1461
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -420,26 +436,7 @@ msgstr ""
 "!%s\n"
 "Fallo al copiar '%s'\n"
 
-#: action.c:1505
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?¿'%s' ya existe - sobreescribir?"
-
-#: action.c:1520
-msgid "'Trying move anyway...\n"
-msgstr "'Intentando mover de todas formas...\n"
-
-#: action.c:1528
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?¿Mover %s a %s?"
-
-#: action.c:1532
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Moviendo %s a %s\n"
-
-#: action.c:1540
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -448,45 +445,59 @@ msgstr ""
 "!%s\n"
 "falla al mover %s a %s\n"
 
-#: action.c:1561
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Intentando mover de todas formas...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?¿Mover %s a %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Moviendo %s a %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!ERROR: No se puede copiar un objeto en él mismo\n"
 
-#: action.c:1576
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!ERROR: No se puede mover/renombrar un objeto en él mismo\n"
 
-#: action.c:1588
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Enlazando %s con %s\n"
 
-#: action.c:1593
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?¿Enlazar %s como %s?"
 
-#: action.c:1636
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Montando %s\n"
 
-#: action.c:1637
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Desmontando %s\n"
 
-#: action.c:1640
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?¿Montar %s?"
 
-#: action.c:1641
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?¿Desmontar %s?"
 
-#: action.c:1662
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -495,7 +506,7 @@ msgstr ""
 "!%s\n"
 "Falló el montaje\n"
 
-#: action.c:1663
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -504,11 +515,11 @@ msgstr ""
 "!%s\n"
 "Falló el desmontaje\n"
 
-#: action.c:1671
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(de todas formas parece que ahora está montado)\n"
 
-#: action.c:1717
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -517,319 +528,319 @@ msgstr ""
 "'\n"
 "Total: %s ("
 
-#: action.c:1723
+#: action.c:2108
 msgid "file"
 msgstr "archivo"
 
-#: action.c:1723
+#: action.c:2108
 msgid "files"
 msgstr "archivos"
 
-#: action.c:1727
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "ningún directorio)\n"
 
-#: action.c:1731
+#: action.c:2116
 msgid "directory"
 msgstr "directorio"
 
-#: action.c:1732
+#: action.c:2117
 msgid "directories"
 msgstr "directorios"
 
-#: action.c:1773
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!¡Punto de montaje sin seleccionar!\n"
 
-#: action.c:1858
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?¿Otra búsqueda?"
 
-#: action.c:1888
-#: action.c:1919
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' es un enlace simbólico\n"
 
-#: action.c:1959
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "Es preciso seleccionar algunos elementos para buscar"
 
-#: action.c:1969
-#: menu.c:228
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Buscar"
 
-#: action.c:2002
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Es necesario seleccionar algunos elementos para calcular"
 
-#: action.c:2006
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Uso de disco"
 
-#: action.c:2042
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Montar / Desmontar"
 
-#: action.c:2059
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
-msgstr "«ROX-Filer» todavía no soporta puntos de montaje en su sistema. Disculpe."
+msgstr ""
+"«ROX-Filer» todavía no soporta puntos de montaje en su sistema. Disculpe."
 
-#: action.c:2073
-#: menu.c:216
-#: tips:173
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Borrar"
 
-#: action.c:2085
-#: tips:178
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Forzar"
 
-#: action.c:2085
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "No confirmar el borrado de elementos sin permisos de escritura"
 
-#: action.c:2088
-#: action.c:2147
-#: action.c:2210
-#: action.c:2283
-#: action.c:2323
-#: tips:180
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Registro"
 
-#: action.c:2088
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Sólo crea registro de los directorios al ser borrados"
 
-#: action.c:2107
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "Es necesario escoger los elementos cuyos permisos quiere modificar"
 
-#: action.c:2115
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Hacer ejecutable/buscable)"
 
-#: action.c:2117
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (Hacer no ejecutable/no buscable)"
 
-#: action.c:2119
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Dar al propietario del archivo permisos de lectura escritura)"
 
-#: action.c:2121
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Privado - acceso permitido sólo al propietario)"
 
-#: action.c:2123
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Acceso público, sin escritura)"
 
-#: action.c:2134
-#: menu.c:189
-#: menu.c:226
-#: tips:53
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Permisos"
 
-#: action.c:2147
-#: action.c:2210
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "No listar los archivos procesados"
 
-#: action.c:2150
-#: action.c:2213
-#: tips:182
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Recursivo"
 
-#: action.c:2150
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Cambiar también el contenido de los subdirectorios"
 
-#: action.c:2154
+#: action.c:2547
 msgid "Command:"
 msgstr "Comando:"
 
-#: action.c:2184
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Tiene que seleccionar el elemento cuyo tipo quiere modificar"
 
-#: action.c:2197
+#: action.c:2590
 msgid "Set type"
 msgstr "Definir tipo"
 
-#: action.c:2213
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Cambiar el contenido de los subdirectorios"
 
-#: action.c:2220
-#: infobox.c:638
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Tipo:"
 
-#: action.c:2267
-#: dnd.c:122
-#: menu.c:2024
-#: tips:167
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Copiar"
 
-#: action.c:2279
-#: action.c:2319
-#: tips:184
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "No confirme cada operación"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Sobreescribir sólo si el origen es más nuevo que el destino"
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Más nuevo"
 
-#: action.c:2280
-#: action.c:2320
-#: tips:185
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Sobreescribir sólo si el origen es más nuevo que el destino"
 
-#: action.c:2283
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "directorios"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Crear registro de directorios sólo al ser movidos"
 
-#: action.c:2307
-#: dnd.c:123
-#: tips:169
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Mover"
 
-#: action.c:2323
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "No crear registro de cada archivo al ser movido"
 
-#: action.c:2346
-#: tips:171
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Crear enlace"
 
-#: action.c:2369
-#: appmenu.c:111
-#: filer.c:646
-#: infobox.c:1051
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Expulsar"
 
-#: action.c:2437
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Borrar elementos tales como"
 
-#: action.c:2441
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Borrando el elemento"
 
-#: action.c:2443
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Borrando los elementos"
 
-#: action.c:2462
+#: action.c:2900
 msgid " and "
 msgstr " y "
 
-#: action.c:2471
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
-msgstr " va a afectar a algunos elementos en el tablero o en el panel - ¿quiere borrarlo igualmente?"
+msgstr ""
+" va a afectar a algunos elementos en el tablero o en el panel - ¿quiere "
+"borrarlo igualmente?"
 
-#: action.c:2478
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
-msgstr " va a afectar a algunos elementos en el tablero o en el panel - ¿quiere borrarlos igualmente?"
+msgstr ""
+" va a afectar a algunos elementos en el tablero o en el panel - ¿quiere "
+"borrarlos igualmente?"
 
-#: appmenu.c:197
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<falta la etiqueta>"
 
-#: appmenu.c:319
+#: appmenu.c:317
 #, c-format
-msgid "Symlink any programs you want into this directory. They will appear in the menu for all items of this type (%s/%s)."
-msgstr "Cree los enlaces simbólicos de los programas que quiera en este directorio. Aparecerán en el menú para todos los elementos de este tipo (%s/%s)."
+msgid ""
+"Symlink any programs you want into this directory. They will appear in the "
+"menu for all items of this type (%s/%s)."
+msgstr ""
+"Cree los enlaces simbólicos de los programas que quiera en este directorio. "
+"Aparecerán en el menú para todos los elementos de este tipo (%s/%s)."
 
-#: appmenu.c:363
-#: menu.c:239
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Personalizar el menú"
 
-#: appmenu.c:420
-#: menu.c:257
-#: toolbar.c:158
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Ayuda"
 
-#: bookmarks.c:148
-#: log.c:160
-msgid "Path"
-msgstr "Ruta"
-
-#: bookmarks.c:156
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Título"
 
-#: bookmarks.c:305
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Ruta"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "No es posible guardar en los favoritos un recurso no local '%s'\n"
 
-#: bookmarks.c:313
-#: bookmarks.c:631
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' no es un directorio"
 
-#: bookmarks.c:519
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Debe seleccionar algunas líneas para borrar"
 
-#: bookmarks.c:543
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Sitúe el cursor en una entrada de la lista para mover"
 
-#: bookmarks.c:563
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Este elemento ya está al final"
 
-#: bookmarks.c:637
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
-msgstr "No es posible guardar en los favoritos directorios no locales como '%s'"
+msgstr ""
+"No es posible guardar en los favoritos directorios no locales como '%s'"
 
-#: bookmarks.c:779
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Añadir nuevo marcapáginas"
 
-#: bookmarks.c:786
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Editar marcapáginas"
 
-#: bookmarks.c:791
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Visitado recientemente"
 
-#: bulk_rename.c:66
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Renombrar archivos en grupo"
 
-#: bulk_rename.c:69
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Revertir"
 
-#: bulk_rename.c:74
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "Hacer en la columna «Nuevo» una copia de la columna «Antiguo»"
 
-#: bulk_rename.c:79
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "_Renombrar"
 
-#: bulk_rename.c:92
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Sustituir:"
 
-#: bulk_rename.c:99
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -843,58 +854,72 @@ msgstr ""
 "\\. coincidencia a un punto \n"
 "\\.htm$ coincidencia al '.htm' en 'index.htm', etc"
 
-#: bulk_rename.c:107
+#: bulk_rename.c:109
 msgid "With:"
 msgstr "Por:"
 
-#: bulk_rename.c:114
-msgid "The first match in each filename will be replaced by this string. The only special characters are back-references from \\0 to \\9. To use them literally, they have to be escaped with a backslash."
-msgstr "La primera coincidencia en cada nombre de archivo será sustituida por esta expresión. Los únicos caracteres especiales son copias de las referencias de \\0 a \\9. Para usarlos, literalmente, tienen que ser escapados con una barra invertida«\\»."
+#: bulk_rename.c:116
+msgid ""
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
+msgstr ""
+"La primera coincidencia en cada nombre de archivo será sustituida por esta "
+"expresión. Los únicos caracteres especiales son copias de las referencias de "
+"\\0 a \\9. Para usarlos, literalmente, tienen que ser escapados con una "
+"barra invertida«\\»."
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Aplicar"
 
-#: bulk_rename.c:123
-msgid "Do a search-and-replace in the New column. The files are not actually renamed until you click on the Rename button below."
-msgstr "Buscar y sustituir en los archivos de la columna Nuevo. Los archivos no son realmente renombrados hasta que presione el botón Renombrar, abajo."
+#: bulk_rename.c:125
+msgid ""
+"Do a search-and-replace in the New column. The files are not actually "
+"renamed until you click on the Rename button below."
+msgstr ""
+"Buscar y sustituir en los archivos de la columna Nuevo. Los archivos no son "
+"realmente renombrados hasta que presione el botón Renombrar, abajo."
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Nombre antiguo"
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Nombre nuevo"
 
-#: bulk_rename.c:293
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr "Ninguna expresión (en la columna Nuevo) coincide con la expresión dada"
 
-#: bulk_rename.c:298
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Un nombre coincide, pero el resultado fue el mismo"
 
-#: bulk_rename.c:301
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d los nombres coinciden, pero los resultados fueron los mismos"
 
-#: bulk_rename.c:327
-msgid "Specify a regular expression to match, and a string to replace matches with."
-msgstr "Especifique una expresión regular para coincidencias, y una expresión para sustituirlas."
+#: bulk_rename.c:330
+msgid ""
+"Specify a regular expression to match, and a string to replace matches with."
+msgstr ""
+"Especifique una expresión regular para coincidencias, y una expresión para "
+"sustituirlas."
 
-#: bulk_rename.c:344
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (para '%s')"
 
-#: bulk_rename.c:377
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr "Un archivo llamado '%s' ya existe. Abandonando el renombrado en grupo."
 
-#: bulk_rename.c:382
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -905,17 +930,21 @@ msgstr ""
 "%s\n"
 "Abandonando el renombrado en grupo."
 
-#: bulk_rename.c:444
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "El archivo llamado '%s' ya existe"
 
-#: bulk_rename.c:455
+#: bulk_rename.c:458
 #, c-format
-msgid "Some of the New names contain / characters (eg '%s'). This will cause the files to end up in different directories. Continue?"
-msgstr "Algunos de los Nuevos nombres contienen el carácter / (ej. '%s'). Esto hará que los archivos terminen en directorios diferentes. ¿Continuar?"
+msgid ""
+"Some of the New names contain / characters (eg '%s'). This will cause the "
+"files to end up in different directories. Continue?"
+msgstr ""
+"Algunos de los Nuevos nombres contienen el carácter / (ej. '%s'). Esto hará "
+"que los archivos terminen en directorios diferentes. ¿Continuar?"
 
-#: bulk_rename.c:470
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Ninguno  de los nombres fue cambiado. ¡No se hace nada!"
 
@@ -939,113 +968,178 @@ msgstr ""
 "%s\n"
 "%s"
 
-#: dir.c:1041
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "No es posible ver estadísticas del directorio: %s"
 
-#: dir.c:1050
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "No es posible abrir el directorio: %s"
 
-#: display.c:659
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Tamaño"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "Fallo en lstat(2): %s"
 
-#: dnd.c:124
-msgid "Link (relative)"
-msgstr "Crear enlace (relativo)"
-
-#: dnd.c:125
-msgid "Link (absolute)"
-msgstr "Crear enlace (absoluto)"
-
-#: dnd.c:424
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Ocurrió un error interno - tipo de información no válida"
 
-#: dnd.c:563
+#: dnd.c:565
 msgid "Drag a directory here to bookmark it."
 msgstr "Arrastre un directorio aquí para añadirlo a marcapáginas"
 
-#: dnd.c:578
+#: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
-msgstr "Ocurrió un error en el protocolo XDS: el nombre de una archivo no puede contener '/'\n"
+msgstr ""
+"Ocurrió un error en el protocolo XDS: el nombre de una archivo no puede "
+"contener '/'\n"
 
-#: dnd.c:603
-msgid "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/plain) did not contain a leafname\n"
-msgstr "Destino XdndDirectSave0 disponible, pero el elemento XdndDirectSave0 (tipo texto/simple) no contiene un nombre de archivo\n"
+#: dnd.c:605
+msgid ""
+"XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
+"plain) did not contain a leafname\n"
+msgstr ""
+"Destino XdndDirectSave0 disponible, pero el elemento XdndDirectSave0 (tipo "
+"texto/simple) no contiene un nombre de archivo\n"
 
-#: dnd.c:616
+#: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
-msgstr "Disculpe - es necesario un destino del tipo text/uri-list o XdndDirectSave0."
+msgstr ""
+"Disculpe - es necesario un destino del tipo text/uri-list o XdndDirectSave0."
 
-#: dnd.c:619
-msgid "Sorry - I require a target type of text/uri-list or application/octet-stream."
-msgstr "Disculpe - Es necesario el destino del tipo text/uri-list o application/octet-stream."
+#: dnd.c:621
+msgid ""
+"Sorry - I require a target type of text/uri-list or application/octet-stream."
+msgstr ""
+"Disculpe - Es necesario el destino del tipo text/uri-list o application/"
+"octet-stream."
 
-#: dnd.c:689
+#: dnd.c:691
 #, c-format
 msgid ""
-"Failed to add some items to the pinboard, because they are on a remote machine. For example:\n"
+"Failed to add some items to the pinboard, because they are on a remote "
+"machine. For example:\n"
 "\n"
 "%s"
 msgstr ""
-"Fallo al añadir algunos elementos al tablero, ya que están en una máquina remota. Por ejemplo:\n"
+"Fallo al añadir algunos elementos al tablero, ya que están en una máquina "
+"remota. Por ejemplo:\n"
 "\"\n"
 "%s"
 
-#: dnd.c:764
+#: dnd.c:766
 msgid "Unknown target"
 msgstr "Destino desconocido"
 
-#: dnd.c:797
+#: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
-msgstr "Disculpe - La aplicación remota no consigue o no quiere enviar los datos"
+msgstr ""
+"Disculpe - La aplicación remota no consigue o no quiere enviar los datos"
 
-#: dnd.c:810
+#: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
-msgstr "Hubo un error en protocolo XDS: el código de retorno debería ser 'S', 'F' o 'E'\n"
+msgstr ""
+"Hubo un error en protocolo XDS: el código de retorno debería ser 'S', 'F' o "
+"'E'\n"
 
-#: dnd.c:843
+#: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
-msgstr "Disculpe, no es posible mostrar un menú de acciones para un archivo remoto / datos en bruto"
+msgstr ""
+"Disculpe, no es posible mostrar un menú de acciones para un archivo remoto / "
+"datos en bruto"
 
-#: dnd.c:859
+#: dnd.c:861
 msgid "UntitledData"
 msgstr "DatosSinNombre"
 
-#: dnd.c:886
+#: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
 msgstr "Ocurrió un error al guardar el archivo: %s"
 
-#: dnd.c:959
+#: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
 msgstr "No hay URI's en text/uri-list (¡nada que hacer!)"
 
-#: dnd.c:991
-msgid "Can't get data from remote machine (application/octet-stream not provided)"
-msgstr "No es posible obtener datos de la máquina remota (application/octet-stream no disponible)"
+#: dnd.c:993
+msgid ""
+"Can't get data from remote machine (application/octet-stream not provided)"
+msgstr ""
+"No es posible obtener datos de la máquina remota (application/octet-stream "
+"no disponible)"
 
-#: dnd.c:1014
-msgid "Some of these files are on a different machine - they will be ignored - sorry"
-msgstr "Disculpe - Algunos de estos archivos están en una máquina diferente - van a ser ignorados"
+#: dnd.c:1015 menu.c:2406
+msgid ""
+"Some of these files are on a different machine - they will be ignored - sorry"
+msgstr ""
+"Disculpe - Algunos de estos archivos están en una máquina diferente - van a "
+"ser ignorados"
 
-#: dnd.c:1021
-msgid "None of these files are on the local machine - I can't operate on multiple remote files - sorry."
-msgstr "Ninguno de estos archivos está en la máquina local - no se puede operar en múltiples archivos remotos."
+#: dnd.c:1024 menu.c:2414
+msgid ""
+"None of these files are on the local machine - I can't operate on multiple "
+"remote files - sorry."
+msgstr ""
+"Ninguno de estos archivos está en la máquina local - no se puede operar en "
+"múltiples archivos remotos."
 
-#: dnd.c:1034
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "La acción solicitada es desconocida"
 
-#: dnd.c:1042
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Ocurrió un error al obtener la lista de archivos: %s"
+
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Crear enlace (relativo)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Crear enlace (absoluto)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Crear enlace (relativo)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Crear enlace (absoluto)"
 
 #: dropbox.c:112
 msgid "Show"
@@ -1060,8 +1154,12 @@ msgid "<nothing>"
 msgstr "<nada>"
 
 #: dropbox.c:237
-msgid "I can't show you the currently set item, because nothing is currently set. Drag something onto me!"
-msgstr "No se puede mostrar el elemento definido actualmente, ya que no hay nada definido actualmente. ¡Arrastre algo aquí!"
+msgid ""
+"I can't show you the currently set item, because nothing is currently set. "
+"Drag something onto me!"
+msgstr ""
+"No se puede mostrar el elemento definido actualmente, ya que no hay nada "
+"definido actualmente. ¡Arrastre algo aquí!"
 
 #: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
@@ -1072,8 +1170,7 @@ msgstr "Disculpe, debe soltar un archivo exactamente en el área de destino."
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr "Disculpe, no se puede usar '%s' porque no es un archivo local."
 
-#: dropbox.c:278
-#: pinboard.c:932
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1082,7 +1179,7 @@ msgstr ""
 "No se puede acceder '%s':\n"
 "%s"
 
-#: filer.c:461
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1091,16 +1188,7 @@ msgstr ""
 "Ocurrió un error al explorar '%s':\n"
 "%s\n"
 
-#: filer.c:465
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Ocurrió un error al explorar '%s':\n"
-"%s"
-
-#: filer.c:621
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1110,141 +1198,168 @@ msgstr ""
 "\n"
 "Desmontar un dispositivo hace que sea seguro extraerlo."
 
-#: filer.c:626
+#: filer.c:889
 msgid "Perform the same action in future for this mount point"
 msgstr "Realizar la misma acción en el futuro para este punto de montaje"
 
-#: filer.c:633
+#: filer.c:896
 msgid "No change"
 msgstr "Sin cambios"
 
-#: filer.c:639
-#: infobox.c:1049
-#: menu.c:872
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Desmontar"
 
-#: filer.c:743
-msgid "Directory missing/deleted"
-msgstr "Directorio ausente/borrado"
-
-#: filer.c:1107
+#: filer.c:1490
 #, c-format
 msgid ""
-"Group %s is not set. Select some files and press Ctrl+%s to set the group. Press %s on its own to reselect the files later.\n"
+"Group %s is not set. Select some files and press Ctrl+%s to set the group. "
+"Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"El grupo %s no está definido. Seleccione algunos archivos y haga clic en Ctrl+%s para definir el grupo. Presione sólo %s para seleccionar los archivos más tarde.\n"
+"El grupo %s no está definido. Seleccione algunos archivos y haga clic en Ctrl"
+"+%s para definir el grupo. Presione sólo %s para seleccionar los archivos "
+"más tarde.\n"
 "Asegúrese de que «BloqNum» está activado al usar el teclado numérico."
 
-#: filer.c:1343
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "No se puede acceder al directorio '%s'"
-
-#: filer.c:1495
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "No se encuentra el directorio '%s'."
-
-#: filer.c:1795
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: filer.c:2076
+#: filer.c:2655
 msgid "A"
 msgstr "A"
 
-#: filer.c:2078
-#: find.c:923
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr "G"
 
-#: filer.c:2083
+#: filer.c:2664
 msgid "S"
 msgstr "S"
 
-#: filer.c:2085
+#: filer.c:2669
 msgid "T"
 msgstr "T"
 
-#: filer.c:2095
-msgid "All, "
-msgstr "Todos."
+#: filer.c:2670
+msgid "D"
+msgstr ""
 
-#: filer.c:2098
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
 msgstr "Glob (%s),"
 
-#: filer.c:2106
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Explorando."
 
-#: filer.c:2108
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Miniaturas, "
 
-#: filer.c:2384
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Miniaturas, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Enlace simbólico a "
 
-#: filer.c:2426
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "El nombre del archivo no es un UTF-8 válido. Debe renombrarlo.\n"
 
-#: filer.c:2743
-#: menu.c:2014
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "¡El elemento ya no existe!"
 
-#: filer.c:3549
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Seleccione las propiedades de visualización para guardar"
 
-#: filer.c:3553
+#: filer.c:4712
+#, fuzzy
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr "<b>Guardar ajustes de visualización para el directorio</b>"
+
+#: filer.c:4713
 msgid "<b>Save display settings for directory</b>"
 msgstr "<b>Guardar ajustes de visualización para el directorio</b>"
 
-#: filer.c:3560
+#: filer.c:4720
 msgid "Select settings to save"
 msgstr "Seleccione los ajustes para guardar"
 
-#: filer.c:3567
+#: filer.c:4727
 msgid "Position"
 msgstr "Posición"
 
-#: filer.c:3572
-#: toolbar.c:133
-#: toolbar.c:137
-#: tips:39
-msgid "Size"
-msgstr "Tamaño"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Ventana"
 
-#: filer.c:3577
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Mostrar ocultos"
 
-#: filer.c:3583
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Estilo de visualización"
 
-#: filer.c:3589
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Ordenar por tipo y propietario"
 
-#: filer.c:3594
-#: toolbar.c:141
+#: filer.c:4754
 msgid "Details"
 msgstr "Detalles"
 
-#: filer.c:3599
-#: tips:92
-#: tips:93
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Miniaturas"
 
-#: filer.c:3605
+#: filer.c:4765
 msgid "Filter"
 msgstr "Filtro"
 
@@ -1468,15 +1583,19 @@ msgstr "bloques"
 msgid "Save As:"
 msgstr "Guardar como:"
 
-#: gtksavebox.c:395
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Sin nombre"
 
-#: gtksavebox.c:471
-msgid "Remote application wants to use Direct Save, but I can't read the XdndDirectSave0 (type text/plain) property.\n"
-msgstr "Una aplicación remota quiere usar «Direct Save», pero no se puede leer la propiedad XdndDirectSave0 (type text/plain).\n"
+#: gtksavebox.c:477
+msgid ""
+"Remote application wants to use Direct Save, but I can't read the "
+"XdndDirectSave0 (type text/plain) property.\n"
+msgstr ""
+"Una aplicación remota quiere usar «Direct Save», pero no se puede leer la "
+"propiedad XdndDirectSave0 (type text/plain).\n"
 
-#: gtksavebox.c:596
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1484,7 +1603,7 @@ msgstr ""
 "Arrastre el icono a un visor de directorio\n"
 "(o introduzca la ruta completa)"
 
-#: gui_support.c:330
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1492,195 +1611,192 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:399
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
-msgstr "Intentando leer un archivo XML como un archivo de texto. El archivo '%s' puede estar dañado."
+msgstr ""
+"Intentando leer un archivo XML como un archivo de texto. El archivo '%s' "
+"puede estar dañado."
 
-#: gui_support.c:416
+#: gui_support.c:542
 #, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
-"This may be due to upgrading from a previous version of ROX-Filer. Open the Options window and try changing something and then changing it back (causing the file to be resaved).\n"
+"This may be due to upgrading from a previous version of ROX-Filer. Open the "
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
 "Ocurrió un error en el archivo '%s' en la línea %d: \n"
 "\"%s\"\n"
-"Esto puede ser debido al actualizar desde una versión antigua del «ROX-Filer». Abra la ventana «Opciones» elija deshacer y presione en Guardar.\n"
+"Esto puede ser debido al actualizar desde una versión antigua del «ROX-"
+"Filer». Abra la ventana «Opciones» elija deshacer y presione en Guardar.\n"
 "Los siguientes errores serán ignorados."
 
-#: gui_support.c:1008
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Línea perdida o incorrecta en los datos «text/uri-list»"
 
-#: gui_support.c:1341
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "No se puede abrir el archivo '%s': %s"
 
-#: gui_support.c:1385
-#, c-format
-msgid "Failed to load image '%s': reason not known, probably a corrupt image file"
-msgstr "Fallo al cargar la imagen '%s': razón desconocida, es probable que el archivo de imagen esté dañado"
-
-#: gui_support.c:1450
+#: gui_support.c:1517
 #, c-format
 msgid ""
-"This program (%s) cannot be run, as the 0launch command is not available. It can be downloaded from here:\n"
+"Failed to load image '%s': reason not known, probably a corrupt image file"
+msgstr ""
+"Fallo al cargar la imagen '%s': razón desconocida, es probable que el "
+"archivo de imagen esté dañado"
+
+#: gui_support.c:1583
+#, c-format
+msgid ""
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
-"Esta aplicación (%s) no puede ejecutarse, ya que el comando «0launch» no está disponible. Puede descargarlo desde este enlace:\n"
+"Esta aplicación (%s) no puede ejecutarse, ya que el comando «0launch» no "
+"está disponible. Puede descargarlo desde este enlace:\n"
 "\n"
 "http://0install.net/injector.html"
 
 #: i18n.c:39
-msgid "Note that you must save your choices and restart the filer for the new language setting to take full effect."
-msgstr "Tenga en cuenta que tiene que guardar su selección y reiniciar el programa para que las nuevas definiciones de idioma tengan efecto."
+msgid ""
+"Note that you must save your choices and restart the filer for the new "
+"language setting to take full effect."
+msgstr ""
+"Tenga en cuenta que tiene que guardar su selección y reiniciar el programa "
+"para que las nuevas definiciones de idioma tengan efecto."
 
-#: icon.c:76
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(clic para definir)"
 
-#: icon.c:131
-msgid "ROX-Filer"
-msgstr "«ROX-Filer»"
-
-#: icon.c:132
-#: menu.c:258
-msgid "About ROX-Filer..."
-msgstr "Acerca de «ROX-Filer»..."
-
-#: icon.c:133
-#: menu.c:259
-msgid "Show Help Files"
-msgstr "Mostrar archivos de ayuda"
-
-#: icon.c:134
-#: menu.c:260
-msgid "Manual"
-msgstr "Manual"
-
-#: icon.c:136
-#: menu.c:235
-msgid "Options..."
-msgstr "Opciones..."
-
-#: icon.c:137
-#: menu.c:244
-msgid "Home Directory"
-msgstr "Directorio «Home»"
-
-#: icon.c:138
-#: icon.c:1410
-#: menu.c:212
-#: type.c:223
-msgid "File"
-msgstr "Archivo"
-
-#: icon.c:139
-#: menu.c:218
-#: menu.c:885
-msgid "Shift Open"
-msgstr "Abrir Con «Mayús»"
-
-#: icon.c:140
-#: menu.c:223
-msgid "Properties"
-msgstr "Propiedades"
-
-#: icon.c:141
-#: menu.c:221
-msgid "Set Run Action..."
-msgstr "Definir qué ejecutar..."
-
-#: icon.c:142
-#: menu.c:222
-msgid "Set Icon..."
-msgstr "Definir icono..."
-
-#: icon.c:143
-#: icon.c:867
-msgid "Edit Item"
-msgstr "Editar elemento"
-
-#: icon.c:144
-msgid "Show Location"
-msgstr "Mostrar localización"
-
-#: icon.c:145
-msgid "Remove Item(s)"
-msgstr "Eliminar elemento(s)"
-
-#: icon.c:318
-#: log.c:110
-#: menu.c:774
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:331
+#: icon.c:311
 msgid "Nothing"
 msgstr "Nada"
 
-#: icon.c:592
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "¡La localización debe contener al menos un carácter!"
 
-#: icon.c:657
+#: icon.c:641
 #, c-format
 msgid "You must unlock '%s' before removing it"
 msgstr "Debe desbloquear '%s' antes de quitarlo"
 
-#: icon.c:667
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Antes de quitarlo debe seleccionar algún elemento"
 
-#: icon.c:673
+#: icon.c:657
 msgid "An item must be unlocked before it can be removed."
 msgstr "El elemento debe ser desbloqueado antes de quitarlo."
 
-#: icon.c:687
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Debes abrir el menú sobre un elemento"
 
-#: icon.c:712
-#: menu.c:1285
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "Sólo se puede definir la acción de ejecutar para un archivo regular"
 
-#: icon.c:798
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Presione el atajo deseado (ej. Control+F1)"
 
-#: icon.c:820
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "¡Falla el acceso al teclado!"
 
-#: icon.c:870
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Editar elemento"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Presione en el icono para abrir:"
 
-#: icon.c:880
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Argumentos necesarios (para ejecutables):"
 
-#: icon.c:894
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "El texto mostrado bajo el icono es:"
 
-#: icon.c:907
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "El atajo de teclado es:"
 
-#: icon.c:927
+#: icon.c:910
 msgid "Locked"
 msgstr "Bloqueado"
 
-#: icon.c:932
+#: icon.c:915
 msgid "Locking an item prevents it from being accidentally removed"
 msgstr "El bloqueo de un elemento impide que sea eliminado accidentalmente"
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "«ROX-Filer»"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Acerca de «ROX-Filer»..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Mostrar archivos de ayuda"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Manual"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Opciones..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Directorio «Home»"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Archivo"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Abrir Con «Mayús»"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Propiedades"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Definir qué ejecutar..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Definir icono..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Mostrar localización"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Eliminar elemento(s)"
 
 #: infobox.c:113
 #, c-format
@@ -1691,43 +1807,40 @@ msgstr "¿Quiere confirmar a apertura de la ventana  %d ?"
 msgid "Show Info"
 msgstr "Información"
 
-#: infobox.c:136
-#: menu.c:779
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(utf-8 incorrecto)"
 
-#: infobox.c:261
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Mostrar archivos de ayuda"
 
-#: infobox.c:274
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Permisos</b>"
 
-#: infobox.c:292
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>El contenido indica...</b>"
 
-#: infobox.c:302
+#: infobox.c:319
 msgid "<b>When all directories are closed</b>"
 msgstr "<b>Cuando se cierran todos los directorios</b>"
 
-#: infobox.c:438
-#: infobox.c:579
-#: support.c:349
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "bytes"
 
-#: infobox.c:461
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Falló al leer el tamaño"
 
-#: infobox.c:522
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' ya no es un enlace simbólico"
 
-#: infobox.c:529
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1736,7 +1849,7 @@ msgstr ""
 "Fallo al deshacer el vínculo '%s':\n"
 "%s"
 
-#: infobox.c:534
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1747,184 +1860,185 @@ msgstr ""
 "%s\n"
 "(nota: el enlace antiguo fue eliminado)"
 
-#: infobox.c:558
-#: tips:242
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Error:"
 
-#: infobox.c:565
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Directorio real:"
 
-#: infobox.c:568
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Propietario, Grupo:"
 
-#: infobox.c:575
-#: infobox.c:590
-#: infobox.c:599
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Tamaño:"
 
-#: infobox.c:600
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Explorando"
 
-#: infobox.c:625
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Falló la exploración"
 
-#: infobox.c:632
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Cambiar fecha:"
 
-#: infobox.c:634
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Modificar fecha:"
 
-#: infobox.c:636
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Hora de acceso: "
 
-#: infobox.c:644
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Atributos extendidos:"
 
-#: infobox.c:646
+#: infobox.c:667
 msgid "Present"
 msgstr "Presente"
 
-#: infobox.c:647
+#: infobox.c:668
 msgid "None"
 msgstr "Ninguno"
 
-#: infobox.c:648
+#: infobox.c:669
 msgid "Not supported"
 msgstr "No soportado"
 
-#: infobox.c:660
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Destino del enlace:"
 
-#: infobox.c:672
-#: infobox.c:675
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Acción:"
 
-#: infobox.c:672
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Ejecutar archivo"
 
-#: infobox.c:784
+#: infobox.c:805
 msgid "Comment"
 msgstr "Comentario"
 
-#: infobox.c:786
+#: infobox.c:807
 msgid "Execute"
 msgstr "Ejecutar"
 
-#: infobox.c:800
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<todavía nada>"
 
-#: infobox.c:871
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "el archivo(1) dice... %s"
 
-#: infobox.c:928
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "No fue posible cambiar los permisos: %s"
 
-#: infobox.c:946
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Propietario"
 
-#: infobox.c:948
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Grupo"
 
-#: infobox.c:950
+#: infobox.c:974
 msgid "World"
 msgstr "Mundo"
 
-#: infobox.c:953
+#: infobox.c:977
 msgid "Read"
 msgstr "Leer"
 
-#: infobox.c:956
+#: infobox.c:980
 msgid "Write"
 msgstr "Escribir"
 
-#: infobox.c:959
+#: infobox.c:983
 msgid "Exec"
 msgstr "Ejecutar"
 
-#: infobox.c:977
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:984
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:991
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Pegajoso"
 
-#: infobox.c:1047
+#: infobox.c:1071
 msgid "Do nothing"
 msgstr "No hacer nada"
 
-#: infobox.c:1053
+#: infobox.c:1077
 msgid "Ask"
 msgstr "Preguntar"
 
-#: infobox.c:1065
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Enlace simbólico"
 
-#: infobox.c:1068
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "Aplicación ROX"
 
-#: infobox.c:1076
+#: infobox.c:1100
 msgid "mounted"
 msgstr "montado"
 
-#: infobox.c:1076
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "desmontado"
 
-#: infobox.c:1080
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Punto de montaje para %s (%s)"
 
-#: infobox.c:1083
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Punto de montaje (%s)"
 
-#: log.c:55
+#: log.c:54
 msgid "ROX-Filer started"
 msgstr "«ROX-Filer» activado"
 
-#: log.c:112
+#: log.c:115
 #, c-format
 msgid "%s on %d items"
 msgstr "%s en %d elementos"
 
-#: log.c:125
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Copiar..."
+
+#: log.c:139
 msgid "Item"
 msgstr "Elemento"
 
-#: log.c:149
+#: log.c:165
 msgid "Time"
 msgstr "Hora"
 
-#: log.c:154
+#: log.c:170
 msgid "Action"
 msgstr "Acción"
 
@@ -2012,7 +2126,8 @@ msgstr ""
 "                               \tderecho de la pantalla\n"
 "  -R, --RPC\t\tinvocar method call read from stdin\n"
 "  -s, --show=FILE\tabrir el directorio mostrando FILE\n"
-"  -S, --rox-session\tusar las opciones predeterminadas de panel y escritorio, y -n\n"
+"  -S, --rox-session\tusar las opciones predeterminadas de panel y "
+"escritorio, y -n\n"
 "  -t, --top=PANEL\tabrir PANEL como un panel en el borde\n"
 "                            \tsuperior de la pantalla\n"
 "  -u, --user\t\tmostrar el nombre de usuario en cada ventana \n"
@@ -2024,71 +2139,69 @@ msgstr ""
 
 #: main.c:237
 msgid ""
-"We got a BadWindow error from the X server. This might be due to this GTK bug (during drag-and-drop?):\n"
+"We got a BadWindow error from the X server. This might be due to this GTK "
+"bug (during drag-and-drop?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Trying to continue..."
 msgstr ""
-"Tenemos un error BadWindow del servidor X. Esto puede ser debido a este bug del GTK (¿al hacer arrastar-y-soltar?):\n"
+"Tenemos un error BadWindow del servidor X. Esto puede ser debido a este bug "
+"del GTK (¿al hacer arrastar-y-soltar?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Intentando continuar..."
 
-#: main.c:400
-msgid "The -o argument is no longer used. You can turn on override redirect from the Options box instead."
-msgstr "El argumento -o ya no se usa. Puede en su lugar activar «override» en la ventana de «Opciones»."
+#: main.c:399
+msgid ""
+"The -o argument is no longer used. You can turn on override redirect from "
+"the Options box instead."
+msgstr ""
+"El argumento -o ya no se usa. Puede en su lugar activar «override» en la "
+"ventana de «Opciones»."
 
-#: main.c:529
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Ejecutando como usuario '%s'"
 
-#: main.c:690
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Compilado con GTK versión %s\n"
 
-#: main.c:691
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Ejecutando con GTK versión %d.%d.%d\n"
 
-#: main.c:695
+#: main.c:693
 msgid "features set at compile time"
 msgstr "características definidas al compilar"
 
-#: main.c:696
+#: main.c:694
 msgid "Large File Support"
 msgstr "Soporte para archivos largos (LFS)"
 
-#: main.c:703
-msgid "Inotify support"
-msgstr "Soporte para «Inotify»"
-
-#: main.c:710
-msgid "Dnotify support"
-msgstr "Soporte para «dnotify»"
-
-#: main.c:717
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Compatibilidad binaria"
 
-#: main.c:719
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Sí (puede ejecutarse con versiones antiguas del glibc)"
 
-#: main.c:721
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "No (no se encuentra apsymbols.h)"
 
-#: main.c:725
+#: main.c:709
 msgid "Extended attribute support"
 msgstr "Soporte para atributos extendidos"
 
-#: main.c:876
+#: main.c:856
 #, c-format
 msgid "Unable to read '%s': %s"
 msgstr "Incapaz de leer '%s': %s"
 
-#: main.c:918
+#: main.c:895
 #, c-format
 msgid ""
 "Left-click to run %s.\n"
@@ -2097,455 +2210,622 @@ msgstr ""
 "Presione en el botón izquierdo para ejecutar %s.\n"
 "Presiona el botón derecho para listar las versiones."
 
-#: menu.c:185
-#: tips:28
-msgid "Display"
-msgstr "Mostrar"
-
-#: menu.c:186
-#: tips:33
-msgid "Icons View"
-msgstr "Vista de iconos"
-
-#: menu.c:187
-msgid "Icons, With..."
-msgstr "Iconos con..."
-
-#: menu.c:188
-#: tips:52
-msgid "Sizes"
-msgstr "Tamaños"
-
-#: menu.c:190
-#: tips:226
-msgid "Types"
-msgstr "Tipos"
-
-#: menu.c:191
-#: tips:55
-msgid "Times"
-msgstr "Fechas"
-
-#: menu.c:192
-#: tips:34
-#: tips:70
-msgid "List View"
-msgstr "Lista"
-
-#: menu.c:194
-msgid "Bigger Icons"
-msgstr "Iconos grandes"
-
-#: menu.c:195
-msgid "Smaller Icons"
-msgstr "Iconos pequeños"
-
-#: menu.c:196
-#: tips:49
-msgid "Automatic"
-msgstr "Automático"
-
-#: menu.c:198
-msgid "Sort by Name"
-msgstr "Ordenar por nombre"
-
-#: menu.c:199
-msgid "Sort by Type"
-msgstr "Ordenar por tipo"
-
-#: menu.c:200
-msgid "Sort by Date"
-msgstr "Ordenar por fecha"
-
-#: menu.c:201
-msgid "Sort by Size"
-msgstr "Ordenar por tamaño"
-
-#: menu.c:202
-msgid "Sort by Owner"
-msgstr "Ordenar por propietario"
-
-#: menu.c:203
-msgid "Sort by Group"
-msgstr "Ordenar por grupo"
-
-#: menu.c:204
-msgid "Reversed"
-msgstr "Orden inverso"
-
-#: menu.c:206
-msgid "Show Hidden"
-msgstr "Mostrar ocultos"
-
-#: menu.c:207
-msgid "Filter Files..."
-msgstr "Filtrar archivos..."
-
-#: menu.c:208
-msgid "Filter Directories With Files"
-msgstr "Filtrar directorios con archivos"
-
-#: menu.c:209
-msgid "Show Thumbnails"
-msgstr "Mostrar miniaturas"
-
-#: menu.c:210
-msgid "Refresh"
-msgstr "Actualizar"
-
-#: menu.c:211
-msgid "Save Current Display Settings..."
-msgstr "Guardar ajustes de visualización..."
-
-#: menu.c:213
-msgid "Copy..."
-msgstr "Copiar..."
-
-#: menu.c:214
-msgid "Rename..."
-msgstr "Renombrar..."
-
-#: menu.c:215
-msgid "Link..."
-msgstr "Crear enlace..."
-
-#: menu.c:219
-msgid "Send To..."
-msgstr "Enviar a..."
-
-#: menu.c:224
-msgid "Count"
-msgstr "Tamaño"
-
-#: menu.c:225
-msgid "Set Type..."
-msgstr "Definir tipo..."
-
-#: menu.c:229
-#: toolbar.c:154
-msgid "Select"
-msgstr "Seleccionar"
-
-#: menu.c:230
-msgid "Select All"
-msgstr "Seleccionar todos"
-
-#: menu.c:231
-msgid "Clear Selection"
-msgstr "Limpiar selección"
-
-#: menu.c:232
-msgid "Invert Selection"
-msgstr "Invertir selección"
-
-#: menu.c:233
-msgid "Select by Name..."
-msgstr "Seleccionar por nombre..."
-
-#: menu.c:234
-msgid "Select If..."
-msgstr "Seleccionar si..."
-
-#: menu.c:236
-msgid "New"
-msgstr "Nuevo"
-
-#: menu.c:238
-msgid "Blank file"
-msgstr "Archivo en blanco"
-
-#: menu.c:240
-#: tasklist.c:309
-msgid "Window"
-msgstr "Ventana"
-
-#: menu.c:241
-msgid "Parent, New Window"
-msgstr "Directorio anterior, nueva ventana"
-
-#: menu.c:242
-msgid "Parent, Same Window"
-msgstr "Directorio anterior, misma ventana"
-
-#: menu.c:243
-msgid "New Window"
-msgstr "Nueva ventana"
-
-#: menu.c:245
-msgid "Show Bookmarks"
-msgstr "Mostrar marcapáginas"
-
-#: menu.c:246
-msgid "Show Log"
-msgstr "Mostrar registro"
-
-#: menu.c:247
-msgid "Follow Symbolic Links"
-msgstr "Seguir enlaces simbólicos"
-
-#: menu.c:248
-msgid "Resize Window"
-msgstr "Redimensionar ventana"
-
-#: menu.c:251
-msgid "Close Window"
-msgstr "Cerrar ventana"
-
-#: menu.c:253
-msgid "Enter Path..."
-msgstr "Introducir la ruta..."
-
-#: menu.c:254
-msgid "Shell Command..."
-msgstr "Comando de terminal..."
-
-#: menu.c:255
-msgid "Terminal Here"
-msgstr "Abrir aquí un terminal"
-
-#: menu.c:256
-msgid "Switch to Terminal"
-msgstr "Cambiar a una terminal"
-
-#: menu.c:725
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "Presione la tecla «Shift+Mayús» y haga clic sobre un archivo para enviarlo a algún sitio"
-
-#: menu.c:764
-msgid "Next Click"
-msgstr "Siguiente clic"
-
-#: menu.c:786
-#, c-format
-msgid "%d items"
-msgstr "%d elementos"
-
-#: menu.c:874
-msgid "Open unmounted"
-msgstr "Abrir desmontado"
-
-#: menu.c:877
-msgid "Show Target"
-msgstr "Mostrar destino"
-
-#: menu.c:879
-msgid "Look Inside"
-msgstr "Mostrar contenido"
-
-#: menu.c:881
-msgid "Open As Text"
-msgstr "Abrir como texto"
-
-#: menu.c:1052
-msgid ""
-"Extended attributes, used to store types, are not supported for this file or files.\n"
-"This may be due to lack of support from the filesystem or the C library, or it may simply be that the filesystem needs to be mounted with the right mount option ('user_xattr' on Linux)."
-msgstr ""
-"Los atributos extendidos, usados para guardar los tipos de archivo, no son soportados por este(s) archivo(s).\n"
-"Esto puede ser debido a falta de soporte por parte del sistema de archivos o de la biblioteca de C, o puede simplemente ser necesario montar el sistema de archivos con las opciones de montaje correctas ('user_xattr' en Linux)."
-
-#: menu.c:1058
-msgid "Setting type not supported for some of these files"
-msgstr "Definir el tipo no está soportado por algunos de estos archivos"
-
-#: menu.c:1095
-msgid "_Relative link"
-msgstr "Enlace _relativo"
-
-#: menu.c:1101
-msgid ""
-"If on, the symlink will store the path from the symlink to the target file. Use this if the symlink and the target will be moved together.\n"
-"If off, the path from the root directory is stored - use this if the symlink may move but the target will stay put."
-msgstr ""
-"Si está activado, el enlace simbólico guardará el camino desde éste al archivo de destino. Úsalo de este modo si el enlace y el destino se moverán juntos.\n"
-"Si esta desactivado, el enlace guardará el camino a partir del directorio de raíz - úsalo de este modo si el enlace podrá moverse pero el destino deberá permanecer en el mismo sitio."
-
-#: menu.c:1171
-msgid "New pathname is not absolute"
-msgstr "La nueva ruta no es absoluta"
-
-#: menu.c:1239
-#, c-format
-msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
-msgstr "El enlace a partir de '%s' ya existe. ¿Sustituir por un enlace a '%s'?"
-
-#: menu.c:1245
-msgid "_Replace"
-msgstr "_Sustituir"
-
-#: menu.c:1365
-#: menu.c:1406
-#: menu.c:1468
-msgid "Create"
-msgstr "Crear"
-
-#: menu.c:1366
-msgid "NewDir"
-msgstr "NuevoDirectorio"
-
-#: menu.c:1380
-#: menu.c:1386
+#: main.c:942 menu.c:1723 menu.c:1729
 #, c-format
 msgid "Error creating '%s': %s"
 msgstr "Ocurrió un error al crear '%s': %s"
 
-#: menu.c:1407
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Guardar como:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
+msgid "Display"
+msgstr "Mostrar"
+
+#: menu.c:641 tips:49
+msgid "Icons View"
+msgstr "Vista de iconos"
+
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
+msgstr "Iconos con..."
+
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Tema de iconos"
+
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Permisos"
+
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Iconos con..."
+
+#: menu.c:647 tips:50 tips:98 tips:99
+msgid "List View"
+msgstr "Lista"
+
+#: menu.c:651
+msgid "Bigger Icons"
+msgstr "Iconos grandes"
+
+#: menu.c:653
+msgid "Smaller Icons"
+msgstr "Iconos pequeños"
+
+#: menu.c:655 tips:71
+msgid "Automatic"
+msgstr "Automático"
+
+#: menu.c:661
+msgid "Sort by Name"
+msgstr "Ordenar por nombre"
+
+#: menu.c:662
+msgid "Sort by Type"
+msgstr "Ordenar por tipo"
+
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
+msgstr "Ordenar por fecha"
+
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Ordenar por fecha"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Ordenar por fecha"
+
+#: menu.c:666
+msgid "Sort by Size"
+msgstr "Ordenar por tamaño"
+
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Permisos"
+
+#: menu.c:668
+msgid "Sort by Owner"
+msgstr "Ordenar por propietario"
+
+#: menu.c:669
+msgid "Sort by Group"
+msgstr "Ordenar por grupo"
+
+#: menu.c:671
+msgid "Reversed"
+msgstr "Orden inverso"
+
+#: menu.c:675
+msgid "Show Hidden"
+msgstr "Mostrar ocultos"
+
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Mostrar archivos de ayuda"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "ningún directorio)\n"
+
+#: menu.c:679
+msgid "Filter Files..."
+msgstr "Filtrar archivos..."
+
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Filtrar archivos..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr "Filtrar directorios con archivos"
+
+#: menu.c:682
+msgid "Show Thumbnails"
+msgstr "Mostrar miniaturas"
+
+#: menu.c:683
+msgid "Refresh"
+msgstr "Actualizar"
+
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Actualizar"
+
+#: menu.c:686
+#, fuzzy
+msgid "Save Display Settings..."
+msgstr "Guardar ajustes de visualización..."
+
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Guardar ajustes de visualización..."
+
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Tamaño"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
+msgid "Rename..."
+msgstr "Renombrar..."
+
+#: menu.c:700
+msgid "Link..."
+msgstr "Crear enlace..."
+
+#: menu.c:708
+msgid "Send To..."
+msgstr "Enviar a..."
+
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Atributos extendidos"
+
+#: menu.c:721
+msgid "Count"
+msgstr "Tamaño"
+
+#: menu.c:723
+msgid "Set Type..."
+msgstr "Definir tipo..."
+
+#: menu.c:731 toolbar.c:179
+msgid "Select"
+msgstr "Seleccionar"
+
+#: menu.c:733
+msgid "Select All"
+msgstr "Seleccionar todos"
+
+#: menu.c:735
+msgid "Clear Selection"
+msgstr "Limpiar selección"
+
+#: menu.c:736
+msgid "Invert Selection"
+msgstr "Invertir selección"
+
+#: menu.c:737
+msgid "Select by Name..."
+msgstr "Seleccionar por nombre..."
+
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Seleccionar si..."
+
+#: menu.c:741
+msgid "Select If..."
+msgstr "Seleccionar si..."
+
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
+msgid "New"
+msgstr "Nuevo"
+
+#: menu.c:752
+msgid "Blank file"
+msgstr "Archivo en blanco"
+
+#: menu.c:756 tasklist.c:305
+msgid "Window"
+msgstr "Ventana"
+
+#: menu.c:758
+msgid "Parent, New Window"
+msgstr "Directorio anterior, nueva ventana"
+
+#: menu.c:759
+msgid "Parent, Same Window"
+msgstr "Directorio anterior, misma ventana"
+
+#: menu.c:761 tips:44
+msgid "New Window"
+msgstr "Nueva ventana"
+
+#: menu.c:764
+msgid "Show Bookmarks"
+msgstr "Mostrar marcapáginas"
+
+#: menu.c:766
+msgid "Show Log"
+msgstr "Mostrar registro"
+
+#: menu.c:768
+msgid "Follow Symbolic Links"
+msgstr "Seguir enlaces simbólicos"
+
+#: menu.c:769
+msgid "Resize Window"
+msgstr "Redimensionar ventana"
+
+#: menu.c:771
+msgid "Close Window"
+msgstr "Cerrar ventana"
+
+#: menu.c:776
+msgid "Enter Path..."
+msgstr "Introducir la ruta..."
+
+#: menu.c:778
+msgid "Shell Command..."
+msgstr "Comando de terminal..."
+
+#: menu.c:780
+msgid "Terminal Here"
+msgstr "Abrir aquí un terminal"
+
+#: menu.c:782
+msgid "Switch to Terminal"
+msgstr "Cambiar a una terminal"
+
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Personalizar el menú"
+
+#: menu.c:976
+msgid "Next Click"
+msgstr "Siguiente clic"
+
+#: menu.c:998
+#, c-format
+msgid "%d items"
+msgstr "%d elementos"
+
+#: menu.c:1094
+msgid "Open unmounted"
+msgstr "Abrir desmontado"
+
+#: menu.c:1097
+msgid "Show Target"
+msgstr "Mostrar destino"
+
+#: menu.c:1099
+msgid "Look Inside"
+msgstr "Mostrar contenido"
+
+#: menu.c:1101
+msgid "Open As Text"
+msgstr "Abrir como texto"
+
+#: menu.c:1320
+msgid ""
+"Extended attributes, used to store types, are not supported for this file or "
+"files.\n"
+"This may be due to lack of support from the filesystem or the C library, or "
+"it may simply be that the filesystem needs to be mounted with the right "
+"mount option ('user_xattr' on Linux)."
+msgstr ""
+"Los atributos extendidos, usados para guardar los tipos de archivo, no son "
+"soportados por este(s) archivo(s).\n"
+"Esto puede ser debido a falta de soporte por parte del sistema de archivos o "
+"de la biblioteca de C, o puede simplemente ser necesario montar el sistema "
+"de archivos con las opciones de montaje correctas ('user_xattr' en Linux)."
+
+#: menu.c:1326
+msgid "Setting type not supported for some of these files"
+msgstr "Definir el tipo no está soportado por algunos de estos archivos"
+
+#: menu.c:1364
+msgid "_Relative link"
+msgstr "Enlace _relativo"
+
+#: menu.c:1370
+msgid ""
+"If on, the symlink will store the path from the symlink to the target file. "
+"Use this if the symlink and the target will be moved together.\n"
+"If off, the path from the root directory is stored - use this if the symlink "
+"may move but the target will stay put."
+msgstr ""
+"Si está activado, el enlace simbólico guardará el camino desde éste al "
+"archivo de destino. Úsalo de este modo si el enlace y el destino se moverán "
+"juntos.\n"
+"Si esta desactivado, el enlace guardará el camino a partir del directorio de "
+"raíz - úsalo de este modo si el enlace podrá moverse pero el destino deberá "
+"permanecer en el mismo sitio."
+
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
+msgid "New pathname is not absolute"
+msgstr "La nueva ruta no es absoluta"
+
+#: menu.c:1540
+#, c-format
+msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
+msgstr "El enlace a partir de '%s' ya existe. ¿Sustituir por un enlace a '%s'?"
+
+#: menu.c:1546
+msgid "_Replace"
+msgstr "_Sustituir"
+
+#: menu.c:1704
+msgid "NewDir"
+msgstr "NuevoDirectorio"
+
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Crear"
+
+#: menu.c:1755
 msgid "NewFile"
 msgstr "NuevoArchivo"
 
-#: menu.c:1425
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
-msgstr "Ocurrió un error al crear el archivo: no fue posible encontrar el modelo para %s"
+msgstr ""
+"Ocurrió un error al crear el archivo: no fue posible encontrar el modelo "
+"para %s"
 
-#: menu.c:1498
-#, c-format
+#: menu.c:1847
+#, fuzzy
 msgid ""
-"The `Send To' menu provides a quick way to send some files to an application. The applications listed are those in the following directories:\n"
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Cree los enlaces simbólicos de los programas que quiera en este directorio. "
+"Aparecerán en el menú para todos los elementos de este tipo (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
+msgid ""
+"The `Send To' menu provides a quick way to send some files to an "
+"application. The applications listed are those in the following "
+"directories:\n"
 "\n"
 "%s\n"
 "%s\n"
 "The `Send To' menu may be opened by Shift+Menu clicking over a file.\n"
 "\n"
 "Advanced use:\n"
-"You can also create subdirectories called `.text_html', `.text', etc which will only be shown for files of that type. `.group' is shown only when multiple files are selected."
+"You can also create subdirectories called `.text_html', `.text', etc which "
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
-"El menú «Enviar a...» permite enviar fácilmente archivos a una aplicación. Las aplicaciones listadas están en los siguientes directorios:\n"
+"El menú «Enviar a...» permite enviar fácilmente archivos a una aplicación. "
+"Las aplicaciones listadas están en los siguientes directorios:\n"
 "\n"
 "%s\n"
 "%s\n"
 "El menú «Enviar a...» puede ser abierto con Shift+Clic sobre un archivo.\n"
 "\n"
 "Uso avanzado:\n"
-"Puede también crear subdirectorios llamados «.text_html», «.text», etc que serán presentados sólo para archivos de ese tipo. «.group» es mostrado sólo cuando sean seleccionados varios archivos."
+"Puede también crear subdirectorios llamados «.text_html», «.text», etc que "
+"serán presentados sólo para archivos de ese tipo. «.group» es mostrado sólo "
+"cuando sean seleccionados varios archivos."
 
-#: menu.c:1509
-msgid "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift drag) any applications you want into it."
-msgstr "Ahora se mostrará el directorio «Enviar a»; en él deberá crear enlaces simbólicos (Ctrl+Shift arrastar) a las aplicaciones que quiera."
+#: menu.c:1895
+msgid ""
+"I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
+"drag) any applications you want into it."
+msgstr ""
+"Ahora se mostrará el directorio «Enviar a»; en él deberá crear enlaces "
+"simbólicos (Ctrl+Shift arrastar) a las aplicaciones que quiera."
 
-#: menu.c:1512
-#: menu.c:1552
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
-msgstr "Disculpe - Su variable CHOICESPATH -elección de la ruta- no permite la personalización."
+msgstr ""
+"Disculpe - Su variable CHOICESPATH -elección de la ruta- no permite la "
+"personalización."
 
-#: menu.c:1545
+#: menu.c:1931
 #, c-format
 msgid ""
-"Any files placed in your Templates directories will appear on the `New' menu. Choosing one of them will make a copy of it as the new file.\n"
+"Any files placed in your Templates directories will appear on the `New' "
+"menu. Choosing one of them will make a copy of it as the new file.\n"
 "\n"
 "The following directories contain templates:\n"
 "\n"
 "%s\n"
 "%s\n"
 msgstr ""
-"Cualquier archivo colocado en su directorio de plantillas aparecerá en el menú «Nuevo». Escogiendo uno de ellos creará una copia de éste como un nuevo archivo.\n"
+"Cualquier archivo colocado en su directorio de plantillas aparecerá en el "
+"menú «Nuevo». Escogiendo uno de ellos creará una copia de éste como un nuevo "
+"archivo.\n"
 "\"\n"
 "Los siguientes directorios contienen plantillas:\n"
 "\n"
 "%s\n"
 "%s\n"
 
-#: menu.c:1550
-msgid "I'll show you your Templates directory now; you should place any template files you want inside it."
-msgstr "Ahora se mostrará el directorio de plantillas; en él deberá colocar los archivos-plantilla que quiera."
+#: menu.c:1936
+msgid ""
+"I'll show you your Templates directory now; you should place any template "
+"files you want inside it."
+msgstr ""
+"Ahora se mostrará el directorio de plantillas; en él deberá colocar los "
+"archivos-plantilla que quiera."
 
-#: menu.c:1667
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Personalizar"
 
-#: menu.c:1740
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Personalizar el menú"
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Este ya es el nombre canónico para este directorio."
 
-#: menu.c:1771
-msgid "You can't open a second view onto this directory because the `Unique Windows' option is turned on in the Options window."
-msgstr "No es posible abrir una segunda vista para este directorio porque la opción «ventanas únicas» está activada en la ventana de Opciones."
+#: menu.c:2200
+msgid ""
+"You can't open a second view onto this directory because the `Unique "
+"Windows' option is turned on in the Options window."
+msgstr ""
+"No es posible abrir una segunda vista para este directorio porque la opción "
+"«ventanas únicas» está activada en la ventana de Opciones."
 
-#: menu.c:1897
-msgid "Copy ... ?"
-msgstr "Copiar ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1900
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?¿Copiar %s en %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?¿Copiar %s en %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Renombrar ... ?"
 
-#: menu.c:1903
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Crear enlace ... ?"
 
-#: menu.c:1906
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Abrir con «Mayús» ... ?"
 
-#: menu.c:1909
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Propiedades de ... ?"
 
-#: menu.c:1912
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Atributos extendidos"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Definir tipo de ... ?"
 
-#: menu.c:1915
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Definir acción a ejecutar para ... ?"
 
-#: menu.c:1918
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Definir icono para ... ?"
 
-#: menu.c:1921
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Enviar ... a ... ?"
 
-#: menu.c:1924
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "BORRAR ... ?"
 
-#: menu.c:1927
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Calcular el tamaño de ... ?"
 
-#: menu.c:1930
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Definir permisos de ... ?"
 
-#: menu.c:1933
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Buscar dentro de ... ?"
 
-#: menu.c:1997
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Copiar ... ?"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr ""
 "Esto sólo es posible hacerlo con un elemento cada vez.\n"
-"Rox tiene una política muy visual, arrastre directamente los elementos a la ventana de destino."
+"Rox tiene una política muy visual, arrastre directamente los elementos a la "
+"ventana de destino."
 
-#: menu.c:2029
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Renombrar"
 
-#: menu.c:2034
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Crear enlace"
 
-#: menu.c:2063
+#: menu.c:2654
 msgid ""
-"User-definable shortcuts are disabled by default in Gtk2, and you have not enabled them. You can turn this feature on by:\n"
+"User-definable shortcuts are disabled by default in Gtk2, and you have not "
+"enabled them. You can turn this feature on by:\n"
 "\n"
-"1) using an XSettings manager, such as ROX-Session or gnome-settings-daemon, or\n"
+"1) using an XSettings manager, such as ROX-Session or gnome-settings-daemon, "
+"or\n"
 "\n"
 "2) adding this line to ~/.gtkrc-2.0:\n"
 "\tgtk-can-change-accels = 1\n"
 "\t(this only works if NOT using XSETTINGS)"
 msgstr ""
-"Los atajos definibles por el usuario están  desactivados por omisión en Gtk2, y usted no los activó. Puede activar esta característica al:\n"
+"Los atajos definibles por el usuario están  desactivados por omisión en "
+"Gtk2, y usted no los activó. Puede activar esta característica al:\n"
 "\n"
-"1) usar un gestor de XSettings, tal como ROX-Session o con gnome-settings-daemon, o\n"
+"1) usar un gestor de XSettings, tal como ROX-Session o con gnome-settings-"
+"daemon, o\n"
 "\n"
 "2) añadiendo esta línea al ~/.gtkrc-2.0:\n"
 "\tgtk-can-change-accels = 1\n"
 "\t(esto funciona si NO se utiliza XSETTINGS)"
 
-#: menu.c:2074
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2553,7 +2833,8 @@ msgid ""
 "- Move the pointer over the item you want to use,\n"
 "- Press the key you want attached to it.\n"
 "\n"
-"The key will appear next to the menu item and you can just press that key without opening the menu in future."
+"The key will appear next to the menu item and you can just press that key "
+"without opening the menu in future."
 msgstr ""
 "Para definir un atajo de teclado para un elemento del menú:\n"
 "\n"
@@ -2561,41 +2842,79 @@ msgstr ""
 "- Mueva el puntero sobre el elemento que quiere usar,\n"
 "- Presione la tecla que quiere asociar al menú.\n"
 "\n"
-"La tecla aparecerá al lado del elemento del menú, y en el futuro podrá simplemente presionar en esa tecla sin tener que abrir el menú."
+"La tecla aparecerá al lado del elemento del menú, y en el futuro podrá "
+"simplemente presionar en esa tecla sin tener que abrir el menú."
 
-#: menu.c:2089
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Definir atajos de teclado"
 
-#: minibuffer.c:129
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Ir a:"
 
-#: minibuffer.c:130
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Comando:"
 
-#: minibuffer.c:131
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Seleccionar si:"
 
-#: minibuffer.c:132
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Seleccionar nombre:"
 
-#: minibuffer.c:133
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Seleccionar si:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Patrón:"
 
-#: minibuffer.c:265
-msgid "Enter the name of a file and I'll display it for you. Press Tab to fill in the longest match. Escape to close the minibuffer."
-msgstr "Introduzca el nombre de un archivo a ser mostrado por el gestor, presione TAB para autocompletar con la selección más próxima, Esc para cerrar."
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
 
-#: minibuffer.c:271
-msgid "Enter a shell command to execute. Click on a file to add it to the buffer."
-msgstr "Introduzca el comando de terminal a ejecutar. Haga clic en un archivo para asignarlo."
+#: minibuffer.c:320
+msgid ""
+"Enter the name of a file and I'll display it for you. Press Tab to fill in "
+"the longest match. Escape to close the minibuffer."
+msgstr ""
+"Introduzca el nombre de un archivo a ser mostrado por el gestor, presione "
+"TAB para autocompletar con la selección más próxima, Esc para cerrar."
 
-#: minibuffer.c:276
+#: minibuffer.c:326
+msgid ""
+"Enter a shell command to execute. Click on a file to add it to the buffer."
+msgstr ""
+"Introduzca el comando de terminal a ejecutar. Haga clic en un archivo para "
+"asignarlo."
+
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Introduzca un patrón de nombre de archivo para seleccionar los "
+"coincidentes:\n"
+"\n"
+"? equivale a cualquier carácter\n"
+"* equivale a cero o a más caracteres\n"
+"[aA] equivale a «a» o «A»\n"
+"[a-z] equivale a cualquier carácter desde la «a» la «z» (minúscula)\n"
+"*.png equivale a cualquier nombre que termine en «.png»"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2605,7 +2924,8 @@ msgid ""
 "[a-z] means any character from a to z (lowercase)\n"
 "*.png means any name ending in '.png'"
 msgstr ""
-"Introduzca un patrón de nombre de archivo para seleccionar los coincidentes:\n"
+"Introduzca un patrón de nombre de archivo para seleccionar los "
+"coincidentes:\n"
 "\n"
 "? equivale a cualquier carácter\n"
 "* equivale a cero o a más caracteres\n"
@@ -2613,51 +2933,67 @@ msgstr ""
 "[a-z] equivale a cualquier carácter desde la «a» la «z» (minúscula)\n"
 "*.png equivale a cualquier nombre que termine en «.png»"
 
-#: minibuffer.c:288
-msgid "Enter a pattern to match for files to be shown.  An empty filter turns the filter off."
-msgstr "Introduzca un patrón para los archivos que serán mostrados. Un filtro vacío equivale a un filtro desactivado."
+#: minibuffer.c:352
+msgid ""
+"Enter a pattern to match for files to be shown.  An empty filter turns the "
+"filter off."
+msgstr ""
+"Introduzca un patrón para los archivos que serán mostrados. Un filtro vacío "
+"equivale a un filtro desactivado."
 
-#: minibuffer.c:908
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Introduzca un patrón para los archivos que serán mostrados. Un filtro vacío "
+"equivale a un filtro desactivado."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Condición de búsqueda no válida"
 
 #: mount.c:103
 #, c-format
 msgid "File system table \"%s\" not found, cannot monitor system mounts"
-msgstr "No se encuentra la tabla del sistema de archivos \"%s\", no se supervisan los montajes"
+msgstr ""
+"No se encuentra la tabla del sistema de archivos \"%s\", no se supervisan "
+"los montajes"
 
 #: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s total, %s usado, %s libre (%.1f %%)"
 
-#: options.c:275
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "ROX-Filer convirtió su archivo de Opciones al nuevo formato XML"
 
-#: options.c:535
-#: options.c:1256
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(predefinido)"
 
-#: options.c:805
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Ocurrió un error interno: %s no es legible"
 
-#: options.c:914
+#: options.c:929
 msgid "Options"
 msgstr "Opciones"
 
-#: options.c:959
+#: options.c:974
 msgid "_Revert"
 msgstr "_Revertir"
 
-#: options.c:965
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
-msgstr "Restaurar todas las opciones a como estaban cuando abrió la ventana de «Opciones»."
+msgstr ""
+"Restaurar todas las opciones a como estaban cuando abrió la ventana de "
+"«Opciones»."
 
-#: options.c:980
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2666,52 +3002,55 @@ msgstr ""
 "Las opciones se guardarán como:\n"
 "%s"
 
-#: options.c:988
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(No está disponible guardar por CHOICESPATH -elección de la ruta-)"
 
-#: options.c:1161
-#: usericons.c:452
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Se produjo un error guardando %s: %s"
 
-#: options.c:1793
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Falta '='"
 
-#: panel.c:322
+#: panel.c:326
 #, c-format
 msgid "Unable to replace '%s'"
 msgstr "No se puede sustituir '%s'"
 
-#: panel.c:326
+#: panel.c:330
 #, c-format
 msgid "Unable to save '%s'"
 msgstr "No se puede guardar '%s'"
 
-#: panel.c:529
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "El antiguo archivo de panel fue convertido al nuevo formato XML."
 
-#: panel.c:637
-msgid "You have tried to close a panel via the window manager - I usually find that this is accidental... really close?"
-msgstr "Has intentado cerrar un panel usando el gestor de ventanas - Normalmente eso es accidental... ¿realmente quiere cerrarlo?"
+#: panel.c:670
+msgid ""
+"You have tried to close a panel via the window manager - I usually find that "
+"this is accidental... really close?"
+msgstr ""
+"Has intentado cerrar un panel usando el gestor de ventanas - Normalmente eso "
+"es accidental... ¿realmente quiere cerrarlo?"
 
-#: panel.c:738
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Falta < or > en el archivo de configuración del panel"
 
-#: panel.c:1610
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Se produjo un error guardando el panel %s: %s"
 
-#: panel.c:1925
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "¡La mini aplicación se cerró sin crear un «widget»!"
 
-#: panel.c:2021
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2720,45 +3059,44 @@ msgstr ""
 "Se produjo un error ejecutando mini aplicación:\n"
 "%s"
 
-#: panel.c:2646
+#: panel.c:2751
 msgid "Are you sure you want to remove this panel from the desktop?"
 msgstr "¿Está seguro de que quiere eliminar este panel del escritorio?"
 
-#: panel.c:2649
-#: panel.c:2676
+#: panel.c:2754 panel.c:2781
 msgid "Remove Panel"
 msgstr "Eliminar panel"
 
-#: panel.c:2672
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Opciones del panel..."
 
-#: panel.c:2757
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Monitor Xinerama %d no disponible"
 
-#: panel.c:2787
+#: panel.c:2897
 msgid "Top"
 msgstr "Arriba"
 
-#: panel.c:2789
+#: panel.c:2899
 msgid "Bottom"
 msgstr "Abajo"
 
-#: panel.c:2791
+#: panel.c:2901
 msgid "Left"
 msgstr "Izquierda"
 
-#: panel.c:2793
+#: panel.c:2903
 msgid "Right"
 msgstr "Derecha"
 
-#: panel.c:2795
+#: panel.c:2905
 msgid "Default"
 msgstr "Predeterminado"
 
-#: panel.c:2799
+#: panel.c:2909
 msgid "Unknown side"
 msgstr "Desconocido"
 
@@ -2767,18 +3105,28 @@ msgid "Your old pinboard file has been converted to the new XML format."
 msgstr "Su antiguo tablero fue convertido al nuevo formato XML"
 
 #: pinboard.c:711
-msgid "The backdrop handler must be an application directory. Drag an application directory into the Set Backdrop dialog box, or (for programmers) pass it to the SOAP SetBackdropApp method."
-msgstr "El gestor del fondo debe ser un directorio de aplicación. Arrastre una aplicación del directorio al cuadro de diálogo, o (para programadores) asignarlo a SetBackdropApp método SOAP."
+msgid ""
+"The backdrop handler must be an application directory. Drag an application "
+"directory into the Set Backdrop dialog box, or (for programmers) pass it to "
+"the SOAP SetBackdropApp method."
+msgstr ""
+"El gestor del fondo debe ser un directorio de aplicación. Arrastre una "
+"aplicación del directorio al cuadro de diálogo, o (para programadores) "
+"asignarlo a SetBackdropApp método SOAP."
 
 #: pinboard.c:730
 msgid ""
-"You can only set the backdrop to an image or to a program which knows how to manage ROX-Filer's backdrop.\n"
+"You can only set the backdrop to an image or to a program which knows how to "
+"manage ROX-Filer's backdrop.\n"
 "\n"
-"Programmers: the application's AppInfo.xml must contain the CanSetBackdrop element, as described in ROX-Filer's manual."
+"Programmers: the application's AppInfo.xml must contain the CanSetBackdrop "
+"element, as described in ROX-Filer's manual."
 msgstr ""
-"Sólo podrá crear un fondo con una imagen o un programa para que «ROX-Filer» sepa como manejarla.\n"
+"Sólo podrá crear un fondo con una imagen o un programa para que «ROX-Filer» "
+"sepa como manejarla.\n"
 "\n"
-"Programadores: la aplicación AppInfo.xml debe contener el elemento CanSetBackdrop, tal como se describe en el manual de «ROX-Filer»."
+"Programadores: la aplicación AppInfo.xml debe contener el elemento "
+"CanSetBackdrop, tal como se describe en el manual de «ROX-Filer»."
 
 #: pinboard.c:750
 msgid "Set backdrop"
@@ -2805,8 +3153,12 @@ msgid "Scale"
 msgstr "Escalado"
 
 #: pinboard.c:779
-msgid "Scale the image to fit the backdrop area, regardless of image dimensions - overscale"
-msgstr "Escala la imagen para adaptarla al tamaño del fondo, independientemente de las dimensiones -"
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr ""
+"Escala la imagen para adaptarla al tamaño del fondo, independientemente de "
+"las dimensiones -"
 
 #: pinboard.c:781
 msgid "Fit"
@@ -2833,35 +3185,43 @@ msgid "Drop an image here"
 msgstr "Suelte una imagen aquí"
 
 #: pinboard.c:851
-msgid "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox -p=Default' to turn it on in future."
-msgstr "Ningún tablero estaba en uso... el tablero «Default» está seleccionado. Utilice «rox -p=Default» para activarlo en el futuro"
+msgid ""
+"No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
+"-p=Default' to turn it on in future."
+msgstr ""
+"Ningún tablero estaba en uso... el tablero «Default» está seleccionado. "
+"Utilice «rox -p=Default» para activarlo en el futuro"
 
 #: pinboard.c:945
-msgid "Only files (and certain applications) can be used to set the background image."
-msgstr "Sólo se pueden utilizar archivos (y algunas aplicaciones) para fijar una imagen de fondo."
+msgid ""
+"Only files (and certain applications) can be used to set the background "
+"image."
+msgstr ""
+"Sólo se pueden utilizar archivos (y algunas aplicaciones) para fijar una "
+"imagen de fondo."
 
-#: pinboard.c:1602
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Falta '>' en la etiqueta del icono"
 
-#: pinboard.c:1611
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Falta ',' después de la etiqueta del icono"
 
-#: pinboard.c:1699
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Se produjo un error guardando el tablero %s: %s"
 
-#: pinboard.c:2244
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Fondo de pantalla..."
 
-#: pinboard.c:2247
+#: pinboard.c:2250
 msgid "Add Panel"
 msgstr "Añadir panel"
 
-#: pinboard.c:2341
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2872,7 +3232,7 @@ msgstr ""
 "%s\n"
 "Fondo eliminado."
 
-#: pixmaps.c:969
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2881,212 +3241,270 @@ msgstr ""
 "No se pueden eliminar miniaturas en %s:\n"
 "%s"
 
-#: pixmaps.c:990
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "No hay miniaturas para borrar"
 
-#: pixmaps.c:1003
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Eliminar miniaturas de la «caché»"
 
-#: remote.c:722
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Estilo '%s' desconocido"
 
-#: remote.c:744
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Detalles del tipo '%s' desconocidos"
 
-#: remote.c:772
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Tipo de ordenación '%s' desconocido"
 
-#: remote.c:1247
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Intento de invocar el método '%s' SOAP desconocido"
 
-#: run.c:99
-#: run.c:152
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "El programa %s no se encuentra - ¿borrado?"
 
-#: run.c:302
+#: run.c:359
+#, c-format
+msgid ""
+"No run action specified for files of this type (%s/%s) - you can set a run "
+"action by choosing `Set Run Action' from the File menu, or you can just drag "
+"the file to an application.%s"
+msgstr ""
+"No se especificó ninguna acción para archivos de este tipo (%s/%s) - Defina "
+"la acción Ejecutar en el menú «Siguiente clic» o arrastre este archivo a una "
+"aplicación.%s"
+
+#: run.c:365
+msgid ""
+"\n"
+"\n"
+"Note: If this is a computer program which you want to run, you need to set "
+"the execute bit by choosing Permissions from the File menu."
+msgstr ""
+"\n"
+"\n"
+"Nota: si se trata de ejecutar una aplicación, necesita ajustar el bit de "
+"ejecución en el menú «Permisos»."
+
+#: run.c:373
 #, c-format
 msgid "File doesn't exist, or I can't access it: %s"
 msgstr "El archivo: %s no existe o no se puede acceder a él"
 
-#: run.c:307
+#: run.c:378
 #, c-format
 msgid "I don't know how to open '%s'"
 msgstr "No se sabe como abrir '%s'"
 
-#: run.c:338
+#: run.c:409
 #, c-format
 msgid "'%s' is not a valid URI"
 msgstr "'%s' no es una URI válida"
 
-#: run.c:349
+#: run.c:420
 #, c-format
 msgid "%s not accessable"
 msgstr "%s no es accesible"
 
-#: run.c:357
+#: run.c:428
 #, c-format
 msgid "Non-local URL %s"
 msgstr "%s no es una URL local"
 
-#: run.c:374
+#: run.c:445
 #, c-format
 msgid "%s: no handler for %s"
 msgstr "%s: no es manejado por %s"
 
-#: run.c:394
+#: run.c:465
 msgid ""
 "Application:\n"
-"This is an application directory - you can run it as a program, or open it (hold down Shift while you open it). Most applications provide their own help here, but this one doesn't."
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
 msgstr ""
 "Aplicación:\n"
-"Esto es un directorio de aplicación - puede ejecutarlo como un programa, o abrirlo (clic «Mayús» mientras lo abre). La mayoría de las aplicaciones tienen su propia ayuda aquí, pero ésta no lo hace."
+"Esto es un directorio de aplicación - puede ejecutarlo como un programa, o "
+"abrirlo (clic «Mayús» mientras lo abre). La mayoría de las aplicaciones "
+"tienen su propia ayuda aquí, pero ésta no lo hace."
 
-#: run.c:478
+#: run.c:549
 #, c-format
 msgid "Could not send data to program: %s"
 msgstr "No se pudieron enviar los datos al programa: %s"
 
-#: run.c:508
+#: run.c:578
 #, c-format
 msgid "Could not read link: %s"
 msgstr "No se puede leer el enlace: %s"
 
-#: run.c:536
+#: run.c:606
 #, c-format
 msgid "Broken symlink (or you don't have permission to follow it): %s"
 msgstr "Enlace simbólico roto (o usted no tiene permiso para usarlo): %s"
 
-#: run.c:573
-#, c-format
-msgid "No run action specified for files of this type (%s/%s) - you can set a run action by choosing `Set Run Action' from the File menu, or you can just drag the file to an application.%s"
-msgstr "No se especificó ninguna acción para archivos de este tipo (%s/%s) - Defina la acción Ejecutar en el menú «Siguiente clic» o arrastre este archivo a una aplicación.%s"
-
-#: run.c:579
-msgid ""
-"\n"
-"\n"
-"Note: If this is a computer program which you want to run, you need to set the execute bit by choosing Permissions from the File menu."
-msgstr ""
-"\n"
-"\n"
-"Nota: si se trata de ejecutar una aplicación, necesita ajustar el bit de ejecución en el menú «Permisos»."
-
-#: run.c:753
+#: run.c:785
 #, c-format
 msgid ""
-"Executable '%s' is world-writeable! Refusing to run. Please change the permissions now (this problem may have been caused by a bug in earlier versions of the filer).\n"
+"Executable '%s' is world-writeable! Refusing to run. Please change the "
+"permissions now (this problem may have been caused by a bug in earlier "
+"versions of the filer).\n"
 "\n"
-"Having (non-symlink) run actions world-writeable means that other people who use your computer can replace your run actions with malicious versions.\n"
+"Having (non-symlink) run actions world-writeable means that other people who "
+"use your computer can replace your run actions with malicious versions.\n"
 "\n"
-"If you trust everyone who could write to these files then you needn't worry. Otherwise, you should check, or even just delete, all the existing run actions."
+"If you trust everyone who could write to these files then you needn't worry. "
+"Otherwise, you should check, or even just delete, all the existing run "
+"actions."
 msgstr ""
-"¡El ejecutable '%s' es escribible por todos! Se rehúsa su ejecución. Por favor cambie los permisos ahora (este problema puede ser causado por un fallo en las versiones anteriores del gestor).\n"
+"¡El ejecutable '%s' es escribible por todos! Se rehúsa su ejecución. Por "
+"favor cambie los permisos ahora (este problema puede ser causado por un "
+"fallo en las versiones anteriores del gestor).\n"
 "\n"
-"Hay ejecutables (no enlaces simbólicos) escribibles por todos, eso significa que cualquier persona que maneje su computadora puede sustituir sus aplicaciones por otras con código malicioso.\n"
+"Hay ejecutables (no enlaces simbólicos) escribibles por todos, eso significa "
+"que cualquier persona que maneje su computadora puede sustituir sus "
+"aplicaciones por otras con código malicioso.\n"
 "\n"
-"Si usted confía en quien pueda escribir en estos archivos no debe preocuparse. En caso contrario, debería comprobar, o suprimir, todos los permisos que afecten a archivos ejecutables."
+"Si usted confía en quien pueda escribir en estos archivos no debe "
+"preocuparse. En caso contrario, debería comprobar, o suprimir, todos los "
+"permisos que afecten a archivos ejecutables."
 
-#: run.c:766
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Evita problemas de seguridad)"
 
-#: support.c:272
-msgid "B"
-msgstr "B"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:351
+#: support.c:381
 msgid "byte"
 msgstr "byte"
 
-#: support.c:1596
-#: support.c:1650
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
 msgstr "Fallo al abrir y analizar el archivo '%s': %s"
 
-#: support.c:1607
-#: support.c:1661
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
 msgstr "Fallo mapeando el archivo '%s': %s"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close"
 msgstr "Cerrar"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close filer window"
 msgstr "Cerrar la ventana del gestor"
 
-#: toolbar.c:117
+#: toolbar.c:120
 msgid "Up"
 msgstr "Subir"
 
-#: toolbar.c:117
-msgid "Change to parent directory"
-msgstr "Cambiar al directorio superior"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:121
+#: toolbar.c:126
 msgid "Home"
 msgstr "Inicio"
 
-#: toolbar.c:121
-msgid "Change to home directory"
-msgstr "Cambiar a directorio de inicio"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks"
-msgstr "Marcadores"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks menu"
-msgstr "Menú de marcadores"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:129
+#: toolbar.c:138
 msgid "Scan"
 msgstr "Analizar"
 
-#: toolbar.c:129
-msgid "Rescan directory contents"
-msgstr "Actualizar los contenidos del directorio"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:133
-msgid "Change icon size"
-msgstr "Cambiar tamaño del icono"
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Tamaño"
 
-#: toolbar.c:137
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automático"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
 msgstr "Tamaño automático"
 
-#: toolbar.c:141
-msgid "Show extra details"
-msgstr "Mostrar detalles extra"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Lista"
 
-#: toolbar.c:145
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
 msgstr "Ordenar"
 
-#: toolbar.c:145
+#: toolbar.c:165
 msgid "Change sort criteria"
 msgstr "Cambiar criterio de ordenación"
 
-#: toolbar.c:149
-msgid "Hidden"
-msgstr "Oculto"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:149
+#: toolbar.c:169
 msgid ""
 "Left: Show/hide hidden files\n"
 "Right: Show/hide thumbnails"
@@ -3094,111 +3512,154 @@ msgstr ""
 "Izquierda: muestra/oculta archivos ocultos\n"
 "Derecha: muestra/oculta miniaturas"
 
-#: toolbar.c:154
-msgid "Select all/invert selection"
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+#, fuzzy
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+"Izquierda: muestra/oculta archivos ocultos\n"
+"Derecha: muestra/oculta miniaturas"
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
 msgstr "Seleccionar todo/invertir la selección"
 
-#: toolbar.c:158
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
 msgstr "Mostrar ayuda de «ROX-Filer»"
 
-#: toolbar.c:221
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
 msgstr " (%u oculto)"
 
-#: toolbar.c:229
-#: tips:58
+#: toolbar.c:276 tips:79
 msgid "items"
 msgstr "elementos"
 
-#: toolbar.c:229
+#: toolbar.c:276
 msgid "item"
 msgstr "elemento"
 
-#: toolbar.c:232
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
 msgstr "Sin elementos%s"
 
-#: toolbar.c:251
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
 msgstr "%u seleccionado (%s)"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by name"
 msgstr "Ordenar por nombre"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by type"
 msgstr "Ordenar por tipo"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by date"
 msgstr "Ordenar por fecha"
 
-#: toolbar.c:446
+#: toolbar.c:535
 msgid "Sort by size"
 msgstr "Ordenar por tamaño"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by owner"
 msgstr "Ordenar por propietario"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by group"
 msgstr "Ordenar por grupo"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "ascending"
 msgstr "ascendente"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "descending"
 msgstr "descendente"
 
-#: type.c:214
+#: toolbar.c:891
+#, fuzzy
+msgid "_N_Items_"
+msgstr "Elemento"
+
+#: type.c:221
 msgid "Sym link"
 msgstr "Enlace simbólico"
 
-#: type.c:216
+#: type.c:223
 msgid "Mount point"
 msgstr "Punto de montaje"
 
-#: type.c:218
+#: type.c:225
 msgid "App dir"
 msgstr "Directorio de aplicaciones"
 
-#: type.c:225
+#: type.c:232
 msgid "Dir"
 msgstr "Directorio"
 
-#: type.c:227
+#: type.c:234
 msgid "Char dev"
 msgstr "Dispositivo de carácter"
 
-#: type.c:229
+#: type.c:236
 msgid "Block dev"
 msgstr "Dispositivo de bloque"
 
-#: type.c:231
+#: type.c:238
 msgid "Pipe"
 msgstr "Canalización"
 
-#: type.c:233
+#: type.c:240
 msgid "Socket"
 msgstr "Socket"
 
-#: type.c:235
+#: type.c:242
 msgid "Door"
 msgstr "Puerta"
 
-#: type.c:238
+#: type.c:245
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: type.c:554
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3208,81 +3669,90 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:735
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "¡No es una aplicación o archivo ejecutable!"
 
-#: type.c:795
+#: type.c:839
 msgid "No run action defined"
 msgstr "No está definida ninguna acción para ejecutar"
 
-#: type.c:799
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Se produjo un error en: %s manejando %s"
 
-#: type.c:814
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "La aplicación %s no es válida (AppRun defectuoso)"
 
-#: type.c:825
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "No ejecutable %s"
 
-#: type.c:858
+#: type.c:902
 msgid "Set run action"
 msgstr "Definir acción para ejecutar"
 
-#: type.c:864
-msgid "If a handler for the specific type isn't set up, use this as the default."
-msgstr "Si el programa usado para este tipo de archivo no está definido, usar este como predeterminado."
+#: type.c:908
+msgid ""
+"If a handler for the specific type isn't set up, use this as the default."
+msgstr ""
+"Si el programa usado para este tipo de archivo no está definido, usar este "
+"como predeterminado."
 
-#: type.c:866
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Predeterminar para todos `%s/<cualquier>'"
 
-#: type.c:870
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Utilizar esta aplicación para todos los archivos del mismo tipo MIME"
 
-#: type.c:872
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Sólo para los del tipo `%s' (%s/%s)"
 
-#: type.c:878
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Arrastre la aplicación apropiada aquí"
 
-#: type.c:893
+#: type.c:963
 msgid "OR"
 msgstr "O"
 
-#: type.c:900
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Introduzca un comando de terminal:"
 
-#: type.c:929
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Usar el comando"
 
-#: type.c:959
-msgid "A run action already exists and is quite a big program - are you sure you want to delete it?"
-msgstr "Ya está especificada una acción y es un programa - ¿está seguro de que quiere eliminarlo?"
+#: type.c:1030
+msgid ""
+"A run action already exists and is quite a big program - are you sure you "
+"want to delete it?"
+msgstr ""
+"Ya está especificada una acción y es un programa - ¿está seguro de que "
+"quiere eliminarlo?"
 
-#: type.c:970
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "No se puede eliminar %s: %s"
 
-#: type.c:1007
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
-msgstr "La opción guardar fue desactivada por la variable CHOICESPATH -elección de la ruta-"
+msgstr ""
+"La opción guardar fue desactivada por la variable CHOICESPATH -elección de "
+"la ruta-"
 
-#: type.c:1309
+#: type.c:1395
 #, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
@@ -3291,25 +3761,26 @@ msgstr ""
 "Fallo creando el enlace simbólico '%s':\n"
 "%s"
 
-#: usericons.c:179
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "La ruta indicada no existe. El icono no fue cambiado."
 
-#: usericons.c:189
-#: usericons.c:618
+#: usericons.c:198 usericons.c:644
 msgid ""
-"Unable to load image file -- maybe it's not in a format I understand, or maybe the permissions are wrong?\n"
+"Unable to load image file -- maybe it's not in a format I understand, or "
+"maybe the permissions are wrong?\n"
 "The icon has not been changed."
 msgstr ""
-"No es posible cargar la imagen -- o está en un formato desconocido o no tiene los permisos apropiados\n"
+"No es posible cargar la imagen -- o está en un formato desconocido o no "
+"tiene los permisos apropiados\n"
 "El icono no fue cambiado."
 
-#: usericons.c:235
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "¿Quiere borrar el icono '%s'?"
 
-#: usericons.c:239
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3318,54 +3789,68 @@ msgstr ""
 "No se puede borrar '%s':\n"
 "%s"
 
-#: usericons.c:272
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Definir icono"
 
-#: usericons.c:281
-msgid "Use a copy of the image as the default for all files of these MIME types."
-msgstr "Use una copia de la imagen como predeterminada para todos los archivos de este tipo MIME."
+#: usericons.c:290
+msgid ""
+"Use a copy of the image as the default for all files of these MIME types."
+msgstr ""
+"Use una copia de la imagen como predeterminada para todos los archivos de "
+"este tipo MIME."
 
-#: usericons.c:283
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Predeterminar para todos `%s/<cualquier>'"
 
-#: usericons.c:288
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "Use una copia de la imagen para todos los archivos de este tipo MIME."
 
-#: usericons.c:290
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Para todos los del tipo `%s' (%s/%s)"
 
-#: usericons.c:296
-msgid "Add the file and image filenames to your personal list. The setting will be lost if the image or the file is moved."
-msgstr "Añadir el archivo y los nombres de las imágenes a tu lista personal. Esto se perderá si la imagen o el archivo se mueven."
+#: usericons.c:305
+msgid ""
+"Add the file and image filenames to your personal list. The setting will be "
+"lost if the image or the file is moved."
+msgstr ""
+"Añadir el archivo y los nombres de las imágenes a tu lista personal. Esto se "
+"perderá si la imagen o el archivo se mueven."
 
-#: usericons.c:299
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Sólo para el archivo `%s'"
 
-#: usericons.c:307
-msgid "Copy the image inside the directory, as a hidden file called '.DirIcon'. All users will then see the icon, and you can move the directory around safely. This is usually the best option if you can write to the directory."
-msgstr "Copiar la imagen dentro del directorio, como un archivo oculto llamado |. DirIcon ». Todos los usuarios verán el icono, y pueden mover el directorio con seguridad. Normalmente esta es la mejor opción si usted puede escribir en el directorio."
+#: usericons.c:316
+msgid ""
+"Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
+"users will then see the icon, and you can move the directory around safely. "
+"This is usually the best option if you can write to the directory."
+msgstr ""
+"Copiar la imagen dentro del directorio, como un archivo oculto llamado |. "
+"DirIcon ». Todos los usuarios verán el icono, y pueden mover el directorio "
+"con seguridad. Normalmente esta es la mejor opción si usted puede escribir "
+"en el directorio."
 
-#: usericons.c:313
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Copie la imagen a este directorio"
 
-#: usericons.c:319
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Arrastre un archivo de icono aquí"
 
-#: usericons.c:589
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "-elección de la ruta-"
 
-#: usericons.c:633
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3374,41 +3859,57 @@ msgstr ""
 "Se produjo un error creando la imagen '%s':\n"
 "%s"
 
-#: view_details.c:957
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
 msgid "Mono font"
 msgstr "Fuente «Mono»"
 
-#: view_details.c:958
+#: view_details.c:1019
 msgid "Font for displaying mono-spaced text"
 msgstr "Fuente para mostrar texto mono-espaciado"
 
-#: view_details.c:1059
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Nombre"
 
-#: view_details.c:1062
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Tipo"
 
-#: view_details.c:1065
-msgid "_Permissions"
-msgstr "_Permisos"
-
-#: view_details.c:1070
-msgid "_Owner"
-msgstr "Pr_opietario"
-
-#: view_details.c:1072
-msgid "_Group"
-msgstr "_Grupo"
-
-#: view_details.c:1074
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Tamaño"
 
-#: view_details.c:1080
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Permisos"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "Pr_opietario"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Grupo"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "Última _modificación"
+
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Atributos extendidos"
 
 #: tips:1
 msgid "Filer windows"
@@ -3423,586 +3924,1079 @@ msgid "Never automatically resize"
 msgstr "No ajustar nunca automáticamente"
 
 #: tips:4
-msgid "You'll have to resize windows manually, using the window manager, the `Resize Window' menu entry or by double-clicking on the window background."
-msgstr "Tendrá que cambiar el tamaño de las ventanas manualmente, utilizando el gestor de ventanas, en la entrada del menú «Redimensionar ventana» o haciendo doble clic en el fondo d la ventana."
+msgid ""
+"You'll have to resize windows manually, using the window manager, the "
+"`Resize Window' menu entry or by double-clicking on the window background."
+msgstr ""
+"Tendrá que cambiar el tamaño de las ventanas manualmente, utilizando el "
+"gestor de ventanas, en la entrada del menú «Redimensionar ventana» o "
+"haciendo doble clic en el fondo d la ventana."
 
 #: tips:5
 msgid "Resize when changing the display style"
 msgstr "Redimensionar cuando cambie el estilo de ventana"
 
 #: tips:6
-msgid "Changing the size of the icons or which details are displayed will resize the window for you."
-msgstr "Cambia el tamaño de los iconos o los detalles que se muestran redimensionará la ventana por ti."
+msgid ""
+"Changing the size of the icons or which details are displayed will resize "
+"the window for you."
+msgstr ""
+"Cambia el tamaño de los iconos o los detalles que se muestran redimensionará "
+"la ventana por ti."
 
 #: tips:7
 msgid "Always resize"
 msgstr "Redimensionar siempre"
 
 #: tips:8
-msgid "The filer will resize windows whenever it seems useful (that is, when changing directory or display style)."
-msgstr "El gestor redimensionará ventanas siempre que parezca útil (es decir, cambiando el directorio o el estilo)."
+msgid ""
+"The filer will resize windows whenever it seems useful (that is, when "
+"changing directory or display style)."
+msgstr ""
+"El gestor redimensionará ventanas siempre que parezca útil (es decir, "
+"cambiando el directorio o el estilo)."
 
 #: tips:9
 msgid "Largest window size:"
 msgstr "Tamaño de la ventana más grande"
 
-#: tips:10
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
 #: tips:11
-msgid "The largest size, as a percentage of the screen size, that the auto-resizer will resize a window to."
-msgstr "El tamaño mayor, como un porcentaje del tamaño de la pantalla, al que se redimensionará automáticamente una ventana."
+msgid ""
+"The largest size, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"El tamaño mayor, como un porcentaje del tamaño de la pantalla, al que se "
+"redimensionará automáticamente una ventana."
 
 #: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Tamaño de la ventana más grande"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"El tamaño mayor, como un porcentaje del tamaño de la pantalla, al que se "
+"redimensionará automáticamente una ventana."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Comportamiento de la ventana"
 
-#: tips:13
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Marcas en la barra de título cortas"
 
-#: tips:14
-msgid "Use single letters instead of words for Scanning, All and Thumbs indicators in the titlebar."
-msgstr "Usar letras en vez de palabras para la exploración, indicadores de «Todo» y «Miniaturas» en la barra de título."
+#: tips:17
+msgid ""
+"Use single letters instead of words for Scanning, All and Thumbs indicators "
+"in the titlebar."
+msgstr ""
+"Usar letras en vez de palabras para la exploración, indicadores de «Todo» y "
+"«Miniaturas» en la barra de título."
 
-#: tips:15
+#: tips:18
 msgid "Unique windows"
 msgstr "Ventanas únicas"
 
-#: tips:16
-msgid "If you open a directory and that directory is already displayed in another window, then this option causes the other window to be closed."
-msgstr "Si abre un directorio que ya está abierto en otra ventana, esto hará que la otra ventana sea cerrada."
+#: tips:19
+msgid ""
+"If you open a directory and that directory is already displayed in another "
+"window, then this option causes the other window to be closed."
+msgstr ""
+"Si abre un directorio que ya está abierto en otra ventana, esto hará que la "
+"otra ventana sea cerrada."
 
-#: tips:17
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Ventana"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Ventana nueva en botón 1"
 
-#: tips:18
-msgid "Clicking with mouse button 1 (usually the left button) opens a directory in a new window with this turned on. Clicking with the button-2 (middle) will reuse the current window."
-msgstr "Activando esta opción, al hacer clic en el botón 1 (normalmente el izquierdo) abre el directorio en una ventana nueva. Hacer clic con el botón 2 (el del medio) hará que se abra en la ventana actual."
+#: tips:25
+msgid ""
+"Clicking with mouse button 1 (usually the left button) opens a directory in "
+"a new window with this turned on. Clicking with the button-2 (middle) will "
+"reuse the current window."
+msgstr ""
+"Activando esta opción, al hacer clic en el botón 1 (normalmente el "
+"izquierdo) abre el directorio en una ventana nueva. Hacer clic con el botón "
+"2 (el del medio) hará que se abra en la ventana actual."
 
-#: tips:19
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Navegación con un sólo clic"
 
-#: tips:20
-#: tips:116
-msgid "Clicking on an item opens it with this on. Hold down Control to select the item instead. If off, clicking once selects an item; double click to open things."
-msgstr "Hacer clic una vez abre el elemento. Para seleccionarlo pulse la tecla «Ctrl». Si esta opción esta desactivada, con un sólo clic selecciona y con dos lo abre."
+#: tips:27 tips:191
+msgid ""
+"Clicking on an item opens it with this on. Hold down Control to select the "
+"item instead. If off, clicking once selects an item; double click to open "
+"things."
+msgstr ""
+"Hacer clic una vez abre el elemento. Para seleccionarlo pulse la tecla "
+"«Ctrl». Si esta opción esta desactivada, con un sólo clic selecciona y con "
+"dos lo abre."
 
-#: tips:21
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Doble clic sobre el fondo redimensiona"
 
-#: tips:22
-msgid "If on then double clicking on the window background resizes the window, just like clicking on the Automatic size mode button in the toolbar."
-msgstr "Si hace doble clic sobre el fondo de la ventana, redimensiona la ventana como si hiciera clic en el icono de tamaño automático en la barra de tareas."
+#: tips:29
+msgid ""
+"If on then double clicking on the window background resizes the window, just "
+"like clicking on the Automatic size mode button in the toolbar."
+msgstr ""
+"Si hace doble clic sobre el fondo de la ventana, redimensiona la ventana "
+"como si hiciera clic en el icono de tamaño automático en la barra de tareas."
 
-#: tips:23
+#: tips:30
 msgid "Sorting"
 msgstr "Ordenando"
 
-#: tips:24
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Los directorios van antes (al ordenarlos por nombres)"
 
-#: tips:25
-msgid "If this is on then directories will always appear before anything else when sorting by name."
-msgstr "Activada esta opción, los directorios aparecerán antes que los archivos cuando se ordena por nombre."
+#: tips:32
+msgid ""
+"If this is on then directories will always appear before anything else when "
+"sorting by name."
+msgstr ""
+"Activada esta opción, los directorios aparecerán antes que los archivos "
+"cuando se ordena por nombre."
 
-#: tips:26
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Nombres en mayúscula van antes (al ordenar por nombres)"
 
-#: tips:27
-msgid "If on, all filenames starting with a capital letter come before filenames starting with lowercase ones."
-msgstr "Activada esta opción los archivos cuyos nombres comienzan con una mayúscula van antes que los archivos cuyos nombres comienzan con minúsculas."
-
-#: tips:29
-msgid "Default settings for new windows"
-msgstr "Ajustes predeterminados para ventanas nuevas"
-
-#: tips:30
-msgid "Inherit options from source window"
-msgstr "Heredar opciones de la ventana origen"
-
-#: tips:31
-msgid "If this is on then display options for a new window are inherited from the source window if possible, otherwise they are set to the defaults below."
-msgstr "Activando esta opción, las ventanas nuevas heredan los ajustes de la ventana origen, si es posible, de lo contrario toman como predeterminado el aquí definido."
-
-#: tips:32
-msgid "View type:"
-msgstr "Ver tipo: "
+#: tips:34
+msgid ""
+"If on, all filenames starting with a capital letter come before filenames "
+"starting with lowercase ones."
+msgstr ""
+"Activada esta opción los archivos cuyos nombres comienzan con una mayúscula "
+"van antes que los archivos cuyos nombres comienzan con minúsculas."
 
 #: tips:35
-msgid "Sort by:"
-msgstr "Ordenar por: "
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Los directorios van antes (al ordenarlos por nombres)"
 
-#: tips:37
-#: tips:54
-msgid "Type"
-msgstr "Tipo"
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Segundo"
 
 #: tips:38
-msgid "Date"
-msgstr "Fecha"
-
-#: tips:40
-msgid "Show hidden files"
-msgstr "Mostrar archivos ocultos"
-
-#: tips:41
-msgid "If this is on then files whose names start with a dot are shown too, otherwise they are hidden."
-msgstr "Si está activada, los archivos cuyos nombres comienzan con un punto se mostrarán, si no, permanecerán ocultos."
-
-#: tips:42
 msgid "Show extended attribute indicator"
 msgstr "Mostrar indicador de atributo extendido"
 
-#: tips:43
-msgid "If this is on then files which have one or more extended attributes set will have an emblem added to indicate this."
-msgstr "Si está activada la opción, los archivos que tienen uno o más atributos extendidos tendrán un emblema añadido para indicarlo."
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+"Si está activada la opción, los archivos que tienen uno o más atributos "
+"extendidos tendrán un emblema añadido para indicarlo."
 
-#: tips:44
-msgid "Icon View"
-msgstr "Ver como iconos"
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
 
 #: tips:45
-msgid "Default size:"
-msgstr "Tamaño predeterminado: "
+msgid "Default settings for new windows"
+msgstr "Ajustes predeterminados para ventanas nuevas"
 
 #: tips:46
-msgid "Huge Icons"
-msgstr "Iconos gigantes"
+msgid "Inherit options from source window"
+msgstr "Heredar opciones de la ventana origen"
 
 #: tips:47
-#: tips:217
-msgid "Large Icons"
-msgstr "Iconos grandes"
+msgid ""
+"If this is on then display options for a new window are inherited from the "
+"source window if possible, otherwise they are set to the defaults below."
+msgstr ""
+"Activando esta opción, las ventanas nuevas heredan los ajustes de la ventana "
+"origen, si es posible, de lo contrario toman como predeterminado el aquí "
+"definido."
 
 #: tips:48
-#: tips:216
-msgid "Small Icons"
-msgstr "Iconos pequeños"
-
-#: tips:50
-msgid "Default details:"
-msgstr "Detalles predeterminados:"
+msgid "View type:"
+msgstr "Ver tipo: "
 
 #: tips:51
-msgid "No details"
-msgstr "Sin detalles"
+msgid "Sort by:"
+msgstr "Ordenar por: "
+
+#: tips:53 tips:76 tips:114
+msgid "Type"
+msgstr "Tipo"
+
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
+msgstr "Fecha"
+
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Fecha"
 
 #: tips:56
-msgid "Automatic small icons:"
-msgstr "Iconos pequeños automáticamente:"
+#, fuzzy
+msgid "Date (a)"
+msgstr "Fecha"
 
-#: tips:57
-msgid "Change at:"
-msgstr "Cambiar a:"
+#: tips:58
+msgid "Show hidden files"
+msgstr "Mostrar archivos ocultos"
 
 #: tips:59
-msgid "When automatic icon sizing is selected: If the directory contains this many items then it will be shown using Small Icons, otherwise Large Icons will be used."
-msgstr "Cuando se selecciona el tamaño automático: si el directorio contiene muchos elementos se mostrarán iconos pequeños, si no, se mostrarán los iconos grandes."
+msgid ""
+"If this is on then files whose names start with a dot are shown too, "
+"otherwise they are hidden."
+msgstr ""
+"Si está activada, los archivos cuyos nombres comienzan con un punto se "
+"mostrarán, si no, permanecerán ocultos."
 
 #: tips:60
-msgid "Max width (Large icons):"
-msgstr "Anchura máxima (iconos grandes):"
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Mostrar archivos ocultos"
 
 #: tips:61
-#: tips:64
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Si está activada, los archivos cuyos nombres comienzan con un punto se "
+"mostrarán, si no, permanecerán ocultos."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Iconos gigantes"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
 msgid "pixels"
 msgstr "píxeles"
 
-#: tips:62
-msgid "Text wider than this is broken onto two lines in Large Icons mode. In Huge Icons mode, text is wrapped when 50% wider than this."
-msgstr "El texto más ancho que esto se romperá en dos líneas en el modo de Iconos grandes. En el modo Gigante, el texto se cortará cuando supere el 50% de esta anchura."
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
 
-#: tips:63
-msgid "(Small Icons):"
+#: tips:65 tips:66
+msgid "Icon View"
+msgstr "Ver como iconos"
+
+#: tips:67
+msgid "Default size:"
+msgstr "Tamaño predeterminado: "
+
+#: tips:68
+msgid "Huge Icons"
+msgstr "Iconos gigantes"
+
+#: tips:69 tips:296
+msgid "Large Icons"
+msgstr "Iconos grandes"
+
+#: tips:70 tips:295
+msgid "Small Icons"
+msgstr "Iconos pequeños"
+
+#: tips:72
+msgid "Default details:"
+msgstr "Detalles predeterminados:"
+
+#: tips:73
+msgid "No details"
+msgstr "Sin detalles"
+
+#: tips:74
+msgid "Sizes"
+msgstr "Tamaños"
+
+#: tips:77
+msgid "Times"
+msgstr "Fechas"
+
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
+msgstr "Iconos pequeños automáticamente:"
+
+#: tips:80
+msgid ""
+"When automatic icon sizing is selected: If the directory contains this many "
+"items then it will be shown using Small Icons, otherwise Large Icons will be "
+"used."
+msgstr ""
+"Cuando se selecciona el tamaño automático: si el directorio contiene muchos "
+"elementos se mostrarán iconos pequeños, si no, se mostrarán los iconos "
+"grandes."
+
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Iconos grandes"
+
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
+msgstr ""
+"El texto más ancho que esto se romperá en dos líneas en el modo de Iconos "
+"grandes. En el modo Gigante, el texto se cortará cuando supere el 50% de "
+"esta anchura."
+
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
+
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
+#: tips:88
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr ""
+"Si se activa esta opción, los iconos grandes se mostrarán en columnas, si no "
+"en filas."
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
 msgstr "(Iconos pequeños):"
 
-#: tips:65
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "Anchura máxima para el texto bajo los iconos pequeños."
 
-#: tips:66
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "Ordenar los iconos pequeñas en vertical"
 
-#: tips:67
-msgid "If this option is on, then small icons are arranged in columns, not rows."
-msgstr "Si se activa esta opción, los iconos pequeños se mostrarán en columnas, si no en filas."
+#: tips:93
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
+msgstr ""
+"Si se activa esta opción, los iconos pequeños se mostrarán en columnas, si "
+"no en filas."
 
-#: tips:68
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "Ordenar los iconos grandes en vertical"
 
-#: tips:69
-msgid "If this option is on, then large icons are arranged in columns, not rows."
-msgstr "Si se activa esta opción, los iconos grandes se mostrarán en columnas, si no en filas."
+#: tips:95
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
+msgstr ""
+"Si se activa esta opción, los iconos grandes se mostrarán en columnas, si no "
+"en filas."
 
-#: tips:71
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Mostrar encabezamientos de las columnas"
 
-#: tips:72
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
-msgstr "Activando esta opción los encabezamientos de las columnas se mostrarán en la vista de lista."
+msgstr ""
+"Activando esta opción los encabezamientos de las columnas se mostrarán en la "
+"vista de lista."
 
-#: tips:73
+#: tips:102
 msgid "Show full type"
 msgstr "Mostrar todos los tipos"
 
-#: tips:74
-msgid "If this is on then the full description of each object's type will be show rather than a short summary of its basic type."
-msgstr "Activando esta opción, la descripción completa de cada tipo de objeto no se muestra más que como un resumen de su tipo básico."
+#: tips:103
+msgid ""
+"If this is on then the full description of each object's type will be show "
+"rather than a short summary of its basic type."
+msgstr ""
+"Activando esta opción, la descripción completa de cada tipo de objeto no se "
+"muestra más que como un resumen de su tipo básico."
 
-#: tips:75
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Anchura máxima para el texto bajo los iconos pequeños."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Mostrar encabezamientos de las columnas"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Activando esta opción los encabezamientos de las columnas se mostrarán en la "
+"vista de lista."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Activando esta opción los encabezamientos de las columnas se mostrarán en la "
+"vista de lista."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Activando esta opción los encabezamientos de las columnas se mostrarán en la "
+"vista de lista."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Activando esta opción los encabezamientos de las columnas se mostrarán en la "
+"vista de lista."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Activando esta opción los encabezamientos de las columnas se mostrarán en la "
+"vista de lista."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Activando esta opción los encabezamientos de las columnas se mostrarán en la "
+"vista de lista."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "Última _modificación"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Activando esta opción los encabezamientos de las columnas se mostrarán en la "
+"vista de lista."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Activando esta opción los encabezamientos de las columnas se mostrarán en la "
+"vista de lista."
+
+#: tips:128
+#, fuzzy
+msgid "Last Accessed"
+msgstr "%s no es accesible"
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Activando esta opción los encabezamientos de las columnas se mostrarán en la "
+"vista de lista."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Herramientas/Mini búfer"
 
-#: tips:76
+#: tips:131
 msgid "Toolbar"
 msgstr "Barra de herramientas"
 
-#: tips:77
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Tipo de barra de herramientas:"
 
-#: tips:78
+#: tips:133
 msgid "No toolbar"
 msgstr "Sin barra de herramientas"
 
-#: tips:79
+#: tips:134
 msgid "Icons only"
 msgstr "Sólo iconos"
 
-#: tips:80
+#: tips:135
 msgid "Text under icons"
 msgstr "Texto bajo los iconos"
 
-#: tips:81
+#: tips:136
 msgid "Text beside icons"
 msgstr "Texto al lado de los iconos"
 
-#: tips:82
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Sólo el panel"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Muestra la totalidad de los elementos"
 
-#: tips:83
-msgid "Show the number of items displayed in a filer window, as well as the number of hidden items (if any). When there's a selection, show the number of selected items and their combined size."
-msgstr "Muestra el número de elementos que aparece en una ventana del gestor, así como el número de elementos ocultos (en su caso). Cuando hay una selección, muestra el número de elementos seleccionados y su tamaño combinado."
+#: tips:139
+msgid ""
+"Show the number of items displayed in a filer window, as well as the number "
+"of hidden items (if any). When there's a selection, show the number of "
+"selected items and their combined size."
+msgstr ""
+"Muestra el número de elementos que aparece en una ventana del gestor, así "
+"como el número de elementos ocultos (en su caso). Cuando hay una selección, "
+"muestra el número de elementos seleccionados y su tamaño combinado."
 
-#: tips:84
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Seleccione los botones que desee tener en la barra:"
 
-#: tips:85
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
-msgstr "La anchura de la barra de herramientas establece el ancho mínimo de la ventana"
+msgstr ""
+"La anchura de la barra de herramientas establece el ancho mínimo de la "
+"ventana"
 
-#: tips:86
-msgid "Each filer window is constrained to be wide enough to show the whole of the toolbar"
-msgstr "Las ventanas son obligadas a ser lo suficientemente amplias como para mostrar la totalidad de la barra de herramientas"
+#: tips:142
+msgid ""
+"Each filer window is constrained to be wide enough to show the whole of the "
+"toolbar"
+msgstr ""
+"Las ventanas son obligadas a ser lo suficientemente amplias como para "
+"mostrar la totalidad de la barra de herramientas"
 
-#: tips:87
+#: tips:143
 msgid "Minibuffer"
 msgstr "Mini búfer"
 
-#: tips:88
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Pitido si falla autocompletar con «Tab»"
 
-#: tips:89
-msgid "When using the `Enter Path...' minibuffer and Tab is pressed, beep if nothing happens (eg, because there are several possibilities and the next letter varies)."
-msgstr "Cuando se usa «Introducir la ruta...» y se presiona «Tab», se escucha un pitido si no ocurre nada (Ej.: porque hay varias posibilidades y la siguiente letra varía)."
+#: tips:145
+msgid ""
+"When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
+"nothing happens (eg, because there are several possibilities and the next "
+"letter varies)."
+msgstr ""
+"Cuando se usa «Introducir la ruta...» y se presiona «Tab», se escucha un "
+"pitido si no ocurre nada (Ej.: porque hay varias posibilidades y la "
+"siguiente letra varía)."
 
-#: tips:90
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Pitido si hay varias coincidencias"
 
-#: tips:91
-msgid "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there is more than one matching file, even though some more letters were added."
-msgstr "Cuando se usa «Introducir la ruta...» y se presiona «Tab», se escucha un pitido si hay más de un archivo que encaja, incluso si algunas letras más fueron añadidas."
+#: tips:147
+msgid ""
+"When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
+"is more than one matching file, even though some more letters were added."
+msgstr ""
+"Cuando se usa «Introducir la ruta...» y se presiona «Tab», se escucha un "
+"pitido si hay más de un archivo que encaja, incluso si algunas letras más "
+"fueron añadidas."
 
-#: tips:94
-msgid "When thumbnails are turned on, each image file in a directory is loaded and a small thumbnail of it is shown."
-msgstr "Cuando se activan las miniaturas, cada archivo de imagen de un directorio carga una pequeña miniatura para mostrar."
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Gestor de descargas"
 
-#: tips:95
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Se produjo un error en: %s manejando %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
+msgid ""
+"When thumbnails are turned on, each image file in a directory is loaded and "
+"a small thumbnail of it is shown."
+msgstr ""
+"Cuando se activan las miniaturas, cada archivo de imagen de un directorio "
+"carga una pequeña miniatura para mostrar."
+
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Mostrar miniaturas"
 
-#: tips:96
-msgid "This is the default setting for new windows. Use the Display menu to turn thumbnails on and off for individual windows."
-msgstr "Esta es la configuración predeterminada para las ventanas nuevas. Use el menú desplegable para activar/desactivar las miniaturas en las ventanas."
+#: tips:156
+msgid ""
+"This is the default setting for new windows. Use the Display menu to turn "
+"thumbnails on and off for individual windows."
+msgstr ""
+"Esta es la configuración predeterminada para las ventanas nuevas. Use el "
+"menú desplegable para activar/desactivar las miniaturas en las ventanas."
 
-#: tips:97
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Mostrar miniaturas"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "Miniaturas de vídeo"
 
-#: tips:98
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Caché de miniaturas"
 
-#: tips:99
-msgid "To speed things up, the generated thumbnails are stored in the hidden ~/.thumbnails directory. Click here to remove all the cached thumbnails. They will be created again as needed."
-msgstr "Para acelerar el trabajo, as miniaturas generadas son almacenadas en el directorio oculto ~/.thumbnails. Haga clic aquí para eliminar la cache de las miniaturas. Si es necesario volverán a crearse."
+#: tips:161
+#, fuzzy
+msgid ""
+"To speed things up, the generated thumbnails are stored in the hidden ~/."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
+msgstr ""
+"Para acelerar el trabajo, as miniaturas generadas son almacenadas en el "
+"directorio oculto ~/.thumbnails. Haga clic aquí para eliminar la cache de "
+"las miniaturas. Si es necesario volverán a crearse."
 
-#: tips:100
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
 msgid "Manage thumbnails"
 msgstr "Gestión de miniaturas"
 
-#: tips:101
-#: tips:158
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Miniaturas de vídeo"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Segundo"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Escritorio"
 
-#: tips:102
-msgid "When using a pinboard, you can drag files and applications onto the desktop background to create shortcuts to them."
-msgstr "Usando un tablero, usted puede arrastrar archivos y aplicaciones en el fondo del escritorio para crear accesos rápidos."
+#: tips:177
+msgid ""
+"When using a pinboard, you can drag files and applications onto the desktop "
+"background to create shortcuts to them."
+msgstr ""
+"Usando un tablero, usted puede arrastrar archivos y aplicaciones en el fondo "
+"del escritorio para crear accesos rápidos."
 
-#: tips:103
-#: tips:213
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Apariencia"
 
-#: tips:104
+#: tips:179
 msgid "Foreground:"
 msgstr "Primer plano"
 
-#: tips:105
+#: tips:180
 msgid "Text shadow:"
 msgstr "Texto sombreado"
 
-#: tips:106
+#: tips:181
 msgid "Background:"
 msgstr "Segundo plano"
 
-#: tips:107
+#: tips:182
 msgid "No shadow"
 msgstr "Sin sombra"
 
-#: tips:108
+#: tips:183
 msgid "Thin"
 msgstr "Delgado"
 
-#: tips:109
+#: tips:184
 msgid "Thick"
 msgstr "Grueso"
 
-#: tips:110
+#: tips:185
 msgid "Use custom font:"
 msgstr "Usar fuentes personalizadas"
 
-#: tips:111
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Fuente utilizada para el texto bajo los iconos"
 
-#: tips:112
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Escalado rápido de imágenes"
 
-#: tips:113
-msgid "Choose between the fast or slow method of scaling backdrop images.  The slow method can give better results."
-msgstr "Escoja entre el método rápido o lento de escalado de imágenes para el fondo. El método lento puede dar mejores resultados."
+#: tips:188
+msgid ""
+"Choose between the fast or slow method of scaling backdrop images.  The slow "
+"method can give better results."
+msgstr ""
+"Escoja entre el método rápido o lento de escalado de imágenes para el fondo. "
+"El método lento puede dar mejores resultados."
 
-#: tips:114
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Comportamiento del tablero"
 
-#: tips:115
+#: tips:190
 msgid "Single-click to open"
 msgstr "Un sólo clic para abrir"
 
-#: tips:117
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Mantener los iconos dentro de los limites de la pantalla"
 
-#: tips:118
-msgid "If this is set, pinboard icons are always kept completely within screen limits, including the label."
-msgstr "Activada esta opción, los iconos se mantienen siempre dentro de los límites de la pantalla, incluida la etiqueta."
+#: tips:193
+msgid ""
+"If this is set, pinboard icons are always kept completely within screen "
+"limits, including the label."
+msgstr ""
+"Activada esta opción, los iconos se mantienen siempre dentro de los límites "
+"de la pantalla, incluida la etiqueta."
 
-#: tips:119
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Rejilla de separación de iconos"
 
-#: tips:120
+#: tips:195
 msgid "Fine"
 msgstr "Fina"
 
-#: tips:121
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "Usar rejilla de 2 píxeles para posicionar los iconos en el escritorio"
 
-#: tips:122
+#: tips:197
 msgid "Medium"
 msgstr "Media"
 
-#: tips:123
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "Usar rejilla de 16 píxeles para posicionar los iconos en el escritorio"
 
-#: tips:124
+#: tips:199
 msgid "Coarse"
 msgstr "Gruesa"
 
-#: tips:125
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "Usar rejilla de 32 píxeles para posicionar los iconos en el escritorio"
 
-#: tips:126
-#: tips:128
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Ventanas como iconos"
 
-#: tips:127
-msgid "Most window managers provide a way to iconify (or 'minimise') windows, and various programs, including ROX-Filer, can be used to display the iconified windows."
-msgstr "La mayoría de gestores de ventanas proporcionan una forma de «iconificar» (o «minimizar»), las ventanas, de diversos programas, entre ellos «ROX-Filer», puede utilizarlo para mostrar las ventanas como iconos."
+#: tips:202
+msgid ""
+"Most window managers provide a way to iconify (or 'minimise') windows, and "
+"various programs, including ROX-Filer, can be used to display the iconified "
+"windows."
+msgstr ""
+"La mayoría de gestores de ventanas proporcionan una forma de «iconificar» (o "
+"«minimizar»), las ventanas, de diversos programas, entre ellos «ROX-Filer», "
+"puede utilizarlo para mostrar las ventanas como iconos."
 
-#: tips:129
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Mostrar ventanas como iconos"
 
-#: tips:130
-msgid "If this option is on, the filer will show each iconified window as a small button on the pinboard. Requires a compatible window manager, and the pinboard must be in use."
-msgstr "Activada esta opción, el gestor muestra cada ventana como un pequeño botón en el tablero. Requiere un gestor de ventanas compatible, y el tablero debe estar en uso."
+#: tips:205
+msgid ""
+"If this option is on, the filer will show each iconified window as a small "
+"button on the pinboard. Requires a compatible window manager, and the "
+"pinboard must be in use."
+msgstr ""
+"Activada esta opción, el gestor muestra cada ventana como un pequeño botón "
+"en el tablero. Requiere un gestor de ventanas compatible, y el tablero debe "
+"estar en uso."
 
-#: tips:131
+#: tips:206
 msgid "Show per workspace"
 msgstr "Mostrar por espacio de trabajo"
 
-#: tips:132
-msgid "If this option is on, the filer will only show iconified windows associated with the current workspace."
-msgstr "Activada esta opción, el gestor sólo mostrará como iconos las ventanas asociadas con el actual espacio de trabajo."
+#: tips:207
+msgid ""
+"If this option is on, the filer will only show iconified windows associated "
+"with the current workspace."
+msgstr ""
+"Activada esta opción, el gestor sólo mostrará como iconos las ventanas "
+"asociadas con el actual espacio de trabajo."
 
-#: tips:133
+#: tips:208
 msgid "Iconify to the"
 msgstr "Poner los iconos"
 
-#: tips:134
+#: tips:209
 msgid "top-left"
 msgstr "arriba a la izquierda"
 
-#: tips:135
+#: tips:210
 msgid "top-right"
 msgstr "arriba a la derecha"
 
-#: tips:136
+#: tips:211
 msgid "bottom-left"
 msgstr "abajo a la izquierda"
 
-#: tips:137
+#: tips:212
 msgid "bottom-right"
 msgstr "abajo a la derecha"
 
-#: tips:138
+#: tips:213
 msgid ", going"
 msgstr ", en"
 
-#: tips:139
+#: tips:214
 msgid "horizontally"
 msgstr "horizontal"
 
-#: tips:140
+#: tips:215
 msgid "vertically"
 msgstr "vertical"
 
-#: tips:141
-msgid "Sometimes the filer doesn't know about your desktop furniture and puts iconified windows under (for example) the Gnome panel. You can define a top or bottom margin to avoid placing the icons there. The filer already knows about its own panel."
-msgstr "Algunas veces el gestor no sabe de los demás objetos que puede haber en el escritorio y pone las ventanas iconificadas debajo, por ejemplo, del panel de Gnome. Usted puede definir un margen inferior para evitar colocar iconos ahí. El gestor ya sabe de su propio panel."
+#: tips:216
+msgid ""
+"Sometimes the filer doesn't know about your desktop furniture and puts "
+"iconified windows under (for example) the Gnome panel. You can define a top "
+"or bottom margin to avoid placing the icons there. The filer already knows "
+"about its own panel."
+msgstr ""
+"Algunas veces el gestor no sabe de los demás objetos que puede haber en el "
+"escritorio y pone las ventanas iconificadas debajo, por ejemplo, del panel "
+"de Gnome. Usted puede definir un margen inferior para evitar colocar iconos "
+"ahí. El gestor ya sabe de su propio panel."
 
-#: tips:142
+#: tips:217
 msgid "Top margin"
 msgstr "Margen superior"
 
-#: tips:143
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Altura de zona prohibida en el borde superior de la pantalla."
 
-#: tips:144
+#: tips:219
 msgid "Bottom margin"
 msgstr "Margen inferior"
 
-#: tips:145
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "Altura de zona prohibida en el borde inferior de la pantalla."
 
-#: tips:146
+#: tips:221
 msgid "Left margin"
 msgstr "Margen izquierdo"
 
-#: tips:147
+#: tips:222
 msgid "Width of no-go area at left of screen."
 msgstr "Anchura de zona prohibida en el borde izquierdo de la pantalla."
 
-#: tips:148
+#: tips:223
 msgid "Right margin"
 msgstr "Margen derecho"
 
-#: tips:149
+#: tips:224
 msgid "Width of no-go area at right of screen."
 msgstr "Anchura de zona prohibida en el borde derecho de la pantalla."
 
-#: tips:150
+#: tips:225
 msgid "Desktop"
 msgstr "Escritorio"
 
-#: tips:151
-msgid "When run by a session manager program (such as ROX-Session) the filer can open up a panel and/or the pinboard.  Here you configure which."
-msgstr "Cuando se ejecuta un administrador de sesiones (como ROX-Session) el gestor puede abrir un panel y/o un tablero. Configúrelo aquí."
+#: tips:226
+msgid ""
+"When run by a session manager program (such as ROX-Session) the filer can "
+"open up a panel and/or the pinboard.  Here you configure which."
+msgstr ""
+"Cuando se ejecuta un administrador de sesiones (como ROX-Session) el gestor "
+"puede abrir un panel y/o un tablero. Configúrelo aquí."
 
-#: tips:152
+#: tips:227
 msgid "Panel only"
 msgstr "Sólo el panel"
 
-#: tips:153
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Sólo se muestra el panel"
 
-#: tips:154
+#: tips:229
 msgid "Pinboard only"
 msgstr "Sólo el tablero"
 
-#: tips:155
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "Sólo se muestra el tablero (escritorio)"
 
-#: tips:156
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "Panel y tablero"
 
-#: tips:157
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "Muestre tanto el panel como el tablero"
 
-#: tips:159
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "Ponga el nombre del tablero que va a ser mostrado"
 
-#: tips:160
-msgid "Panel (obsolete)"
-msgstr "Panel (obsoleto)"
-
-#: tips:161
-msgid "Enter the name of the panel to show here. This option is now only used when upgrading from an old version."
-msgstr "Ponga el nombre del panel que va ser mostrado. Esta opción ahora sólo se usa si actualizó de una versión anterior."
-
-#: tips:162
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
-msgstr "Los cambios sólo tendrán efecto después de que inicie de nuevo «ROX-Filer»"
+msgstr ""
+"Los cambios sólo tendrán efecto después de que inicie de nuevo «ROX-Filer»"
 
-#: tips:163
-msgid "The session manager activates these options by using the -S or --rox-session argument to rox."
-msgstr "El administrador de sesiones activa estas opciones usando «-S» o «--rox-session» como argumentos de «rox»."
+#: tips:236
+#, fuzzy
+msgid ""
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
+msgstr ""
+"El administrador de sesiones activa estas opciones usando «-S» o «--rox-"
+"session» como argumentos de «rox»."
 
-#: tips:164
+#: tips:237
 msgid "Action windows"
 msgstr "Acciones en las ventanas"
 
-#: tips:165
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4010,460 +5004,788 @@ msgstr ""
 "La ventana de acciones aparece cuando se inicia una operación\n"
 "en segundo plano, como copiar o borrar archivos."
 
-#: tips:166
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Iniciar (silenciosamente) estas acciones"
 
-#: tips:168
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Copiar archivos sin pedir confirmación"
 
-#: tips:170
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Mover archivos sin pedir confirmación"
 
-#: tips:172
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Crear enlaces a los archivos sin pedir confirmación"
 
-#: tips:174
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Borrar archivos sin pedir confirmación"
 
-#: tips:175
+#: tips:248
 msgid "Mount"
 msgstr "Montar"
 
-#: tips:176
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Montar y desmontar sistemas de archivos sin pedir confirmación"
 
-#: tips:177
+#: tips:250
 msgid "Default settings"
 msgstr "Configuración predeterminada"
 
-#: tips:179
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Forzar"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "No confirmar la eliminación de elementos no escribibles"
 
-#: tips:181
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "No mostrar mucha información en el área de mensajes"
 
-#: tips:183
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "También cambia el contenido de los directorios."
 
-#: tips:186
+#: tips:263
 msgid "Mount commands"
 msgstr "Comandos para el montaje"
 
-#: tips:187
+#: tips:264
 msgid "Mount command"
 msgstr "Orden de montaje"
 
-#: tips:188
+#: tips:265
 msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
-msgstr "Orden para montar el sistema de archivos, si no está seguro use «mount»"
+msgstr ""
+"Orden para montar el sistema de archivos, si no está seguro use «mount»"
 
-#: tips:189
+#: tips:266
 msgid "Unmount command"
 msgstr "Orden de desmontaje"
 
-#: tips:190
-msgid "The command used to unmount a filesystem. If unsure, use \"umount\" (yes, without the first \"n\")."
-msgstr "Orden para desmontar el sistema de archivos, si no está seguro use «umount»(sí, sin «un»)."
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+"Orden para desmontar el sistema de archivos, si no está seguro use "
+"«umount»(sí, sin «un»)."
 
-#: tips:191
+#: tips:268
 msgid "Eject command"
 msgstr "Orden de expulsión"
 
-#: tips:192
+#: tips:269
 msgid "The command used to eject removable media. If unsure, use \"eject\"."
-msgstr "Orden usada para expulsar dispositivos extraíbles, si no esta seguro use «eject»"
+msgstr ""
+"Orden usada para expulsar dispositivos extraíbles, si no esta seguro use "
+"«eject»"
 
-#: tips:193
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Arrastrar y pegar"
 
-#: tips:194
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Arrastrar a iconos"
 
-#: tips:195
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Permite arrastrar iconos a la ventana del gestor"
 
-#: tips:196
-msgid "When this is on you can drag a file over a sub-directory or program in a filer window. The item will highlight when you do this and dropping the file will put it into that directory, or load it into the program."
-msgstr "Con esta opción activada usted puede arrastrar un archivo a la ventana de un subdirectorio o a un programa. El ítem se resaltará cuando hagas esto y al soltar el archivo lo pondrá dentro del directorio, o lo cargará con el programa."
+#: tips:275
+msgid ""
+"When this is on you can drag a file over a sub-directory or program in a "
+"filer window. The item will highlight when you do this and dropping the file "
+"will put it into that directory, or load it into the program."
+msgstr ""
+"Con esta opción activada usted puede arrastrar un archivo a la ventana de un "
+"subdirectorio o a un programa. El ítem se resaltará cuando hagas esto y al "
+"soltar el archivo lo pondrá dentro del directorio, o lo cargará con el "
+"programa."
 
-#: tips:197
+#: tips:276
 msgid "Directories spring open"
 msgstr "Apertura automática de directorios"
 
-#: tips:198
-msgid "This option, which requires the above option to be turned on too, causes the highlighted directory to 'spring open' after the file is held over it for a short while."
-msgstr "Esta opción, que requiere que la opción de arriba esté también activada, hace que el directorio pase a foco como «apertura automática» durante un breve tiempo después de que el archivo sea desplazado sobre él."
+#: tips:277
+msgid ""
+"This option, which requires the above option to be turned on too, causes the "
+"highlighted directory to 'spring open' after the file is held over it for a "
+"short while."
+msgstr ""
+"Esta opción, que requiere que la opción de arriba esté también activada, "
+"hace que el directorio pase a foco como «apertura automática» durante un "
+"breve tiempo después de que el archivo sea desplazado sobre él."
 
-#: tips:199
+#: tips:278
 msgid "Spring delay:"
 msgstr "Retardo de «apertura automática»:"
 
-#: tips:200
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:201
-msgid "This option sets how long, in ms, you must hold a file over a directory before it will spring open. The above option must be turned on for this to have any effect."
-msgstr "En esta opción se indica cuánto tiempo, en ms, debe mantenerse un archivo sobre un directorio antes de que adopte «apertura automática». Esa opción debe haber sido activada para que esto tenga efecto."
+#: tips:280
+msgid ""
+"This option sets how long, in ms, you must hold a file over a directory "
+"before it will spring open. The above option must be turned on for this to "
+"have any effect."
+msgstr ""
+"En esta opción se indica cuánto tiempo, en ms, debe mantenerse un archivo "
+"sobre un directorio antes de que adopte «apertura automática». Esa opción "
+"debe haber sido activada para que esto tenga efecto."
 
-#: tips:202
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Cuando se arrastran los archivos con el botón izquierdo del ratón"
 
-#: tips:203
-#: tips:207
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Mostrar un menú de acciones posibles"
 
-#: tips:204
+#: tips:283
 msgid "Copy the files"
 msgstr "Copiar los archivos"
 
-#: tips:205
-msgid "Note that you can still get the menu to appear, by dragging with Alt held down."
-msgstr "Observe que puede obtener el menú desplegable, arrastrando al tiempo que mantiene presionada la tecla «Alt»."
+#: tips:284
+msgid ""
+"Note that you can still get the menu to appear, by dragging with Alt held "
+"down."
+msgstr ""
+"Observe que puede obtener el menú desplegable, arrastrando al tiempo que "
+"mantiene presionada la tecla «Alt»."
 
-#: tips:206
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Cuando arrastra los archivos con el botón del medio del ratón"
 
-#: tips:208
+#: tips:287
 msgid "Move the files"
 msgstr "Mover los archivos"
 
-#: tips:209
-msgid "Note that you can still get the menu to appear, by dragging with the left button and holding down the Alt key."
-msgstr "Observe que puede obtener el menú desplegable, arrastrando con el botón izquierdo al tiempo que mantiene presionada la tecla «Alt»."
+#: tips:288
+msgid ""
+"Note that you can still get the menu to appear, by dragging with the left "
+"button and holding down the Alt key."
+msgstr ""
+"Observe que puede obtener el menú desplegable, arrastrando con el botón "
+"izquierdo al tiempo que mantiene presionada la tecla «Alt»."
 
-#: tips:210
+#: tips:289
 msgid "Download handler"
 msgstr "Gestor de descargas"
 
-#: tips:211
+#: tips:290
 msgid ""
-"When you drag a file from a web browser or other remote source, this program will be run to download it. $1 is the URI dragged to the filer, and the current directory is the destination. Eg:\n"
+"When you drag a file from a web browser or other remote source, this program "
+"will be run to download it. $1 is the URI dragged to the filer, and the "
+"current directory is the destination. Eg:\n"
 "xterm -e wget $1"
 msgstr ""
-"Cuando usted arrastra un archivo de un navegador web u otra fuente remota, este programa será el encargado de descargarlo. $1 es la URI arrastrada al gestor, y el directorio actual será el de destino. Ej:\n"
+"Cuando usted arrastra un archivo de un navegador web u otra fuente remota, "
+"este programa será el encargado de descargarlo. $1 es la URI arrastrada al "
+"gestor, y el directorio actual será el de destino. Ej:\n"
 "xterm-e wget $1"
 
-#: tips:212
+#: tips:291
 msgid "Menus"
 msgstr "Menús"
 
-#: tips:214
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Tamaño de los iconos en el menú: "
 
-#: tips:215
+#: tips:294
 msgid "No Icons"
 msgstr "Sin iconos"
 
-#: tips:218
+#: tips:297
 msgid "Same as current window"
 msgstr "Ventana actual"
 
-#: tips:219
+#: tips:298
 msgid "Same as default"
 msgstr "Predeterminado"
 
-#: tips:220
+#: tips:299
 msgid "Behaviour"
 msgstr "Comportamiento"
 
-#: tips:221
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Menú de archivo con clic en botón derecho"
 
-#: tips:222
-msgid "Show the File menu instead of the main menu when right-clicking with files selected (the main menu can be accessed by holding down Control)."
-msgstr "Muestra el menú de archivo en vez del menú principal cuando se presiona el botón derecho con archivo seleccionados (para acceder al menú principal mantenga presionada la tecla «Ctrl»."
+#: tips:301
+msgid ""
+"Show the File menu instead of the main menu when right-clicking with files "
+"selected (the main menu can be accessed by holding down Control)."
+msgstr ""
+"Muestra el menú de archivo en vez del menú principal cuando se presiona el "
+"botón derecho con archivo seleccionados (para acceder al menú principal "
+"mantenga presionada la tecla «Ctrl»."
 
-#: tips:223
+#: tips:302
 msgid "Terminal emulator program"
 msgstr "Programa emulador de terminal"
 
-#: tips:224
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
-msgstr "Este programa se iniciará cuando elija en el menú «Abrir aquí un terminal»"
+msgstr ""
+"Este programa se iniciará cuando elija en el menú «Abrir aquí un terminal»"
 
-#: tips:225
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Atajos de teclado"
 
-#: tips:227
+#: tips:305
+msgid "Types"
+msgstr "Tipos"
+
+#: tips:306
 msgid "MIME types"
 msgstr "Tipos MIME"
 
-#: tips:228
-msgid "The filer uses a set of rules to work out the correct MIME type for each regular file, and then chooses a suitable icon for that type."
-msgstr "El gestor de archivos usa un juego de reglas para buscar el tipo MIME correcto para cada archivo regular y luego escoge el icono adecuado para ese tipo."
+#: tips:307
+msgid ""
+"The filer uses a set of rules to work out the correct MIME type for each "
+"regular file, and then chooses a suitable icon for that type."
+msgstr ""
+"El gestor de archivos usa un juego de reglas para buscar el tipo MIME "
+"correcto para cada archivo regular y luego escoge el icono adecuado para ese "
+"tipo."
 
-#: tips:229
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "Editar las reglas MIME"
 
-#: tips:230
+#: tips:309
 msgid "Themes"
 msgstr "Temas"
 
-#: tips:231
+#: tips:310
 msgid "Icon theme"
 msgstr "Tema de iconos"
 
-#: tips:232
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "Los temas de iconos deben estar en el directorio «~/.icons»"
 
-#: tips:233
-msgid "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note that icons set this way override those from the selected theme."
-msgstr "Utilice el cuadro de diálogo «Definir iconos ...» para configurar el icono de cada tipo MIME. Tenga en cuenta que los iconos definidos de esta forma anulan a los del tema seleccionado."
+#: tips:312
+msgid ""
+"Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
+"that icons set this way override those from the selected theme."
+msgstr ""
+"Utilice el cuadro de diálogo «Definir iconos ...» para configurar el icono "
+"de cada tipo MIME. Tenga en cuenta que los iconos definidos de esta forma "
+"anulan a los del tema seleccionado."
 
-#: tips:234
+#: tips:313
 msgid "Colours"
 msgstr "Colores"
 
-#: tips:235
+#: tips:314
 msgid "File type colours"
 msgstr "Colores de tipos de archivo"
 
-#: tips:236
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Colorear los archivos según estos tipos"
 
-#: tips:237
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
-msgstr "Los nombres de archivo (y de los detalles) han de colocarse de acuerdo con el tipo de archivo"
+msgstr ""
+"Los nombres de archivo (y de los detalles) han de colocarse de acuerdo con "
+"el tipo de archivo"
 
-#: tips:238
+#: tips:317
 msgid "Directory:"
 msgstr "Directorio:"
 
-#: tips:239
+#: tips:318
 msgid "Regular file:"
 msgstr "Archivo regular:"
 
-#: tips:240
+#: tips:319
 msgid "Pipe:"
 msgstr "Canalización:"
 
-#: tips:241
+#: tips:320
 msgid "Socket:"
 msgstr "Socket:"
 
-#: tips:243
-msgid "Error, such as a symlink which points to a non-existant file, or a file which the filer does not have permission to examine."
-msgstr "Se produjo un error, el enlace simbólico apunta a un archivo que no existe o a un archivo en el que el gestor no tiene permisos para acceder."
+#: tips:322
+msgid ""
+"Error, such as a symlink which points to a non-existant file, or a file "
+"which the filer does not have permission to examine."
+msgstr ""
+"Se produjo un error, el enlace simbólico apunta a un archivo que no existe o "
+"a un archivo en el que el gestor no tiene permisos para acceder."
 
-#: tips:244
+#: tips:323
 msgid "Character device:"
 msgstr "Dispositivo de carácter:"
 
-#: tips:245
+#: tips:324
 msgid "Block device:"
 msgstr "Dispositivo de bloque:"
 
-#: tips:246
+#: tips:325
 msgid "Door:"
 msgstr "Puerta:"
 
-#: tips:247
-msgid "Door files are a bit like sockets or pipes, and have only been seen on Solaris."
-msgstr "Archivos de puerta son como «sockets» o «canalizaciones» y sólo se usan en Solaris."
+#: tips:326
+msgid ""
+"Door files are a bit like sockets or pipes, and have only been seen on "
+"Solaris."
+msgstr ""
+"Archivos de puerta son como «sockets» o «canalizaciones» y sólo se usan en "
+"Solaris."
 
-#: tips:248
+#: tips:327
 msgid "Executable file:"
 msgstr "Archivo ejecutable:"
 
-#: tips:249
+#: tips:328
 msgid "Application directory:"
 msgstr "Directorio de aplicación:"
 
-#: tips:250
+#: tips:329
 msgid "Unknown type:"
 msgstr "Tipo desconocido:"
 
-#: tips:251
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Segundo plano"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Usar fuentes personalizadas"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Compatibilidad"
 
-#: tips:252
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Problemas en el gestor de ventanas"
 
-#: tips:253
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
-msgstr "Sobreescribir el control del gestor de ventanas con el tablero y el panel"
+msgstr ""
+"Sobreescribir el control del gestor de ventanas con el tablero y el panel"
 
-#: tips:254
-msgid "Some window managers don't support the new Extended Window Manager Hints system, and so treat the pinboard and panels like normal windows. Turn this on to fix problems such as the pinboard coming to the front when you click on it, titlebars and other decorations appearing around windows, or having them appear in window-select lists."
-msgstr "Algunos gestores de ventanas no soportan el nuevo sistema «Extended Window Manager Hints» y tratan a los tableros y paneles como ventanas normales. Active esta opción para solucionar problemas como que el tablero se vea en primer plano cuando presiona en él, barras de título y otras decoraciones de ventanas, o que tengan que aparecer en la lista de ventanas."
+#: tips:340
+msgid ""
+"Some window managers don't support the new Extended Window Manager Hints "
+"system, and so treat the pinboard and panels like normal windows. Turn this "
+"on to fix problems such as the pinboard coming to the front when you click "
+"on it, titlebars and other decorations appearing around windows, or having "
+"them appear in window-select lists."
+msgstr ""
+"Algunos gestores de ventanas no soportan el nuevo sistema «Extended Window "
+"Manager Hints» y tratan a los tableros y paneles como ventanas normales. "
+"Active esta opción para solucionar problemas como que el tablero se vea en "
+"primer plano cuando presiona en él, barras de título y otras decoraciones de "
+"ventanas, o que tengan que aparecer en la lista de ventanas."
 
-#: tips:255
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "Enviar los clics del ratón del escritorio al gestor de ventanas"
 
-#: tips:256
-msgid "Normally, right clicking on the desktop background will open the pinboard menu and left clicking will clear the selection. Turn this on to forward the events to your window manager instead. Clicks on icons will not be forwarded."
-msgstr "Normalmente, hacer clic derecho en el fondo del escritorio abre el menú y en el izquierdo limpia la selección. Active esta opción si desea enviar estos eventos al gestor de ventanas. Los clics en los iconos no serán enviados."
+#: tips:342
+msgid ""
+"Normally, right clicking on the desktop background will open the pinboard "
+"menu and left clicking will clear the selection. Turn this on to forward the "
+"events to your window manager instead. Clicks on icons will not be forwarded."
+msgstr ""
+"Normalmente, hacer clic derecho en el fondo del escritorio abre el menú y en "
+"el izquierdo limpia la selección. Active esta opción si desea enviar estos "
+"eventos al gestor de ventanas. Los clics en los iconos no serán enviados."
 
-#: tips:257
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Menús de «Blackbox» cortados"
 
-#: tips:258
-msgid "Blackbox, Fluxbox and similar window managers do not yet work well with the ROX-Filer pinboard. This option enables some workarounds. These window managers are expected to change their behaviour in new versions so that this isn't necessary."
-msgstr "Blackbox, Fluxbox y gestores de ventanas similares todavía no trabajan bien con el tablero de ROX-Filer. Esta opción soluciona algunos problemas. Se espera que estos gestores de ventanas cambien su comportamiento en nuevas versiones para que esto no sea necesario."
+#: tips:344
+msgid ""
+"Blackbox, Fluxbox and similar window managers do not yet work well with the "
+"ROX-Filer pinboard. This option enables some workarounds. These window "
+"managers are expected to change their behaviour in new versions so that this "
+"isn't necessary."
+msgstr ""
+"Blackbox, Fluxbox y gestores de ventanas similares todavía no trabajan bien "
+"con el tablero de ROX-Filer. Esta opción soluciona algunos problemas. Se "
+"espera que estos gestores de ventanas cambien su comportamiento en nuevas "
+"versiones para que esto no sea necesario."
 
-#: tips:259
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "Dejar «fijo» el panel"
 
-#: tips:260
-msgid "Makes sure panels stay against screen edges. Disable this option if the panel stays above other windows against your wishes. Requires a restart to take effect."
-msgstr "Asegura que los paneles se mantienen en los bordes de la pantalla. Desactive esta opción si el panel se mantiene por encima de otras ventanas en contra de sus deseos. Requiere un reinicio para tener efecto."
+#: tips:346
+msgid ""
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
+msgstr ""
+"Asegura que los paneles se mantienen en los bordes de la pantalla. Desactive "
+"esta opción si el panel se mantiene por encima de otras ventanas en contra "
+"de sus deseos. Requiere un reinicio para tener efecto."
 
-#: tips:261
+#: tips:347
 msgid "Panel stays on top"
 msgstr "El panel permanece en primer plano"
 
-#: tips:262
-msgid "Keeps the panel above other windows. Enable this option to make sure the dock option works correctly in some versions of compiz. May require a restart to take effect."
-msgstr "Mantiene el panel por encima de otras ventanas. Active esta opción para asegurarse de que la opción acoplar funciona correctamente en algunas versiones de compiz. Puede requerir un reinicio para tener efecto."
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+"Mantiene el panel por encima de otras ventanas. Active esta opción para "
+"asegurarse de que la opción acoplar funciona correctamente en algunas "
+"versiones de compiz. Puede requerir un reinicio para tener efecto."
 
-#: tips:263
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Arrastrar y soltar"
 
-#: tips:264
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "No usar nombres de host"
 
-#: tips:265
-msgid "Some older applications don't support XDND fully and may need to have this option turned on. Use this if dragging files to an application shows a + sign on the pointer but the drop doesn't work."
-msgstr "Algunas aplicaciones antiguas no soportan «XDND» y pueden precisar que esta opción esté activada. Use esta opción si al arrastrar un archivo a la aplicación muestra un «+» en el puntero, pero no trabaja."
+#: tips:353
+msgid ""
+"Some older applications don't support XDND fully and may need to have this "
+"option turned on. Use this if dragging files to an application shows a + "
+"sign on the pointer but the drop doesn't work."
+msgstr ""
+"Algunas aplicaciones antiguas no soportan «XDND» y pueden precisar que esta "
+"opción esté activada. Use esta opción si al arrastrar un archivo a la "
+"aplicación muestra un «+» en el puntero, pero no trabaja."
 
-#: tips:266
-msgid "Extended attributes"
-msgstr "Atributos extendidos"
-
-#: tips:267
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "No usar los atributos extendidos"
 
-#: tips:268
-msgid "This disables the use of extended attributes available in newer operating systems and file systems.  With this option set the 'Set Type' menu entry is disabled, the MIME type of the file is only derived from the file name and the properties window does not report extended attributes."
-msgstr "Esto desactiva el uso de atributos extendidos disponible en los nuevos sistemas operativos y sistemas de archivos. Con esta opción la entrada «Definir tipo» del menú está desactivada, y para el tipo MIME se utiliza únicamente el nombre de los archivos y la ventana de propiedades nos informa de ellos."
+#: tips:356
+msgid ""
+"This disables the use of extended attributes available in newer operating "
+"systems and file systems.  With this option set the 'Set Type' menu entry is "
+"disabled, the MIME type of the file is only derived from the file name and "
+"the properties window does not report extended attributes."
+msgstr ""
+"Esto desactiva el uso de atributos extendidos disponible en los nuevos "
+"sistemas operativos y sistemas de archivos. Con esta opción la entrada "
+"«Definir tipo» del menú está desactivada, y para el tipo MIME se utiliza "
+"únicamente el nombre de los archivos y la ventana de propiedades nos informa "
+"de ellos."
 
-#: ../Templates.glade:7
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Borde inferior"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "Borde derecho"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
 msgid "ROX-Filer log viewer"
 msgstr "Visor del registro de «ROX-Filer»"
 
-#: ../Templates.glade:22
+#: ../Templates.ui.h:2
 msgid "Recently performed actions..."
 msgstr "Acciones realizadas recientemente---"
 
-#: ../Templates.glade:77
+#: ../Templates.ui.h:3
 msgid "Open Directory"
 msgstr "Abrir directorio"
 
-#: ../Templates.glade:129
+#: ../Templates.ui.h:4
 msgid "Panel Options"
 msgstr "Opciones del panel"
 
-#: ../Templates.glade:169
-msgid "Every icon on this panel is shown with an image and some text."
-msgstr "Cada icono del panel es mostrado como una imagen y algún texto"
-
-#: ../Templates.glade:170
+#: ../Templates.ui.h:5
 msgid "Image and Text"
 msgstr "Imagen y texto"
 
-#: ../Templates.glade:186
-msgid "Applications in this panel have just an image, everything else has both an image and text."
-msgstr "Sólo las aplicaciones tienen imagen, todo lo demás tiene tanto imagen como texto."
+#: ../Templates.ui.h:6
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Cada icono del panel es mostrado como una imagen y algún texto"
 
-#: ../Templates.glade:187
+#: ../Templates.ui.h:7
 msgid "Image only for applications"
 msgstr "Imagen sólo para aplicaciones"
 
-#: ../Templates.glade:205
-msgid "Only the image is shown for icons in this panel."
-msgstr "Sólo se muestra la imagen para iconos en el panel"
+#: ../Templates.ui.h:8
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"Sólo las aplicaciones tienen imagen, todo lo demás tiene tanto imagen como "
+"texto."
 
-#: ../Templates.glade:206
+#: ../Templates.ui.h:9
 msgid "Image only"
 msgstr "Sólo imagen"
 
-#: ../Templates.glade:235
+#: ../Templates.ui.h:10
+msgid "Only the image is shown for icons in this panel."
+msgstr "Sólo se muestra la imagen para iconos en el panel"
+
+#: ../Templates.ui.h:11
 msgid "Panel width"
 msgstr "Anchura del panel"
 
-#: ../Templates.glade:247
+#: ../Templates.ui.h:12
 msgid "The size of this panel."
 msgstr "Tamaño de este panel"
 
-#: ../Templates.glade:259
+#: ../Templates.ui.h:13
 msgid "px"
 msgstr "px"
 
-#: ../Templates.glade:278
-msgid "Ask the window manager not to cover this panel when maximising windows, otherwise leave just 2 pixels at the edge of the screen to allow auto-raising. Some window managers may not honour this setting."
-msgstr "Indicarle al gestor de ventanas que no cubra este panel cuando se maximicen las ventanas, de lo contrario, deje sólo 2 píxeles del borde de la pantalla para permitir el redimensionado. En algunos gestores de ventanas no podrá establecer esta configuración."
+#: ../Templates.ui.h:14
+msgid "Transparency"
+msgstr ""
 
-#: ../Templates.glade:279
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
 msgid "Do not cover panel"
 msgstr "No tapar el panel"
 
-#: ../Templates.glade:297
+#: ../Templates.ui.h:19
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Indicarle al gestor de ventanas que no cubra este panel cuando se maximicen "
+"las ventanas, de lo contrario, deje sólo 2 píxeles del borde de la pantalla "
+"para permitir el redimensionado. En algunos gestores de ventanas no podrá "
+"establecer esta configuración."
+
+#: ../Templates.ui.h:20
 msgid "<b>Panel style</b>"
 msgstr "<b>Estilo de panel</b>"
 
-#: ../Templates.glade:331
-msgid "If you use multiple monitors with Xinerama, use this option to confine the panel to one monitor."
-msgstr "Si utiliza múltiples monitores con «Xinerama», utilice esta opción para asignar el panel a un monitor ."
-
-#: ../Templates.glade:332
+#: ../Templates.ui.h:21
 msgid "Confine to Xinerama monitor"
 msgstr "Asignar un monitor Xinerama"
 
-#: ../Templates.glade:347
-msgid "The monitor this panel is confined to when using Xinerama. The numbering starts from zero."
-msgstr "Monitor del panel asignado con Xinerama. La numeración comienza desde cero."
+#: ../Templates.ui.h:22
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Si utiliza múltiples monitores con «Xinerama», utilice esta opción para "
+"asignar el panel a un monitor ."
 
-#: ../Templates.glade:372
+#: ../Templates.ui.h:23
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+"Monitor del panel asignado con Xinerama. La numeración comienza desde cero."
+
+#: ../Templates.ui.h:24
 msgid "<b>Xinerama</b>"
 msgstr "<b>Xinerama</b>"
 
-#: ../Templates.glade:407
+#: ../Templates.ui.h:25
 msgid "Right edge"
 msgstr "Borde derecho"
 
-#: ../Templates.glade:426
+#: ../Templates.ui.h:26
 msgid "Left edge"
 msgstr "Borde izquierdo"
 
-#: ../Templates.glade:443
+#: ../Templates.ui.h:27
 msgid "Bottom edge"
 msgstr "Borde inferior"
 
-#: ../Templates.glade:462
+#: ../Templates.ui.h:28
 msgid "Top edge"
 msgstr "Borde superior"
 
-#: ../Templates.glade:496
+#: ../Templates.ui.h:29
 msgid "<b>Position</b>"
 msgstr "<b>Posición</b>"
 
+#~ msgid "<dir>"
+#~ msgstr "<dir>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?¿'%s' ya existe - sobreescribir?"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ocurrió un error al explorar '%s':\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Directorio ausente/borrado"
+
+#~ msgid "Directory '%s' is not accessible"
+#~ msgstr "No se puede acceder al directorio '%s'"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "No se encuentra el directorio '%s'."
+
+#~ msgid "Cancel"
+#~ msgstr "Cancelar"
+
+#~ msgid "All, "
+#~ msgstr "Todos."
+
+#~ msgid "Inotify support"
+#~ msgstr "Soporte para «Inotify»"
+
+#~ msgid "Dnotify support"
+#~ msgstr "Soporte para «dnotify»"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Presione la tecla «Shift+Mayús» y haga clic sobre un archivo para "
+#~ "enviarlo a algún sitio"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Cambiar al directorio superior"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Cambiar a directorio de inicio"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Marcadores"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Menú de marcadores"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Actualizar los contenidos del directorio"
+
+#~ msgid "Change icon size"
+#~ msgstr "Cambiar tamaño del icono"
+
+#~ msgid "Show extra details"
+#~ msgstr "Mostrar detalles extra"
+
+#~ msgid "Hidden"
+#~ msgstr "Oculto"
+
+#~ msgid "Change at:"
+#~ msgstr "Cambiar a:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Anchura máxima (iconos grandes):"
+
+#~ msgid "Panel (obsolete)"
+#~ msgstr "Panel (obsoleto)"
+
+#~ msgid ""
+#~ "Enter the name of the panel to show here. This option is now only used "
+#~ "when upgrading from an old version."
+#~ msgstr ""
+#~ "Ponga el nombre del panel que va ser mostrado. Esta opción ahora sólo se "
+#~ "usa si actualizó de una versión anterior."

--- a/ROX-Filer/src/po/et_EE.po
+++ b/ROX-Filer/src/po/et_EE.po
@@ -1,63 +1,66 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: ROX-Filer 2.1.6\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-12-27 18:49+0200\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2005-12-27 19:01+0200\n"
 "Last-Translator: Teet Tärno <devlin@hot.ee>\n"
 "Language-Team: Estonian <et@li.org>\n"
+"Language: et\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: abox.c:127
-msgid "<dir>"
-msgstr "<ver>"
+msgid "<src>"
+msgstr ""
 
-#: abox.c:220
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Vaikne"
 
-#: abox.c:229
+#: abox.c:247
 msgid "Quiet"
 msgstr "Vaikne"
 
-#: abox.c:229
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Ära küsi kinnitust iga kord"
 
-#: abox.c:456
-#: tips:61
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Nimi"
 
-#: abox.c:462
-#: menu.c:230
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Kataloog"
 
-#: abox.c:551
+#: abox.c:546
 msgid "Expression:"
 msgstr "Avaldis:"
 
-#: action.c:58
+#: action.c:57
 msgid "See the attr(5) man page for full details."
 msgstr "Lisainfo saamiseks vaadake attr(5) man-lehekülge."
 
-#: action.c:60
+#: action.c:59
 msgid "See the fsattr(5) man page for full details."
 msgstr "Lisainfo saamiseks vaadake fsattr(5) man-lehekülge."
 
-#: action.c:62
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr "Teil ei tundu olevat opsüsteemi toetust."
 
-#: action.c:188
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Otsiavaldiste abi"
 
-#: action.c:199
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -73,10 +76,13 @@ msgid ""
 "<b>IsReg system(grep -q fred \"%\")</b> (contains the word 'fred')\n"
 "\n"
 "<u>Simple Tests</u>\n"
-"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</b> (types)\n"
-"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> (permissions)\n"
+"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
+"b> (types)\n"
+"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
+"(permissions)\n"
 "<b>IsEmpty, IsMine</b>\n"
-"A pattern in single quotes is a shell-style wildcard pattern to match. If it\n"
+"A pattern in single quotes is a shell-style wildcard pattern to match. If "
+"it\n"
 "contains a slash then the match is against the full path; otherwise it is\n"
 "against the leafname only.\n"
 "\n"
@@ -84,7 +90,8 @@ msgid ""
 "<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (compare two values)\n"
 "<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (file sizes)\n"
 "<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (times)\n"
-"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> (values)\n"
+"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
+"(values)\n"
 "\n"
 "<u>Specials</u>\n"
 "<b>system(command)</b> (true if 'command' returns with a zero exit status;\n"
@@ -105,38 +112,45 @@ msgstr ""
 "<b>IsReg system(grep -q fred \"%\")</b> (sisaldab sõna 'fred')\n"
 "\n"
 "<u>Lihtsad testid</u>\n"
-"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</b> (tüübid)\n"
-"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> (failiõigused)\n"
+"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
+"b> (tüübid)\n"
+"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
+"(failiõigused)\n"
 "<b>IsEmpty, IsMine</b>\n"
-"Ühekordsetes jutumärkides olevat mustrit võrreldakse käsurea stiilis. Kui see\n"
+"Ühekordsetes jutumärkides olevat mustrit võrreldakse käsurea stiilis. Kui "
+"see\n"
 "sisaldab kaldkriipsu, võrreldakse täieliku rajaga, muidu ainult \n"
 "failinimega.\n"
 "\n"
 "<u>Võrdlused</u>\n"
-"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (kahe väärtuse võrdlemine)\n"
+"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (kahe väärtuse "
+"võrdlemine)\n"
 "<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (failisuurused)\n"
 "<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (ajad)\n"
-"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> (väärtused)\n"
+"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
+"(väärtused)\n"
 "\n"
 "<u>Erikäsud</u>\n"
 "<b>system(Befehl)</b> (tõene, kui 'käsu' väljundväärtus on null;\n"
 "% 'käsus' asendatakse faili rajaga)\n"
 "<b>prune</b> (väär ja keelab kotaloogi sisu otsimast)."
 
-#: action.c:246
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Abi õiguste muutmise kohta"
 
-#: action.c:257
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
 "\n"
 "The format of a command is: <b>CHANGE, CHANGE, ...</b>\n"
 "Each <b>CHANGE</b> is: <b>WHO HOW PERMISSIONS</b>\n"
-"<b>WHO</b> is some combination of <b>u</b>, <b>g</b> and <b>o</b> which determines whether to\n"
+"<b>WHO</b> is some combination of <b>u</b>, <b>g</b> and <b>o</b> which "
+"determines whether to\n"
 "change the permissions for the User (owner), Group or Others.\n"
-"<b>HOW</b> is <b>+</b>, <b>-</b> or <b>=</b> to add, remove or set exactly the permissions.\n"
+"<b>HOW</b> is <b>+</b>, <b>-</b> or <b>=</b> to add, remove or set exactly "
+"the permissions.\n"
 "<b>PERMISSIONS</b> is some combination of the letters <b>rwxXstugo</b>\n"
 "\n"
 "Bracketed text and spaces are ignored.\n"
@@ -144,7 +158,8 @@ msgid ""
 "<u>Examples</u>\n"
 "<b>u+rw</b>: the file owner gains read and write permission\n"
 "<b>g=u</b>: the group permissions are set to be the same as the user's\n"
-"<b>o=u-w</b>: others get the same permissions as the owner, but without write permission\n"
+"<b>o=u-w</b>: others get the same permissions as the owner, but without "
+"write permission\n"
 "<b>a+x</b>: <b>a</b>ll get execute/access permission - same as <b>ugo+x</b>\n"
 "<b>a+X</b>: directories become accessable by everyone; files which were\n"
 "executable by anyone become executable by everyone\n"
@@ -159,9 +174,11 @@ msgstr ""
 "\n"
 "Käsuvorming on: <b>MUUDATUS, MUUDATUD, ...</b>\n"
 "Iga <b>MUUDATUS</b> on kujul: <b>KES MIDA ÕIGUSED</b>\n"
-"<b>KES</b> on kombinatsioon tähtedest <b>u</b>, <b>g</b> und <b>o</b>, mis määrab, kelle õigusi muudetakse:\n"
+"<b>KES</b> on kombinatsioon tähtedest <b>u</b>, <b>g</b> und <b>o</b>, mis "
+"määrab, kelle õigusi muudetakse:\n"
 "Omaniku (User),  grupi (Group) või kõigi muude (Others).\n"
-"<b>MIDA</b> on <b>+</b>, <b>-</b> või <b>=</b>, et lisade, eemaldada või täpselt seada õigusi.\n"
+"<b>MIDA</b> on <b>+</b>, <b>-</b> või <b>=</b>, et lisade, eemaldada või "
+"täpselt seada õigusi.\n"
 "<b>ÕIGUSED</b> on mingi kombinatsioon tähtedest <b>rwxXstugo</b>\n"
 "\n"
 "Nurksulgudes teksti ja tühikuid ignoreeritakse.\n"
@@ -170,21 +187,24 @@ msgstr ""
 "\n"
 "<b>u+rw</b>: faili omanik saab lugemis- ja kirjutamisõiguse\n"
 "<b>g=u</b>: grupi õigused seatakse samadeks kui omanikul\n"
-"<b>o=u-w</b>: kõik muud saavad samad õigused kui omanik, välja arvatud kirjutamisõigus\n"
+"<b>o=u-w</b>: kõik muud saavad samad õigused kui omanik, välja arvatud "
+"kirjutamisõigus\n"
 "<b>a+x</b>: kõik saavad õiguse käivitada - sama kui <b>ugo+x</b>\n"
-"<b>a+X</b>: kõik saavad õiguse kataloogidele ligi pääseda; failid, millele oli kellegil käivitusõigus, \n"
+"<b>a+X</b>: kõik saavad õiguse kataloogidele ligi pääseda; failid, millele "
+"oli kellegil käivitusõigus, \n"
 "muutuvad kõigi poolt käivitatavateks\n"
 "<b>u+rw, go+r</b>: kaks käsku korraga!\n"
-"<b>u+s</b>: sea SetUID-bitt - tihti ei oma mingit efekti skriptifailide puhul\n"
+"<b>u+s</b>: sea SetUID-bitt - tihti ei oma mingit efekti skriptifailide "
+"puhul\n"
 "<b>755</b>: sea ligipääsuõigused otse\n"
 "\n"
 "Täpsemat infot saate lugeda chmod(1) man-leheküljelt."
 
-#: action.c:298
+#: action.c:308
 msgid "Set type reference"
 msgstr "Sea tüüpide viiteid"
 
-#: action.c:309
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -213,55 +233,55 @@ msgstr ""
 "ainult mõnigatel failisüsteemidel ning sõltuvalt opsüsteemist.\n"
 "\n"
 
-#: action.c:416
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Protsess lõpetatud..\n"
 
-#: action.c:432
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Oli üks viga.\n"
 
-#: action.c:434
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Oli %d viga.\n"
 
-#: action.c:458
+#: action.c:516
 msgid "ERROR reading"
 msgstr "VIGA lugemisel"
 
-#: action.c:501
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Valmis\n"
 
-#: action.c:557
-#: support.c:396
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "VIGA"
 
-#: action.c:711
-#: main.c:686
-#: main.c:693
-#: main.c:707
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Jaa"
 
-#: action.c:714
-#: main.c:688
-#: main.c:695
-#: main.c:707
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Ei"
 
-#: action.c:732
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -269,7 +289,7 @@ msgstr ""
 "\n"
 "Ootan tütarprotsesside lõpetamist...\n"
 
-#: action.c:739
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -277,41 +297,41 @@ msgstr ""
 "\n"
 "Proovin SULGEDA kontrolli alt väljunud protsessi...\n"
 
-#: action.c:892
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Inhalt von %s zählen?"
 
-#: action.c:928
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Kustutada %s'%s' ?"
 
-#: action.c:929
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "KIRJUTUSKAITSEGA"
 
-#: action.c:936
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "Kustutan '%s'\n"
 
-#: action.c:949
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "Kataloog '%s' kustutatud\n"
 
-#: action.c:982
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?'Väljastada %s'?"
 
-#: action.c:989
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Väljastan '%s'\n"
 
-#: action.c:1008
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -320,83 +340,95 @@ msgstr ""
 "!%s\n"
 "väljastamine ebaõnnestus\n"
 
-#: action.c:1027
-#: action.c:1046
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?'Kontrollida %s'?"
 
-#: action.c:1043
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Vigane otsingutingimus - muutke ja proovige uuesti\n"
 
-#: action.c:1053
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'('%s' kontrollimise juures)\n"
 
-#: action.c:1127
-#: action.c:1152
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Muuda '%s' loabitte?"
 
-#: action.c:1133
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Muuda '%s loabitte'\n"
 
-#: action.c:1150
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Vigane moodi käsk - muutke seda ja proovige veelkord\n"
 
-#: action.c:1207
-#: action.c:1227
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?Muuda '%s' tüüpi?"
+
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Muuda '%s' tüüpi?"
 
-#: action.c:1224
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Vigane tüüp - muutke seda ja proovige veelkord\n"
 
-#: action.c:1246
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Muuda '%s' tüübiks '%s'\n"
 
-#: action.c:1325
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'Muuda '%s' tüübiks '%s'\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' on juba olemas - %s?"
 
-#: action.c:1327
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "ühenda sisu"
 
-#: action.c:1328
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "kirjuta üle"
 
-#: action.c:1344
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Üritan ikkagi kopeerida...\n"
 
-#: action.c:1353
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Kopeeri %s nime alla %s?"
 
-#: action.c:1357
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Kopeerin %s nime alla: %s\n"
 
-#: action.c:1372
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!VIGA: Sihtkoht on juba olemas, aga pole kataloog\n"
 
-#: action.c:1444
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -405,26 +437,7 @@ msgstr ""
 "!%s\n"
 "'%s' kopeerimine ebaõnnestus\n"
 
-#: action.c:1488
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' on juba olemas - kas kirjutan üle?"
-
-#: action.c:1503
-msgid "'Trying move anyway...\n"
-msgstr "'Üritan siiski tõsta...\n"
-
-#: action.c:1511
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Tõstan %s nime alla %s?"
-
-#: action.c:1515
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Tõstan %s nime alla %s\n"
-
-#: action.c:1523
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -433,45 +446,59 @@ msgstr ""
 "!%s\n"
 "%s tõstmine nime alla %s ebaõnnestus\n"
 
-#: action.c:1544
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Üritan siiski tõsta...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Tõstan %s nime alla %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Tõstan %s nime alla %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!VIGA: Objekti ei ole võimalik sama nime alla kopeerida\n"
 
-#: action.c:1559
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!VIGA: Objekti pole võimalik sama nime alla tõsta\n"
 
-#: action.c:1571
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Loon viida %s nime alla %s\n"
 
-#: action.c:1576
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Luua viit %s nime alla %s?"
 
-#: action.c:1618
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Ühendan %s \n"
 
-#: action.c:1619
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Lahutan %s\n"
 
-#: action.c:1622
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?%s ühendada?"
 
-#: action.c:1623
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?%s lahutada?"
 
-#: action.c:1643
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -480,7 +507,7 @@ msgstr ""
 "!%s\n"
 "Ühendamine ebaõnnestus\n"
 
-#: action.c:1644
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -489,11 +516,11 @@ msgstr ""
 "!%s\n"
 "Lahutamine ebaõnnestus\n"
 
-#: action.c:1652
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(tundub olevat juba niigi ühendatud)\n"
 
-#: action.c:1698
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -502,316 +529,313 @@ msgstr ""
 "'\n"
 "Kokku: %s ("
 
-#: action.c:1704
+#: action.c:2108
 msgid "file"
 msgstr "fail"
 
-#: action.c:1704
+#: action.c:2108
 msgid "files"
 msgstr "failid"
 
-#: action.c:1708
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "pole katalooge)\n"
 
-#: action.c:1712
+#: action.c:2116
 msgid "directory"
 msgstr "kataloog"
 
-#: action.c:1713
+#: action.c:2117
 msgid "directories"
 msgstr "kataloogid"
 
-#: action.c:1754
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Ühenduspunkti pole valitud!\n"
 
-#: action.c:1839
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Otsida veel?"
 
-#: action.c:1869
-#: action.c:1900
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' on sümbolviit\n"
 
-#: action.c:1940
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "Palun valige mõni kataloog, millest otsida"
 
-#: action.c:1950
-#: menu.c:221
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Otsi"
 
-#: action.c:1983
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Palun valige objekte loendamiseks"
 
-#: action.c:1987
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Kasutatud kettaruum"
 
-#: action.c:2023
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Ühenda / Lahuta"
 
-#: action.c:2038
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr "Vabandust, aga ROX-Filer ei toeta teie masinas veel ühenduspunkte"
 
-#: action.c:2052
-#: menu.c:209
-#: tips:209
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Kustuta"
 
-#: action.c:2064
-#: tips:214
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Sunni"
 
-#: action.c:2064
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Kirjutuskeeluga objektide kustutamisel ära küsi kinnitust"
 
-#: action.c:2067
-#: action.c:2124
-#: action.c:2185
-#: action.c:2240
-#: action.c:2278
-#: tips:216
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Lühidalt"
 
-#: action.c:2067
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Näita vaid kustutavaid katalooge"
 
-#: action.c:2084
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "Valige objekte, mille loabitte te tahate muuta"
 
-#: action.c:2092
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Luba käivitamine/otsimine)"
 
-#: action.c:2094
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (Keela käivitamine/otsimine)"
 
-#: action.c:2096
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Luba omanikul lugeda ja kirjutada)"
 
-#: action.c:2098
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Luba ligipääs vaid omanikule)"
 
-#: action.c:2100
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Luba kõigil lugeda, keela kirjutamine)"
 
-#: action.c:2111
-#: menu.c:183
-#: menu.c:219
-#: tips:76
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Õigused"
 
-#: action.c:2124
-#: action.c:2185
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Ära näita käsitletud faile"
 
-#: action.c:2127
-#: action.c:2188
-#: tips:218
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Rekursiivne"
 
-#: action.c:2127
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Muuda ka alamkataloogide sisu"
 
-#: action.c:2131
+#: action.c:2547
 msgid "Command:"
 msgstr "Käsk:"
 
-#: action.c:2159
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Valige objekte, mille tüüpi te tahate muuta"
 
-#: action.c:2172
+#: action.c:2590
 msgid "Set type"
 msgstr "Muuda tüüpi"
 
-#: action.c:2188
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Muuda ka alamkataloogide sisu"
 
-#: action.c:2195
-#: infobox.c:620
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Tüüp:"
 
-#: action.c:2224
-#: dnd.c:124
-#: menu.c:1988
-#: tips:203
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Kopeeri"
 
-#: action.c:2236
-#: action.c:2274
-#: tips:220
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Ära küsi kinnitust iga kord"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Kirjuta üle vaid siis, kui lähtefail on uuem."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Uuem"
 
-#: action.c:2237
-#: action.c:2275
-#: tips:221
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Kirjuta üle vaid siis, kui lähtefail on uuem."
 
-#: action.c:2240
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "kataloogid"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Näita vaid kopeeritavaid katalooge"
 
-#: action.c:2262
-#: dnd.c:125
-#: tips:205
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Tõsta"
 
-#: action.c:2278
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Ära näita iga faili, mida tõstetakse"
 
-#: action.c:2298
-#: tips:207
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Loo viit"
 
-#: action.c:2319
-#: appmenu.c:113
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Väljasta"
 
-#: action.c:2378
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Kustuta objektid "
 
-#: action.c:2382
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Kustuta objekt"
 
-#: action.c:2384
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Kustuta objektid "
 
-#: action.c:2403
+#: action.c:2900
 msgid " and "
 msgstr " ja "
 
-#: action.c:2412
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr " mõjutab faili töölaual või paneelil - kas kustutan siiski? "
 
-#: action.c:2419
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr " mõjutab faile töölaual või paneelil - kas kustutan siiski?"
 
-#: appmenu.c:198
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<Kirjeldus puudub>"
 
-#: appmenu.c:295
+#: appmenu.c:317
 #, c-format
-msgid "Symlink any programs you want into this directory. They will appear in the menu for all items of this type (%s/%s)."
-msgstr "Loo antud kataloogi sümbolviidad programmidele, mida soovid näha kõigi tüüpi (%s/%s) objektide puhul menüüs"
+msgid ""
+"Symlink any programs you want into this directory. They will appear in the "
+"menu for all items of this type (%s/%s)."
+msgstr ""
+"Loo antud kataloogi sümbolviidad programmidele, mida soovid näha kõigi tüüpi "
+"(%s/%s) objektide puhul menüüs"
 
-#: appmenu.c:339
-#: menu.c:232
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Kohanda menüüd..."
 
-#: appmenu.c:396
-#: menu.c:249
-#: toolbar.c:159
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Abi"
 
-#: bookmarks.c:147
-msgid "Path"
-msgstr "Tee"
-
-#: bookmarks.c:155
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Pealkiri"
 
-#: bookmarks.c:304
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Tee"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Võrguaadressi '%s' pole võimalik lisada järjehoidjatesse \n"
 
-#: bookmarks.c:312
-#: bookmarks.c:630
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' ei ole kataloog"
 
-#: bookmarks.c:518
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Vali järjehoidja"
 
-#: bookmarks.c:542
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Järjehoidja tõstmiseks valige ta kursoriga"
 
-#: bookmarks.c:562
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Olete nimekirja lõpus"
 
-#: bookmarks.c:636
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Võrgukataloogi '%s' ei saa lisada järjehoidjatesse"
 
-#: bookmarks.c:778
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Lisa järjehoidja"
 
-#: bookmarks.c:785
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Muuda järjehoidjaid"
 
-#: bookmarks.c:790
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Hiljuti külastatud"
 
-#: bulk_rename.c:68
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Nimeta faile ümber hulgi"
 
-#: bulk_rename.c:71
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Taasta"
 
-#: bulk_rename.c:76
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "Tee Pärast-tulpa koopia Enne-tulba sisust"
 
-#: bulk_rename.c:81
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "_Nimeta ümber"
 
-#: bulk_rename.c:94
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Asenda:"
 
-#: bulk_rename.c:101
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -830,53 +854,64 @@ msgid "With:"
 msgstr "Stringiga:"
 
 #: bulk_rename.c:116
-msgid "The first match in each filename will be replaced by this string. There are no special characters."
-msgstr "Esimene vaste igas failinimes asendatakse selle stringiga. Erimärke pole."
+#, fuzzy
+msgid ""
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
+msgstr ""
+"Esimene vaste igas failinimes asendatakse selle stringiga. Erimärke pole."
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Rakenda"
 
-#: bulk_rename.c:123
-msgid "Do a search-and-replace in the New column. The files are not actually renamed until you click on the Rename button below."
-msgstr "Soorita asendus Pärast tulbas.Faile endid ei nimetata ümber enne, kui klõpsate all asuvale 'Nimeta ümber' nupule."
+#: bulk_rename.c:125
+msgid ""
+"Do a search-and-replace in the New column. The files are not actually "
+"renamed until you click on the Rename button below."
+msgstr ""
+"Soorita asendus Pärast tulbas.Faile endid ei nimetata ümber enne, kui "
+"klõpsate all asuvale 'Nimeta ümber' nupule."
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Vana nimi"
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Uus nimi"
 
-#: bulk_rename.c:259
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr "Ükski string (Pärast tulbas) ei vastanud antud avaldisele"
 
-#: bulk_rename.c:264
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Üks nimi vastas avaldisele, kuid tulemus oli muutumatu"
 
-#: bulk_rename.c:267
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d nime vastas avaldisele, kuid tulemused olid samad"
 
-#: bulk_rename.c:293
-msgid "Specify a regular expression to match, and a string to replace matches with."
-msgstr "Määra regulaaravaldis, mida otsitakse ja string, millega asendatakse tulemus."
+#: bulk_rename.c:330
+msgid ""
+"Specify a regular expression to match, and a string to replace matches with."
+msgstr ""
+"Määra regulaaravaldis, mida otsitakse ja string, millega asendatakse tulemus."
 
-#: bulk_rename.c:310
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s·('%s' asemel)"
 
-#: bulk_rename.c:343
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr "Fail nimega '%s' on juba olemas. Hulgiümbernimetamine katkestatud."
 
-#: bulk_rename.c:348
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -887,66 +922,87 @@ msgstr ""
 "%s\n"
 "Hulgiümbernimetane katkestatud."
 
-#: bulk_rename.c:410
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "Fail nimega '%s' on juba olemas"
 
-#: bulk_rename.c:421
+#: bulk_rename.c:458
 #, c-format
-msgid "Some of the New names contain / characters (eg '%s'). This will cause the files to end up in different directories. Continue?"
-msgstr "Mõned nimed Pärast tulbas sisaldavad / märke (näit. '%s'). Selle tagajärjel tõstetakse failid erinevatesse kataloogidesse. Kas jätkan?"
+msgid ""
+"Some of the New names contain / characters (eg '%s'). This will cause the "
+"files to end up in different directories. Continue?"
+msgstr ""
+"Mõned nimed Pärast tulbas sisaldavad / märke (näit. '%s'). Selle tagajärjel "
+"tõstetakse failid erinevatesse kataloogidesse. Kas jätkan?"
 
-#: bulk_rename.c:436
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Ükski nimi pole muutunud. Pole midagi teha!"
 
-#: choices.c:428
-msgid "Choices migration"
-msgstr "Valikute ümbertõstmine"
+#: choices.c:434
+#, c-format
+msgid "%d directories could not be migrated"
+msgstr "%d kataloogi ei õnnestunud ümber tõsta"
 
 #: choices.c:436
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Choices have been moved from \n"
-"<b>%s</b>\n"
+"%s\n"
 " to the new location \n"
-"<b>%s</b>\n"
+"%s\n"
+"%s"
 msgstr ""
 "Choices on tõstetud ümber asukohast \n"
 "<b>%s</b>\n"
 " uude asukohta \n"
 "<b>%s</b>\n"
 
-#: choices.c:447
-#, c-format
-msgid "%d directories could not be migrated"
-msgstr "%d kataloogi ei õnnestunud ümber tõsta"
-
-#: dir.c:982
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Ei õnnestu lugeda kataloogi %s"
 
-#: dir.c:991
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Kataloogi %s ei õnnestu avada"
 
-#: display.c:614
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Suurus"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) ebaõnnestus: %s"
 
-#: dnd.c:126
-msgid "Link (relative)"
-msgstr "Sümbolviit"
-
-#: dnd.c:127
-msgid "Link (absolute)"
-msgstr "Absoluutne viit"
-
-#: dnd.c:426
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Sisemine viga - vigane info tüüp"
 
@@ -959,25 +1015,33 @@ msgid "XDS protocol error: leafname may not contain '/'\n"
 msgstr "XDS protokolli viga: failinimi ei tohi sisaldada '/' märki\n"
 
 #: dnd.c:605
-msgid "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/plain) did not contain a leafname\n"
-msgstr "On XdndDirectSave0-sihtmärk, kuid XdndDirectSave0-aatomis (tüüp text/plain) polnud failinime\n"
+msgid ""
+"XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
+"plain) did not contain a leafname\n"
+msgstr ""
+"On XdndDirectSave0-sihtmärk, kuid XdndDirectSave0-aatomis (tüüp text/plain) "
+"polnud failinime\n"
 
 #: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
 msgstr "Vabandust - vajan text/uri-list või XdndDirectSave0 tüüpi sihtmärki"
 
 #: dnd.c:621
-msgid "Sorry - I require a target type of text/uri-list or application/octet-stream."
-msgstr "Vabandust - vajan text/uri-list või application/octet-stream tüüpi sihtmärki."
+msgid ""
+"Sorry - I require a target type of text/uri-list or application/octet-stream."
+msgstr ""
+"Vabandust - vajan text/uri-list või application/octet-stream tüüpi sihtmärki."
 
 #: dnd.c:691
 #, c-format
 msgid ""
-"Failed to add some items to the pinboard, because they are on a remote machine. For example:\n"
+"Failed to add some items to the pinboard, because they are on a remote "
+"machine. For example:\n"
 "\n"
 "%s"
 msgstr ""
-"Mõnede objektide lisamine töölauale ebaõnnestus, kuna nad pole kohalikus masinas. Näiteks:\n"
+"Mõnede objektide lisamine töölauale ebaõnnestus, kuna nad pole kohalikus "
+"masinas. Näiteks:\n"
 "\n"
 "%s"
 
@@ -991,7 +1055,8 @@ msgstr "Vabandust - Võrgurakendus ei taha/oska mulle infot saata"
 
 #: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
-msgstr "XDS protokolli viga: tagastatud väärtus peab olema kas 'S', 'F' või 'E'\n"
+msgstr ""
+"XDS protokolli viga: tagastatud väärtus peab olema kas 'S', 'F' või 'E'\n"
 
 #: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
@@ -1011,53 +1076,81 @@ msgid "No URIs in the text/uri-list (nothing to do!)"
 msgstr "text/uri-list nimekirjas pole ühtegi aadressi (pole tegevust!)"
 
 #: dnd.c:993
-msgid "Can't get data from remote machine (application/octet-stream not provided)"
-msgstr "Võrgust pole võimalik andmeid saada (application/octet-stream pole saadaval)"
+msgid ""
+"Can't get data from remote machine (application/octet-stream not provided)"
+msgstr ""
+"Võrgust pole võimalik andmeid saada (application/octet-stream pole saadaval)"
 
-#: dnd.c:1016
-msgid "Some of these files are on a different machine - they will be ignored - sorry"
+#: dnd.c:1015 menu.c:2406
+msgid ""
+"Some of these files are on a different machine - they will be ignored - sorry"
 msgstr "Vabandust - osad failid jätan vahele, kuna need asuvad teises masinas"
 
-#: dnd.c:1023
-msgid "None of these files are on the local machine - I can't operate on multiple remote files - sorry."
-msgstr "Vabandust - ükski failidest ei asu siin masinas. Ma ei saa mitme mitte-kohaliku failiga töötada."
+#: dnd.c:1024 menu.c:2414
+msgid ""
+"None of these files are on the local machine - I can't operate on multiple "
+"remote files - sorry."
+msgstr ""
+"Vabandust - ükski failidest ei asu siin masinas. Ma ei saa mitme mitte-"
+"kohaliku failiga töötada."
 
-#: dnd.c:1036
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Sooviti tundmatut tegevus"
 
-#: dnd.c:1044
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Viga failide nimekirja hankides: %s"
 
-#: dropbox.c:114
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Sümbolviit"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Absoluutne viit"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Sümbolviit"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Absoluutne viit"
+
+#: dropbox.c:112
 msgid "Show"
 msgstr "Näita"
 
-#: dropbox.c:120
+#: dropbox.c:118
 msgid "Show the current choice in a filer window"
 msgstr "Näita praegust valikut failihalduri aknas"
 
-#: dropbox.c:174
+#: dropbox.c:172
 msgid "<nothing>"
 msgstr "<eimidagi>"
 
-#: dropbox.c:239
-msgid "I can't show you the currently set item, because nothing is currently set. Drag something onto me!"
-msgstr "Ma ei saa näidata praegust valikut, kuna midagi pole valitud ! Lohista siia midagi !"
+#: dropbox.c:237
+msgid ""
+"I can't show you the currently set item, because nothing is currently set. "
+"Drag something onto me!"
+msgstr ""
+"Ma ei saa näidata praegust valikut, kuna midagi pole valitud ! Lohista siia "
+"midagi !"
 
-#: dropbox.c:263
+#: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
 msgstr "Vabandust, te saate siia lohistada vaid ühe faili."
 
-#: dropbox.c:273
+#: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr "Ei saa kasutada '%s' kuna see pole kohalik fail."
 
-#: dropbox.c:280
-#: pinboard.c:853
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1066,7 +1159,7 @@ msgstr ""
 "Puudub ligipääs: '%s':\n"
 "%s"
 
-#: filer.c:454
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1075,16 +1168,7 @@ msgstr ""
 "Viga '%s' skaneerimisel:\n"
 "%s\n"
 
-#: filer.c:458
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Viga '%s' skaneerimisel:\n"
-"%s"
-
-#: filer.c:563
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1094,358 +1178,403 @@ msgstr ""
 "\n"
 "Pärast lahutamist on seadme/ketta eemaldamine ohutu."
 
-#: filer.c:567
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 msgid "No change"
 msgstr "Pole muutust"
 
-#: filer.c:573
-#: menu.c:860
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Lahuta"
 
-#: filer.c:670
-msgid "Directory missing/deleted"
-msgstr "Kataloog on kadunud/kustutatud"
-
-#: filer.c:1034
+#: filer.c:1490
 #, c-format
 msgid ""
-"Group %s is not set. Select some files and press Ctrl+%s to set the group. Press %s on its own to reselect the files later.\n"
+"Group %s is not set. Select some files and press Ctrl+%s to set the group. "
+"Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
-msgstr "Grupp %s pole määratud. Grupi määramiseks valige mõned failid ja vajutage Ctrl+%s. Failide hiljem uuesti valimiseks vajutage vaid %s. Numbriklahvistiku kasutamisel peab Teil Numlock aktiivne olema"
+msgstr ""
+"Grupp %s pole määratud. Grupi määramiseks valige mõned failid ja vajutage "
+"Ctrl+%s. Failide hiljem uuesti valimiseks vajutage vaid %s. "
+"Numbriklahvistiku kasutamisel peab Teil Numlock aktiivne olema"
 
-#: filer.c:1270
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Puudub ligipääs kataloogile '%s'"
-
-#: filer.c:1422
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Kataloogi '%s' ei leitud."
-
-#: filer.c:1716
-msgid "Cancel"
-msgstr "Tühista"
-
-#: filer.c:1997
+#: filer.c:2655
 msgid "A"
 msgstr "A"
 
-#: filer.c:1999
-#: find.c:925
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr "G"
 
-#: filer.c:2004
+#: filer.c:2664
 msgid "S"
 msgstr "S"
 
-#: filer.c:2006
+#: filer.c:2669
 msgid "T"
 msgstr "T"
 
-#: filer.c:2016
-msgid "All, "
-msgstr "KÃµik, "
+#: filer.c:2670
+msgid "D"
+msgstr ""
 
-#: filer.c:2019
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
 msgstr "Glob (%s), "
 
-#: filer.c:2027
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Skaneerin, "
 
-#: filer.c:2029
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Pisipildid, "
 
-#: filer.c:2305
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Pisipildid, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Sümbolviit failile "
 
-#: filer.c:2347
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "Failinimi pole kodeeringus UTF-8. Te peaksite faili ümber nimetama.\n"
 
-#: filer.c:2658
-#: menu.c:1978
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "Objekti pole enam olemas!"
 
-#: filer.c:3334
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Vali ekraani asetused, mida salvestada"
 
-#: filer.c:3341
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Vali ekraani asetused, mida salvestada"
+
+#: filer.c:4727
 msgid "Position"
 msgstr "Asukoht"
 
-#: filer.c:3346
-#: toolbar.c:135
-#: toolbar.c:139
-#: tips:64
-msgid "Size"
-msgstr "Suurus"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Aken"
 
-#: filer.c:3351
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Näita peidetud"
 
-#: filer.c:3357
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Vaate stiil"
 
-#: filer.c:3363
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Sorteerimistüüp ja järjekord"
 
-#: filer.c:3368
-#: toolbar.c:143
+#: filer.c:4754
 msgid "Details"
 msgstr "Lisainfo"
 
-#: filer.c:3373
-#: tips:115
-#: tips:116
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Pisipildid"
 
-#: filer.c:3379
+#: filer.c:4765
 msgid "Filter"
 msgstr "Filter"
 
-#: find.c:487
+#: find.c:485
 msgid "And"
 msgstr "Ja"
 
-#: find.c:511
+#: find.c:509
 msgid "Not"
 msgstr "Mitte"
 
-#: find.c:554
+#: find.c:552
 msgid "system"
 msgstr "süsteem"
 
-#: find.c:562
+#: find.c:560
 msgid "prune"
 msgstr "pügada"
 
-#: find.c:650
+#: find.c:648
 msgid "After"
 msgstr "Pärast"
 
-#: find.c:652
+#: find.c:650
 msgid "Before"
 msgstr "Enne"
 
-#: find.c:746
+#: find.c:744
 msgid "IsReg"
 msgstr "lsReg"
 
-#: find.c:748
+#: find.c:746
 msgid "IsLink"
 msgstr "IsLink"
 
-#: find.c:750
+#: find.c:748
 msgid "IsDir"
 msgstr "IsDir"
 
-#: find.c:752
+#: find.c:750
 msgid "IsChar"
 msgstr "IsChar"
 
-#: find.c:754
+#: find.c:752
 msgid "IsBlock"
 msgstr "IsBlock"
 
-#: find.c:756
+#: find.c:754
 msgid "IsDev"
 msgstr "IsDev"
 
-#: find.c:758
+#: find.c:756
 msgid "IsPipe"
 msgstr "IsPipe"
 
-#: find.c:760
+#: find.c:758
 msgid "IsSocket"
 msgstr "IsSocket"
 
-#: find.c:762
+#: find.c:760
 msgid "IsDoor"
 msgstr "IsDoor"
 
-#: find.c:764
+#: find.c:762
 msgid "IsSUID"
 msgstr "IsSUID"
 
-#: find.c:766
+#: find.c:764
 msgid "IsSGID"
 msgstr "IsSGID"
 
-#: find.c:768
+#: find.c:766
 msgid "IsSticky"
 msgstr "IsSticky"
 
-#: find.c:770
+#: find.c:768
 msgid "IsReadable"
 msgstr "IsReadable"
 
-#: find.c:772
+#: find.c:770
 msgid "IsWriteable"
 msgstr "IsWritable"
 
-#: find.c:774
+#: find.c:772
 msgid "IsExecutable"
 msgstr "IsExecutable"
 
-#: find.c:776
+#: find.c:774
 msgid "IsEmpty"
 msgstr "IsEmpty"
 
-#: find.c:778
+#: find.c:776
 msgid "IsMine"
 msgstr "IsMine"
 
-#: find.c:906
+#: find.c:904
 msgid "Now"
 msgstr "Nüüd"
 
-#: find.c:919
+#: find.c:917
 msgid "Byte"
 msgstr "Bait"
 
-#: find.c:919
+#: find.c:917
 msgid "Bytes"
 msgstr "Baiti"
 
-#: find.c:921
+#: find.c:919
 msgid "Kb"
 msgstr "Kb"
 
-#: find.c:921
+#: find.c:919
 msgid "K"
 msgstr "K"
 
-#: find.c:923
+#: find.c:921
 msgid "Mb"
 msgstr "Mb"
 
-#: find.c:923
+#: find.c:921
 msgid "M"
 msgstr "M"
 
-#: find.c:925
+#: find.c:923
 msgid "Gb"
 msgstr "Gb"
 
-#: find.c:927
+#: find.c:925
 msgid "Sec"
 msgstr "Sek"
 
-#: find.c:927
+#: find.c:925
 msgid "Secs"
 msgstr "Sekki"
 
-#: find.c:929
+#: find.c:927
 msgid "Min"
 msgstr "Min"
 
-#: find.c:929
+#: find.c:927
 msgid "Mins"
 msgstr "Minuteid"
 
-#: find.c:931
+#: find.c:929
 msgid "Hour"
 msgstr "Tund"
 
-#: find.c:931
+#: find.c:929
 msgid "Hours"
 msgstr "Tunnid"
 
-#: find.c:933
+#: find.c:931
 msgid "Day"
 msgstr "Päev"
 
-#: find.c:933
+#: find.c:931
 msgid "Days"
 msgstr "Päevi"
 
-#: find.c:935
+#: find.c:933
 msgid "Week"
 msgstr "Nädal"
 
-#: find.c:935
+#: find.c:933
 msgid "Weeks"
 msgstr "Nädalaid"
 
-#: find.c:937
+#: find.c:935
 msgid "Year"
 msgstr "Aasta"
 
-#: find.c:937
+#: find.c:935
 msgid "Years"
 msgstr "Aastaid"
 
-#: find.c:946
+#: find.c:944
 msgid "Ago"
 msgstr "Tagasi"
 
-#: find.c:948
+#: find.c:946
 msgid "Hence"
 msgstr "Seetõttu"
 
-#: find.c:963
+#: find.c:961
 msgid "atime"
 msgstr "atime"
 
-#: find.c:965
+#: find.c:963
 msgid "ctime"
 msgstr "ctime"
 
-#: find.c:967
+#: find.c:965
 msgid "mtime"
 msgstr "mtime"
 
-#: find.c:969
+#: find.c:967
 msgid "size"
 msgstr "suurus"
 
-#: find.c:971
+#: find.c:969
 msgid "inode"
 msgstr "inode"
 
-#: find.c:973
+#: find.c:971
 msgid "nlinks"
 msgstr "nlinks"
 
-#: find.c:975
+#: find.c:973
 msgid "uid"
 msgstr "uid"
 
-#: find.c:977
+#: find.c:975
 msgid "gid"
 msgstr "gid"
 
-#: find.c:979
+#: find.c:977
 msgid "blocks"
 msgstr "plokid"
 
-#: gtksavebox.c:251
+#: gtksavebox.c:249
 msgid "Save As:"
 msgstr "Salvesta kui:"
 
-#: gtksavebox.c:397
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Nimetu"
 
-#: gtksavebox.c:473
-msgid "Remote application wants to use Direct Save, but I can't read the XdndDirectSave0 (type text/plain) property.\n"
-msgstr "Võrgurakendus soovib Direct Save kasutada, kuid ma ei suuda XdndDirectSave0-atribuuti (tüüpi text/plain) lugeda.\n"
+#: gtksavebox.c:477
+msgid ""
+"Remote application wants to use Direct Save, but I can't read the "
+"XdndDirectSave0 (type text/plain) property.\n"
+msgstr ""
+"Võrgurakendus soovib Direct Save kasutada, kuid ma ei suuda XdndDirectSave0-"
+"atribuuti (tüüpi text/plain) lugeda.\n"
 
-#: gtksavebox.c:598
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1453,7 +1582,7 @@ msgstr ""
 "Lohistage ikoon kataloogivaate peale \n"
 "või sisestage faili asukoht täisrajaga"
 
-#: gui_support.c:331
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1461,219 +1590,237 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:400
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr "Proovin XML-faili teksti kujul lugeda. Fail '%s' võib olla vigane."
 
-#: gui_support.c:417
+#: gui_support.c:542
 #, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
-"This may be due to upgrading from a previous version of ROX-Filer. Open the Options window and try changing something and then changing it back (causing the file to be resaved).\n"
+"This may be due to upgrading from a previous version of ROX-Filer. Open the "
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
 "Viga failis '%s' real %d: \n"
 "\"%s\"\n"
-"See võib johtuda vanema ROX-Filer'i versiooni uuendamisest.Avage Eelistuste aken, muutke mõnda suvandit ja muutke see tagasi (mis põhjustab faili uuesti salvestamise).\n"
+"See võib johtuda vanema ROX-Filer'i versiooni uuendamisest.Avage Eelistuste "
+"aken, muutke mõnda suvandit ja muutke see tagasi (mis põhjustab faili uuesti "
+"salvestamise).\n"
 "Edasisi vigu eiratakse."
 
-#: gui_support.c:1001
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Vigane või puuduv reavahetus text/uri-list andmetes"
 
-#: gui_support.c:1333
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "Faili '%s' avamine ebaõnnestus: %s"
 
-#: gui_support.c:1377
+#: gui_support.c:1517
 #, c-format
-msgid "Failed to load image '%s': reason not known, probably a corrupt image file"
-msgstr "Pildi '%s' laadimine ebaõnnestus: põhjus pole teada, tõenäoliselt vigane pildifail"
-
-#: gui_support.c:1428
 msgid ""
-"This program cannot be run, as the 0launch command is not available. It can be downloaded from here:\n"
+"Failed to load image '%s': reason not known, probably a corrupt image file"
+msgstr ""
+"Pildi '%s' laadimine ebaõnnestus: põhjus pole teada, tõenäoliselt vigane "
+"pildifail"
+
+#: gui_support.c:1583
+#, fuzzy, c-format
+msgid ""
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
-"Seda programmi pole võimalik jooksutada, kuna puudub 0launch käsk. Seda saate alla laadida aadressilt:\n"
+"Seda programmi pole võimalik jooksutada, kuna puudub 0launch käsk. Seda "
+"saate alla laadida aadressilt:\n"
 "\n"
 "http://0install.net/injector.html"
 
-#: i18n.c:38
-msgid "Note that you must save your choices and restart the filer for the new language setting to take full effect."
-msgstr "Te peate failihalduri uuesti käivitama, enne kui Teie valitud keel aktiveerub."
+#: i18n.c:39
+msgid ""
+"Note that you must save your choices and restart the filer for the new "
+"language setting to take full effect."
+msgstr ""
+"Te peate failihalduri uuesti käivitama, enne kui Teie valitud keel "
+"aktiveerub."
 
-#: icon.c:78
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(Valimiseks klõpsa)"
 
-#: icon.c:133
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:134
-#: menu.c:250
-msgid "About ROX-Filer..."
-msgstr "ROX-Filer'i kohta..."
-
-#: icon.c:135
-#: menu.c:251
-msgid "Show Help Files"
-msgstr "Näita abiinfot"
-
-#: icon.c:136
-#: menu.c:252
-msgid "Manual"
-msgstr "Juhend"
-
-#: icon.c:138
-#: menu.c:228
-msgid "Options..."
-msgstr "Eelistused..."
-
-#: icon.c:139
-#: menu.c:237
-msgid "Home Directory"
-msgstr "Kodukataloog"
-
-#: icon.c:140
-#: icon.c:1340
-#: menu.c:205
-#: type.c:218
-msgid "File"
-msgstr "Fail"
-
-#: icon.c:141
-#: menu.c:211
-#: menu.c:873
-msgid "Shift Open"
-msgstr "Ava tekstina"
-
-#: icon.c:142
-#: menu.c:216
-msgid "Properties"
-msgstr "Omadused"
-
-#: icon.c:143
-#: menu.c:214
-msgid "Set Run Action..."
-msgstr "Sea avaja..."
-
-#: icon.c:144
-#: menu.c:215
-msgid "Set Icon..."
-msgstr "Sea ikoon..."
-
-#: icon.c:145
-#: icon.c:806
-msgid "Edit Item"
-msgstr "Muuda elementi"
-
-#: icon.c:146
-msgid "Show Location"
-msgstr "Näita asukohta"
-
-#: icon.c:147
-msgid "Remove Item(s)"
-msgstr "Eemalda elemente"
-
-#: icon.c:278
-#: menu.c:762
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s·'%s'"
 
-#: icon.c:291
+#: icon.c:311
 msgid "Nothing"
 msgstr "Ei midagi"
 
-#: icon.c:547
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "Asukoha nimes peab olema vähemalt 1 täht!"
 
-#: icon.c:613
+#: icon.c:641
+#, c-format
+msgid "You must unlock '%s' before removing it"
+msgstr ""
+
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Elementide eemaldamiseks valige mõned neist"
 
-#: icon.c:627
+#: icon.c:657
+msgid "An item must be unlocked before it can be removed."
+msgstr ""
+
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Palun avage menüü mõne elemendi kohal"
 
-#: icon.c:652
-#: menu.c:1258
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "Faili käivitajat saate muuta vaid tavafailide puhul"
 
-#: icon.c:738
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Vajutage soovitud klahvikambinatsiooni (näit. Ctrl+F1)"
 
-#: icon.c:760
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Ei õnnestunud klaviatuuri haarata!"
 
-#: icon.c:809
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Muuda elementi"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Ikoonile klõpsamine avab:"
 
-#: icon.c:819
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Käivitatavale failile edastatavad argumendid:"
 
-#: icon.c:833
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "Tekst ikooni all on:"
 
-#: icon.c:846
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "Klahvikombinatsioon on:"
 
-#: infobox.c:112
+#: icon.c:910
+#, fuzzy
+msgid "Locked"
+msgstr "Sokkel"
+
+#: icon.c:915
+msgid "Locking an item prevents it from being accidentally removed"
+msgstr ""
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "ROX-Filer'i kohta..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Näita abiinfot"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Juhend"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Eelistused..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Kodukataloog"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Fail"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Ava tekstina"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Omadused"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Sea avaja..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Sea ikoon..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Näita asukohta"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Eemalda elemente"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
 msgstr "Kas tõesti soovite avada %d akent?"
 
-#: infobox.c:113
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Näita infot"
 
-#: infobox.c:135
-#: menu.c:767
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(vigane utf-8)"
 
-#: infobox.c:260
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Näita _abiinfot"
 
-#: infobox.c:273
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Õigused</b>"
 
-#: infobox.c:287
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>Sisu järgi otsustades...</b>"
 
-#: infobox.c:424
-#: infobox.c:565
-#: support.c:350
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Näita vaid kopeeritavaid katalooge"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "baite"
 
-#: infobox.c:447
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Ebaõnnestus suuruse lugemine"
 
-#: infobox.c:508
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' pole enam sümbolviit"
 
-#: infobox.c:515
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1682,7 +1829,7 @@ msgstr ""
 "Kustutamine ebaõnnestus '%s':\n"
 "%s"
 
-#: infobox.c:520
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1693,149 +1840,194 @@ msgstr ""
 "%s peale ebaõnnestus\n"
 "(märkus: vana viit kustutati)"
 
-#: infobox.c:544
-#: tips:271
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Viga:"
 
-#: infobox.c:551
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Tegelik kataloog:"
 
-#: infobox.c:554
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Omanik, grupp:"
 
-#: infobox.c:561
-#: infobox.c:576
-#: infobox.c:585
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Suurus:"
 
-#: infobox.c:586
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Skaneerin"
 
-#: infobox.c:607
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Skaneerimine ebaõnnestus"
 
-#: infobox.c:614
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Viimati muudetud:"
 
-#: infobox.c:616
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Loodud:"
 
-#: infobox.c:618
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Viimati avatud:"
 
-#: infobox.c:626
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Laiendatud atribuudid:"
 
-#: infobox.c:628
+#: infobox.c:667
 msgid "Present"
 msgstr "Olemas"
 
-#: infobox.c:629
+#: infobox.c:668
 msgid "None"
 msgstr "Puudub"
 
-#: infobox.c:630
+#: infobox.c:669
 msgid "Not supported"
 msgstr "Pole toetatud"
 
-#: infobox.c:642
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Viida sihtmärk:"
 
-#: infobox.c:654
-#: infobox.c:657
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Avatakse:"
 
-#: infobox.c:654
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Käivita fail"
 
-#: infobox.c:749
+#: infobox.c:805
+#, fuzzy
+msgid "Comment"
+msgstr "Käsk:"
+
+#: infobox.c:807
+#, fuzzy
+msgid "Execute"
+msgstr "Käivita fail"
+
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<veel ei midagi>"
 
-#: infobox.c:819
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "file(1) ütleb... %s"
 
-#: infobox.c:876
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Ei suutnud muuta %s loabitte"
 
-#: infobox.c:894
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Omanik"
 
-#: infobox.c:896
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Grupp"
 
-#: infobox.c:898
+#: infobox.c:974
 msgid "World"
 msgstr "Maailm"
 
-#: infobox.c:901
+#: infobox.c:977
 msgid "Read"
 msgstr "Loe"
 
-#: infobox.c:903
+#: infobox.c:980
 msgid "Write"
 msgstr "Kirjuta"
 
-#: infobox.c:905
+#: infobox.c:983
 msgid "Exec"
 msgstr "Käivita"
 
-#: infobox.c:922
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:929
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:936
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky"
 
-#: infobox.c:958
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<eimidagi>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Sümbolviit"
 
-#: infobox.c:961
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX rakendus"
 
-#: infobox.c:969
+#: infobox.c:1100
 msgid "mounted"
 msgstr "ühendatud"
 
-#: infobox.c:969
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "lahutatud"
 
-#: infobox.c:973
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "%s ühenduspunkt (%s)"
 
-#: infobox.c:976
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Ühenduspunkt (%s)"
+
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d elementi"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Kopeeri..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "Muuda elementi"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Ajad"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Eelistused"
 
 #: main.c:95
 msgid ""
@@ -1872,6 +2064,7 @@ msgstr ""
 "\n"
 
 #: main.c:115
+#, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Open each directory or file listed, or the current working\n"
@@ -1893,10 +2086,12 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
-"Report bugs to "
+"Report bugs to %s.\n"
+"Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
 "Kasutamine: ROX-Filer/AppRun [VÕTI]... [FAIL]...\n"
 "Ava iga käsureal ette antud kataloog/fail või \n"
@@ -1922,508 +2117,683 @@ msgstr ""
 "\n"
 "Vigadest teatage "
 
-#: main.c:136
+#: main.c:237
 msgid ""
-".\n"
-"Home page (including updated versions): http://rox.sourceforge.net/\n"
-msgstr ""
-".\n"
-"Kodulehekülg (kus ka uued versioonid): http://rox.sourceforge.net/\n"
-
-#: main.c:234
-msgid ""
-"We got a BadWindow error from the X server. This might be due to this GTK bug (during drag-and-drop?):\n"
+"We got a BadWindow error from the X server. This might be due to this GTK "
+"bug (during drag-and-drop?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Trying to continue..."
 msgstr ""
-"Me saime BadWindow vea X serverilt. See võib olla tingitud järgnevast GTK puugist (lohistamise ajal?):\n"
+"Me saime BadWindow vea X serverilt. See võib olla tingitud järgnevast GTK "
+"puugist (lohistamise ajal?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Üritan jätkata..."
 
-#: main.c:392
-msgid "The -o argument is no longer used. You can turn on override redirect from the Options box instead."
-msgstr "Käsurea võti -o pole enam kasutusel. See on tõstetud Eelistused->Ühilduvus alla."
+#: main.c:399
+msgid ""
+"The -o argument is no longer used. You can turn on override redirect from "
+"the Options box instead."
+msgstr ""
+"Käsurea võti -o pole enam kasutusel. See on tõstetud Eelistused->Ühilduvus "
+"alla."
 
-#: main.c:513
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Jookse kasutaja '%s' nime all"
 
-#: main.c:678
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Kompileeritud GTK versiooniga %s\n"
 
-#: main.c:679
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Jookseb GTK versiooniga %d.%d.%d\n"
 
-#: main.c:683
+#: main.c:693
 msgid "features set at compile time"
 msgstr "kompileerimise ajal seatud eelistused"
 
-#: main.c:684
+#: main.c:694
 msgid "Large File Support"
 msgstr "Suurte failide toetus"
 
-#: main.c:691
-msgid "Dnotify support"
-msgstr "Dnotify-toetus"
-
-#: main.c:698
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Binaarne ühilduvus"
 
-#: main.c:700
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Jah (suudab joosta ka vanemate glibc versioonidega)"
 
-#: main.c:702
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Ei (apsymbols.h ei leitud)"
 
-#: main.c:706
+#: main.c:709
 msgid "Extended attribute support"
 msgstr "Laiendatud atribuutide toetus"
 
-#: menu.c:179
-#: tips:53
-msgid "Display"
-msgstr "Vaade"
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr "Faili '%s' avamine ebaõnnestus: %s"
 
-#: menu.c:180
-#: tips:58
-msgid "Icons View"
-msgstr "Ikoonivaade"
-
-#: menu.c:181
-msgid "Icons, With..."
-msgstr "Ikoonid ja..."
-
-#: menu.c:182
-#: tips:75
-msgid "Sizes"
-msgstr "Suurused"
-
-#: menu.c:184
-#: tips:255
-msgid "Types"
-msgstr "Tüübid"
-
-#: menu.c:185
-#: tips:78
-msgid "Times"
-msgstr "Ajad"
-
-#: menu.c:186
-#: tips:59
-#: tips:93
-msgid "List View"
-msgstr "Loend-vaade"
-
-#: menu.c:188
-msgid "Bigger Icons"
-msgstr "Suuremad ikoonid"
-
-#: menu.c:189
-msgid "Smaller Icons"
-msgstr "Väiksemad ikoonid"
-
-#: menu.c:190
-#: tips:72
-msgid "Automatic"
-msgstr "Automaatne"
-
-#: menu.c:192
-msgid "Sort by Name"
-msgstr "Sorteeri nime järgi"
-
-#: menu.c:193
-msgid "Sort by Type"
-msgstr "Sorteeri tüübi järgi"
-
-#: menu.c:194
-msgid "Sort by Date"
-msgstr "Sorteeri kuupäeva järgi"
-
-#: menu.c:195
-msgid "Sort by Size"
-msgstr "Sorteeri suuruse järgi"
-
-#: menu.c:196
-msgid "Sort by Owner"
-msgstr "Sorteeri omaniku järgi"
-
-#: menu.c:197
-msgid "Sort by Group"
-msgstr "Sorteeri grupi järgi"
-
-#: menu.c:198
-msgid "Reversed"
-msgstr "Pööratud järjekorras"
-
-#: menu.c:200
-msgid "Show Hidden"
-msgstr "Näita peidetud"
-
-#: menu.c:201
-msgid "Filter Files..."
-msgstr "Filtreeri faile..."
-
-#: menu.c:202
-msgid "Show Thumbnails"
-msgstr "Näita pisipilte"
-
-#: menu.c:203
-msgid "Refresh"
-msgstr "Värskenda"
-
-#: menu.c:204
-msgid "Save Display Settings..."
-msgstr "Salvesta ekraaniasetused..."
-
-#: menu.c:206
-msgid "Copy..."
-msgstr "Kopeeri..."
-
-#: menu.c:207
-msgid "Rename..."
-msgstr "Nimeta ümber..."
-
-#: menu.c:208
-msgid "Link..."
-msgstr "Loo viit..."
-
-#: menu.c:212
-msgid "Send To..."
-msgstr "Ava kasutades..."
-
-#: menu.c:217
-msgid "Count"
-msgstr "Loenda"
-
-#: menu.c:218
-msgid "Set Type..."
-msgstr "Sea tüüp..."
-
-#: menu.c:222
-#: toolbar.c:155
-msgid "Select"
-msgstr "Vali"
-
-#: menu.c:223
-msgid "Select All"
-msgstr "Vali kõik"
-
-#: menu.c:224
-msgid "Clear Selection"
-msgstr "Tühista valik"
-
-#: menu.c:225
-msgid "Invert Selection"
-msgstr "Pööra valik ümber"
-
-#: menu.c:226
-msgid "Select by Name..."
-msgstr "Vali nime järgi..."
-
-#: menu.c:227
-msgid "Select If..."
-msgstr "Vali mustri abil..."
-
-#: menu.c:229
-msgid "New"
-msgstr "Uus"
-
-#: menu.c:231
-msgid "Blank file"
-msgstr "Tühi fail"
-
-#: menu.c:233
-#: tasklist.c:308
-msgid "Window"
-msgstr "Aken"
-
-#: menu.c:234
-msgid "Parent, New Window"
-msgstr "Ava ülemine kataloog uues aknas"
-
-#: menu.c:235
-msgid "Parent, Same Window"
-msgstr "Ava ülemine kataloog samas aknas"
-
-#: menu.c:236
-msgid "New Window"
-msgstr "Uus aken"
-
-#: menu.c:238
-msgid "Show Bookmarks"
-msgstr "Näita järjehoidjaid"
-
-#: menu.c:239
-msgid "Follow Symbolic Links"
-msgstr "Järgi sümbolviitu"
-
-#: menu.c:240
-msgid "Resize Window"
-msgstr "Kohalda akna suurust"
-
-#: menu.c:243
-msgid "Close Window"
-msgstr "Sulge aken"
-
-#: menu.c:245
-msgid "Enter Path..."
-msgstr "Sisesta tee..."
-
-#: menu.c:246
-msgid "Shell Command..."
-msgstr "Käsurea korraldus..."
-
-#: menu.c:247
-msgid "Terminal Here"
-msgstr "Terminal siia"
-
-#: menu.c:248
-msgid "Switch to Terminal"
-msgstr "Hüppa terminali"
-
-#: menu.c:716
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "Klõpsake Shift+Menüü faili kohal, et seda kuhugi saata"
-
-#: menu.c:752
-msgid "Next Click"
-msgstr "Järgmine klõps"
-
-#: menu.c:774
+#: main.c:895
 #, c-format
-msgid "%d items"
-msgstr "%d elementi"
-
-#: menu.c:862
-msgid "Open unmounted"
-msgstr "Ava, aga ära ühenda"
-
-#: menu.c:865
-msgid "Show Target"
-msgstr "Näita sihtkohta"
-
-#: menu.c:867
-msgid "Look Inside"
-msgstr "Vaata sisse"
-
-#: menu.c:869
-msgid "Open As Text"
-msgstr "Ava tekstina"
-
-#: menu.c:1029
 msgid ""
-"Extended attributes, used to store types, are not supported for this file or files.\n"
-"This may be due to lack of support from the filesystem or the C library, or it may simply be that the filesystem needs to be mounted with the right mount option ('user_xattr' on Linux)."
+"Left-click to run %s.\n"
+"Right-click for a list of versions."
 msgstr ""
-"Laiendatud atribuudid, mida kasutatakse tüübi salvestamiseks, pole selle faili või failide puhul toetatud.\n"
-"Selle põhjuseks võib olla atribuutide toetuse puudumine failisüsteemil või C-teegil, või ka lihtsalt peaksite failisüsteemi ühendamisel edastama õige suvandi ('user_xattr' Linuxi puhul)."
 
-#: menu.c:1035
-msgid "Setting type not supported for some of these files"
-msgstr "Tüübi seadmine pole mõnede antud failide puhul toetatud"
-
-#: menu.c:1070
-msgid "_Relative link"
-msgstr "_Relative link"
-
-#: menu.c:1076
-msgid ""
-"If on, the symlink will store the path from the symlink to the target file. Use this if the symlink and the target will be moved together.\n"
-"If off, the path from the root directory is stored - use this if the symlink may move but the target will stay put."
-msgstr ""
-"Kui selle suvandi sisse lülite, salvestatakse viida juures teekond sihtfailini. Kasutage seda siis, kui soovite viita ja sihtfaili koos liigutada.\n"
-"Kui suvandi välja lülite, salvestatakse viida juures teekond sihtfailini juurkataloogist. Kasutage siis, kui liigutate viita, aga mitte sihtfaili."
-
-#: menu.c:1146
-msgid "New pathname is not absolute"
-msgstr "Failitee pole absoluutne"
-
-#: menu.c:1212
-#, c-format
-msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
-msgstr "Sümbolviit '%s' on juba olemas. Asendada see viidaga failile '%s'?"
-
-#: menu.c:1218
-msgid "_Replace"
-msgstr "_Asenda"
-
-#: menu.c:1338
-#: menu.c:1379
-#: menu.c:1439
-msgid "Create"
-msgstr "Tekita"
-
-#: menu.c:1339
-msgid "NewDir"
-msgstr "UusKataloog"
-
-#: menu.c:1353
-#: menu.c:1359
+#: main.c:942 menu.c:1723 menu.c:1729
 #, c-format
 msgid "Error creating '%s': %s"
 msgstr "Faili '%s' loomisel oli viga: %s"
 
-#: menu.c:1380
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Salvesta kui:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
+msgid "Display"
+msgstr "Vaade"
+
+#: menu.c:641 tips:49
+msgid "Icons View"
+msgstr "Ikoonivaade"
+
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
+msgstr "Ikoonid ja..."
+
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Ikooniteema"
+
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Õigused"
+
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Ikoonid ja..."
+
+#: menu.c:647 tips:50 tips:98 tips:99
+msgid "List View"
+msgstr "Loend-vaade"
+
+#: menu.c:651
+msgid "Bigger Icons"
+msgstr "Suuremad ikoonid"
+
+#: menu.c:653
+msgid "Smaller Icons"
+msgstr "Väiksemad ikoonid"
+
+#: menu.c:655 tips:71
+msgid "Automatic"
+msgstr "Automaatne"
+
+#: menu.c:661
+msgid "Sort by Name"
+msgstr "Sorteeri nime järgi"
+
+#: menu.c:662
+msgid "Sort by Type"
+msgstr "Sorteeri tüübi järgi"
+
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
+msgstr "Sorteeri kuupäeva järgi"
+
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Sorteeri kuupäeva järgi"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Sorteeri kuupäeva järgi"
+
+#: menu.c:666
+msgid "Sort by Size"
+msgstr "Sorteeri suuruse järgi"
+
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Õigused"
+
+#: menu.c:668
+msgid "Sort by Owner"
+msgstr "Sorteeri omaniku järgi"
+
+#: menu.c:669
+msgid "Sort by Group"
+msgstr "Sorteeri grupi järgi"
+
+#: menu.c:671
+msgid "Reversed"
+msgstr "Pööratud järjekorras"
+
+#: menu.c:675
+msgid "Show Hidden"
+msgstr "Näita peidetud"
+
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Näita abiinfot"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "pole katalooge)\n"
+
+#: menu.c:679
+msgid "Filter Files..."
+msgstr "Filtreeri faile..."
+
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Filtreeri faile..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
+msgid "Show Thumbnails"
+msgstr "Näita pisipilte"
+
+#: menu.c:683
+msgid "Refresh"
+msgstr "Värskenda"
+
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Värskenda"
+
+#: menu.c:686
+msgid "Save Display Settings..."
+msgstr "Salvesta ekraaniasetused..."
+
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Salvesta ekraaniasetused..."
+
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Loenda"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
+msgid "Rename..."
+msgstr "Nimeta ümber..."
+
+#: menu.c:700
+msgid "Link..."
+msgstr "Loo viit..."
+
+#: menu.c:708
+msgid "Send To..."
+msgstr "Ava kasutades..."
+
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Laiendatud atribuudid"
+
+#: menu.c:721
+msgid "Count"
+msgstr "Loenda"
+
+#: menu.c:723
+msgid "Set Type..."
+msgstr "Sea tüüp..."
+
+#: menu.c:731 toolbar.c:179
+msgid "Select"
+msgstr "Vali"
+
+#: menu.c:733
+msgid "Select All"
+msgstr "Vali kõik"
+
+#: menu.c:735
+msgid "Clear Selection"
+msgstr "Tühista valik"
+
+#: menu.c:736
+msgid "Invert Selection"
+msgstr "Pööra valik ümber"
+
+#: menu.c:737
+msgid "Select by Name..."
+msgstr "Vali nime järgi..."
+
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Vali mustri abil..."
+
+#: menu.c:741
+msgid "Select If..."
+msgstr "Vali mustri abil..."
+
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
+msgid "New"
+msgstr "Uus"
+
+#: menu.c:752
+msgid "Blank file"
+msgstr "Tühi fail"
+
+#: menu.c:756 tasklist.c:305
+msgid "Window"
+msgstr "Aken"
+
+#: menu.c:758
+msgid "Parent, New Window"
+msgstr "Ava ülemine kataloog uues aknas"
+
+#: menu.c:759
+msgid "Parent, Same Window"
+msgstr "Ava ülemine kataloog samas aknas"
+
+#: menu.c:761 tips:44
+msgid "New Window"
+msgstr "Uus aken"
+
+#: menu.c:764
+msgid "Show Bookmarks"
+msgstr "Näita järjehoidjaid"
+
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Näita infot"
+
+#: menu.c:768
+msgid "Follow Symbolic Links"
+msgstr "Järgi sümbolviitu"
+
+#: menu.c:769
+msgid "Resize Window"
+msgstr "Kohalda akna suurust"
+
+#: menu.c:771
+msgid "Close Window"
+msgstr "Sulge aken"
+
+#: menu.c:776
+msgid "Enter Path..."
+msgstr "Sisesta tee..."
+
+#: menu.c:778
+msgid "Shell Command..."
+msgstr "Käsurea korraldus..."
+
+#: menu.c:780
+msgid "Terminal Here"
+msgstr "Terminal siia"
+
+#: menu.c:782
+msgid "Switch to Terminal"
+msgstr "Hüppa terminali"
+
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Kohanda menüüd..."
+
+#: menu.c:976
+msgid "Next Click"
+msgstr "Järgmine klõps"
+
+#: menu.c:998
+#, c-format
+msgid "%d items"
+msgstr "%d elementi"
+
+#: menu.c:1094
+msgid "Open unmounted"
+msgstr "Ava, aga ära ühenda"
+
+#: menu.c:1097
+msgid "Show Target"
+msgstr "Näita sihtkohta"
+
+#: menu.c:1099
+msgid "Look Inside"
+msgstr "Vaata sisse"
+
+#: menu.c:1101
+msgid "Open As Text"
+msgstr "Ava tekstina"
+
+#: menu.c:1320
+msgid ""
+"Extended attributes, used to store types, are not supported for this file or "
+"files.\n"
+"This may be due to lack of support from the filesystem or the C library, or "
+"it may simply be that the filesystem needs to be mounted with the right "
+"mount option ('user_xattr' on Linux)."
+msgstr ""
+"Laiendatud atribuudid, mida kasutatakse tüübi salvestamiseks, pole selle "
+"faili või failide puhul toetatud.\n"
+"Selle põhjuseks võib olla atribuutide toetuse puudumine failisüsteemil või C-"
+"teegil, või ka lihtsalt peaksite failisüsteemi ühendamisel edastama õige "
+"suvandi ('user_xattr' Linuxi puhul)."
+
+#: menu.c:1326
+msgid "Setting type not supported for some of these files"
+msgstr "Tüübi seadmine pole mõnede antud failide puhul toetatud"
+
+#: menu.c:1364
+msgid "_Relative link"
+msgstr "_Relative link"
+
+#: menu.c:1370
+msgid ""
+"If on, the symlink will store the path from the symlink to the target file. "
+"Use this if the symlink and the target will be moved together.\n"
+"If off, the path from the root directory is stored - use this if the symlink "
+"may move but the target will stay put."
+msgstr ""
+"Kui selle suvandi sisse lülite, salvestatakse viida juures teekond "
+"sihtfailini. Kasutage seda siis, kui soovite viita ja sihtfaili koos "
+"liigutada.\n"
+"Kui suvandi välja lülite, salvestatakse viida juures teekond sihtfailini "
+"juurkataloogist. Kasutage siis, kui liigutate viita, aga mitte sihtfaili."
+
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
+msgid "New pathname is not absolute"
+msgstr "Failitee pole absoluutne"
+
+#: menu.c:1540
+#, c-format
+msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
+msgstr "Sümbolviit '%s' on juba olemas. Asendada see viidaga failile '%s'?"
+
+#: menu.c:1546
+msgid "_Replace"
+msgstr "_Asenda"
+
+#: menu.c:1704
+msgid "NewDir"
+msgstr "UusKataloog"
+
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Tekita"
+
+#: menu.c:1755
 msgid "NewFile"
 msgstr "UusFail"
 
-#: menu.c:1398
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "Viga faili loomisel: ei leidnud malli %s jaoks"
 
-#: menu.c:1469
-#, c-format
+#: menu.c:1847
+#, fuzzy
 msgid ""
-"The `Send To' menu provides a quick way to send some files to an application. The applications listed are those in the following directories:\n"
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Loo antud kataloogi sümbolviidad programmidele, mida soovid näha kõigi tüüpi "
+"(%s/%s) objektide puhul menüüs"
+
+#: menu.c:1883
+#, fuzzy, c-format
+msgid ""
+"The `Send To' menu provides a quick way to send some files to an "
+"application. The applications listed are those in the following "
+"directories:\n"
 "\n"
 "%s\n"
 "%s\n"
 "The `Send To' menu may be opened by Shift+Menu clicking over a file.\n"
 "\n"
 "Advanced use:\n"
-"You can also create subdirectories called `.text_html', `.text', etc which will only be shown for files of that type. `.group' is shown only when multiple files are selected."
+"You can also create subdirectories called `.text_html', `.text', etc which "
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
-"`Ava kasutades'-menüü võimaldab määrata failide avamiseks rakendusi (või nende viitasid), mis asuvad järgnevates kataloogides:\n"
+"`Ava kasutades'-menüü võimaldab määrata failide avamiseks rakendusi (või "
+"nende viitasid), mis asuvad järgnevates kataloogides:\n"
 "\n"
 "%s\n"
 "%s\n"
-"`Ava kasutades'-menüü avaneb, klõpsates Shift+Menüü (vaikimisi parem hiirenupp) faili peal.\n"
+"`Ava kasutades'-menüü avaneb, klõpsates Shift+Menüü (vaikimisi parem "
+"hiirenupp) faili peal.\n"
 "Edasijõudnud kasutus:\n"
-"Te võite ka luua alamkatalooge nimedega `.text_html', `.text', jne, mida näidatakse vaid vastavat tüüpi failide puhul. `.group' näidatakse juhul, kui mitu faili on valitud."
+"Te võite ka luua alamkatalooge nimedega `.text_html', `.text', jne, mida "
+"näidatakse vaid vastavat tüüpi failide puhul. `.group' näidatakse juhul, kui "
+"mitu faili on valitud."
 
-#: menu.c:1480
-msgid "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift drag) any applications you want into it."
-msgstr "Näitan 'Ava kasutades' kataloogi; Te saate sinna luua viitasid (Ctrl+Shift-lohista) rakendustele."
+#: menu.c:1895
+msgid ""
+"I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
+"drag) any applications you want into it."
+msgstr ""
+"Näitan 'Ava kasutades' kataloogi; Te saate sinna luua viitasid (Ctrl+Shift-"
+"lohista) rakendustele."
 
-#: menu.c:1483
-#: menu.c:1523
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
-msgstr "Vabandust: Teie CHOICESPATH muutuja lubab eelistusi muuta vaid kasutajal root."
+msgstr ""
+"Vabandust: Teie CHOICESPATH muutuja lubab eelistusi muuta vaid kasutajal "
+"root."
 
-#: menu.c:1516
+#: menu.c:1931
 #, c-format
 msgid ""
-"Any files placed in your Templates directories will appear on the `New' menu. Choosing one of them will make a copy of it as the new file.\n"
+"Any files placed in your Templates directories will appear on the `New' "
+"menu. Choosing one of them will make a copy of it as the new file.\n"
 "\n"
 "The following directories contain templates:\n"
 "\n"
 "%s\n"
 "%s\n"
 msgstr ""
-"Teie Mallide kataloogi paigutatud failid on näha `Uus' menüüs. Nendest mõna valimine tekitab uue failina koopia mallist.\n"
+"Teie Mallide kataloogi paigutatud failid on näha `Uus' menüüs. Nendest mõna "
+"valimine tekitab uue failina koopia mallist.\n"
 "\n"
 "Järgnevad kataloogid sisaldavad malle:\n"
 "\n"
 "%s\n"
 "%s\n"
 
-#: menu.c:1521
-msgid "I'll show you your Templates directory now; you should place any template files you want inside it."
+#: menu.c:1936
+msgid ""
+"I'll show you your Templates directory now; you should place any template "
+"files you want inside it."
 msgstr "Näitan Mallide kataloogi; Te saate mallide failid panna sinna sisse."
 
-#: menu.c:1638
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Kohanda"
 
-#: menu.c:1704
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Kohanda menüüd..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "See ongi juba antud kataloogi kanooniline nimi."
 
-#: menu.c:1735
-msgid "You can't open a second view onto this directory because the `Unique Windows' option is turned on in the Options window."
-msgstr "Te ei saa avada teist akent selle kataloogiga, kuna eelistustes on aktiveeritud  'Näita ühes aknas'."
+#: menu.c:2200
+msgid ""
+"You can't open a second view onto this directory because the `Unique "
+"Windows' option is turned on in the Options window."
+msgstr ""
+"Te ei saa avada teist akent selle kataloogiga, kuna eelistustes on "
+"aktiveeritud  'Näita ühes aknas'."
 
-#: menu.c:1861
-msgid "Copy ... ?"
-msgstr "Kopeeri ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1864
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Kopeeri %s nime alla %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Kopeeri %s nime alla %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Nimeta ümber ... ?"
 
-#: menu.c:1867
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Tekita viit ... ?"
 
-#: menu.c:1870
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Ava tekstina ... ?"
 
-#: menu.c:1873
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Omadused ... ?"
 
-#: menu.c:1876
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Laiendatud atribuudid"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Sea ... tüüpi ?"
 
-#: menu.c:1879
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Avaja seadmine ... jaoks ?"
 
-#: menu.c:1882
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Sea ... ikooni ?"
 
-#: menu.c:1885
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Ava ... kasutades ... ?"
 
-#: menu.c:1888
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "KUSTUTA ... ?"
 
-#: menu.c:1891
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Loenda kokku ... suurused ?"
 
-#: menu.c:1894
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Muuda ... loabitte ?"
 
-#: menu.c:1897
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Otsi ... seest ?"
 
-#: menu.c:1961
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Kopeeri ... ?"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Antud tegevust ei saa läbi viia mitme failiga"
 
-#: menu.c:1993
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Nimeta ümber"
 
-#: menu.c:1998
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Loo viit"
 
-#: menu.c:2027
+#: menu.c:2654
 msgid ""
-"User-definable shortcuts are disabled by default in Gtk2, and you have not enabled them. You can turn this feature on by:\n"
+"User-definable shortcuts are disabled by default in Gtk2, and you have not "
+"enabled them. You can turn this feature on by:\n"
 "\n"
-"1) using an XSettings manager, such as ROX-Session or gnome-settings-daemon, or\n"
+"1) using an XSettings manager, such as ROX-Session or gnome-settings-daemon, "
+"or\n"
 "\n"
 "2) adding this line to ~/.gtkrc-2.0:\n"
 "\tgtk-can-change-accels = 1\n"
 "\t(this only works if NOT using XSETTINGS)"
 msgstr ""
-"Kiirklahvide kasutajate poolt muutmine on Gtk2 rakendustes vaikimisi keelatud. Te saate need lubada järgnevalt:\n"
-"1) Kasutades XSettings-haldurit, nagu näiteks ROX-Session või gnome-settings-daemon, või\n"
+"Kiirklahvide kasutajate poolt muutmine on Gtk2 rakendustes vaikimisi "
+"keelatud. Te saate need lubada järgnevalt:\n"
+"1) Kasutades XSettings-haldurit, nagu näiteks ROX-Session või gnome-settings-"
+"daemon, või\n"
 "\n"
 "2) Lisades faili ~/.gtkrc-2.0 rea:\n"
 "\tgtk-can-change-accels = 1\n"
 "\t(see töötab vaid siis, kui te EI kasuta XSETTINGS)"
 
-#: menu.c:2038
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2431,7 +2801,8 @@ msgid ""
 "- Move the pointer over the item you want to use,\n"
 "- Press the key you want attached to it.\n"
 "\n"
-"The key will appear next to the menu item and you can just press that key without opening the menu in future."
+"The key will appear next to the menu item and you can just press that key "
+"without opening the menu in future."
 msgstr ""
 "Kiirklahvide määramiseks:\n"
 "\n"
@@ -2439,41 +2810,77 @@ msgstr ""
 "- Liikuge hiirekursoriga soovitud tegevuse kohale,\n"
 "- Vajutage kiirklahvi, mida soovite tegevusele määrata.\n"
 "\n"
-" Määratud kiirklahv ilmub nähtavale menüüs tegevuse kõrval. Edaspidi piisab tegevuse väljakutsumiseks kiirklahvi vajutamisest ja menüüd pole vaja avada."
+" Määratud kiirklahv ilmub nähtavale menüüs tegevuse kõrval. Edaspidi piisab "
+"tegevuse väljakutsumiseks kiirklahvi vajutamisest ja menüüd pole vaja avada."
 
-#: menu.c:2053
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Määra kiirklahve"
 
-#: minibuffer.c:131
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Mine:"
 
-#: minibuffer.c:132
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Shell:"
 
-#: minibuffer.c:133
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Vali mustri abil:"
 
-#: minibuffer.c:134
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Vali nimetatud:"
 
-#: minibuffer.c:135
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Vali mustri abil:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Mall:"
 
-#: minibuffer.c:264
-msgid "Enter the name of a file and I'll display it for you. Press Tab to fill in the longest match. Escape to close the minibuffer."
-msgstr "Sisestage failinimi, mida näidata. TAB klahv lõpetab nimesid. Esc klahv sulgeb minipuhvri."
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
 
-#: minibuffer.c:270
-msgid "Enter a shell command to execute. Click on a file to add it to the buffer."
-msgstr "Sisestage täidetav shelli käsk. Klõpsake failil, lisamaks seda puhvrisse."
+#: minibuffer.c:320
+msgid ""
+"Enter the name of a file and I'll display it for you. Press Tab to fill in "
+"the longest match. Escape to close the minibuffer."
+msgstr ""
+"Sisestage failinimi, mida näidata. TAB klahv lõpetab nimesid. Esc klahv "
+"sulgeb minipuhvri."
 
-#: minibuffer.c:275
+#: minibuffer.c:326
+msgid ""
+"Enter a shell command to execute. Click on a file to add it to the buffer."
+msgstr ""
+"Sisestage täidetav shelli käsk. Klõpsake failil, lisamaks seda puhvrisse."
+
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Siseta failinime muster, et valida kõik sobivad failid:\n"
+"\n"
+"? tähendab ühte suvalist märki\n"
+"* tähendab 0 või mitu suvalist märki\n"
+"[aA] tähendab 'a' või 'A'\n"
+"[a-z] tähendab märki a ja z vahel (väiksed tähed)\n"
+"*.png tähendab ükskõiik millist '.png' lõpuga nime"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2491,46 +2898,63 @@ msgstr ""
 "[a-z] tähendab märki a ja z vahel (väiksed tähed)\n"
 "*.png tähendab ükskõiik millist '.png' lõpuga nime"
 
-#: minibuffer.c:287
-msgid "Enter a pattern to match for files to be shown.  An empty filter turns the filter off."
-msgstr "Sisesta muster, millele vastavaid faile kuvatakse.  Tühja filtri puhul lülitakse filter välja."
+#: minibuffer.c:352
+msgid ""
+"Enter a pattern to match for files to be shown.  An empty filter turns the "
+"filter off."
+msgstr ""
+"Sisesta muster, millele vastavaid faile kuvatakse.  Tühja filtri puhul "
+"lülitakse filter välja."
 
-#: minibuffer.c:907
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Sisesta muster, millele vastavaid faile kuvatakse.  Tühja filtri puhul "
+"lülitakse filter välja."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Vigane otsinguparameeter"
 
-#: mount.c:374
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s·kokku,·%s·kasutusel,·%s·vaba·(%.1f·%%)"
 
-#: options.c:277
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "Teie vana eelistustefail teisendati uude XML-põhisesse vormingusse"
 
-#: options.c:535
-#: options.c:1257
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(kasuta vaikimisi asetusi)"
 
-#: options.c:805
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Sisemine viga: %s pole loetav"
 
-#: options.c:916
+#: options.c:929
 msgid "Options"
 msgstr "Eelistused"
 
-#: options.c:961
+#: options.c:974
 msgid "_Revert"
 msgstr "_Taastatav"
 
-#: options.c:967
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr "Taasta kõik asetused eelistuste akna avamise hetke seisule."
 
-#: options.c:982
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2539,42 +2963,55 @@ msgstr ""
 "Eelistused salvestati nime alla:\n"
 "%s"
 
-#: options.c:990
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(CHOICESPATH keelab muudatuste salvestamise)"
 
-#: options.c:1163
-#: usericons.c:450
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Viga %s salvestamisel: %s"
 
-#: options.c:1794
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Puudub '='"
 
-#: panel.c:439
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr "Faili '%s' avamine ebaõnnestus: %s"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "Teie paneeli asetused on teisendati uude XML-põhisesse vormingusse."
 
-#: panel.c:546
-msgid "You have tried to close a panel via the window manager - I usually find that this is accidental... really close?"
-msgstr "Te üritasite paneeli sulgeda aknahalduri kaudu - enamasti pole see soovitud ... Tõesti sulgeda ?"
+#: panel.c:670
+msgid ""
+"You have tried to close a panel via the window manager - I usually find that "
+"this is accidental... really close?"
+msgstr ""
+"Te üritasite paneeli sulgeda aknahalduri kaudu - enamasti pole see "
+"soovitud ... Tõesti sulgeda ?"
 
-#: panel.c:639
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Puuduv < või > paneeli asetuste failis"
 
-#: panel.c:1519
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Paneeli %s salvestamisel oli viga : %s"
 
-#: panel.c:1835
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "Applet väljus ilma kasutajaliidese elementi loomata!"
 
-#: panel.c:1934
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2583,148 +3020,176 @@ msgstr ""
 "Viga appleti käivitamisel:\n"
 "%s"
 
-#: panel.c:2338
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "Kas tõesti soovite avada %d akent?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Eemalda elemente"
+
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Paneeli valikud..."
 
-#: panel.c:2430
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Xinerama ekraan %d pole saadaval"
 
-#: panel.c:2505
-msgid "Panel Options"
-msgstr "Paneeli valikud"
+#: panel.c:2897
+msgid "Top"
+msgstr ""
 
-#: panel.c:2520
-#, c-format
-msgid "Panel: %s"
-msgstr "Paneel: %s"
-
-#: panel.c:2528
-msgid "Select the panel's position:"
-msgstr "Vali paneeli asend:"
-
-#: panel.c:2534
-msgid "Top-edge panel"
-msgstr "Paneel üleval servas"
-
-#: panel.c:2535
-msgid "Top edge"
-msgstr "Üleval"
-
-#: panel.c:2536
-msgid "Bottom edge panel"
-msgstr "Paneel all servas"
-
-#: panel.c:2537
-msgid "Bottom edge"
+#: panel.c:2899
+#, fuzzy
+msgid "Bottom"
 msgstr "Alumine serv"
 
-#: panel.c:2538
-msgid "Left edge panel"
-msgstr "Paneel vasakul servas"
-
-#: panel.c:2539
-msgid "Left edge"
+#: panel.c:2901
+#, fuzzy
+msgid "Left"
 msgstr "Vasakul"
 
-#: panel.c:2540
-msgid "Right-edge panel"
-msgstr "Paneel paremal servas"
-
-#: panel.c:2541
-msgid "Right edge"
+#: panel.c:2903
+#, fuzzy
+msgid "Right"
 msgstr "Paremal"
+
+#: panel.c:2905
+#, fuzzy
+msgid "Default"
+msgstr "Vaikimisi suurus:"
+
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "Tundmatu"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
 msgstr "Teie töölaua asetuste fail teisaldati uude XML-põhisesse vormingusse."
 
-#: pinboard.c:635
-msgid "The backdrop handler must be an application directory. Drag an application directory into the Set Backdrop dialog box, or (for programmers) pass it to the SOAP SetBackdropApp method."
-msgstr "Taustahaldur peab olema kataloograkendus. Lohistage kataloograkendus 'Muuda tausta' dialoogikasti või (programmeerijate jaoks) edastage see SOAP SetBackdropApp meetodi argumendina."
-
-#: pinboard.c:654
+#: pinboard.c:711
 msgid ""
-"You can only set the backdrop to an image or to a program which knows how to manage ROX-Filer's backdrop.\n"
-"\n"
-"Programmers: the application's AppInfo.xml must contain the CanSetBackdrop element, as described in ROX-Filer's manual."
+"The backdrop handler must be an application directory. Drag an application "
+"directory into the Set Backdrop dialog box, or (for programmers) pass it to "
+"the SOAP SetBackdropApp method."
 msgstr ""
-"Taustaks saate määrata kas pildi või rakenduse, mis oskab hallata Rox-Filer'i tausta.\n"
-"\n"
-"Programmeerijatele: rakenduse Appinfo.xml peab sisaldama CanSetBackdrop elementi, nagu kirjeldatud ROX-Filer'i käsiraamatus."
+"Taustahaldur peab olema kataloograkendus. Lohistage kataloograkendus 'Muuda "
+"tausta' dialoogikasti või (programmeerijate jaoks) edastage see SOAP "
+"SetBackdropApp meetodi argumendina."
 
-#: pinboard.c:674
+#: pinboard.c:730
+msgid ""
+"You can only set the backdrop to an image or to a program which knows how to "
+"manage ROX-Filer's backdrop.\n"
+"\n"
+"Programmers: the application's AppInfo.xml must contain the CanSetBackdrop "
+"element, as described in ROX-Filer's manual."
+msgstr ""
+"Taustaks saate määrata kas pildi või rakenduse, mis oskab hallata Rox-"
+"Filer'i tausta.\n"
+"\n"
+"Programmeerijatele: rakenduse Appinfo.xml peab sisaldama CanSetBackdrop "
+"elementi, nagu kirjeldatud ROX-Filer'i käsiraamatus."
+
+#: pinboard.c:750
 msgid "Set backdrop"
 msgstr "Muuda tausta"
 
-#: pinboard.c:685
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
 msgstr "Vali tausta positsioon ja lohista pilt kasti:"
 
-#: pinboard.c:698
+#: pinboard.c:774
 msgid "Centre the image without scaling it"
 msgstr "Keskjoonda pilt ilma maksimiseerimata"
 
-#: pinboard.c:699
+#: pinboard.c:775
 msgid "Centre"
 msgstr "Keskjoonda"
 
-#: pinboard.c:700
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr "Maksimiseeri pilt üle tausta ilma mõõtude suhet muutmata"
 
-#: pinboard.c:702
+#: pinboard.c:778
 msgid "Scale"
 msgstr "Maksimiseeri"
 
-#: pinboard.c:703
+#: pinboard.c:779
+#, fuzzy
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr "Maksimiseeri pilt üle tausta ilma mõõtude suhet muutmata"
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Filter"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
 msgstr "Venita pilt üle tausta"
 
-#: pinboard.c:704
+#: pinboard.c:783
 msgid "Stretch"
 msgstr "Venita"
 
-#: pinboard.c:705
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr "Laota pilt taustale paanidena"
 
-#: pinboard.c:706
+#: pinboard.c:785
 msgid "Tile"
 msgstr "Paanidena"
 
-#: pinboard.c:711
+#: pinboard.c:790
 msgid "Drop an image here"
 msgstr "Lohistage siia pilt"
 
-#: pinboard.c:772
-msgid "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox -p=Default' to turn it on in future."
-msgstr "Töölaua asetusi ei leitud. Avan vaikimisi töölaua.Kasutage ROX-Filer'i käivitamisel parameetrit 'rox -p=Default', et sama töölauda tulevikus aktiveerida."
+#: pinboard.c:851
+msgid ""
+"No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
+"-p=Default' to turn it on in future."
+msgstr ""
+"Töölaua asetusi ei leitud. Avan vaikimisi töölaua.Kasutage ROX-Filer'i "
+"käivitamisel parameetrit 'rox -p=Default', et sama töölauda tulevikus "
+"aktiveerida."
 
-#: pinboard.c:866
-msgid "Only files (and certain applications) can be used to set the background image."
+#: pinboard.c:945
+msgid ""
+"Only files (and certain applications) can be used to set the background "
+"image."
 msgstr "Tausta seadmiseks saate kasutada vaid pilte (ja teatud rakendusi)."
 
-#: pinboard.c:1480
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Ikooni sildis puudub '>'"
 
-#: pinboard.c:1489
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Ikooni sildis puudub ','"
 
-#: pinboard.c:1574
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Viga %s töölaua asetuste salvestamisel: %s"
 
-#: pinboard.c:2118
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Taust..."
 
-#: pinboard.c:2211
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Paneel"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2735,7 +3200,7 @@ msgstr ""
 "%s\n"
 "Taust eemaldatud."
 
-#: pixmaps.c:954
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2744,308 +3209,418 @@ msgstr ""
 "Ei saa eemaldada pisipilti %s:\n"
 "%s"
 
-#: pixmaps.c:975
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Pole pisipilte, mida kustutada"
 
-#: pixmaps.c:988
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Kustuta pisipiltide puhver"
 
-#: remote.c:628
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Tundmatu stiil '%s'"
 
-#: remote.c:650
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Tundmatu omaduste tüüp '%s'"
 
-#: remote.c:678
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Tundmatu sortimistüüp '%s'"
 
-#: remote.c:1124
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Kutsuti tundmatut SOAP-meetodit '%s'"
 
-#: rox_gettext.c:95
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Vigane .gmo tõlkefail (liiga lühike): %s"
-
-#: rox_gettext.c:108
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Vigane .gmo tõlkefail (ei leitud GNU maagilist päist): %s"
-
-#: run.c:100
-#: run.c:153
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "Rakendust %s ei leitud - on see kustutatud?"
 
-#: run.c:303
+#: run.c:359
+#, c-format
+msgid ""
+"No run action specified for files of this type (%s/%s) - you can set a run "
+"action by choosing `Set Run Action' from the File menu, or you can just drag "
+"the file to an application.%s"
+msgstr ""
+"Failitüübi (%s/%s) jaoks pole seatud avajat - Te saate seda seada, valides "
+"Fail-menüüst 'Sea avaja...', või lohistades faili rakenduse peale. %s"
+
+#: run.c:365
+msgid ""
+"\n"
+"\n"
+"Note: If this is a computer program which you want to run, you need to set "
+"the execute bit by choosing Permissions from the File menu."
+msgstr ""
+"\n"
+"\n"
+"Note: Kui te soovite jooksutada arvutiprogrammi, peate te seadma "
+"käivitusbiti, valides Fail menüüst Õigused."
+
+#: run.c:373
 #, c-format
 msgid "File doesn't exist, or I can't access it: %s"
 msgstr "Faili pole olemas või ei saa seda avada: %s"
 
-#: run.c:308
+#: run.c:378
 #, c-format
 msgid "I don't know how to open '%s'"
 msgstr "Ma ei oska avada '%s'"
 
-#: run.c:339
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' pole enam sümbolviit"
+
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "Puudub ligipääs kataloogile '%s'"
+
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "Mittekäivitatav fail %s"
+
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Viga käsitlejas %s: %s"
+
+#: run.c:465
 msgid ""
 "Application:\n"
-"This is an application directory - you can run it as a program, or open it (hold down Shift while you open it). Most applications provide their own help here, but this one doesn't."
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
 msgstr ""
 "Rakendus:\n"
-"See on kataloograkendus (application directory). Te võite seda käivitada kui programmi või avada kui kataloogi (Shift+klõps)Enamus rakendusi näitavad omaenda abiinfot, kuid mitte see."
+"See on kataloograkendus (application directory). Te võite seda käivitada kui "
+"programmi või avada kui kataloogi (Shift+klõps)Enamus rakendusi näitavad "
+"omaenda abiinfot, kuid mitte see."
 
-#: run.c:423
+#: run.c:549
 #, c-format
 msgid "Could not send data to program: %s"
 msgstr "Ei suutnud saata andmeid rakendusele: %s"
 
-#: run.c:453
+#: run.c:578
 #, c-format
 msgid "Could not read link: %s"
 msgstr "Ei suutnud lugeda viita: %s"
 
-#: run.c:481
+#: run.c:606
 #, c-format
 msgid "Broken symlink (or you don't have permission to follow it): %s"
 msgstr "Katkine viit (või puuduvad teil õigused sellele järgneda): %s"
 
-#: run.c:518
-#, c-format
-msgid "No run action specified for files of this type (%s/%s) - you can set a run action by choosing `Set Run Action' from the File menu, or you can just drag the file to an application.%s"
-msgstr "Failitüübi (%s/%s) jaoks pole seatud avajat - Te saate seda seada, valides Fail-menüüst 'Sea avaja...', või lohistades faili rakenduse peale. %s"
-
-#: run.c:524
-msgid ""
-"\n"
-"\n"
-"Note: If this is a computer program which you want to run, you need to set the execute bit by choosing Permissions from the File menu."
-msgstr ""
-"\n"
-"\n"
-"Note: Kui te soovite jooksutada arvutiprogrammi, peate te seadma käivitusbiti, valides Fail menüüst Õigused."
-
-#: run.c:668
+#: run.c:785
 #, c-format
 msgid ""
-"Executable '%s' is world-writeable! Refusing to run. Please change the permissions now (this problem may have been caused by a bug in earlier versions of the filer).\n"
+"Executable '%s' is world-writeable! Refusing to run. Please change the "
+"permissions now (this problem may have been caused by a bug in earlier "
+"versions of the filer).\n"
 "\n"
-"Having (non-symlink) run actions world-writeable means that other people who use your computer can replace your run actions with malicious versions.\n"
+"Having (non-symlink) run actions world-writeable means that other people who "
+"use your computer can replace your run actions with malicious versions.\n"
 "\n"
-"If you trust everyone who could write to these files then you needn't worry. Otherwise, you should check, or even just delete, all the existing run actions."
+"If you trust everyone who could write to these files then you needn't worry. "
+"Otherwise, you should check, or even just delete, all the existing run "
+"actions."
 msgstr ""
-"Programm '%s' on kõigile kirjutatav! Keeldun käivitamast seda. Palun muutke faili ligipääsuõigusi (probleem võib olla pärit failihalduri vanemast, vigasest, versioonist).\n"
+"Programm '%s' on kõigile kirjutatav! Keeldun käivitamast seda. Palun muutke "
+"faili ligipääsuõigusi (probleem võib olla pärit failihalduri vanemast, "
+"vigasest, versioonist).\n"
 "\n"
-"Kõigile kirjutatav programmifail (välja arvatud sümboolsed viidad) tähendab seda, et kõik teie arvuti kasutajad saavad teie programmi muuta, asendades selle potentsiaalselt ohtliku programmiga.\n"
+"Kõigile kirjutatav programmifail (välja arvatud sümboolsed viidad) tähendab "
+"seda, et kõik teie arvuti kasutajad saavad teie programmi muuta, asendades "
+"selle potentsiaalselt ohtliku programmiga.\n"
 "\n"
-"Juhul, kui te usaldate absoluutselt kõiki kasutajaid, kellel on olnud ligipääs, ei pruugi te muretseda. Vastasel juhul peaksite üle kontrollima või isegi kustutama kõik käivitamis-seosed"
+"Juhul, kui te usaldate absoluutselt kõiki kasutajaid, kellel on olnud "
+"ligipääs, ei pruugi te muretseda. Vastasel juhul peaksite üle kontrollima "
+"või isegi kustutama kõik käivitamis-seosed"
 
-#: run.c:681
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Lahenda turvaprobleem)"
 
-#: support.c:273
-msgid "B"
-msgstr "B"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:352
+#: support.c:381
 msgid "byte"
 msgstr "bait"
 
-#: support.c:1565
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
 msgstr "Faili '%s' avamine ja stat ebaõnnestus: %s"
 
-#: support.c:1576
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
 msgstr "Faili '%s' mmap avamine ebaõnnestus: %s"
 
-#: toolbar.c:115
+#: toolbar.c:116
 msgid "Close"
 msgstr "Sulge"
 
-#: toolbar.c:115
+#: toolbar.c:116
 msgid "Close filer window"
 msgstr "Sulge failihalduri aken"
 
-#: toolbar.c:119
+#: toolbar.c:120
 msgid "Up"
 msgstr "Üles"
 
-#: toolbar.c:119
-msgid "Change to parent directory"
-msgstr "Mine ülevalpoolsesse kataloogi"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:123
+#: toolbar.c:126
 msgid "Home"
 msgstr "Kodu"
 
-#: toolbar.c:123
-msgid "Change to home directory"
-msgstr "Mine kodukataloogi"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:127
-msgid "Bookmarks"
-msgstr "Järjehoidjad"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:127
-msgid "Bookmarks menu"
-msgstr "Järjehoidjate-menüü"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:131
+#: toolbar.c:138
 msgid "Scan"
 msgstr "Skaneerida"
 
-#: toolbar.c:131
-msgid "Rescan directory contents"
-msgstr "Skaneeri uuesti kataloogi sisu"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:135
-msgid "Change icon size"
-msgstr "Muuda ikooni suurust"
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Suurus"
 
-#: toolbar.c:139
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automaatne"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
 msgstr "Automaatselt kohanduv ikoonisuurus"
 
-#: toolbar.c:143
-msgid "Show extra details"
-msgstr "Näita rohkem infot"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Loend-vaade"
 
-#: toolbar.c:147
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
 msgstr "Sordi"
 
-#: toolbar.c:147
+#: toolbar.c:165
 msgid "Change sort criteria"
 msgstr "Muuda sortimiskriteeriume:"
 
-#: toolbar.c:151
-msgid "Hidden"
-msgstr "Peidetud"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:151
-msgid "Show/hide hidden files"
-msgstr "Näita/varja peidetud faile"
+#: toolbar.c:169
+msgid ""
+"Left: Show/hide hidden files\n"
+"Right: Show/hide thumbnails"
+msgstr ""
 
-#: toolbar.c:155
-msgid "Select all/invert selection"
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
 msgstr "Vali kõik/pööra valik ümber"
 
-#: toolbar.c:159
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
 msgstr "Näita ROX-Filer'i abiinfot"
 
-#: toolbar.c:222
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
 msgstr " (%u peidetud)"
 
-#: toolbar.c:230
-#: tips:81
+#: toolbar.c:276 tips:79
 msgid "items"
 msgstr "faili"
 
-#: toolbar.c:230
+#: toolbar.c:276
 msgid "item"
 msgstr "fail"
 
-#: toolbar.c:233
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
 msgstr "Pole faile%s"
 
-#: toolbar.c:252
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
 msgstr "%u faili valitud (%s)"
 
-#: toolbar.c:424
+#: toolbar.c:535
 msgid "Sort by name"
 msgstr "Sorteeri nime järgi"
 
-#: toolbar.c:424
+#: toolbar.c:535
 msgid "Sort by type"
 msgstr "Sorteeri tüübi järgi"
 
-#: toolbar.c:424
+#: toolbar.c:535
 msgid "Sort by date"
 msgstr "Sorteeri aja järgi"
 
-#: toolbar.c:425
+#: toolbar.c:535
 msgid "Sort by size"
 msgstr "Sorteeri suuruse järgi"
 
-#: toolbar.c:425
+#: toolbar.c:536
 msgid "Sort by owner"
 msgstr "Sorteeri omaniku järgi"
 
-#: toolbar.c:425
+#: toolbar.c:536
 msgid "Sort by group"
 msgstr "Sorteeri grupi järgi"
 
-#: toolbar.c:459
+#: toolbar.c:568
 msgid "ascending"
 msgstr "tõusev"
 
-#: toolbar.c:459
+#: toolbar.c:568
 msgid "descending"
 msgstr "langev"
 
-#: type.c:209
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
 msgid "Sym link"
 msgstr "Süm. viit"
 
-#: type.c:211
+#: type.c:223
 msgid "Mount point"
 msgstr "Ühenduspunkt"
 
-#: type.c:213
+#: type.c:225
 msgid "App dir"
 msgstr "Rakenduskat"
 
-#: type.c:220
+#: type.c:232
 msgid "Dir"
 msgstr "Kat"
 
-#: type.c:222
+#: type.c:234
 msgid "Char dev"
 msgstr "Märkseade"
 
-#: type.c:224
+#: type.c:236
 msgid "Block dev"
 msgstr "Blokkseade"
 
-#: type.c:226
+#: type.c:238
 msgid "Pipe"
 msgstr "Toru"
 
-#: type.c:228
+#: type.c:240
 msgid "Socket"
 msgstr "Sokkel"
 
-#: type.c:230
+#: type.c:242
 msgid "Door"
 msgstr "Uks"
 
-#: type.c:233
+#: type.c:245
 msgid "Unknown"
 msgstr "Tundmatu"
 
-#: type.c:457
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3055,117 +3630,114 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:638
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "See pole programm! Andke mulle selle asemel rakendus!"
 
-#: type.c:699
+#: type.c:839
 msgid "No run action defined"
 msgstr "Avamisseost pole määratud"
 
-#: type.c:725
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Viga käsitlejas %s: %s"
 
-#: type.c:740
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Mittekehtiv rakendus %s (vigane AppRun)"
 
-#: type.c:751
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "Mittekäivitatav fail %s"
 
-#: type.c:784
+#: type.c:902
 msgid "Set run action"
 msgstr "Sea avaja"
 
-#: type.c:790
-msgid "If a handler for the specific type isn't set up, use this as the default."
+#: type.c:908
+msgid ""
+"If a handler for the specific type isn't set up, use this as the default."
 msgstr "Kui failitüübile pole avajat määratud, kasutada vaikimisi seda."
 
-#: type.c:792
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Kasuta vaikimisi '%s/<misiganes>' avamiseks"
 
-#: type.c:796
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Kasuta seda rakendust antud MIME-tüübiga failide avamiseks."
 
-#: type.c:798
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Ainult tüübi `%s' (%s/%s) jaoks"
 
-#: type.c:804
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Lohistage siia sobiv rakendus"
 
-#: type.c:819
+#: type.c:963
 msgid "OR"
 msgstr "VÕI"
 
-#: type.c:826
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Sisestage shelli käsk:"
 
-#: type.c:855
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Kasuta käsku"
 
-#: type.c:885
-msgid "A run action already exists and is quite a big program - are you sure you want to delete it?"
-msgstr "Käivitaja on juba määratud ja see on üsna suur programm - oled kindel, et soovid seda kustutada?"
+#: type.c:1030
+msgid ""
+"A run action already exists and is quite a big program - are you sure you "
+"want to delete it?"
+msgstr ""
+"Käivitaja on juba määratud ja see on üsna suur programm - oled kindel, et "
+"soovid seda kustutada?"
 
-#: type.c:896
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Ei saa eemaldada %s: %s"
 
-#: type.c:933
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "Seadete salvestamise keelab CHOICESPATH-keskkonnamuutuja"
 
-#: type.c:1208
-#, c-format
-msgid "Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr "Ikooniteemas '%s' pole MIME ikoone. Kasutan Rox vaikimisi teemat.."
-
-#: type.c:1223
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-application:postscript' icon couldn't be loaded for some reason, or %s is a link to an invalid directory; try deleting it)"
+"%s"
 msgstr ""
-"Sümbolviida '%s' loomine ebaõnnestus:\n"
-"%s\n"
-"\n"
-"(see võib tähendada, et ROX teema on juba seal olemas, kuid mingil põhjusel ei suudetud laadida 'mime-application:postscript' ikooni või on %s viide vigasele kataloogile, proovige see kustutada)"
+"Kustutamine ebaõnnestus '%s':\n"
+"%s"
 
-#: usericons.c:181
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "Faili, milleni teekonna sisestasite, pole olemas. Ikooni ei muudetud."
 
-#: usericons.c:191
-#: usericons.c:616
+#: usericons.c:198 usericons.c:644
 msgid ""
-"Unable to load image file -- maybe it's not in a format I understand, or maybe the permissions are wrong?\n"
+"Unable to load image file -- maybe it's not in a format I understand, or "
+"maybe the permissions are wrong?\n"
 "The icon has not been changed."
 msgstr ""
-"Pildifaili ei õnnestu laadida - võib-olla on see mulle tundmatus vormingus või on ligipääsuõigused väärad?\n"
+"Pildifaili ei õnnestu laadida - võib-olla on see mulle tundmatus vormingus "
+"või on ligipääsuõigused väärad?\n"
 "Ikooni ei muudetud."
 
-#: usericons.c:238
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Tõesti kustutada ikoon '%s'?"
 
-#: usericons.c:242
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3174,54 +3746,66 @@ msgstr ""
 "Ei suuda kustutada '%s':\n"
 "%s"
 
-#: usericons.c:270
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Sea ikooni"
 
-#: usericons.c:279
-msgid "Use a copy of the image as the default for all files of these MIME types."
-msgstr "Kasuta koopiat pildist vaikimisi kõigi selle MIME-tüübiga failide jaoks."
+#: usericons.c:290
+msgid ""
+"Use a copy of the image as the default for all files of these MIME types."
+msgstr ""
+"Kasuta koopiat pildist vaikimisi kõigi selle MIME-tüübiga failide jaoks."
 
-#: usericons.c:281
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Sea ikoon kõigi tüüpi `%s/<misiganes>' failide jaoks"
 
-#: usericons.c:286
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "Kasuta koopiat pildist kõigi antud MIME-tüübiga failide jaoks."
 
-#: usericons.c:288
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Failidele, mis on tüüpi `%s' (%s/%s)"
 
-#: usericons.c:294
-msgid "Add the file and image filenames to your personal list. The setting will be lost if the image or the file is moved."
-msgstr "Lisage faili ja pildi failinimed oma isiklikku nimekirja. See asetus läheb kaotsi, kui pilt või fail mujale tõstetakse."
+#: usericons.c:305
+msgid ""
+"Add the file and image filenames to your personal list. The setting will be "
+"lost if the image or the file is moved."
+msgstr ""
+"Lisage faili ja pildi failinimed oma isiklikku nimekirja. See asetus läheb "
+"kaotsi, kui pilt või fail mujale tõstetakse."
 
-#: usericons.c:297
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Ainult faili `%s' jaoks"
 
-#: usericons.c:305
-msgid "Copy the image inside the directory, as a hidden file called '.DirIcon'. All users will then see the icon, and you can move the directory around safely. This is usually the best option if you can write to the directory."
-msgstr "Kopeeri pilt kataloogi sisse peidetud faili '.DirIcon'. nime alla.Kõik kasutajad näevad ikooni ja ketaloogi võib probleemitult mujale tõsta. See on enamasti parim valik, kui Teil on kirjutusõigus antud kataloogile."
+#: usericons.c:316
+msgid ""
+"Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
+"users will then see the icon, and you can move the directory around safely. "
+"This is usually the best option if you can write to the directory."
+msgstr ""
+"Kopeeri pilt kataloogi sisse peidetud faili '.DirIcon'. nime alla.Kõik "
+"kasutajad näevad ikooni ja ketaloogi võib probleemitult mujale tõsta. See on "
+"enamasti parim valik, kui Teil on kirjutusõigus antud kataloogile."
 
-#: usericons.c:311
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Kopeeri pilt kataloogi"
 
-#: usericons.c:317
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Lohistage siia ikoonifail"
 
-#: usericons.c:587
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "Ikooni seadmise keelab CHOICESPATH-keskkonnamuutuja"
 
-#: usericons.c:631
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3230,773 +3814,1115 @@ msgstr ""
 "Viga pildi kopeerimisel '%s':\n"
 "%s"
 
-#: view_details.c:1012
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
+msgid "Mono font"
+msgstr ""
+
+#: view_details.c:1019
+msgid "Font for displaying mono-spaced text"
+msgstr ""
+
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Nimi"
 
-#: view_details.c:1015
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Tüüp"
 
-#: view_details.c:1018
-msgid "_Permissions"
-msgstr "_Ligipääsuõigused"
-
-#: view_details.c:1019
-msgid "_Owner"
-msgstr "_Omanik"
-
-#: view_details.c:1021
-msgid "_Group"
-msgstr "_Grupp"
-
-#: view_details.c:1023
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Suurus"
 
-#: view_details.c:1025
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Ligipääsuõigused"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_Omanik"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Grupp"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "Viimati _muudetud"
 
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Laiendatud atribuudid"
+
 #: tips:1
-msgid "Translation"
-msgstr "Tõlge"
-
-#: tips:2
-msgid "Language"
-msgstr "Keel"
-
-#: tips:3
-msgid "Use the LANG environment variable"
-msgstr "Kasutage LANG keskkonnamuutujat"
-
-#: tips:4
-msgid "Basque"
-msgstr "Baski"
-
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Hiina (traditsiooniline)"
-
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Hiina (lihtsustatud)"
-
-#: tips:7
-msgid "Czech"
-msgstr "Tšehhi"
-
-#: tips:8
-msgid "Danish"
-msgstr "Taani"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Hollandi"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Inglise (tõlkimata)"
-
-#: tips:11
-msgid "Estonian"
-msgstr "Eesti"
-
-#: tips:12
-msgid "Finnish"
-msgstr "Soome"
-
-#: tips:13
-msgid "French"
-msgstr "Prantsuse"
-
-#: tips:14
-msgid "German"
-msgstr "Saksa"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Ungari"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Jaapani"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "Norra"
-
-#: tips:18
-msgid "Italian"
-msgstr "Itaalia"
-
-#: tips:19
-msgid "Polish"
-msgstr "Poola"
-
-#: tips:20
-msgid "Portuguese (Portugal)"
-msgstr "Portugali (Portugal)"
-
-#: tips:21
-msgid "Portuguese (Brasil)"
-msgstr "Portugali (Brasiilia)"
-
-#: tips:22
-msgid "Romanian"
-msgstr "Rumeenia"
-
-#: tips:23
-msgid "Russian"
-msgstr "Vene"
-
-#: tips:24
-msgid "Spanish"
-msgstr "Hispaania"
-
-#: tips:25
-msgid "Swedish"
-msgstr "Rootsi"
-
-#: tips:26
 msgid "Filer windows"
 msgstr "Failihalduri aknad"
 
-#: tips:27
+#: tips:2
 msgid "Auto-resize filer windows"
 msgstr "Automaatselt muuda failihalduri akende suurust"
 
-#: tips:28
+#: tips:3
 msgid "Never automatically resize"
 msgstr "Ära kunagi sea suurust automaatselt"
 
-#: tips:29
-msgid "You'll have to resize windows manually, using the window manager, the `Resize Window' menu entry or by double-clicking on the window background."
-msgstr "Te peate akna suurust muutma käsitsi, kasutades; aknahalduri võimalusi, menüüvalikut `Kohalda akna suurust'-või topeltklõpsates akna tausta."
+#: tips:4
+msgid ""
+"You'll have to resize windows manually, using the window manager, the "
+"`Resize Window' menu entry or by double-clicking on the window background."
+msgstr ""
+"Te peate akna suurust muutma käsitsi, kasutades; aknahalduri võimalusi, "
+"menüüvalikut `Kohalda akna suurust'-või topeltklõpsates akna tausta."
 
-#: tips:30
+#: tips:5
 msgid "Resize when changing the display style"
 msgstr "Kohalda akna suurust vaate muutmisel"
 
-#: tips:31
-msgid "Changing the size of the icons or which details are displayed will resize the window for you."
-msgstr "Ikoonide suuruse või näidatavate omaduste hulga muutmisel muudetakse akna suurust automaatselt."
+#: tips:6
+msgid ""
+"Changing the size of the icons or which details are displayed will resize "
+"the window for you."
+msgstr ""
+"Ikoonide suuruse või näidatavate omaduste hulga muutmisel muudetakse akna "
+"suurust automaatselt."
 
-#: tips:32
+#: tips:7
 msgid "Always resize"
 msgstr "Alati muuda suurust"
 
-#: tips:33
-msgid "The filer will resize windows whenever it seems useful (that is, when changing directory or display style)."
-msgstr "Failihaldur muudab akna suurust iga kord, kui see tundub mõistlik (s.t. kataloogi vahetamisel või vaate muutmisel)."
+#: tips:8
+msgid ""
+"The filer will resize windows whenever it seems useful (that is, when "
+"changing directory or display style)."
+msgstr ""
+"Failihaldur muudab akna suurust iga kord, kui see tundub mõistlik (s.t. "
+"kataloogi vahetamisel või vaate muutmisel)."
 
-#: tips:34
+#: tips:9
 msgid "Largest window size:"
 msgstr "Akna maksimaalne suurus:"
 
-#: tips:35
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:36
-msgid "The largest size, as a percentage of the screen size, that the auto-resizer will resize a window to."
-msgstr "Maksimaalne suurus, milleni aken automaatselt suurust muutes tohib kasvada, väljendatuna protsentides ekraanist."
+#: tips:11
+msgid ""
+"The largest size, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Maksimaalne suurus, milleni aken automaatselt suurust muutes tohib kasvada, "
+"väljendatuna protsentides ekraanist."
 
-#: tips:37
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Akna maksimaalne suurus:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Maksimaalne suurus, milleni aken automaatselt suurust muutes tohib kasvada, "
+"väljendatuna protsentides ekraanist."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Akende käitumine"
 
-#: tips:38
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Lühiindikaatorid aknapäisel"
 
-#: tips:39
-msgid "Use single letters instead of words for Scanning, All and Thumbs indicators in the titlebar."
-msgstr "Kasuta ühetähelisi lühendeid sõnade 'Skaneerin', 'Kõik', 'Pisipildid' asemel akna päises."
+#: tips:17
+msgid ""
+"Use single letters instead of words for Scanning, All and Thumbs indicators "
+"in the titlebar."
+msgstr ""
+"Kasuta ühetähelisi lühendeid sõnade 'Skaneerin', 'Kõik', 'Pisipildid' asemel "
+"akna päises."
 
-#: tips:40
+#: tips:18
 msgid "Unique windows"
 msgstr "Akende uuestikasutamine"
 
-#: tips:41
-msgid "If you open a directory and that directory is already displayed in another window, then this option causes the other window to be closed."
-msgstr "Kui antud suvand on sisse lülitud, siis kataloogi avamise puhul, mis on juba avatud mõnes teises failihalduri aknas, suletakse teine aken."
+#: tips:19
+msgid ""
+"If you open a directory and that directory is already displayed in another "
+"window, then this option causes the other window to be closed."
+msgstr ""
+"Kui antud suvand on sisse lülitud, siis kataloogi avamise puhul, mis on juba "
+"avatud mõnes teises failihalduri aknas, suletakse teine aken."
 
-#: tips:42
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Aken"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Ava nupuga 1 kataloog uues aknas"
 
-#: tips:43
-msgid "Clicking with mouse button 1 (usually the left button) opens a directory in a new window with this turned on. Clicking with the button-2 (middle) will reuse the current window."
-msgstr "Klõpsates esimese hiirenupuga (tavaliselt vasak nupp) avatakse kataloog uues aknas. Klõpsates teise nupuga (keskmine hiirenupp) avatakse kataloog samas aknas."
+#: tips:25
+msgid ""
+"Clicking with mouse button 1 (usually the left button) opens a directory in "
+"a new window with this turned on. Clicking with the button-2 (middle) will "
+"reuse the current window."
+msgstr ""
+"Klõpsates esimese hiirenupuga (tavaliselt vasak nupp) avatakse kataloog uues "
+"aknas. Klõpsates teise nupuga (keskmine hiirenupp) avatakse kataloog samas "
+"aknas."
 
-#: tips:44
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Ühe klõpsuga avamine"
 
-#: tips:45
-#: tips:138
-msgid "Clicking on an item opens it with this on. Hold down Control to select the item instead. If off, clicking once selects an item; double click to open things."
-msgstr "Kui antud suvand on sisse lülitud, siis üks hiireklõps avab faili/kataloogi. Hoidke all Control-klahvi, et faili valida. Kui suvand on keelatud, siis üks klõps valib faili ja kaks klõpsu avab selle."
+#: tips:27 tips:191
+msgid ""
+"Clicking on an item opens it with this on. Hold down Control to select the "
+"item instead. If off, clicking once selects an item; double click to open "
+"things."
+msgstr ""
+"Kui antud suvand on sisse lülitud, siis üks hiireklõps avab faili/kataloogi. "
+"Hoidke all Control-klahvi, et faili valida. Kui suvand on keelatud, siis üks "
+"klõps valib faili ja kaks klõpsu avab selle."
 
-#: tips:46
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Topeltklõps taustale muudab suurust"
 
-#: tips:47
-msgid "If on then double clicking on the window background resizes the window, just like clicking on the Automatic size mode button in the toolbar."
-msgstr "Kui see suvand on sisse lülitud, muudab akna taustale topeltkõpsamine aknasuurust, käitudes nagu Automaatse suuruse nupp nupuribas."
+#: tips:29
+msgid ""
+"If on then double clicking on the window background resizes the window, just "
+"like clicking on the Automatic size mode button in the toolbar."
+msgstr ""
+"Kui see suvand on sisse lülitud, muudab akna taustale topeltkõpsamine "
+"aknasuurust, käitudes nagu Automaatse suuruse nupp nupuribas."
 
-#: tips:48
+#: tips:30
 msgid "Sorting"
 msgstr "Sordi"
 
-#: tips:49
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Katalooge näidatakse enne (nimede järgi sortides)"
 
-#: tips:50
-msgid "If this is on then directories will always appear before anything else when sorting by name."
+#: tips:32
+msgid ""
+"If this is on then directories will always appear before anything else when "
+"sorting by name."
 msgstr "Nimede järgi sortides näidatakse katalooge alati enne muid faile."
 
-#: tips:51
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Suurtähed enne väiketähti (nimede järgi sortides)"
 
-#: tips:52
-msgid "If on, all filenames starting with a capital letter come before filenames starting with lowercase ones."
+#: tips:34
+msgid ""
+"If on, all filenames starting with a capital letter come before filenames "
+"starting with lowercase ones."
 msgstr "Suurtähtedega algavaid faile näidatakse enne väiketähtedega algavaid."
 
-#: tips:54
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Katalooge näidatakse enne (nimede järgi sortides)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sek"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "Laiendatud atribuutide toetus"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "Vaikimisi asetused uutele akendele"
 
-#: tips:55
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "Kasuta algse akna seadeid"
 
-#: tips:56
-msgid "If this is on then display options for a new window are inherited from the source window if possible, otherwise they are set to the defaults below."
-msgstr "Kui suvand on lubatud, kasutatakse uue akna puhul algse akna seadeid (kui võimalik), vastasel juhul kasutatakse vaikimisi asetusi."
+#: tips:47
+msgid ""
+"If this is on then display options for a new window are inherited from the "
+"source window if possible, otherwise they are set to the defaults below."
+msgstr ""
+"Kui suvand on lubatud, kasutatakse uue akna puhul algse akna seadeid (kui "
+"võimalik), vastasel juhul kasutatakse vaikimisi asetusi."
 
-#: tips:57
+#: tips:48
 msgid "View type:"
 msgstr "Vaate tüüp:"
 
-#: tips:60
+#: tips:51
 msgid "Sort by:"
 msgstr "Sordi tunnuse järgi:"
 
-#: tips:62
-#: tips:77
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Tüüp"
 
-#: tips:63
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Kuupäev"
 
-#: tips:65
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Kuupäev"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Kuupäev"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Näita peidetud faile"
 
-#: tips:66
-msgid "If this is on then files whose names start with a dot are shown too, otherwise they are hidden."
-msgstr "Kui suvand on sees, näidatakse faile, mis algavad punktiga, vastasel juhul peidetakse need."
+#: tips:59
+msgid ""
+"If this is on then files whose names start with a dot are shown too, "
+"otherwise they are hidden."
+msgstr ""
+"Kui suvand on sees, näidatakse faile, mis algavad punktiga, vastasel juhul "
+"peidetakse need."
 
-#: tips:67
-msgid "Icon View"
-msgstr "Ikoonidega vaade"
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Näita peidetud faile"
 
-#: tips:68
-msgid "Default size:"
-msgstr "Vaikimisi suurus:"
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Kui suvand on sees, näidatakse faile, mis algavad punktiga, vastasel juhul "
+"peidetakse need."
 
-#: tips:69
-msgid "Huge Icons"
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
 msgstr "Väga suured ikoonid"
 
-#: tips:70
-#: tips:246
-msgid "Large Icons"
-msgstr "Suured ikoonid"
-
-#: tips:71
-#: tips:245
-msgid "Small Icons"
-msgstr "Väikesed ikoonid"
-
-#: tips:73
-msgid "Default details:"
-msgstr "Vaikimisi üksikasjad:"
-
-#: tips:74
-msgid "No details"
-msgstr "Pole üksikasju"
-
-#: tips:79
-msgid "Automatic small icons:"
-msgstr "Automaatselt väiksed ikoonid:"
-
-#: tips:80
-msgid "Change at:"
-msgstr "Muuda alates:"
-
-#: tips:82
-msgid "When automatic icon sizing is selected: If the directory contains this many items then it will be shown using Small Icons, otherwise Large Icons will be used."
-msgstr "Juhul kui on lubatud automaatselt ikoonide suuruse muutmine ja kataloogis on vähemalt nii palju faile, näidatakse neid väikeste ikoonidega, vastasel juhul kasutatakse suuri ikoone."
-
-#: tips:83
-msgid "Max width (Large icons):"
-msgstr "Maksimumlaius (suurte ikoonidega):"
-
-#: tips:84
-#: tips:87
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
 msgid "pixels"
 msgstr "pikslit"
 
-#: tips:85
-msgid "Text wider than this is broken onto two lines in Large Icons mode. In Huge Icons mode, text is wrapped when 50% wider than this."
-msgstr "Sellest numbrist laiem tekst murtakse suurte ikoonide puhul järgmisele reale. Väga suurte ikoonide puhul murtakse tekst siis, kui tekst on 50% laiem sellest arvust."
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
+msgid "Icon View"
+msgstr "Ikoonidega vaade"
+
+#: tips:67
+msgid "Default size:"
+msgstr "Vaikimisi suurus:"
+
+#: tips:68
+msgid "Huge Icons"
+msgstr "Väga suured ikoonid"
+
+#: tips:69 tips:296
+msgid "Large Icons"
+msgstr "Suured ikoonid"
+
+#: tips:70 tips:295
+msgid "Small Icons"
+msgstr "Väikesed ikoonid"
+
+#: tips:72
+msgid "Default details:"
+msgstr "Vaikimisi üksikasjad:"
+
+#: tips:73
+msgid "No details"
+msgstr "Pole üksikasju"
+
+#: tips:74
+msgid "Sizes"
+msgstr "Suurused"
+
+#: tips:77
+msgid "Times"
+msgstr "Ajad"
+
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
+msgstr "Automaatselt väiksed ikoonid:"
+
+#: tips:80
+msgid ""
+"When automatic icon sizing is selected: If the directory contains this many "
+"items then it will be shown using Small Icons, otherwise Large Icons will be "
+"used."
+msgstr ""
+"Juhul kui on lubatud automaatselt ikoonide suuruse muutmine ja kataloogis on "
+"vähemalt nii palju faile, näidatakse neid väikeste ikoonidega, vastasel "
+"juhul kasutatakse suuri ikoone."
+
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Suured ikoonid"
+
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
+msgstr ""
+"Sellest numbrist laiem tekst murtakse suurte ikoonide puhul järgmisele "
+"reale. Väga suurte ikoonide puhul murtakse tekst siis, kui tekst on 50% "
+"laiem sellest arvust."
+
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
 
 #: tips:86
-msgid "(Small Icons):"
-msgstr "(Väikesed ikoonid):"
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
+
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
 
 #: tips:88
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr ""
+"Kui see valik on lubatud, järjestatakse suured ikoonid tulpadesse, mitte "
+"ridadesse."
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "(Väikesed ikoonid):"
+
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "Teksti maksimaalne laius väikese ikooni kõrval."
 
-#: tips:89
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "Järjesta väikesed ikoonid vertikaalselt"
 
-#: tips:90
-msgid "If this option is on, then small icons are arranged in columns, not rows."
-msgstr "Kui see suvand on lubatud, järjestatakse väikesed ikoonid tulpadesse, mitte ridadesse."
+#: tips:93
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
+msgstr ""
+"Kui see suvand on lubatud, järjestatakse väikesed ikoonid tulpadesse, mitte "
+"ridadesse."
 
-#: tips:91
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "Järjesta suured ikoonid vertikaalselt."
 
-#: tips:92
-msgid "If this option is on, then large icons are arranged in columns, not rows."
-msgstr "Kui see valik on lubatud, järjestatakse suured ikoonid tulpadesse, mitte ridadesse."
+#: tips:95
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
+msgstr ""
+"Kui see valik on lubatud, järjestatakse suured ikoonid tulpadesse, mitte "
+"ridadesse."
 
-#: tips:94
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Näita tulpade päiseid"
 
-#: tips:95
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr "Näidatakse päiseid tulpade kohal nimekirjavaate puhul."
 
-#: tips:96
+#: tips:102
 msgid "Show full type"
 msgstr "Näita täielikku tüübiinfot"
 
-#: tips:97
-msgid "If this is on then the full description of each object's type will be show rather than a short summary of its basic type."
-msgstr "Kui see valik on lubatud, siis näidatakse iga objektijuures tema tüübi täiskirjeldust, mitte selle tüübi lühikokkuvõtet."
+#: tips:103
+msgid ""
+"If this is on then the full description of each object's type will be show "
+"rather than a short summary of its basic type."
+msgstr ""
+"Kui see valik on lubatud, siis näidatakse iga objektijuures tema tüübi "
+"täiskirjeldust, mitte selle tüübi lühikokkuvõtet."
 
-#: tips:98
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Teksti maksimaalne laius väikese ikooni kõrval."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Näita tulpade päiseid"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr "Näidatakse päiseid tulpade kohal nimekirjavaate puhul."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr "Näidatakse päiseid tulpade kohal nimekirjavaate puhul."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr "Näidatakse päiseid tulpade kohal nimekirjavaate puhul."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr "Näidatakse päiseid tulpade kohal nimekirjavaate puhul."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr "Näidatakse päiseid tulpade kohal nimekirjavaate puhul."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr "Näidatakse päiseid tulpade kohal nimekirjavaate puhul."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "Viimati _muudetud"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr "Näidatakse päiseid tulpade kohal nimekirjavaate puhul."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr "Näidatakse päiseid tulpade kohal nimekirjavaate puhul."
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr "Näidatakse päiseid tulpade kohal nimekirjavaate puhul."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Nupuriba/Käsurida"
 
-#: tips:99
+#: tips:131
 msgid "Toolbar"
 msgstr "Nupuriba"
 
-#: tips:100
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Nupurea tüüp:"
 
-#: tips:101
+#: tips:133
 msgid "No toolbar"
 msgstr "Pole nupuriba"
 
-#: tips:102
+#: tips:134
 msgid "Icons only"
 msgstr "Ainult ikoonid"
 
-#: tips:103
+#: tips:135
 msgid "Text under icons"
 msgstr "Tekst ikoonide all"
 
-#: tips:104
+#: tips:136
 msgid "Text beside icons"
 msgstr "Tekst ikoonide kõrval"
 
-#: tips:105
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Ainult pilt"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Näita objektide arvu nupuribal"
 
-#: tips:106
-msgid "Show the number of items displayed in a filer window, as well as the number of hidden items (if any). When there's a selection, show the number of selected items and their combined size."
-msgstr "Näita failihalduri aknas näha olevate failide/kataloogide arvu ja peidetud failide arvu(kui neid on). Kui mõningaid faile on valitud, näita nende hulka ja failisuuruste summat."
+#: tips:139
+msgid ""
+"Show the number of items displayed in a filer window, as well as the number "
+"of hidden items (if any). When there's a selection, show the number of "
+"selected items and their combined size."
+msgstr ""
+"Näita failihalduri aknas näha olevate failide/kataloogide arvu ja peidetud "
+"failide arvu(kui neid on). Kui mõningaid faile on valitud, näita nende hulka "
+"ja failisuuruste summat."
 
-#: tips:107
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Valige nupud, mida tahate nupuribale:"
 
-#: tips:108
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "Nupuriba laius määrab akna minimaalse laiuse"
 
-#: tips:109
-msgid "Each filer window is constrained to be wide enough to show the whole of the toolbar"
+#: tips:142
+msgid ""
+"Each filer window is constrained to be wide enough to show the whole of the "
+"toolbar"
 msgstr "Failihalduri akendel ei lubata olla kitsamad kui nupuriba laius"
 
-#: tips:110
+#: tips:143
 msgid "Minibuffer"
 msgstr "Käsurida"
 
-#: tips:111
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Tabulaatoriga nime lõpetamise ebaõnnestumisel piiksata"
 
-#: tips:112
-msgid "When using the `Enter Path...' minibuffer and Tab is pressed, beep if nothing happens (eg, because there are several possibilities and the next letter varies)."
-msgstr "Kui te vajutate tabulaatorit 'Sisesta tee ...'-käsureal, kõlab piiksatus, kui midagi ei juhtu (näit. on mitu sobivat failinime ja järgmine täht nendes on erinev)."
+#: tips:145
+msgid ""
+"When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
+"nothing happens (eg, because there are several possibilities and the next "
+"letter varies)."
+msgstr ""
+"Kui te vajutate tabulaatorit 'Sisesta tee ...'-käsureal, kõlab piiksatus, "
+"kui midagi ei juhtu (näit. on mitu sobivat failinime ja järgmine täht nendes "
+"on erinev)."
 
-#: tips:113
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Piiksata kui on mitmeid võimalikke vasteid"
 
-#: tips:114
-msgid "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there is more than one matching file, even though some more letters were added."
-msgstr "Kui vajutate tabulaatorit 'Sisesta tee...'-käsureal, kõlab piiksatus , kui on mitu võimalikku sobivat failinime, ka juhul, kui lisati tähti lõpetatavale nimele."
+#: tips:147
+msgid ""
+"When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
+"is more than one matching file, even though some more letters were added."
+msgstr ""
+"Kui vajutate tabulaatorit 'Sisesta tee...'-käsureal, kõlab piiksatus , kui "
+"on mitu võimalikku sobivat failinime, ka juhul, kui lisati tähti "
+"lõpetatavale nimele."
 
-#: tips:117
-msgid "When thumbnails are turned on, each image file in a directory is loaded and a small thumbnail of it is shown."
-msgstr "Kui pisipildid on lubatud, näidatakse kataloogis pildi vähendatud koopiat tema ikoonina."
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Allalaadimiste haldur"
 
-#: tips:118
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Viga käsitlejas %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
+msgid ""
+"When thumbnails are turned on, each image file in a directory is loaded and "
+"a small thumbnail of it is shown."
+msgstr ""
+"Kui pisipildid on lubatud, näidatakse kataloogis pildi vähendatud koopiat "
+"tema ikoonina."
+
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Näita pisipilte"
 
-#: tips:119
-msgid "This is the default setting for new windows. Use the Display menu to turn thumbnails on and off for individual windows."
-msgstr "See on vaikimisi asetus uute akende jaoks. Kasuta 'Vaade' menüüd pisipiltide lubamiseks/keelamiseks antud aknas."
+#: tips:156
+msgid ""
+"This is the default setting for new windows. Use the Display menu to turn "
+"thumbnails on and off for individual windows."
+msgstr ""
+"See on vaikimisi asetus uute akende jaoks. Kasuta 'Vaade' menüüd pisipiltide "
+"lubamiseks/keelamiseks antud aknas."
 
-#: tips:120
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Näita pisipilte"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "Videopisipildid"
 
-#: tips:121
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Pisipiltide vahemälu"
 
-#: tips:122
-msgid "To speed things up, the generated thumbnails are stored in the hidden ~/.thumbnails directory. Click here to remove all the cached thumbnails. They will be created again as needed."
-msgstr "Pisipiltide kiiremaks laadimiseks puhverdatakse pisipildid peidetud kataloogi ~/.thumbnails. Kõigi salvestatud pisipiltide eemaldamiseks klõpsake siia, Pisipiltide puhver luuakse uuesti vastavalt vajadusele."
+#: tips:161
+#, fuzzy
+msgid ""
+"To speed things up, the generated thumbnails are stored in the hidden ~/."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
+msgstr ""
+"Pisipiltide kiiremaks laadimiseks puhverdatakse pisipildid peidetud "
+"kataloogi ~/.thumbnails. Kõigi salvestatud pisipiltide eemaldamiseks "
+"klõpsake siia, Pisipiltide puhver luuakse uuesti vastavalt vajadusele."
 
-#: tips:123
-#: tips:196
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
+#, fuzzy
+msgid "Manage thumbnails"
+msgstr "Näita pisipilte"
+
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Videopisipildid"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sek"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Töölaud"
 
-#: tips:124
-msgid "When using a pinboard, you can drag files and applications onto the desktop background to create shortcuts to them."
-msgstr "Kui kasutate töölauda, on teil võimalik lohistada faile ja programme oma töölaua taustale, et luua nendeni viitavaid ikoone."
+#: tips:177
+msgid ""
+"When using a pinboard, you can drag files and applications onto the desktop "
+"background to create shortcuts to them."
+msgstr ""
+"Kui kasutate töölauda, on teil võimalik lohistada faile ja programme oma "
+"töölaua taustale, et luua nendeni viitavaid ikoone."
 
-#: tips:125
-#: tips:242
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Välimus"
 
-#: tips:126
+#: tips:179
 msgid "Foreground:"
 msgstr "Esiplaan:"
 
-#: tips:127
+#: tips:180
 msgid "Text shadow:"
 msgstr "Teksti vari:"
 
-#: tips:128
+#: tips:181
 msgid "Background:"
 msgstr "Taust:"
 
-#: tips:129
+#: tips:182
 msgid "No shadow"
 msgstr "Pole varju"
 
-#: tips:130
+#: tips:183
 msgid "Thin"
 msgstr "Õhuke"
 
-#: tips:131
+#: tips:184
 msgid "Thick"
 msgstr "Paks"
 
-#: tips:132
+#: tips:185
 msgid "Use custom font:"
 msgstr "Kasuta muud fonti:"
 
-#: tips:133
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Ikooni alla käiva teksti font"
 
-#: tips:134
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Piltide kiire skaleerimine"
 
-#: tips:135
-msgid "Choose between the fast or slow method of scaling backdrop images.  The slow method can give better results."
-msgstr "Valige kiire ja aeglase meetodi vahel taustapilte skaleerides.  Aeglane meetod võib anda paremaid tulemusi."
+#: tips:188
+msgid ""
+"Choose between the fast or slow method of scaling backdrop images.  The slow "
+"method can give better results."
+msgstr ""
+"Valige kiire ja aeglase meetodi vahel taustapilte skaleerides.  Aeglane "
+"meetod võib anda paremaid tulemusi."
 
-#: tips:136
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Töölaua käitumine"
 
-#: tips:137
+#: tips:190
 msgid "Single-click to open"
 msgstr "Ava ühe klõpsuga"
 
-#: tips:139
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Hoia ikoonid ekraani piirides"
 
-#: tips:140
-msgid "If this is set, pinboard icons are always kept completely within screen limits, including the label."
-msgstr "Ikoonid hoitakse alati ekraani piiride sees, kaasa arvatud ikooni all olev tekst."
+#: tips:193
+msgid ""
+"If this is set, pinboard icons are always kept completely within screen "
+"limits, including the label."
+msgstr ""
+"Ikoonid hoitakse alati ekraani piiride sees, kaasa arvatud ikooni all olev "
+"tekst."
 
-#: tips:141
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Ikooni asetustäpsus:"
 
-#: tips:142
+#: tips:195
 msgid "Fine"
 msgstr "Täpne"
 
-#: tips:143
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "Kasutatakse 2-pikslist sammu ikoonide töölauale paigutamisel."
 
-#: tips:144
+#: tips:197
 msgid "Medium"
 msgstr "Keskmine"
 
-#: tips:145
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "Kasutatakse 16-pikslist sammu ikoonide töölauale paigutamisel."
 
-#: tips:146
+#: tips:199
 msgid "Coarse"
 msgstr "Ebatäpne"
 
-#: tips:147
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "Kasutatakse 32-pikslist sammu ikoonide töölauale paigutamisel."
 
-#: tips:148
-#: tips:150
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Minimeeritud aknad"
 
-#: tips:149
-msgid "Most window managers provide a way to iconify (or 'minimise') windows, and various programs, including ROX-Filer, can be used to display the iconified windows."
-msgstr "Enamus aknahaldureid pakuvad võimalust minimeerida (ikoniseerida) aknaid ja neid aknaid oskavad näidata mitmed programmid, sealhulgas failihaldur Rox."
+#: tips:202
+msgid ""
+"Most window managers provide a way to iconify (or 'minimise') windows, and "
+"various programs, including ROX-Filer, can be used to display the iconified "
+"windows."
+msgstr ""
+"Enamus aknahaldureid pakuvad võimalust minimeerida (ikoniseerida) aknaid ja "
+"neid aknaid oskavad näidata mitmed programmid, sealhulgas failihaldur Rox."
 
-#: tips:151
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Näita minimeeritud aknaid"
 
-#: tips:152
-msgid "If this option is on, the filer will show each iconified window as a small button on the pinboard. Requires a compatible window manager, and the pinboard must be in use."
-msgstr "Iga minimeeritud akna kohta näidatakse töölaual ikooni. Eeldab ühilduvat aknahaldurit ja Rox töölaua kasutuses olemist."
+#: tips:205
+msgid ""
+"If this option is on, the filer will show each iconified window as a small "
+"button on the pinboard. Requires a compatible window manager, and the "
+"pinboard must be in use."
+msgstr ""
+"Iga minimeeritud akna kohta näidatakse töölaual ikooni. Eeldab ühilduvat "
+"aknahaldurit ja Rox töölaua kasutuses olemist."
 
-#: tips:153
+#: tips:206
 msgid "Show per workspace"
 msgstr "Näita töölaua kohta"
 
-#: tips:154
-msgid "If this option is on, the filer will only show iconified windows associated with the current workspace."
-msgstr "Kui see valik on lubatud, näidatakse ainult praeguse töölaua minimeeritud aknaid."
+#: tips:207
+msgid ""
+"If this option is on, the filer will only show iconified windows associated "
+"with the current workspace."
+msgstr ""
+"Kui see valik on lubatud, näidatakse ainult praeguse töölaua minimeeritud "
+"aknaid."
 
-#: tips:155
+#: tips:208
 msgid "Iconify to the"
 msgstr "Minimeeritakse"
 
-#: tips:156
+#: tips:209
 msgid "top-left"
 msgstr "vasakule üles"
 
-#: tips:157
+#: tips:210
 msgid "top-right"
 msgstr "paremale üles"
 
-#: tips:158
+#: tips:211
 msgid "bottom-left"
 msgstr "vasakule alla"
 
-#: tips:159
+#: tips:212
 msgid "bottom-right"
 msgstr "paremale alla"
 
-#: tips:160
+#: tips:213
 msgid ", going"
 msgstr ", rivistades"
 
-#: tips:161
+#: tips:214
 msgid "horizontally"
 msgstr "horisontaalselt"
 
-#: tips:162
+#: tips:215
 msgid "vertically"
 msgstr "vertikaalselt"
 
-#: tips:163
-msgid "Sometimes the filer doesn't know about your desktop furniture and puts iconified windows under (for example) the Gnome panel. You can define a top or bottom margin to avoid placing the icons there. The filer already knows about its own panel."
-msgstr "Mõnikord failihaldur ei ole teadlik muudest töölaual asuvatest graafilistest elementidest ja paigutab minimeeritud aknaid (näiteks) Gnome paneeli alla. Te võite määrata ülemise või alumise piiri, millega keelate failide ekraani servale lähemale paigutamise. Failihaldur on omaenda paneelidest teadlik."
+#: tips:216
+msgid ""
+"Sometimes the filer doesn't know about your desktop furniture and puts "
+"iconified windows under (for example) the Gnome panel. You can define a top "
+"or bottom margin to avoid placing the icons there. The filer already knows "
+"about its own panel."
+msgstr ""
+"Mõnikord failihaldur ei ole teadlik muudest töölaual asuvatest graafilistest "
+"elementidest ja paigutab minimeeritud aknaid (näiteks) Gnome paneeli alla. "
+"Te võite määrata ülemise või alumise piiri, millega keelate failide ekraani "
+"servale lähemale paigutamise. Failihaldur on omaenda paneelidest teadlik."
 
-#: tips:164
+#: tips:217
 msgid "Top margin"
 msgstr "Ülemine piir"
 
-#: tips:165
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Üleval asuv ala, kuhu objekte ei paigutata."
 
-#: tips:166
+#: tips:219
 msgid "Bottom margin"
 msgstr "Alumine piir"
 
-#: tips:167
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "All asuv ala, kuhu objekte ei paigutata."
 
-#: tips:168
-msgid "Panels"
-msgstr "Panels"
+#: tips:221
+#, fuzzy
+msgid "Left margin"
+msgstr "Ülemine piir"
 
-#: tips:169
-msgid "Panels are bars of icons that run along the side of the screen. See the manual for information about using panels."
-msgstr ""
-"Paneelid on ikoonidega ribad, mis jooksevad piki ekraani serva.\n"
-"Paneelidest rohkem teada saamiseks lugege käsiraamatut."
+#: tips:222
+#, fuzzy
+msgid "Width of no-go area at left of screen."
+msgstr "Üleval asuv ala, kuhu objekte ei paigutata."
 
-#: tips:170
-msgid "Panel style"
-msgstr "Paneeli stiil"
+#: tips:223
+#, fuzzy
+msgid "Right margin"
+msgstr "Alumine piir"
 
-#: tips:171
-msgid "Image and text"
-msgstr "Pilt ja tekst"
+#: tips:224
+#, fuzzy
+msgid "Width of no-go area at right of screen."
+msgstr "Üleval asuv ala, kuhu objekte ei paigutata."
 
-#: tips:172
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Igal paneeli ikoonil on nii pilt kui tekst."
-
-#: tips:173
-msgid "Image only for applications"
-msgstr "Pilt ainult rakendustel"
-
-#: tips:174
-msgid "Applications have just an image, everything else has both an image and text."
-msgstr "Rakendustel on ainult pilt, muudel failidel on nii pilt kui tekst."
-
-#: tips:175
-msgid "Image only"
-msgstr "Ainult pilt"
-
-#: tips:176
-msgid "Only the image is shown."
-msgstr "Näidatakse ainult pilti."
-
-#: tips:177
-msgid "Panel width (thin)"
-msgstr "Paneeli laius (kitsas)"
-
-#: tips:178
-msgid "(thick)"
-msgstr "(lai)"
-
-#: tips:179
-msgid "The size of the panels."
-msgstr "Paneeli suurus."
-
-#: tips:180
-msgid "Do not cover panel"
-msgstr "Ära kata paneeli"
-
-#: tips:181
-msgid "Ask the window manager not to cover panels at all when you maximise windows. Some window managers may not honour this. If unset, the filer asks for just a couple of pixels at the edge of the screen to remain uncovered, so that auto-raising works."
-msgstr "Palu aknahalduril mitte paigutada aknaid paneeli kohale, kui aken maksimeeritakse.Mõned aknahaldurid ei tunnusta seda asetust. Kui see suvand on välja lülitud, palub failihaldur paar pikslit ekraani servast vabaks jätta, et paneelide automaatne esiletõusmine toimiks."
-
-#: tips:182
-msgid "Xinerama"
-msgstr "Xinerama"
-
-#: tips:183
-msgid "Confine to Xinerama monitor"
-msgstr "Hoia Xinerama monitori piires"
-
-#: tips:184
-msgid "If you have an Xinerama multi-monitor setup, use this option to confine the panels to one monitor instead of spanning them."
-msgstr "Kui teil on Xinerama mitme monitori süsteem, siis see suvand hoiab paneeli ainult ühel monitoril, mitte kõigil."
-
-#: tips:185
-msgid "The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr "Monitori number, millel on paneelid Xinerama moodis (numbrid algavad 0'st)"
-
-#: tips:186
+#: tips:225
 msgid "Desktop"
 msgstr "Töölaud"
 
-#: tips:187
-msgid "When run by a session manager program (such as ROX-Session) the filer can open up a panel and/or the pinboard.  Here you configure which."
-msgstr "Kui jooksutate failihaldurit sessioonihalduri kaudu (nagu näiteks ROX-Session), võib failihaldur avada paneeli ja/või töölaua. Siin saate sellega seotud asetusi muuta."
+#: tips:226
+msgid ""
+"When run by a session manager program (such as ROX-Session) the filer can "
+"open up a panel and/or the pinboard.  Here you configure which."
+msgstr ""
+"Kui jooksutate failihaldurit sessioonihalduri kaudu (nagu näiteks ROX-"
+"Session), võib failihaldur avada paneeli ja/või töölaua. Siin saate sellega "
+"seotud asetusi muuta."
 
-#: tips:188
+#: tips:227
 msgid "Panel only"
 msgstr "Ainult paneel"
 
-#: tips:189
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Näidatakse ainult paneeli."
 
-#: tips:190
+#: tips:229
 msgid "Pinboard only"
 msgstr "Ainult töölaud"
 
-#: tips:191
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "Näidatakse ainult töölauda."
 
-#: tips:192
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "Paneel ja töölaud"
 
-#: tips:193
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "Näidatakse nii paneeli kui töölauda."
 
-#: tips:194
-msgid "Panel"
-msgstr "Paneel"
-
-#: tips:195
-msgid "Enter the name of the panel to show here."
-msgstr "Sisestage siia näidatava paneeli nimi."
-
-#: tips:197
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "Sisestage siia näidatava töölaua nimi."
 
-#: tips:198
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr "Muutused hakkavad kehtima peale falihalduri uuestikäivitamist."
 
-#: tips:199
-msgid "The session manager activates these options by using the -S or --rox-session argument to rox."
-msgstr "Sessioonihaldur aktiveerib need valikud kasutades -S või --rox-session võtit rox käiitamisel."
+#: tips:236
+#, fuzzy
+msgid ""
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
+msgstr ""
+"Sessioonihaldur aktiveerib need valikud kasutades -S või --rox-session võtit "
+"rox käiitamisel."
 
-#: tips:200
+#: tips:237
 msgid "Action windows"
 msgstr "Tegevusaknad"
 
-#: tips:201
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4004,343 +4930,939 @@ msgstr ""
 "Tegevusaknad avanevad, kui sooritate mõne taustal jooksva \n"
 "tegevuse, nagu failide kopeerimine või kustutamine."
 
-#: tips:202
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Käivita need tegevused ilma küsimata (vaikides):"
 
-#: tips:204
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Enne kopeerimist ei küsita nõusolekut."
 
-#: tips:206
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Enne failide tõstmist ei küsita nõusolekut."
 
-#: tips:208
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Enne viitade loomist failidele ei küsita nõusolekut."
 
-#: tips:210
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Enne failide kustutamist ei küsita nõusolekut."
 
-#: tips:211
+#: tips:248
 msgid "Mount"
 msgstr "Ühenda"
 
-#: tips:212
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Ühenda ja lahuta failisüsteeme ilma nõusolekut küsimata."
 
-#: tips:213
+#: tips:250
 msgid "Default settings"
 msgstr "Vaikimisi asetused"
 
-#: tips:215
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Sunni"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "Enne kirjutuskaitsega elementide kustutamist ei küsita nõusolekut."
 
-#: tips:217
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Näita teadeteaknas vähem infot."
 
-#: tips:219
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Muuda ka alamkataloogide sisu."
 
-#: tips:222
+#: tips:263
+#, fuzzy
+msgid "Mount commands"
+msgstr "Ühenduspunkt"
+
+#: tips:264
+#, fuzzy
+msgid "Mount command"
+msgstr "Ühenduspunkt"
+
+#: tips:265
+msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
+msgstr ""
+
+#: tips:266
+#, fuzzy
+msgid "Unmount command"
+msgstr "Lahuta"
+
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "_Kasuta käsku"
+
+#: tips:269
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Lohistamine"
 
-#: tips:223
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Lohista ikooni peale"
 
-#: tips:224
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Luba lohistada ikoonidele failihalduri aknas"
 
-#: tips:225
-msgid "When this is on you can drag a file over a sub-directory or program in a filer window. The item will highlight when you do this and dropping the file will put it into that directory, or load it into the program."
-msgstr "Kui see suvand on sisse lülitatud, saate te lohistada faili alamkataloogi või programmi peale failihalduri aknas. See objekt tõstetakse esile ja hiirenupu lahti laskmisel fail kas tõstetakse kataloogi või laetakse selle programmi sees."
+#: tips:275
+msgid ""
+"When this is on you can drag a file over a sub-directory or program in a "
+"filer window. The item will highlight when you do this and dropping the file "
+"will put it into that directory, or load it into the program."
+msgstr ""
+"Kui see suvand on sisse lülitatud, saate te lohistada faili alamkataloogi "
+"või programmi peale failihalduri aknas. See objekt tõstetakse esile ja "
+"hiirenupu lahti laskmisel fail kas tõstetakse kataloogi või laetakse selle "
+"programmi sees."
 
-#: tips:226
+#: tips:276
 msgid "Directories spring open"
 msgstr "Lahti hüppavad kataloogid"
 
-#: tips:227
-msgid "This option, which requires the above option to be turned on too, causes the highlighted directory to 'spring open' after the file is held over it for a short while."
-msgstr "See suvand eeldab ka eelmise lubamist. Kui lohistate faili kataloogi peale ja hoiate seda seal veidi aega, \"hüppab\" kataloog ise lahti."
+#: tips:277
+msgid ""
+"This option, which requires the above option to be turned on too, causes the "
+"highlighted directory to 'spring open' after the file is held over it for a "
+"short while."
+msgstr ""
+"See suvand eeldab ka eelmise lubamist. Kui lohistate faili kataloogi peale "
+"ja hoiate seda seal veidi aega, \"hüppab\" kataloog ise lahti."
 
-#: tips:228
+#: tips:278
 msgid "Spring delay:"
 msgstr "Avanemisviivitus:"
 
-#: tips:229
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:230
-msgid "This option sets how long, in ms, you must hold a file over a directory before it will spring open. The above option must be turned on for this to have any effect."
-msgstr "See suvand määrab, kui kaua (millisekundites ehk tuhandiksekundites) peate faili kataloogi kohal hoidma, et kataloog ise avaneks. Eeldab eelneva suvandi lubamist."
+#: tips:280
+msgid ""
+"This option sets how long, in ms, you must hold a file over a directory "
+"before it will spring open. The above option must be turned on for this to "
+"have any effect."
+msgstr ""
+"See suvand määrab, kui kaua (millisekundites ehk tuhandiksekundites) peate "
+"faili kataloogi kohal hoidma, et kataloog ise avaneks. Eeldab eelneva "
+"suvandi lubamist."
 
-#: tips:231
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Faile vasaku hiirenupuga lohistades"
 
-#: tips:232
-#: tips:236
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Näita võimalike tegevuste menüüd"
 
-#: tips:233
+#: tips:283
 msgid "Copy the files"
 msgstr "Kopeeri failid"
 
-#: tips:234
-msgid "Note that you can still get the menu to appear, by dragging with Alt held down."
+#: tips:284
+msgid ""
+"Note that you can still get the menu to appear, by dragging with Alt held "
+"down."
 msgstr "Vajadusel saate te menüü, kui lohistate, Alt-klahvi all hoides."
 
-#: tips:235
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Faile lohistades keskmise nupuga"
 
-#: tips:237
+#: tips:287
 msgid "Move the files"
 msgstr "Tõsta failid"
 
-#: tips:238
-msgid "Note that you can still get the menu to appear, by dragging with the left button and holding down the Alt key."
-msgstr "Vajadusel saate te menüü, kui lohistate vasaku hiirenupuga, Alt-klahvi all hoides."
+#: tips:288
+msgid ""
+"Note that you can still get the menu to appear, by dragging with the left "
+"button and holding down the Alt key."
+msgstr ""
+"Vajadusel saate te menüü, kui lohistate vasaku hiirenupuga, Alt-klahvi all "
+"hoides."
 
-#: tips:239
+#: tips:289
 msgid "Download handler"
 msgstr "Allalaadimiste haldur"
 
-#: tips:240
+#: tips:290
 msgid ""
-"When you drag a file from a web browser or other remote source, this program will be run to download it. $1 is the URI dragged to the filer, and the current directory is the destination. Eg:\n"
+"When you drag a file from a web browser or other remote source, this program "
+"will be run to download it. $1 is the URI dragged to the filer, and the "
+"current directory is the destination. Eg:\n"
 "xterm -e wget $1"
 msgstr ""
-"Kui te lohistate failihaldurisse faili brauserist või mõnest muust mittekohalikust allikast, jooksutatakse seda programmi allalaadimisel. $1 on lohistatud faili URI ja jooksev kataloog on sihtkoht, kuhu salvestatakse. Näiteks:\n"
+"Kui te lohistate failihaldurisse faili brauserist või mõnest muust "
+"mittekohalikust allikast, jooksutatakse seda programmi allalaadimisel. $1 on "
+"lohistatud faili URI ja jooksev kataloog on sihtkoht, kuhu salvestatakse. "
+"Näiteks:\n"
 "xterm -e wget $1"
 
-#: tips:241
+#: tips:291
 msgid "Menus"
 msgstr "Menüüd"
 
-#: tips:243
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Ikoonide suurus menüüs:"
 
-#: tips:244
+#: tips:294
 msgid "No Icons"
 msgstr "Pole ikoone"
 
-#: tips:247
+#: tips:297
 msgid "Same as current window"
 msgstr "Sama kui aktiivsel aknal"
 
-#: tips:248
+#: tips:298
 msgid "Same as default"
 msgstr "Sama kui vaikimisi"
 
-#: tips:249
+#: tips:299
 msgid "Behaviour"
 msgstr "Käitumine"
 
-#: tips:250
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Fail-menüü paremklõpsu puhul"
 
-#: tips:251
-msgid "Show the File menu instead of the main menu when right-clicking with files selected (the main menu can be accessed by holding down Control)."
-msgstr "Näita Fail-menüüd põhimenüü asemel, kui teil on valitud faile ja paremklõpsate (põhimenüü saate, kui hoiate klõpsu ajal all Control-klahvi)"
+#: tips:301
+msgid ""
+"Show the File menu instead of the main menu when right-clicking with files "
+"selected (the main menu can be accessed by holding down Control)."
+msgstr ""
+"Näita Fail-menüüd põhimenüü asemel, kui teil on valitud faile ja "
+"paremklõpsate (põhimenüü saate, kui hoiate klõpsu ajal all Control-klahvi)"
 
-#: tips:252
+#: tips:302
 msgid "Terminal emulator program"
 msgstr "Terminaliprogramm:"
 
-#: tips:253
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr "Programm, mis käivitatakse, kui valite menüüst \"Termina siia\"."
 
-#: tips:254
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Kiirklahvid"
 
-#: tips:256
+#: tips:305
+msgid "Types"
+msgstr "Tüübid"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME-Tüübid"
 
-#: tips:257
-msgid "The filer uses a set of rules to work out the correct MIME type for each regular file, and then chooses a suitable icon for that type."
-msgstr "Failihaldur kasutab reeglite komplekti, et leida sobivat MIME-tüüpi iga tavalise faili jaoks ja valib seejärel failile sobiva ikooni."
+#: tips:307
+msgid ""
+"The filer uses a set of rules to work out the correct MIME type for each "
+"regular file, and then chooses a suitable icon for that type."
+msgstr ""
+"Failihaldur kasutab reeglite komplekti, et leida sobivat MIME-tüüpi iga "
+"tavalise faili jaoks ja valib seejärel failile sobiva ikooni."
 
-#: tips:258
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "Muuda MIME reegleid"
 
-#: tips:259
+#: tips:309
 msgid "Themes"
 msgstr "Teemad"
 
-#: tips:260
+#: tips:310
 msgid "Icon theme"
 msgstr "Ikooniteema"
 
-#: tips:261
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "Teemad peaksid olema ~/.icons kataloogi sees."
 
-#: tips:262
-msgid "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note that icons set this way override those from the selected theme."
-msgstr "Kasutage \"Sea ikooni\" dialoogikasti, et iga MIME-tüübi jaoks ikooni seada.Niimoodi seatud ikoone eelistatakse valitud teema ikoonidele."
+#: tips:312
+msgid ""
+"Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
+"that icons set this way override those from the selected theme."
+msgstr ""
+"Kasutage \"Sea ikooni\" dialoogikasti, et iga MIME-tüübi jaoks ikooni seada."
+"Niimoodi seatud ikoone eelistatakse valitud teema ikoonidele."
 
-#: tips:263
+#: tips:313
 msgid "Colours"
 msgstr "Värvid"
 
-#: tips:264
+#: tips:314
 msgid "File type colours"
 msgstr "Failitüüpide värvid"
 
-#: tips:265
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Värvi failid vastavalt nende tüübile"
 
-#: tips:266
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr "Failinimed (ja üksikasjad) värvitakse vastavalt failitüübile."
 
-#: tips:267
+#: tips:317
 msgid "Directory:"
 msgstr "Kataloog:"
 
-#: tips:268
+#: tips:318
 msgid "Regular file:"
 msgstr "Tavaline fail:"
 
-#: tips:269
+#: tips:319
 msgid "Pipe:"
 msgstr "Toru:"
 
-#: tips:270
+#: tips:320
 msgid "Socket:"
 msgstr "Sokkel:"
 
-#: tips:272
-msgid "Error, such as a symlink which points to a non-existant file, or a file which the filer does not have permission to examine."
-msgstr "Viga, näiteks kui sümbolviide viitab olematule failile või faili avamiseks pole failihalduril õigusi."
+#: tips:322
+msgid ""
+"Error, such as a symlink which points to a non-existant file, or a file "
+"which the filer does not have permission to examine."
+msgstr ""
+"Viga, näiteks kui sümbolviide viitab olematule failile või faili avamiseks "
+"pole failihalduril õigusi."
 
-#: tips:273
+#: tips:323
 msgid "Character device:"
 msgstr "Sümbolseade:"
 
-#: tips:274
+#: tips:324
 msgid "Block device:"
 msgstr "Plokkseade:"
 
-#: tips:275
+#: tips:325
 msgid "Door:"
 msgstr "Uks:"
 
-#: tips:276
-msgid "Door files are a bit like sockets or pipes, and have only been seen on Solaris."
+#: tips:326
+msgid ""
+"Door files are a bit like sockets or pipes, and have only been seen on "
+"Solaris."
 msgstr "Uksed on soklite või torude moodi ja neid kasutatakse vaid Solarises."
 
-#: tips:277
+#: tips:327
 msgid "Executable file:"
 msgstr "Käivitatav fail:"
 
-#: tips:278
+#: tips:328
 msgid "Application directory:"
 msgstr "Kataloograkendus:"
 
-#: tips:279
+#: tips:329
 msgid "Unknown type:"
 msgstr "Tundmatut tüüpi:"
 
-#: tips:280
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Taust:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Kasuta muud fonti:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Ühilduvus"
 
-#: tips:281
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Aknahalduriprobleemid"
 
-#: tips:282
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "Võta aknahaldurilt kontroll töölaua ja paneelide üle"
 
-#: tips:283
-msgid "Some window managers don't support the new Extended Window Manager Hints system, and so treat the pinboard and panels like normal windows. Turn this on to fix problems such as the pinboard coming to the front when you click on it, titlebars and other decorations appearing around windows, or having them appear in window-select lists."
-msgstr "Paljud aknahaldurid ei toeta uut 'Extended Window Manager Hints' süsteemi ja kohtlevad töölauda ja paneele kui tavalisi aknaid. Lülitage sisse see suvand järgmiste probleemide esinedes: töölaud ning paneelid on akendenimistus, päised ning muud dekoratsioonid akendel või kui töölaud hiireklõpsu peale pealmiseks aknaks tõuseb."
+#: tips:340
+msgid ""
+"Some window managers don't support the new Extended Window Manager Hints "
+"system, and so treat the pinboard and panels like normal windows. Turn this "
+"on to fix problems such as the pinboard coming to the front when you click "
+"on it, titlebars and other decorations appearing around windows, or having "
+"them appear in window-select lists."
+msgstr ""
+"Paljud aknahaldurid ei toeta uut 'Extended Window Manager Hints' süsteemi ja "
+"kohtlevad töölauda ja paneele kui tavalisi aknaid. Lülitage sisse see suvand "
+"järgmiste probleemide esinedes: töölaud ning paneelid on akendenimistus, "
+"päised ning muud dekoratsioonid akendel või kui töölaud hiireklõpsu peale "
+"pealmiseks aknaks tõuseb."
 
-#: tips:284
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "Anna kõik hiireklõpsud taustale aknahaldurile edasi"
 
-#: tips:285
-msgid "Normally, right clicking on the desktop background will open the pinboard menu and left clicking will clear the selection. Turn this on to forward the events to your window manager instead. Clicks on icons will not be forwarded."
-msgstr "Enamasti paremklõpsates töölaua taustale avaneb menüü ja vasakklõps tühistab valiku. Antud suvandi sisse lülitades antakse edasi aknahaldurile klõpsud taustale. Edasi ei anta klõpse ikoonidele."
+#: tips:342
+msgid ""
+"Normally, right clicking on the desktop background will open the pinboard "
+"menu and left clicking will clear the selection. Turn this on to forward the "
+"events to your window manager instead. Clicks on icons will not be forwarded."
+msgstr ""
+"Enamasti paremklõpsates töölaua taustale avaneb menüü ja vasakklõps tühistab "
+"valiku. Antud suvandi sisse lülitades antakse edasi aknahaldurile klõpsud "
+"taustale. Edasi ei anta klõpse ikoonidele."
 
-#: tips:286
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Blackboxi taustamenüü häkk"
 
-#: tips:287
-msgid "Blackbox, Fluxbox and similar window managers do not yet work well with the ROX-Filer pinboard. This option enables some workarounds. These window managers are expected to change their behaviour in new versions so that this isn't necessary."
-msgstr "Blackbox, Fluxbox ja neile sarnased aknahaldurid ei tööta veel kuigi hästi Roxi töölauaga. Sellele vastukaaluks aktiveerib antud suvand mõningad meetmed. Nende aknahaldurite järgmistes versioonides on küllap need probleemid juba parandatud."
+#: tips:344
+msgid ""
+"Blackbox, Fluxbox and similar window managers do not yet work well with the "
+"ROX-Filer pinboard. This option enables some workarounds. These window "
+"managers are expected to change their behaviour in new versions so that this "
+"isn't necessary."
+msgstr ""
+"Blackbox, Fluxbox ja neile sarnased aknahaldurid ei tööta veel kuigi hästi "
+"Roxi töölauaga. Sellele vastukaaluks aktiveerib antud suvand mõningad "
+"meetmed. Nende aknahaldurite järgmistes versioonides on küllap need "
+"probleemid juba parandatud."
 
-#: tips:288
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "Paneel on 'dokk'"
 
-#: tips:289
-msgid "Disable this option if the panel stays above other windows against your wishes. Requires a restart to take effect."
-msgstr "Lülige välja see suvand, kui paneel tõuseb soovimatult teiste akende peale. Nõuab uuestikäivitust"
+#: tips:346
+#, fuzzy
+msgid ""
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
+msgstr ""
+"Lülige välja see suvand, kui paneel tõuseb soovimatult teiste akende peale. "
+"Nõuab uuestikäivitust"
 
-#: tips:290
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Paneeli stiil"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Lohistamine"
 
-#: tips:291
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Ära kasuta arvutinimesid"
 
-#: tips:292
-msgid "Some older applications don't support XDND fully and may need to have this option turned on. Use this if dragging files to an application shows a + sign on the pointer but the drop doesn't work."
-msgstr "Mõned vanemad rakendused ei toets XDND protokolli täielikult ja see suvand võib vajalikuks osutuda. Lülitage see sisse, kui faili rakendusele lohitades kursorile lisandub + märk, kuid lohistamine ise ebaõnnestub."
+#: tips:353
+msgid ""
+"Some older applications don't support XDND fully and may need to have this "
+"option turned on. Use this if dragging files to an application shows a + "
+"sign on the pointer but the drop doesn't work."
+msgstr ""
+"Mõned vanemad rakendused ei toets XDND protokolli täielikult ja see suvand "
+"võib vajalikuks osutuda. Lülitage see sisse, kui faili rakendusele lohitades "
+"kursorile lisandub + märk, kuid lohistamine ise ebaõnnestub."
 
-#: tips:293
-msgid "Extended attributes"
-msgstr "Laiendatud atribuudid"
-
-#: tips:294
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Ära kasuta laiendatud atribuute"
 
-#: tips:295
-msgid "This disables the use of extended attributes available in newer operating systems and file systems.  With this option set the 'Set Type' menu entry is disabled, the MIME type of the file is only derived from the file name and the properties window does not report extended attributes."
-msgstr "See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendatud atribuutide kasutamise. Selle suvandi lubamisel 'Sea tüüp' menüüsissekanne keelatakse, faili MIME-tüüp tuletatakse ainult failinimest ja Omaduste aken ei näita infot laiendatud atribuutide kohta"
+#: tips:356
+msgid ""
+"This disables the use of extended attributes available in newer operating "
+"systems and file systems.  With this option set the 'Set Type' menu entry is "
+"disabled, the MIME type of the file is only derived from the file name and "
+"the properties window does not report extended attributes."
+msgstr ""
+"See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendatud "
+"atribuutide kasutamise. Selle suvandi lubamisel 'Sea tüüp' menüüsissekanne "
+"keelatakse, faili MIME-tüüp tuletatakse ainult failinimest ja Omaduste aken "
+"ei näita infot laiendatud atribuutide kohta"
+
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Alumine serv"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "Paremal"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "Kodukataloog"
+
+#: ../Templates.ui.h:4
+msgid "Panel Options"
+msgstr "Paneeli valikud"
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Pilt ja tekst"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Igal paneeli ikoonil on nii pilt kui tekst."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Pilt ainult rakendustel"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr "Rakendustel on ainult pilt, muudel failidel on nii pilt kui tekst."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Ainult pilt"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Näidatakse ainult pilti."
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Paneeli laius (kitsas)"
+
+#: ../Templates.ui.h:12
+#, fuzzy
+msgid "The size of this panel."
+msgstr "Paneeli suurus."
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Tõlge"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "Ära kata paneeli"
+
+#: ../Templates.ui.h:19
+#, fuzzy
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Palu aknahalduril mitte paigutada aknaid paneeli kohale, kui aken "
+"maksimeeritakse.Mõned aknahaldurid ei tunnusta seda asetust. Kui see suvand "
+"on välja lülitud, palub failihaldur paar pikslit ekraani servast vabaks "
+"jätta, et paneelide automaatne esiletõusmine toimiks."
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Paneeli stiil"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Hoia Xinerama monitori piires"
+
+#: ../Templates.ui.h:22
+#, fuzzy
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Kui teil on Xinerama mitme monitori süsteem, siis see suvand hoiab paneeli "
+"ainult ühel monitoril, mitte kõigil."
+
+#: ../Templates.ui.h:23
+#, fuzzy
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+"Monitori number, millel on paneelid Xinerama moodis (numbrid algavad 0'st)"
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "Xinerama"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr "Paremal"
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr "Vasakul"
+
+#: ../Templates.ui.h:27
+msgid "Bottom edge"
+msgstr "Alumine serv"
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr "Üleval"
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "<b>Õigused</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<ver>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' on juba olemas - kas kirjutan üle?"
+
+#~ msgid "Choices migration"
+#~ msgstr "Valikute ümbertõstmine"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Viga '%s' skaneerimisel:\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Kataloog on kadunud/kustutatud"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Kataloogi '%s' ei leitud."
+
+#~ msgid "Cancel"
+#~ msgstr "Tühista"
+
+#~ msgid "All, "
+#~ msgstr "KÃµik, "
+
+#~ msgid ""
+#~ ".\n"
+#~ "Home page (including updated versions): http://rox.sourceforge.net/\n"
+#~ msgstr ""
+#~ ".\n"
+#~ "Kodulehekülg (kus ka uued versioonid): http://rox.sourceforge.net/\n"
+
+#~ msgid "Dnotify support"
+#~ msgstr "Dnotify-toetus"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr "Klõpsake Shift+Menüü faili kohal, et seda kuhugi saata"
+
+#~ msgid "Panel: %s"
+#~ msgstr "Paneel: %s"
+
+#~ msgid "Select the panel's position:"
+#~ msgstr "Vali paneeli asend:"
+
+#~ msgid "Top-edge panel"
+#~ msgstr "Paneel üleval servas"
+
+#~ msgid "Bottom edge panel"
+#~ msgstr "Paneel all servas"
+
+#~ msgid "Left edge panel"
+#~ msgstr "Paneel vasakul servas"
+
+#~ msgid "Right-edge panel"
+#~ msgstr "Paneel paremal servas"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Vigane .gmo tõlkefail (liiga lühike): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr "Vigane .gmo tõlkefail (ei leitud GNU maagilist päist): %s"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Mine ülevalpoolsesse kataloogi"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Mine kodukataloogi"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Järjehoidjad"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Järjehoidjate-menüü"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Skaneeri uuesti kataloogi sisu"
+
+#~ msgid "Change icon size"
+#~ msgstr "Muuda ikooni suurust"
+
+#~ msgid "Show extra details"
+#~ msgstr "Näita rohkem infot"
+
+#~ msgid "Hidden"
+#~ msgstr "Peidetud"
+
+#~ msgid "Show/hide hidden files"
+#~ msgstr "Näita/varja peidetud faile"
+
+#~ msgid ""
+#~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
+#~ "instead."
+#~ msgstr "Ikooniteemas '%s' pole MIME ikoone. Kasutan Rox vaikimisi teemat.."
+
+#~ msgid ""
+#~ "Failed to create symlink '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(this may mean that the ROX theme already exists there, but the 'mime-"
+#~ "application:postscript' icon couldn't be loaded for some reason, or %s is "
+#~ "a link to an invalid directory; try deleting it)"
+#~ msgstr ""
+#~ "Sümbolviida '%s' loomine ebaõnnestus:\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(see võib tähendada, et ROX teema on juba seal olemas, kuid mingil "
+#~ "põhjusel ei suudetud laadida 'mime-application:postscript' ikooni või on "
+#~ "%s viide vigasele kataloogile, proovige see kustutada)"
+
+#~ msgid "Language"
+#~ msgstr "Keel"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "Kasutage LANG keskkonnamuutujat"
+
+#~ msgid "Basque"
+#~ msgstr "Baski"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Hiina (traditsiooniline)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Hiina (lihtsustatud)"
+
+#~ msgid "Czech"
+#~ msgstr "Tšehhi"
+
+#~ msgid "Danish"
+#~ msgstr "Taani"
+
+#~ msgid "Dutch"
+#~ msgstr "Hollandi"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Inglise (tõlkimata)"
+
+#~ msgid "Estonian"
+#~ msgstr "Eesti"
+
+#~ msgid "Finnish"
+#~ msgstr "Soome"
+
+#~ msgid "French"
+#~ msgstr "Prantsuse"
+
+#~ msgid "German"
+#~ msgstr "Saksa"
+
+#~ msgid "Hungarian"
+#~ msgstr "Ungari"
+
+#~ msgid "Japanese"
+#~ msgstr "Jaapani"
+
+#~ msgid "Norwegian"
+#~ msgstr "Norra"
+
+#~ msgid "Italian"
+#~ msgstr "Itaalia"
+
+#~ msgid "Polish"
+#~ msgstr "Poola"
+
+#~ msgid "Portuguese (Portugal)"
+#~ msgstr "Portugali (Portugal)"
+
+#~ msgid "Portuguese (Brasil)"
+#~ msgstr "Portugali (Brasiilia)"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumeenia"
+
+#~ msgid "Russian"
+#~ msgstr "Vene"
+
+#~ msgid "Spanish"
+#~ msgstr "Hispaania"
+
+#~ msgid "Swedish"
+#~ msgstr "Rootsi"
+
+#~ msgid "Change at:"
+#~ msgstr "Muuda alates:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Maksimumlaius (suurte ikoonidega):"
+
+#~ msgid "Panels"
+#~ msgstr "Panels"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Paneelid on ikoonidega ribad, mis jooksevad piki ekraani serva.\n"
+#~ "Paneelidest rohkem teada saamiseks lugege käsiraamatut."
+
+#~ msgid "(thick)"
+#~ msgstr "(lai)"
+
+#~ msgid "Enter the name of the panel to show here."
+#~ msgstr "Sisestage siia näidatava paneeli nimi."
 
 #~ msgid "GNOME-VFS library"
 #~ msgstr "GNOME-VFS-teek"
+
 #~ msgid "No (need 2.8.0 or later)"
 #~ msgstr "Ei (vaja on 2.8.0 või uuem)"
+
 #~ msgid "Open AVFS"
 #~ msgstr "Ava AVFS abil"
+
 #~ msgid "Look inside ... ?"
 #~ msgstr "Vaata ... sisse?"
+
 #~ msgid ""
 #~ "Error loading MIME database:\n"
 #~ "%s"
 #~ msgstr ""
 #~ "Viga MIME-tüüpide andmebaasi laadimisel:\n"
 #~ "%s"
+
 #~ msgid "File '%s' corrupted!"
 #~ msgstr "Fail '%s' on vigane!"
+
 #~ msgid ""
 #~ "The ~/.mime directory has moved. It should now be ~/.local/share/mime. "
 #~ "You should move it there (and make a symlink from ~/.mime to it for older "
@@ -4348,6 +5870,7 @@ msgstr "See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendat
 #~ msgstr ""
 #~ "Kataloog ~/.mime asub nüüd ~/.local/share/mime. Palun tõstke see sinna "
 #~ "(ja ühilduvuse huvides vanade programmidega looge viit vanasse asukohta)."
+
 #~ msgid ""
 #~ "The standard MIME type database (version 0.9 or later) was not found. The "
 #~ "filer will probably not show the correct types for different files. You "
@@ -4367,10 +5890,13 @@ msgstr "See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendat
 #~ "Kui pakk on juba paigaldatud, kontrollige, kas Teil on lugemisõigused "
 #~ "sellele (kontrollige ligipääsuõigusi failile /usr/local/share/mime/globs "
 #~ "või /usr/share/mime/globs)."
+
 #~ msgid "Executable files"
 #~ msgstr "Käivitatavad failid"
+
 #~ msgid "Ignore eXecutable bit for known extensions"
 #~ msgstr "Ignoreeri tuntud laiendiga failide puhul käivitamisbitti"
+
 #~ msgid ""
 #~ "If a file has a known extension (eg '.gif') then ignore the executable "
 #~ "bit. This is useful if you have files on a Windows-type filesystem which "
@@ -4379,34 +5905,45 @@ msgstr "See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendat
 #~ "Kui faili laiend (näiteks '.gif') on tuntud, ignoreeri käivitamisbitti. "
 #~ "See on mõistlik juhul, kui teil on faile Windowsi failisüsteemil ja neid "
 #~ "näidatakse käivitatavate programmidena."
+
 #~ msgid "Icon '%s' not present in theme"
 #~ msgstr "Ikooni '%s' pole teemas"
+
 #~ msgid ""
 #~ "Pinboard icons cannot be drawn because ROX-Filer was compiled against GTK"
 #~ "+-2.0 but is running with GTK+-2.2. Please recompile it."
 #~ msgstr ""
 #~ "TÃ¶Ã¶laua ikoone ei saa kuvada, kuna ROX-Filer kompileeriti GTK+-2.0 "
 #~ "kasutades, kuid praegu jookseb GTK+-2.2. Palun kompileerige uuesti."
+
 #~ msgid "Info"
 #~ msgstr "Info"
+
 #~ msgid "Permissions:"
 #~ msgstr "Loabitid:"
+
 #~ msgid "file(1) says..."
 #~ msgstr "file(1) ÃŒtleb..."
+
 #~ msgid "Symbolic link to %s"
 #~ msgstr "SÃŒmbolviit failile %s"
+
 #~ msgid "No (gnome-vfs-config not found)"
 #~ msgstr "Ei (ei leitud gnome-vfs-config)"
+
 #~ msgid "Help about ... ?"
 #~ msgstr "Abi  ... kohta ?"
+
 #~ msgid "Examine ... ?"
 #~ msgstr "Uuri ... ?"
+
 #~ msgid ""
 #~ "Executable file:\n"
 #~ "This is a file with an eXecute bit set - it can be run as a program."
 #~ msgstr ""
 #~ "KÃ€ivitatav fail:\n"
 #~ "Sellel failil on aktiveeritud kÃ€ivitusbitt (--x)"
+
 #~ msgid ""
 #~ "File:\n"
 #~ "This is a data file. Try using the Info menu item to find out more..."
@@ -4414,6 +5951,7 @@ msgstr "See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendat
 #~ "Fail:\n"
 #~ "See on andmefail. Valige menÃŒÃŒst Info, et selle faili kohta rohkem "
 #~ "teada saada..."
+
 #~ msgid ""
 #~ "Mount point:\n"
 #~ "A mount point is a directory which another filing system can be mounted "
@@ -4424,6 +5962,7 @@ msgstr "See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendat
 #~ "Ãhenduspunkt on kataloog, mille kÃŒlge saab teisi failisÃŒsteeme "
 #~ "ÃŒhendada. KÃµik failid ÃŒhendatud failisÃŒsteemil on kÃ€ttesaadavad "
 #~ "selle kataloogi seest."
+
 #~ msgid ""
 #~ "Device file:\n"
 #~ "Device files allow you to read from or write to a device driver as though "
@@ -4432,6 +5971,7 @@ msgstr "See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendat
 #~ "Seadmefail:\n"
 #~ "Seadmefailid lubavad teil lugeda ja kirjutada andmeid oma seadme "
 #~ "tÃŒÃŒrelisse, nagu oleks tegemist tavalise failiga."
+
 #~ msgid ""
 #~ "Named pipe:\n"
 #~ "Pipes allow different programs to communicate. One program writes data to "
@@ -4440,12 +5980,14 @@ msgstr "See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendat
 #~ "Nimega toru:\n"
 #~ "Torud lubavad erinevatel rakendustel omavahel suhelda. Ãks rakendus "
 #~ "kirjutab andmeid torusse ja teine loeb neid sealt."
+
 #~ msgid ""
 #~ "Socket:\n"
 #~ "Sockets allow processes to communicate."
 #~ msgstr ""
 #~ "Sokkel:\n"
 #~ "Soklid lubavad protsessidel omavahel suhelda."
+
 #~ msgid ""
 #~ "Door:\n"
 #~ "Doors are a little-used Solaris method for processes to communicate."
@@ -4453,6 +5995,7 @@ msgstr "See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendat
 #~ "Uks:\n"
 #~ "Uksed on Solarise poolt kasutatav vÃ€helevinud meetod protsesside "
 #~ "omavaheliseks suhtluseks."
+
 #~ msgid ""
 #~ "Unknown type:\n"
 #~ "I couldn't find out what kind of file this is. Maybe it doesn't exist "
@@ -4461,6 +6004,7 @@ msgstr "See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendat
 #~ "Tundmatut tÃŒÃŒpi:\n"
 #~ "Ei Ãµnnestunud tuvastada faili tÃŒÃŒpi. Ehk pole seda faili enam vÃµi "
 #~ "puuduvad teil Ãµigused otsida kataloogis, kus fail asub ?"
+
 #~ msgid ""
 #~ "Directory:\n"
 #~ "This is a directory. It contains an index to other items - open it to see "
@@ -4469,8 +6013,10 @@ msgstr "See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendat
 #~ "Kataloog:\n"
 #~ "See on kataloog. See sisaldab nimekirja teiste elementide kohta  - avage "
 #~ "see, et nimekirja nÃ€ha."
+
 #~ msgid "Menu on button 2 (RISC OS style)"
 #~ msgstr "MenÃŒÃŒ teise hiirenupuga (RISC OS stiilis)"
+
 #~ msgid ""
 #~ "Use button 2, the middle button (click both buttons at once on two button "
 #~ "mice), to pop up the menu. If off, use button 3 (right) instead."
@@ -4478,4 +6024,3 @@ msgstr "See keelab uuemates opsüsteemides ja failisüsteemides olevate laiendat
 #~ "Kasutage teist hiirenuppu, s.o. keskmist hiirenuppu (klÃµpsake mÃµlemaid "
 #~ "nuppe korraga kahenupulise hiire puhul), et hÃŒpikmenÃŒÃŒd aktiveerida. "
 #~ "Kui suvand on keelatud, kasutage kolmandat (paremat) hiirenuppu."
-

--- a/ROX-Filer/src/po/eu.po
+++ b/ROX-Filer/src/po/eu.po
@@ -7,60 +7,65 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rox-es\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-08-09 14:02+0100\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2005-06-05 23:09+0200\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team:  librezale.org <librezale@librezale.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.9.1\n"
 
 #: abox.c:127
-msgid "<dir>"
-msgstr "<dir>"
+msgid "<src>"
+msgstr ""
 
-#: abox.c:219
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Ixilik"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Quiet"
 msgstr "Ixilik"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Ez berrretsi ekintza bakoitza"
 
-#: abox.c:455 tips:60
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Izena"
 
-#: abox.c:461 menu.c:232
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Direktorio"
 
-#: abox.c:550
+#: abox.c:546
 msgid "Expression:"
 msgstr "Espresioa:"
 
-#: action.c:58
+#: action.c:57
 msgid "See the attr(5) man page for full details."
 msgstr ""
 
-#: action.c:60
+#: action.c:59
 msgid "See the fsattr(5) man page for full details."
 msgstr ""
 
-#: action.c:62
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr ""
 
-#: action.c:188
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Bilaketa espresioari erreferentzia"
 
-#: action.c:199
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -136,11 +141,11 @@ msgstr ""
 "'komandoa'-n % fitxategiaren bideaz aldatuko da)\n"
 "<b>prune</b> (gezurra, eta direktorio baten edukien bilaketa ezintzen du)."
 
-#: action.c:246
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Bilaketa espresioari buruzko argibideak"
 
-#: action.c:257
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -201,11 +206,11 @@ msgstr ""
 "\n"
 "chmod(1) manualaren orria begiratu xehetasun gehiagorako."
 
-#: action.c:298
+#: action.c:308
 msgid "Set type reference"
 msgstr "Mota erreferentzia ezarri"
 
-#: action.c:309
+#: action.c:319
 #, fuzzy
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
@@ -237,48 +242,55 @@ msgstr ""
 "eragileak onartzen badu.\n"
 "\n"
 
-#: action.c:416
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Prozesua amaiturik.\n"
 
-#: action.c:432
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Errore bat gertatu da.\n"
 
-#: action.c:434
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "%d errore gertatu dira.\n"
 
-#: action.c:458
+#: action.c:516
 msgid "ERROR reading"
 msgstr "Irakurketa ERROREA"
 
-#: action.c:501
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Eginda\n"
 
-#: action.c:557 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "ERROREA"
 
-#: action.c:711 main.c:674 main.c:681 main.c:688
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Bai"
 
-#: action.c:714 main.c:676 main.c:690
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Ez"
 
-#: action.c:732
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -286,7 +298,7 @@ msgstr ""
 "\n"
 "Prozesu semeari amaitzeko eskatzen...\n"
 
-#: action.c:739
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -294,41 +306,41 @@ msgstr ""
 "\n"
 "Prozezu iheskorra HIKTZEN saiatzen...\n"
 
-#: action.c:892
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?%s-ren edukia kalkulatu?"
 
-#: action.c:928
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?%s'%s' ezabatu?"
 
-#: action.c:929
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "IDAZKETA-AURKA BABESTURIK"
 
-#: action.c:936
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "''%s' ezabatzen\n"
 
-#: action.c:949
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "''%s' Direktorioa ezabaturik\n"
 
-#: action.c:982
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?'%s' atera?"
 
-#: action.c:989
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "''%s' atera\n"
 
-#: action.c:1008
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -337,80 +349,95 @@ msgstr ""
 "!%s\n"
 "huts ateratzean\n"
 
-#: action.c:1027 action.c:1046
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?'%s' egiaztatu?"
 
-#: action.c:1043
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Bilaketa baldintza baliogabe - aldatu eta berriz saiatu\n"
 
-#: action.c:1053
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'('%s' egiaztatzen)\n"
 
-#: action.c:1127 action.c:1152
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?'%s'-ren baimenak aldatu?"
 
-#: action.c:1133
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "''%s'-ren baimank aldatzen\n"
 
-#: action.c:1150
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Modu baliogabea - aldatu eta ebrriz saiatu\n"
 
-#: action.c:1207 action.c:1227
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?'%s'-ren mota aldatu?"
+
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?'%s'-ren mota aldatu?"
 
-#: action.c:1224
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!mota baliogabea - aldatu eta berriz saiatu\n"
 
-#: action.c:1246
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "''%s'-ren mota '%s'-ra aldatzen\n"
 
-#: action.c:1325
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "''%s'-ren mota '%s'-ra aldatzen\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' badago dagoeneko - %s?"
 
-#: action.c:1327
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "edukiak batu"
 
-#: action.c:1328
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "gainidatzi"
 
-#: action.c:1344
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Hala ere kopiatzen saiatzen...\n"
 
-#: action.c:1353
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?%s %s-ra kopiatu?"
 
-#: action.c:1357
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'%s %s-ra kopiatzen\n"
 
-#: action.c:1372
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!ERROREA Helburua badago baina ez da direktorio bat\n"
 
-#: action.c:1444
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -419,26 +446,7 @@ msgstr ""
 "!%s\n"
 "Huts '%s' kopiatzerakoan\n"
 
-#: action.c:1488
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' badago - gainidatzi?"
-
-#: action.c:1503
-msgid "'Trying move anyway...\n"
-msgstr "'Hala ere mugitzen saiatzen...\n"
-
-#: action.c:1511
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?%s %s-ra mugit?"
-
-#: action.c:1515
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'%s %s-ra mugitzen\n"
-
-#: action.c:1523
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -447,46 +455,60 @@ msgstr ""
 "!%s\n"
 "Huts %s %s-ra mugitzerakoan\n"
 
-#: action.c:1544
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Hala ere mugitzen saiatzen...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?%s %s-ra mugit?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'%s %s-ra mugitzen\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!ERROREA: Ezinda objetu bat bere buruan kopiatu\n"
 
-#: action.c:1559
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!ERROREA: Ezinda objetu bat bere burura mugitu/berrizendatu\n"
 
 # Verificar
-#: action.c:1571
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'%s %s-rekin lotzen\n"
 
-#: action.c:1576
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?%s %s-rekin lotu?"
 
-#: action.c:1618
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'%s muntatzen\n"
 
-#: action.c:1619
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'%s desmuntatzen\n"
 
-#: action.c:1622
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?%s muntatu?"
 
-#: action.c:1623
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?%s desmuntatu?"
 
-#: action.c:1643
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -495,7 +517,7 @@ msgstr ""
 "!%s\n"
 "Huts muntatzerakoan\n"
 
-#: action.c:1644
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -504,11 +526,11 @@ msgstr ""
 "!%s\n"
 "Huts desmunatzerakoan\n"
 
-#: action.c:1652
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(dirudienez muntaturik dagoeneko hala ere)\n"
 
-#: action.c:1698
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -517,296 +539,320 @@ msgstr ""
 "'\n"
 "Guztira: %s ("
 
-#: action.c:1704
+#: action.c:2108
 msgid "file"
 msgstr "fitxategia"
 
-#: action.c:1704
+#: action.c:2108
 msgid "files"
 msgstr "fitxategi"
 
-#: action.c:1708
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "direktoriorik ez)\n"
 
-#: action.c:1712
+#: action.c:2116
 msgid "directory"
 msgstr "direktorio"
 
-#: action.c:1713
+#: action.c:2117
 msgid "directories"
 msgstr "direktorio"
 
-#: action.c:1754
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Ez da muntatzepunturik aukeratu!\n"
 
-#: action.c:1839
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Beste bilaket bat?"
 
-#: action.c:1869 action.c:1900
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' esteka sinboliko bat da\n"
 
-#: action.c:1940
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "Bertan bilatzeko beharko diren elementuak aukeratu behar dituzu"
 
-#: action.c:1950 menu.c:223
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Bilatu"
 
-#: action.c:1983
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Kontatzeko elementu batzuk aukeratu behar dituzu"
 
-#: action.c:1987
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Diska erabilera"
 
-#: action.c:2021
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Muntatu / Desmuntatu"
 
-#: action.c:2034
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr ""
 "ROX-Filer-ek ez ditu oraindik zure sistemako munatze puntuak onartzen. "
 "Barkatu."
 
-#: action.c:2048 menu.c:210 tips:208
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Ezabatu"
 
-#: action.c:2058 tips:213
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Indartu"
 
-#: action.c:2058
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Idazketa aurka babesturiko elementuen ezabatzea ez berretsi"
 
-#: action.c:2061 action.c:2116 action.c:2175 action.c:2228 action.c:2264
-#: tips:215
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Labur"
 
-#: action.c:2061
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Ezabaturik izango diren direktorioak bakarrik bistarazi"
 
-#: action.c:2078
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "Baimenak aldatu nahi dizkiezun elementuak aukeratu behar dituzu"
 
-#: action.c:2086
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (abiarazgarri/irakurgarri egin)"
 
-#: action.c:2088
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (ez-abiarazgarri/ez-irakurgarri egin)"
 
-#: action.c:2090
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Jabeari Irakurketa+Idazketa baimena eman)"
 
-#: action.c:2092
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Pribatu - jabearentza soilik)"
 
-#: action.c:2094
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Sarrera publikoa, idazketarik gabekoa)"
 
-#: action.c:2105 menu.c:184 menu.c:221 tips:75
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Baimenak"
 
-#: action.c:2116 action.c:2175
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Ez zerredatu prozesaturiko fitxategiak"
 
-#: action.c:2119 action.c:2178 tips:217
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Errekurtsibo"
 
-#: action.c:2119
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Azpidirektorioen edukia ere aldatu"
 
-#: action.c:2123
+#: action.c:2547
 msgid "Command:"
 msgstr "Komandoa:"
 
-#: action.c:2151
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Mota aldatu nahi diezun elementuak aukeratu behar dituzu"
 
-#: action.c:2164
+#: action.c:2590
 msgid "Set type"
 msgstr "Mota ezarri"
 
-#: action.c:2178
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Azpikarpeten edukia aldatu"
 
-#: action.c:2185 infobox.c:615
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Mota:"
 
-#: action.c:2214 dnd.c:124 menu.c:1999 tips:202
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Kopiatu"
 
-#: action.c:2224 action.c:2260 tips:219
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Ez berrretsi ekintza bakoitza"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Jatorria helburua baino berriagoa bakarrik gainidatzi."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Berriago"
 
-#: action.c:2225 action.c:2261 tips:220
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Jatorria helburua baino berriagoa bakarrik gainidatzi."
 
-#: action.c:2228
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "direktorio"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Kopiatzen ari diren direktorioak bakarrik bistarazi"
 
-#: action.c:2250 dnd.c:125 tips:204
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Mugitu"
 
-#: action.c:2264
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Ez bistarazi mugitzen ari den fitxategi bakoitza"
 
-#: action.c:2284 tips:206
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Esteka"
 
-#: action.c:2303 appmenu.c:113
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Atera"
 
-#: action.c:2360
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Honelako elementuak ezabatzen: "
 
-#: action.c:2364
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Elementu hau ezabatzen: "
 
-#: action.c:2366
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Elementu hauek ezabatzen: "
 
-#: action.c:2385
+#: action.c:2900
 msgid " and "
 msgstr " eta "
 
-#: action.c:2394
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr ""
 " panelaren edo idazmahaiaren elementu batzui eragigo die  - benetan ezabatu "
 "nahi al duzu?"
 
-#: action.c:2401
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr ""
 " panelaren edo idazmahaiaren elementu batzui eragigo die  - benetan ezabatu "
 "nahi al dituzu?"
 
-#: appmenu.c:198
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<etiketa gabea>"
 
-#: appmenu.c:295
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
 "menu for all items of this type (%s/%s)."
 msgstr ""
-"Crea enlaces simbÛlicos a los programas que quieras en Èste directorio. "
-"Ellos aparecer·n en el men˙ para todos los elementos de Èste tipo (%s/%s)."
+"Crea enlaces simb√≥licos a los programas que quieras en √©ste directorio. "
+"Ellos aparecer√°n en el men√∫ para todos los elementos de √©ste tipo (%s/%s)."
 
-#: appmenu.c:339 menu.c:234
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Menua pertsonalizatu..."
 
-#: appmenu.c:396 menu.c:251 toolbar.c:159
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Laguntza"
 
-#: bookmarks.c:147
-msgid "Path"
-msgstr "Bidea"
-
-#: bookmarks.c:155
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Izenburua"
 
-#: bookmarks.c:304
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Bidea"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "No puedo agregar el recurso no local '%s' a los marcadores\n"
 
-#: bookmarks.c:312 bookmarks.c:630
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' ez da direktorio bat"
 
-#: bookmarks.c:518
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Lehenik ezabatzeko lerro batzuek aukeratu behar dituzu"
 
-#: bookmarks.c:542
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Zerrendako sarrera bat aukeratu mugitzeko"
 
-#: bookmarks.c:562
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Elementu hau dagoeneko azkenekoa da"
 
-#: bookmarks.c:636
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "No puedo agregar directorios no locales como '%s' a los marcadores"
 
-#: bookmarks.c:778
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Laster-marka gehitu"
 
-#: bookmarks.c:785
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Laster-markak editatu"
 
-#: bookmarks.c:790
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Azkenaldian ikusitakoak"
 
-#: bulk_rename.c:68
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Izen aldaketa anitzak"
 
-#: bulk_rename.c:71
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Berezarri"
 
-#: bulk_rename.c:76
+#: bulk_rename.c:77
 #, fuzzy
 msgid "Make the New column a copy of Old"
 msgstr "Lehen zutabea gero zutabearen kopia bat egin."
 
-#: bulk_rename.c:81
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "_Berrizendatu"
 
-#: bulk_rename.c:94
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Aldatu:"
 
-#: bulk_rename.c:101
+#: bulk_rename.c:102
 #, fuzzy
 msgid ""
 "This is a regular expression to search for.\n"
@@ -826,18 +872,20 @@ msgid "With:"
 msgstr "Honekin:"
 
 #: bulk_rename.c:116
+#, fuzzy
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 "Fitxategi izen bakoitzeko lehen parekatze zuzena kate honegatik aldatuko du. "
 "Ez daude karaktere bereizik."
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Ezarri"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 #, fuzzy
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
@@ -846,46 +894,46 @@ msgstr ""
 "Gero zutabean bilatu eta ordeztu egin. Fitxategiak ez dira berrizendatuko "
 "behekaldeko Berrizendatu botoia klikatu arte."
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr ""
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 #, fuzzy
 msgid "New name"
 msgstr "Berrizendatu"
 
-#: bulk_rename.c:259
+#: bulk_rename.c:295
 #, fuzzy
 msgid "No strings (in the New column) matched the given expression"
 msgstr "Ez dago (gero zutabean) espresio hori betetzen duen katerik"
 
-#: bulk_rename.c:264
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Izen bat aurkitu da baina emaitza berdina da"
 
-#: bulk_rename.c:267
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d izen aurkitu dira, baina emaitzak berdinak dira"
 
-#: bulk_rename.c:293
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr "Ezarri bilatzeko espresio bat, eta aurkitutakoak aldatzeko katea."
 
-#: bulk_rename.c:310
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s ('%s'-rentzat)"
 
-#: bulk_rename.c:343
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr ""
 "'%s' izeneko fitxategi bat badago dagoeneko. Berrizendaketa utzi egin da."
 
-#: bulk_rename.c:348
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -895,12 +943,12 @@ msgstr ""
 "Huts '%s' '%s' bezala berrizendatzekoan:\b%s\n"
 "Berrizendaketa uzten."
 
-#: bulk_rename.c:410
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "'%s' izeneko fitxategi bat badago dagoeneko"
 
-#: bulk_rename.c:421
+#: bulk_rename.c:458
 #, fuzzy, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
@@ -909,53 +957,69 @@ msgstr ""
 "Lehen zutabeko fitxategi batenbatek / karakterea du (adib '%s'). Honek "
 "fitxategiak direktorio ezberdinetan amaitzea egin dezake. Jarraitu?"
 
-#: bulk_rename.c:436
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Izenek ez dute aldaketarik. Ezer egiteke!"
 
-#: choices.c:428
-#, fuzzy
-msgid "Choices migration"
-msgstr "Txinatar (tradizionala)"
+#: choices.c:434
+#, c-format
+msgid "%d directories could not be migrated"
+msgstr ""
 
 #: choices.c:436
 #, c-format
 msgid ""
 "Choices have been moved from \n"
-"<b>%s</b>\n"
+"%s\n"
 " to the new location \n"
-"<b>%s</b>\n"
+"%s\n"
+"%s"
 msgstr ""
 
-#: choices.c:447
-#, c-format
-msgid "%d directories could not be migrated"
-msgstr ""
-
-#: dir.c:982
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Direktorio analisia ez da posible izan: %s"
 
-#: dir.c:991
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Ezin izan da direktorioa ireki: %s"
 
-#: display.c:588
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Tamaina"
+
+#: display.c:705
+msgid "‚î§"
+msgstr ""
+
+#: display.c:706
+msgid "‚îê"
+msgstr ""
+
+#: display.c:707
+msgid "‚îò"
+msgstr ""
+
+#: display.c:709
+msgid "‚îú"
+msgstr ""
+
+#: display.c:709
+msgid "‚îå"
+msgstr ""
+
+#: display.c:710
+msgid "‚îº"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) huts egin du: %s"
 
-#: dnd.c:126
-msgid "Link (relative)"
-msgstr ""
-
-#: dnd.c:127
-msgid "Link (absolute)"
-msgstr ""
-
-#: dnd.c:426
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Barne errorea - okerreko informazio mota"
 
@@ -972,7 +1036,7 @@ msgid ""
 "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
 "plain) did not contain a leafname\n"
 msgstr ""
-"Destino XdndDirectSave0 provisto, pero el ·tomo XdndDirectSave0 (tipo text/"
+"Destino XdndDirectSave0 provisto, pero el √°tomo XdndDirectSave0 (tipo text/"
 "plain) no contiene un nombre de archivo\n"
 
 #: dnd.c:618
@@ -995,7 +1059,7 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
-"Fallo al agregar algunos elementos al escritorio porque est·n en una m·quina "
+"Fallo al agregar algunos elementos al escritorio porque est√°n en una m√°quina "
 "remota. Por ejemplo:\n"
 "\n"
 "%s"
@@ -1039,14 +1103,14 @@ msgid ""
 msgstr ""
 "Ezin dira hurruneko makinatik datuak jaso (application/octet-stream ez dago)"
 
-#: dnd.c:1016
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
 "Fitxategi hauetako batzuek beste makina batetan daude - alde batetara utziko "
 "dira - barkatu"
 
-#: dnd.c:1023
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
@@ -1054,28 +1118,44 @@ msgstr ""
 "Fitxategietako bat ere ez ez dago makina lokalean - Ezin da hurruneko "
 "fitxategi bat baino gehiagorekin ekintza egin - barkatu."
 
-#: dnd.c:1036
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Ekintza ezezagun bat eskatu da"
 
-#: dnd.c:1044
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Errorea fitxategi zerrenda eskuratzerakoan: %s"
 
-#: dropbox.c:114
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr ""
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr ""
+
+#: dnd.c:1109
+msgid "Link (relative, sym path)"
+msgstr ""
+
+#: dnd.c:1110
+msgid "Link (absolute, sym path)"
+msgstr ""
+
+#: dropbox.c:112
 msgid "Show"
 msgstr "Ikusi"
 
-#: dropbox.c:120
+#: dropbox.c:118
 msgid "Show the current choice in a filer window"
 msgstr "Huneko aukera kudeatzaile leiho batetan bistarazi"
 
-#: dropbox.c:174
+#: dropbox.c:172
 msgid "<nothing>"
 msgstr "<ezer>"
 
-#: dropbox.c:239
+#: dropbox.c:237
 msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
@@ -1083,18 +1163,18 @@ msgstr ""
 "Ezin da ezarritako elemetua bistarazi ez bait dago batez ezarririk. "
 "Arrastatu ezazu zerbait hona!"
 
-#: dropbox.c:263
+#: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
 msgstr ""
-"Lo siento, tienes que arrastrar exactamente un archvo sobre el ·rea de "
+"Lo siento, tienes que arrastrar exactamente un archvo sobre el √°rea de "
 "arrastre."
 
-#: dropbox.c:273
+#: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr "Ezin da '%s' fitxategi lokal bat ez da eta."
 
-#: dropbox.c:280 pinboard.c:853
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1103,7 +1183,7 @@ msgstr ""
 "Ezin da '%s' eskuratu:\n"
 "%s"
 
-#: filer.c:453
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1112,357 +1192,407 @@ msgstr ""
 "Errorea '%s' irakurtzerakoan:\n"
 "%s\n"
 
-#: filer.c:457
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Errorea '%s' irakurtzerakoan:\n"
-"%s"
-
-#: filer.c:562
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
 "Unmounting a device makes it safe to remove the disk."
 msgstr ""
-"øGailu hau desmuntatu nahi al duzu?\n"
+"¬øGailu hau desmuntatu nahi al duzu?\n"
 "\n"
 "Gailua desmuntatu eta gero diska era ziur batetan atera dezakezu."
 
-#: filer.c:566
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 msgid "No change"
 msgstr "Aldaketa gabea"
 
-#: filer.c:572 menu.c:862
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Desmuntatu"
 
-#: filer.c:669
-msgid "Directory missing/deleted"
-msgstr "Direktorioa ezabatua/falta da"
-
-#: filer.c:1031
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
 "Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"El grupo %s no est· definido. Selecciona algunos archivos y presiona Ctrl+%s "
+"El grupo %s no est√° definido. Selecciona algunos archivos y presiona Ctrl+%s "
 "para definir el grupo. Presiona %s para seleccionar de nuevo los archivos "
-"despuÈs.\n"
-"AsÈgurate que NumLock est· activado si utilizas el teclado numÈrico."
+"despu√©s.\n"
+"As√©gurate que NumLock est√° activado si utilizas el teclado num√©rico."
 
-#: filer.c:1267
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "'%s' direktorioa ez da eskuragarria"
+#: filer.c:2655
+msgid "A"
+msgstr ""
 
-#: filer.c:1419
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "'%s' direktorioa ez da aurkitu."
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
 
-#: filer.c:1713
-msgid "Cancel"
-msgstr "Ezeztatu"
+#: filer.c:2659 find.c:923
+msgid "G"
+msgstr "G"
 
-#: filer.c:2002
+#: filer.c:2664
 msgid "S"
 msgstr "S"
 
-#: filer.c:2004
+#: filer.c:2669
 msgid "T"
 msgstr "A"
 
-#: filer.c:2026
+#: filer.c:2670
+msgid "D"
+msgstr ""
+
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
+#, c-format
+msgid "Glob (%s), "
+msgstr ""
+
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Irakurtzen, "
 
-#: filer.c:2028
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Argazkitxoak, "
 
-#: filer.c:2304
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Argazkitxoak, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Hona esteka sinbolikoa: "
 
-#: filer.c:2335
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "Fitxategi zen hau ez da UTF-8 baliozkoa. Aldatu egin behar duzu.\n"
 
-#: filer.c:2643 menu.c:1989
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "Elementua ez dago dagoeneko!"
 
-#: filer.c:3327
+#: filer.c:4451
+msgid "‚ñº"
+msgstr ""
+
+#: filer.c:4451
+msgid "‚ñΩ"
+msgstr ""
+
+#: filer.c:4462
+msgid "‚ñ∑"
+msgstr ""
+
+#: filer.c:4462
+msgid "‚ñ∂"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Hauatatu gorde ebhar diren pantaila propietateak"
 
-#: filer.c:3334
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Hauatatu gorde ebhar diren pantaila propietateak"
+
+#: filer.c:4727
 msgid "Position"
 msgstr "Kokalekua"
 
-#: filer.c:3339 toolbar.c:135 toolbar.c:139 tips:63
-msgid "Size"
-msgstr "Tamaina"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Leihoa"
 
-#: filer.c:3344
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Mostrar ocultos"
 
-#: filer.c:3350
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Bistaratze estiloa"
 
-#: filer.c:3356
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Saikatze mota eta ordena"
 
 # tips:30 toolbar.c:128/
-#: filer.c:3361 toolbar.c:143
+#: filer.c:4754
 msgid "Details"
 msgstr "Xehetasuna"
 
-#: filer.c:3366 tips:114 tips:115
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Argazkitxoak"
 
-#: filer.c:3372
+#: filer.c:4765
 msgid "Filter"
 msgstr "Iruzkina"
 
-#: find.c:487
+#: find.c:485
 msgid "And"
 msgstr "Eta"
 
-#: find.c:511
+#: find.c:509
 msgid "Not"
 msgstr "Ez"
 
-#: find.c:554
+#: find.c:552
 msgid "system"
 msgstr "sistema"
 
-#: find.c:562
+#: find.c:560
 msgid "prune"
 msgstr "moztu"
 
-#: find.c:650
+#: find.c:648
 msgid "After"
 msgstr "Gero"
 
-#: find.c:652
+#: find.c:650
 msgid "Before"
 msgstr "Lehenago"
 
-#: find.c:746
+#: find.c:744
 msgid "IsReg"
 msgstr "RegDa"
 
-#: find.c:748
+#: find.c:746
 msgid "IsLink"
 msgstr "EstekaDa"
 
-#: find.c:750
+#: find.c:748
 msgid "IsDir"
 msgstr "DirDa"
 
-#: find.c:752
+#: find.c:750
 msgid "IsChar"
 msgstr "KarDa"
 
-#: find.c:754
+#: find.c:752
 msgid "IsBlock"
 msgstr "BlokeDa"
 
-#: find.c:756
+#: find.c:754
 msgid "IsDev"
 msgstr "GailuaDa"
 
-#: find.c:758
+#: find.c:756
 msgid "IsPipe"
 msgstr "TutuaDa"
 
-#: find.c:760
+#: find.c:758
 msgid "IsSocket"
 msgstr "SocketaDa"
 
-#: find.c:762
+#: find.c:760
 msgid "IsDoor"
 msgstr "AteaDa"
 
-#: find.c:764
+#: find.c:762
 msgid "IsSUID"
 msgstr "SUIDDa"
 
-#: find.c:766
+#: find.c:764
 msgid "IsSGID"
 msgstr "SGIDDa"
 
-#: find.c:768
+#: find.c:766
 msgid "IsSticky"
 msgstr "EsPegajoso"
 
-#: find.c:770
+#: find.c:768
 msgid "IsReadable"
 msgstr "IrakurgarriaDa"
 
-#: find.c:772
+#: find.c:770
 msgid "IsWriteable"
 msgstr "IdatzgarriaDa"
 
-#: find.c:774
+#: find.c:772
 msgid "IsExecutable"
 msgstr "AbiarazgarriaDa"
 
-#: find.c:776
+#: find.c:774
 msgid "IsEmpty"
 msgstr "HutsaDa"
 
-#: find.c:778
+#: find.c:776
 msgid "IsMine"
 msgstr "NireaDa"
 
-#: find.c:906
+#: find.c:904
 msgid "Now"
 msgstr "Orain"
 
-#: find.c:919
+#: find.c:917
 msgid "Byte"
 msgstr "Byte"
 
-#: find.c:919
+#: find.c:917
 msgid "Bytes"
 msgstr "Byte"
 
-#: find.c:921
+#: find.c:919
 msgid "Kb"
 msgstr "Kb"
 
-#: find.c:921
+#: find.c:919
 msgid "K"
 msgstr "K"
 
-#: find.c:923
+#: find.c:921
 msgid "Mb"
 msgstr "Mb"
 
-#: find.c:923
+#: find.c:921
 msgid "M"
 msgstr "M"
 
-#: find.c:925
+#: find.c:923
 msgid "Gb"
 msgstr "Gb"
 
 #: find.c:925
-msgid "G"
-msgstr "G"
-
-#: find.c:927
 msgid "Sec"
 msgstr "Seg"
 
-#: find.c:927
+#: find.c:925
 msgid "Secs"
 msgstr "Seg"
 
-#: find.c:929
+#: find.c:927
 msgid "Min"
 msgstr "Min"
 
-#: find.c:929
+#: find.c:927
 msgid "Mins"
 msgstr "Min"
 
-#: find.c:931
+#: find.c:929
 msgid "Hour"
 msgstr "Ordu"
 
-#: find.c:931
+#: find.c:929
 msgid "Hours"
 msgstr "Ordu"
 
-#: find.c:933
+#: find.c:931
 msgid "Day"
 msgstr "Egun"
 
-#: find.c:933
+#: find.c:931
 msgid "Days"
 msgstr "Egun"
 
-#: find.c:935
+#: find.c:933
 msgid "Week"
 msgstr "Aste"
 
-#: find.c:935
+#: find.c:933
 msgid "Weeks"
 msgstr "Aste"
 
-#: find.c:937
+#: find.c:935
 msgid "Year"
 msgstr "Urte"
 
-#: find.c:937
+#: find.c:935
 msgid "Years"
 msgstr "Urte"
 
-#: find.c:946
+#: find.c:944
 msgid "Ago"
 msgstr "dela"
 
-#: find.c:948
+#: find.c:946
 msgid "Hence"
 msgstr "Beraz"
 
-#: find.c:963
+#: find.c:961
 msgid "atime"
 msgstr "sarrera"
 
-#: find.c:965
+#: find.c:963
 msgid "ctime"
 msgstr ""
 
-#: find.c:967
+#: find.c:965
 msgid "mtime"
 msgstr ""
 
-#: find.c:969
+#: find.c:967
 msgid "size"
 msgstr "tamaina"
 
-#: find.c:971
+#: find.c:969
 msgid "inode"
 msgstr "inodoa"
 
-#: find.c:973
+#: find.c:971
 msgid "nlinks"
 msgstr "estekak"
 
-#: find.c:975
+#: find.c:973
 msgid "uid"
 msgstr "uid"
 
-#: find.c:977
+#: find.c:975
 msgid "gid"
 msgstr "gid"
 
-#: find.c:979
+#: find.c:977
 msgid "blocks"
 msgstr "blokea"
 
-#: gtksavebox.c:251
+#: gtksavebox.c:249
 msgid "Save As:"
 msgstr "Honela gorde:"
 
-#: gtksavebox.c:397
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Izen gabe"
 
-#: gtksavebox.c:473
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
@@ -1470,7 +1600,7 @@ msgstr ""
 "Hurruneko aplikazioa \"Direct Save\" erabiltzen saiatzen ari da, baina ezin "
 "da XdndDirectSave0 propietatea (text/plain motakoa) irakurri.\n"
 
-#: gtksavebox.c:598
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1478,7 +1608,7 @@ msgstr ""
 "Ikonoa direktorio leiho batetara arrastatu\n"
 "(edo bide osoa eman)"
 
-#: gui_support.c:331
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1486,20 +1616,21 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:400
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr ""
 "XML fitxategi bat testua balitz bezala irakurtzen saiatu da.\n"
 "'%s' fitxategia hondaturik egon liteke."
 
-#: gui_support.c:417
-#, c-format
+#: gui_support.c:542
+#, fuzzy, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
 "This may be due to upgrading from a previous version of ROX-Filer. Open the "
-"Options window and click on Save.\n"
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
 "Hust '%s' fitxategiaren %d lerroan:\n"
@@ -1508,18 +1639,18 @@ msgstr ""
 "leiohoa ireki eta Gorde-n klik egin zazu.\n"
 "Hurrengo erroreak albo batetara utziko dira."
 
-#: gui_support.c:1000
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Lerro amaiera okerra edo falta da text/uri-list datuetan"
 
-#: gui_support.c:1332
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr ""
 "Hust '%s' ezabatzerakoan:\n"
 "%s"
 
-#: gui_support.c:1376
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
@@ -1527,15 +1658,16 @@ msgstr ""
 "Ezin da '%s' irudia kargatu: arrazoi ezezaguna, ziurrenik hondaturiko irudi "
 "fitxategia"
 
-#: gui_support.c:1427
+#: gui_support.c:1583
+#, c-format
 msgid ""
-"This program cannot be run, as the 0launch command is not available. It can "
-"be downloaded from here:\n"
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
 
-#: i18n.c:38
+#: i18n.c:39
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
@@ -1543,312 +1675,384 @@ msgstr ""
 "Zure ezarpenak gorde eta kudeatzailea berrabiarazi behar duzu hizkuntz "
 "berria guztiz martxan ipintzeko."
 
-#: icon.c:78
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(klik egin ezartzeko)"
 
-#: icon.c:133
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:134 menu.c:252
-msgid "About ROX-Filer..."
-msgstr "ROX-Filer buruz..."
-
-#: icon.c:135 menu.c:253
-msgid "Show Help Files"
-msgstr "Laguntza Bistarazi"
-
-#: icon.c:136 menu.c:254
-msgid "Manual"
-msgstr "Manuala"
-
-#: icon.c:138 menu.c:230
-msgid "Options..."
-msgstr "Aukerak..."
-
-#: icon.c:139 menu.c:239
-msgid "Home Directory"
-msgstr "Etxe direktorioa ireki"
-
-#: icon.c:140 icon.c:1340 menu.c:206 type.c:212
-msgid "File"
-msgstr "Fixategia"
-
-#: icon.c:141 menu.c:212 menu.c:875
-msgid "Shift Open"
-msgstr "Shift Ireki"
-
-#: icon.c:142 menu.c:218
-msgid "Properties"
-msgstr "Propietateak"
-
-#: icon.c:143 menu.c:216
-msgid "Set Run Action..."
-msgstr "Ekintza Ezarri..."
-
-#: icon.c:144 menu.c:217
-msgid "Set Icon..."
-msgstr "Ikonoa Ezarri..."
-
-#: icon.c:145 icon.c:806
-msgid "Edit Item"
-msgstr "Elementua Editatu"
-
-#: icon.c:146
-msgid "Show Location"
-msgstr "Kokalekua Erakutsi"
-
-#: icon.c:147
-msgid "Remove Item(s)"
-msgstr "Elementua(k) Ezabatu"
-
-#: icon.c:278 menu.c:764
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:291
+#: icon.c:311
 msgid "Nothing"
 msgstr "Ezer"
 
-#: icon.c:547
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "Kokalekuak beintzat karaktere bat eduki behar du!"
 
-#: icon.c:613
+#: icon.c:641
+#, c-format
+msgid "You must unlock '%s' before removing it"
+msgstr ""
+
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Leheneik ezabtzeko zenbait elementu aukeratu behar dituzu"
 
-#: icon.c:627
+#: icon.c:657
+msgid "An item must be unlocked before it can be removed."
+msgstr ""
+
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Menua elementu baten gainean ireki behar duzu"
 
-#: icon.c:652 menu.c:1260
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "Fitxategi arruntentzat bakarrik ezarri dezakezu ekintza"
 
-#: icon.c:738
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Sakatu desio duzu laster-tekla  (adibidez, Kontrol+F1)"
 
-#: icon.c:760
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Huts teklatua eskuratzerakoan!"
 
-#: icon.c:809
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Elementua Editatu"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Klik egitean ikonoa ireki egiten da:"
 
-#: icon.c:819
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Erabiliko diren argumentuak (abiarazgarrientzat):"
 
-#: icon.c:833
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "Ikono azpian bistaraziko testua:"
 
-#: icon.c:846
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "LAster-tekla hau da:"
 
-#: infobox.c:112
-#, c-format
-msgid "Are you sure you want to open %d windows?"
-msgstr "øEst·s seguro que quieres abrir %d ventanas?"
+#: icon.c:910
+#, fuzzy
+msgid "Locked"
+msgstr "Socket-a"
+
+#: icon.c:915
+msgid "Locking an item prevents it from being accidentally removed"
+msgstr ""
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "ROX-Filer buruz..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Laguntza Bistarazi"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Manuala"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Aukerak..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Etxe direktorioa ireki"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Fixategia"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Shift Ireki"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Propietateak"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Ekintza Ezarri..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Ikonoa Ezarri..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Kokalekua Erakutsi"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Elementua(k) Ezabatu"
 
 #: infobox.c:113
+#, c-format
+msgid "Are you sure you want to open %d windows?"
+msgstr "¬øEst√°s seguro que quieres abrir %d ventanas?"
+
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Argibideak Bistarazi"
 
-#: infobox.c:135 menu.c:769
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(okerreko utf-8)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "_Laguntza fitxategiak bistarazi"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Baimenak</b>"
 
-#: infobox.c:286
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>Edukiak hau ezartzen du..</b>"
 
-#: infobox.c:423 infobox.c:560 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Kopiatzen ari diren direktorioak bakarrik bistarazi"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "byte"
 
-#: infobox.c:446
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Huts tamaina irakurtzerakoan"
 
-#: infobox.c:504
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
-msgstr "'%s' ya no es un enlace simbÛlico"
+msgstr "'%s' ya no es un enlace simb√≥lico"
 
-#: infobox.c:511
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
 "%s"
 msgstr ""
-"FallÛ la eliminaciÛn de '%s':\n"
+"Fall√≥ la eliminaci√≥n de '%s':\n"
 "%s"
 
-#: infobox.c:516
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
 "%s\n"
 "(note: old link has been deleted)"
 msgstr ""
-"FallÛ la creaciÛn del enlace simbÛlico '%s':\n"
+"Fall√≥ la creaci√≥n del enlace simb√≥lico '%s':\n"
 "%s\n"
 "(nota: el antiguo enlace has sido borrado)"
 
-#: infobox.c:539 tips:270
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Errorea:"
 
-#: infobox.c:546
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Direktorio erreala:"
 
-#: infobox.c:549
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Jabea, Taldea:"
 
-#: infobox.c:556 infobox.c:571 infobox.c:580
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Tamaiana:"
 
-#: infobox.c:581
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Arakatzen"
 
-#: infobox.c:602
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Huts arakatzerakoan"
 
-#: infobox.c:609
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Aldaketa data:"
 
-#: infobox.c:611
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Aldaketa data:"
 
-#: infobox.c:613
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Irakurketa data:"
 
-#: infobox.c:621
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Atributu hedatuak:"
 
-#: infobox.c:623
+#: infobox.c:667
 msgid "Present"
 msgstr "Orain"
 
-#: infobox.c:624
+#: infobox.c:668
 msgid "None"
 msgstr "Batez"
 
-#: infobox.c:625
+#: infobox.c:669
 msgid "Not supported"
 msgstr "Ez Onarturik"
 
-#: infobox.c:637
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Lotura helburua:"
 
-#: infobox.c:649 infobox.c:652
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Loturiko ekintza:"
 
-#: infobox.c:649
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Fitxategia abiarazi"
 
-#: infobox.c:744
+#: infobox.c:805
+#, fuzzy
+msgid "Comment"
+msgstr "Komandoa:"
+
+#: infobox.c:807
+#, fuzzy
+msgid "Execute"
+msgstr "Fitxategia abiarazi"
+
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<batez oraindik>"
 
-#: infobox.c:814
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "(1)fitxategiak dio... %s"
 
-#: infobox.c:871
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Ezin dira baimenak aldatu: %s"
 
-#: infobox.c:889
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Jabea"
 
-#: infobox.c:891
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Taldea"
 
-#: infobox.c:893
+#: infobox.c:974
 msgid "World"
 msgstr "Danak"
 
-#: infobox.c:896
+#: infobox.c:977
 msgid "Read"
 msgstr "Irakurketa"
 
-#: infobox.c:898
+#: infobox.c:980
 msgid "Write"
 msgstr "Idazketa"
 
-#: infobox.c:900
+#: infobox.c:983
 msgid "Exec"
 msgstr "Abiaraztea"
 
-#: infobox.c:917
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:924
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:931
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Itsaskorra"
 
-#: infobox.c:953
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<ezer>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Esteka sinbolikoa"
 
-#: infobox.c:956
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX aplikazioa"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "mounted"
 msgstr "muntaturik"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "desmuntaturik"
 
-#: infobox.c:968
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Punto de montaje para %s (%s)"
 
-#: infobox.c:971
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Punto de montaje (%s)"
+
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d elementu"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Kopiatu..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "Elementua Editatu"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Data"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Aukerak"
 
 #: main.c:95
 msgid ""
@@ -1886,7 +2090,7 @@ msgstr ""
 "\n"
 
 #: main.c:115
-#, fuzzy
+#, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Open each directory or file listed, or the current working\n"
@@ -1908,10 +2112,12 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
-"Report bugs to "
+"Report bugs to %s.\n"
+"Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
 "Erabilera: ROX-Filer/AppRun [AUKERA]... [FITXATEGIA]...\n"
 "Ireki direktorio edo zerrenda bakoitza, edo lan huneko direktorioa\n"
@@ -1936,15 +2142,7 @@ msgstr ""
 "\n"
 "Arazoen berri eman "
 
-#: main.c:136
-msgid ""
-".\n"
-"Home page (including updated versions): http://rox.sourceforge.net/\n"
-msgstr ""
-".\n"
-"Webgunea (eguneraturiko bertsioak barne): http://rox.sourceforge.net/\n"
-
-#: main.c:234
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1952,7 +2150,7 @@ msgid ""
 "Trying to continue..."
 msgstr ""
 
-#: main.c:382
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
@@ -1960,281 +2158,378 @@ msgstr ""
 "-o argumentua ez da luzaroago erabiliko. Aukerak leihoko birbidalketa alde "
 "batetara utzi gaitu dezakezu bere ordez."
 
-#: main.c:489
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "'%s' erbiltzailea bezala abiarazten"
 
-#: main.c:666
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "GTK %s bertsioaz konpilaturik\n"
 
-#: main.c:667
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "GTK bertsioaz %d.%d.%d abiarazirik\n"
 
-#: main.c:671
+#: main.c:693
 msgid "features set at compile time"
 msgstr "Konpilazioan ezarritako funtzioak"
 
-#: main.c:672
+#: main.c:694
 msgid "Large File Support"
 msgstr "Fitxategi Handi Onarpena"
 
-#: main.c:679
-msgid "GNOME-VFS library"
-msgstr "GNOME-VFS liburutegia"
-
-#: main.c:683
-msgid "No (need 2.8.0 or later)"
-msgstr "Ez (2.8.0 edo berriagoa behar du)"
-
-#: main.c:686
-msgid "Dnotify support"
-msgstr "Dnotify Onarpena"
-
-#: main.c:693
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Bitar bateragarritasuna"
 
-#: main.c:695
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Bai (zaharkituriko glibc bertsioekin lan egin dezake)"
 
-#: main.c:697
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Ez (apsymbols.h ez da aurkitu)"
 
-#: menu.c:180 tips:52
+#: main.c:709
+#, fuzzy
+msgid "Extended attribute support"
+msgstr "Atributu hedatuak"
+
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr ""
+"Hust '%s' ezabatzerakoan:\n"
+"%s"
+
+#: main.c:895
+#, c-format
+msgid ""
+"Left-click to run %s.\n"
+"Right-click for a list of versions."
+msgstr ""
+
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Errorea '%s' sortzerakoan: %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Honela gorde:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Bistarazi"
 
-#: menu.c:181 tips:57
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "Ikono bistartzea"
 
-#: menu.c:182
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "Ikonoak, Gehi..."
 
-#: menu.c:183 tips:74
-msgid "Sizes"
-msgstr "Tamainak"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Ikono gaia"
 
-#: menu.c:185 tips:254
-msgid "Types"
-msgstr "Motak"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Baimenak"
 
-#: menu.c:186 tips:77
-msgid "Times"
-msgstr "Data"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Ikonoak, Gehi..."
 
-#: menu.c:187 tips:58 tips:92
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "Zerrenda bistaratzea"
 
-#: menu.c:189
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "Ikono handiagoak"
 
-#: menu.c:190
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "Ikono txikiagoak"
 
-#: menu.c:191 tips:71
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Automatikoa"
 
-#: menu.c:193
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Izenez sailkatu"
 
-#: menu.c:194
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Motaz sailkatu"
 
-#: menu.c:195
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Dataz sailkatu"
 
-#: menu.c:196
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Dataz sailkatu"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Dataz sailkatu"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Tamainaz Sailkatu"
 
-#: menu.c:197
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Baimenak"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "Jabez Sailkatu"
 
-#: menu.c:198
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "Taldez Sailkatu"
 
-#: menu.c:199
+#: menu.c:671
 msgid "Reversed"
 msgstr "Atzezaurrera"
 
-#: menu.c:201
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "Ezkutukoak bistarazi"
 
-#: menu.c:202
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Laguntza Bistarazi"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "direktoriorik ez)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "Fitxategi Iragazkia..."
 
-#: menu.c:203
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Fitxategi Iragazkia..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "Argazkitxoak bistarazi"
 
-#: menu.c:204
+#: menu.c:683
 msgid "Refresh"
 msgstr "Berritu"
 
-#: menu.c:205
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Berritu"
+
+#: menu.c:686
 msgid "Save Display Settings..."
 msgstr "Pantaila ezarpenak gorde..."
 
-#: menu.c:207
-msgid "Copy..."
-msgstr "Kopiatu..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Pantaila ezarpenak gorde..."
 
-#: menu.c:208
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Tamaina"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "Berrizendatu..."
 
-#: menu.c:209
+#: menu.c:700
 msgid "Link..."
 msgstr "Estekatu..."
 
-#: menu.c:213
-msgid "Open AVFS"
-msgstr "AVFS ireki"
-
-#: menu.c:214
+#: menu.c:708
 msgid "Send To..."
 msgstr "Bidali hona..."
 
-#: menu.c:219
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Atributu hedatuak"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Tamaina"
 
-#: menu.c:220
+#: menu.c:723
 msgid "Set Type..."
 msgstr "Mota ezarri..."
 
-#: menu.c:224 toolbar.c:155
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Aukeratu"
 
-#: menu.c:225
+#: menu.c:733
 msgid "Select All"
 msgstr "Danak aukeratu"
 
-#: menu.c:226
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "Eginiko aukera utzi"
 
-#: menu.c:227
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "Aukera alderantzikatu"
 
-#: menu.c:228
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "Izenez aukeratu..."
 
-#: menu.c:229
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Aukeratu..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Aukeratu..."
 
-#: menu.c:231
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Berria"
 
-#: menu.c:233
+#: menu.c:752
 msgid "Blank file"
 msgstr "Fitxategi hutsa"
 
-#: menu.c:235 tasklist.c:308
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Leihoa"
 
-#: menu.c:236
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "Aita, Leiho Berria"
 
-#: menu.c:237
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "Aita, Leiho Berdina"
 
-#: menu.c:238
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "Leiho Berria"
 
-#: menu.c:240
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "Laster-markak bistarazi"
 
-#: menu.c:241
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Argibideak Bistarazi"
+
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "Esteka sinbolikoak jarraitu"
 
-#: menu.c:242
+#: menu.c:769
 msgid "Resize Window"
 msgstr "Leiho tamaina aldatu"
 
-#: menu.c:245
+#: menu.c:771
 msgid "Close Window"
 msgstr "Leihoa itxi"
 
-#: menu.c:247
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Bidea idatzi..."
 
-#: menu.c:248
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Shell Komandoa..."
 
-#: menu.c:249
-msgid "Xterm Here"
+#: menu.c:780
+#, fuzzy
+msgid "Terminal Here"
 msgstr "Xterm Hemen"
 
-#: menu.c:250
-msgid "Switch to xterm"
+#: menu.c:782
+#, fuzzy
+msgid "Switch to Terminal"
 msgstr "xterm-era aldatu"
 
-#: menu.c:718
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr ""
-"Zuk Shift zapalduri duzula fitxategiaren menuan klik egin behar duzu "
-"norabait bidaltzeko"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Menua pertsonalizatu..."
 
-#: menu.c:754
+#: menu.c:976
 msgid "Next Click"
 msgstr "Hurrengo Klik"
 
-#: menu.c:776
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d elementu"
 
-#: menu.c:864
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "Desmuntaturik ireki"
 
-#: menu.c:867
+#: menu.c:1097
 msgid "Show Target"
 msgstr "Helburua Bistarazi"
 
-#: menu.c:869
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "Barrua Begiratu"
 
-#: menu.c:871
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "Testu bezala ireki"
 
-#: menu.c:1031
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2248,15 +2543,15 @@ msgstr ""
 "daiteke, ere fitxategi sistema muntatze aukera zuzenak ezarri behar direla "
 "izan daiteke ('user_xattr' Linux-en)."
 
-#: menu.c:1037
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr "Ezarpen mota ez du onartzen fitxategi batenbatek"
 
-#: menu.c:1072
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "_Esteka erlatiboa"
 
-#: menu.c:1078
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2268,45 +2563,58 @@ msgstr ""
 "Ezgaiturik egon ezkero, erro direktoriotik bidea gordeko da - Esteka mugitu "
 "baina helburu fitxategia leku berdinean geratuko bada erabili."
 
-#: menu.c:1148
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "Bide berria ez da absolutua"
 
-#: menu.c:1214
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr ""
-"Dagoeneko badago '%s'-ren esteka sinboliko bat. ø'%s'-ra estekaz aldatu?"
+"Dagoeneko badago '%s'-ren esteka sinboliko bat. ¬ø'%s'-ra estekaz aldatu?"
 
-#: menu.c:1220
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Aldatu"
 
-#: menu.c:1351 menu.c:1392 menu.c:1452
-msgid "Create"
-msgstr "Sortu"
-
-#: menu.c:1352
+#: menu.c:1704
 msgid "NewDir"
 msgstr "DirBerria"
 
-#: menu.c:1366 menu.c:1372
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Errorea '%s' sortzerakoan: %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Sortu"
 
-#: menu.c:1393
+#: menu.c:1755
 msgid "NewFile"
 msgstr "FitxategiBerria"
 
-#: menu.c:1411
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr ""
 "Errorea fitxategia sortzerakoan: ezin izan da %s-rentzat txantilloia aurkitu"
 
-#: menu.c:1482
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Crea enlaces simb√≥licos a los programas que quieras en √©ste directorio. "
+"Ellos aparecer√°n en el men√∫ para todos los elementos de √©ste tipo (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2318,8 +2626,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "`Bidali Hona' menuak fitxategi batzu aplikazio batetara bidaltzeko bide "
 "azkar bat da. Bistaraziko diren aplikazioa direktorio hauetakoak dira:\n"
@@ -2333,7 +2642,7 @@ msgstr ""
 "fitxategi mota horientzat bistaraziko dena. `.group' -direktorioa fitxategi "
 "anitz aukeraturik daudenean isaraziko da."
 
-#: menu.c:1493
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
@@ -2342,13 +2651,13 @@ msgstr ""
 "aplikazioei esteka sinbolikoak sortu (Ktrl+Shift+arrastatu) beharko "
 "zenizkieke."
 
-#: menu.c:1496 menu.c:1536
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr ""
 "Zure CHOICESPATH aldagaiaren balioak ez ditu pertsonalizazioak onarzen - "
 "barkatu."
 
-#: menu.c:1529
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2360,7 +2669,7 @@ msgid ""
 "%s\n"
 msgstr ""
 
-#: menu.c:1534
+#: menu.c:1936
 #, fuzzy
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
@@ -2370,15 +2679,21 @@ msgstr ""
 "aplikazioei esteka sinbolikoak sortu (Ktrl+Shift+arrastatu) beharko "
 "zenizkieke."
 
-#: menu.c:1651
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Pertsonalizatu"
 
-#: menu.c:1717
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Menua pertsonalizatu..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Hau dagoeneko direktorio honen izen kanonikoa da."
 
-#: menu.c:1748
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2386,75 +2701,103 @@ msgstr ""
 "Ezin duzu direktorio honen bigarren bistaratze leiho bat ireki `Leiho "
 "Bakarrak' aukera gaiturik bait dago ezarpenetan."
 
-#: menu.c:1869
-msgid "Copy ... ?"
-msgstr "Kopiatu ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1872
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?%s %s-ra kopiatu?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?%s %s-ra kopiatu?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Berrizendatu ... ?"
 
-#: menu.c:1875
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Estekatu ... ?"
 
-#: menu.c:1878
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Shift Ireki ... ?"
 
-#: menu.c:1881
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Honen propietateak ... ?"
 
-#: menu.c:1884
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Atributu hedatuak"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Honen Mota Ezarrie ... ?"
 
-#: menu.c:1887
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Honentzat Ekintza Ezarri ... ?"
 
-#: menu.c:1890
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Honentzat Ikonoa Ezarri ... ?"
 
-#: menu.c:1893
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Bidali ... nora ... ?"
 
-#: menu.c:1896
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "EZABATU ... ?"
 
-#: menu.c:1899
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Honen tamaina kalkulatu ... ?"
 
-#: menu.c:1902
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Baimenak ezarri ... ?"
 
-#: menu.c:1905
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Bilatu honen barruan ... ?"
 
-#: menu.c:1908
-msgid "Look inside ... ?"
-msgstr "Bilatu barruan ... ?"
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Kopiatu ... ?"
 
-#: menu.c:1972
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Ezin duzu hau elementu anitzekin egin"
 
-#: menu.c:2004
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Berrizendatu"
 
-#: menu.c:2009
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Esteka"
 
-#: menu.c:2041
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2476,7 +2819,7 @@ msgstr ""
 "\tgtk-can-change-accels = 1\n"
 "\t(XSETTINGS erabiltzen EZ baduzu bakarrik )"
 
-#: menu.c:2052
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2496,31 +2839,40 @@ msgstr ""
 "Menuko elementuaren alboan tekla agertuko da eta aski izango da tekla hori "
 "sakatzea menua ireki gabe hemendik aurrera."
 
-#: menu.c:2067
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Teklatu laster-teklak ezarri"
 
-#: minibuffer.c:131
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Joan:"
 
-#: minibuffer.c:132
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Shell-a:"
 
-#: minibuffer.c:133
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Kasu honetan aukeratu:"
 
-#: minibuffer.c:134
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Hautatu Deiturikoa:"
 
-#: minibuffer.c:135
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Kasu honetan aukeratu:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Patroia:"
 
-#: minibuffer.c:264
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
@@ -2528,14 +2880,34 @@ msgstr ""
 "Fitxategi izena idatzi bistaratzeko. Tab sakaru parekatze luzeena "
 "bistaratzeko. \"Esc\" sakatu minibuffer-a ixteko."
 
-#: minibuffer.c:270
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
 "Idatzi abiarazteko shell komando bat. Klik egin fitxategi batetan buffer-ean "
 "gehitzeko."
 
-#: minibuffer.c:275
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Idatz ezazu parekatze guztiak aukeratzeko bilaketa patroia:\n"
+"\n"
+"? edozein karaktere da\n"
+"* 0 edo karaktere gehiago da\n"
+"[aA] 'a' edo 'A' da\n"
+"[a-z] a-tik z-ra edozeinkaraktere da (minuskulak)\n"
+"*.png '.png'-ez amaitzen den edozein izen da"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2553,7 +2925,7 @@ msgstr ""
 "[a-z] a-tik z-ra edozeinkaraktere da (minuskulak)\n"
 "*.png '.png'-ez amaitzen den edozein izen da"
 
-#: minibuffer.c:287
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
@@ -2561,41 +2933,55 @@ msgstr ""
 "Betetzen duten fitxategiak bistaratzeko patroia bat idatzi. IRagazki huts "
 "batek iragazkia ezgaitzen du."
 
-#: minibuffer.c:895
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Betetzen duten fitxategiak bistaratzeko patroia bat idatzi. IRagazki huts "
+"batek iragazkia ezgaitzen du."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Bilkaeta baldintza okerra"
 
-#: mount.c:374
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s guztira, %s erabilia, %s libre (%.1f %%)"
 
-#: options.c:277
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "ROX-Filer-ek zure aukera fitxategia XML formatu berrira bihurtu du"
 
-#: options.c:535 options.c:1258
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(lehenetsia erabili)"
 
-#: options.c:806
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Barne errorea: %s irakurrezina"
 
-#: options.c:917
+#: options.c:929
 msgid "Options"
 msgstr "Aukerak"
 
-#: options.c:962
+#: options.c:974
 msgid "_Revert"
 msgstr "_Desegin"
 
-#: options.c:968
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr "Berezarri aukera guztiak aukera leiho ireki denean zuten egoerara."
 
-#: options.c:983
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2604,24 +2990,36 @@ msgstr ""
 "Aukerak honela gordeko dira:\n"
 "%s"
 
-#: options.c:991
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(Gordetzea CHOICESPATH dela eta ezgaiturik dago)"
 
-#: options.c:1164 usericons.c:450
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Errorea %s gordetzerakoan: %s"
 
-#: options.c:1794
+#: options.c:1813
 msgid "Missing '='"
 msgstr "'=' bat falta da"
 
-#: panel.c:439
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr ""
+"Hust '%s' ezabatzerakoan:\n"
+"%s"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "Zure panel fitxategi zaharra XML formatu berrira eguneraturik izan da."
 
-#: panel.c:546
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
@@ -2629,20 +3027,20 @@ msgstr ""
 "Leiho kudeatzailearen bidez panel bat ixten saiatu zara - normalean hau "
 "istripu bat izaten da... benetan itxi?"
 
-#: panel.c:639
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Panelaren konfigurazio fitxategian  < bat edo > bat falta da"
 
-#: panel.c:1519
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Errorea %s panela gordetzerakoan: %s"
 
-#: panel.c:1835
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "Applet-a widget bat ere sortu gabe amaiatu da!"
 
-#: panel.c:1934
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2651,69 +3049,59 @@ msgstr ""
 "Errorea applet-a abiaraztean:\n"
 "%s"
 
-#: panel.c:2335
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "¬øEst√°s seguro que quieres abrir %d ventanas?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Elementua(k) Ezabatu"
+
+#: panel.c:2777
 #, fuzzy
 msgid "Panel Options..."
 msgstr "Aukerak..."
 
-#: panel.c:2427
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "%d Xinerama monitorea ez dago erabilgarri"
 
-#: panel.c:2502
+#: panel.c:2897
+msgid "Top"
+msgstr ""
+
+#: panel.c:2899
 #, fuzzy
-msgid "Panel Options"
-msgstr "Aukerak"
-
-#: panel.c:2517
-#, fuzzy, c-format
-msgid "Panel: %s"
-msgstr "Panelak"
-
-#: panel.c:2525
-msgid "Select the panel's position:"
-msgstr ""
-
-#: panel.c:2531
-msgid "Top-edge panel"
-msgstr ""
-
-#: panel.c:2532
-msgid "Top edge"
-msgstr ""
-
-#: panel.c:2533
-msgid "Bottom edge panel"
-msgstr ""
-
-#: panel.c:2534
-#, fuzzy
-msgid "Bottom edge"
+msgid "Bottom"
 msgstr "Behekaldeko marjina"
 
-#: panel.c:2535
-msgid "Left edge panel"
+#: panel.c:2901
+msgid "Left"
 msgstr ""
 
-#: panel.c:2536
-msgid "Left edge"
+#: panel.c:2903
+msgid "Right"
 msgstr ""
 
-#: panel.c:2537
-msgid "Right-edge panel"
-msgstr ""
+#: panel.c:2905
+#, fuzzy
+msgid "Default"
+msgstr "Lehenetsiriko tamaina:"
 
-#: panel.c:2538
-msgid "Right edge"
-msgstr ""
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "Ezezaguna"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
 msgstr ""
 "Zure idazmahai fitxategi zaharra XML formatu berrira eguneratua izan da."
 
-#: pinboard.c:635
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
@@ -2723,7 +3111,7 @@ msgstr ""
 "Aplikazio direktorio bat Idazmahai atzealde ezarpen kutxara arrastatu ezazu, "
 "edo (programentzat) SOAP SetBackdropApp metodora pasa ezazu."
 
-#: pinboard.c:654
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2737,51 +3125,63 @@ msgstr ""
 "Garatzaileak: Aplikazioaren AppInfo.xml CanSetBackdrop elementua eduki behar "
 "du, ROX-Filer manualean argitzen den bezala."
 
-#: pinboard.c:674
+#: pinboard.c:750
 msgid "Set backdrop"
 msgstr "Pantallaren atzeko irudia ezarri"
 
-#: pinboard.c:685
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
 msgstr "Estilo bat aukeratu eta irudi bat arrastatu:"
 
-#: pinboard.c:698
+#: pinboard.c:774
 msgid "Centre the image without scaling it"
 msgstr "Eskala aldatu gabe irudia erdiratu"
 
-#: pinboard.c:699
+#: pinboard.c:775
 msgid "Centre"
 msgstr "Erdiratua"
 
-#: pinboard.c:700
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr "Irudia idazmahaiaren tamainakoa bihurtu baina eraldatu gabe"
 
-#: pinboard.c:702
+#: pinboard.c:778
 msgid "Scale"
 msgstr "Eskalan"
 
-#: pinboard.c:703
+#: pinboard.c:779
+#, fuzzy
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr "Irudia idazmahaiaren tamainakoa bihurtu baina eraldatu gabe"
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Iruzkina"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
 msgstr "Irudia zabaldu pantaila osoa bete dezan"
 
-#: pinboard.c:704
+#: pinboard.c:783
 msgid "Stretch"
 msgstr "Zabaldua"
 
-#: pinboard.c:705
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr "Irudiaz idazmahaian mosaiko bat egin"
 
-#: pinboard.c:706
+#: pinboard.c:785
 msgid "Tile"
 msgstr "Mosaiko"
 
-#: pinboard.c:711
+#: pinboard.c:790
 msgid "Drop an image here"
 msgstr "Askatu irudi bat hemen"
 
-#: pinboard.c:772
+#: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
@@ -2789,7 +3189,7 @@ msgstr ""
 "Ez zegoen idazmahairik erabilia... 'Lehenetsiriko' idazmahaia hautatua izan "
 "da.'rox -p=Default' erabili aurrerago gaitzeko."
 
-#: pinboard.c:866
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
@@ -2797,35 +3197,40 @@ msgstr ""
 "Fitxategiak bakarrik (eta zenbait aplikazio) erabili daitezke idazmahaiaren "
 "atzealde irudia ezartzeko."
 
-#: pinboard.c:1471
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "'>' bat falta da ikonoaren etiketan"
 
-#: pinboard.c:1480
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "',' bat falta da ikono etiketaren ondoren"
 
-#: pinboard.c:1565
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Errorea %s direktorioa gordetzerakoan: %s"
 
-#: pinboard.c:2109
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Pantaila atzekaldea..."
 
-#: pinboard.c:2202
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Panelak"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
 "%s\n"
 "Backdrop removed."
 msgstr ""
-"Error cargando im·gen de fondo de pantala:\n"
+"Error cargando im√°gen de fondo de pantala:\n"
 "%s\n"
 "Fondo de pantalla eliminado."
 
-#: pixmaps.c:991
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2834,62 +3239,89 @@ msgstr ""
 "Ezin dira %s-ko argazkitxoak ezabatu:\n"
 "%s"
 
-#: pixmaps.c:1012
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Ez dago argazkitxorik ezabatzeko"
 
-#: pixmaps.c:1025
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Diskako argazkitxo katxea ezabatu"
 
-#: remote.c:624
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "'%s' estilo ezezaguna"
 
-#: remote.c:646
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "'%s' xehetasun mota ezezaguna"
 
-#: remote.c:674
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "'%s' sailkapen mota ezezaguna"
 
-#: remote.c:1117
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
-msgstr "Intento de invocar un mÈtodo SOAP desconocido '%s'"
+msgstr "Intento de invocar un m√©todo SOAP desconocido '%s'"
 
-#: rox_gettext.c:95
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Archivo de traducciÛn .gmo no v·lido (demasiado corto): %s"
-
-#: rox_gettext.c:108
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr ""
-"Archivo de traducciÛn .gmo no v·lido (no se encontrÛ el n˙mero m·gico GNU): %"
-"s"
-
-#: run.c:96 run.c:141
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "Programa %s no encontrado - borrado?"
 
-#: run.c:287
+#: run.c:359
+#, fuzzy, c-format
+msgid ""
+"No run action specified for files of this type (%s/%s) - you can set a run "
+"action by choosing `Set Run Action' from the File menu, or you can just drag "
+"the file to an application.%s"
+msgstr ""
+"Ez dago ekintza ezarririk fitxategi mota honentzat (%s/%s) - ekintza "
+"ezartzeko menuan`Ekintza Ezarri' aukeratu edo fixtategia aplikazio batetara "
+"arrastatzearekin ere aski da"
+
+#: run.c:365
+msgid ""
+"\n"
+"\n"
+"Note: If this is a computer program which you want to run, you need to set "
+"the execute bit by choosing Permissions from the File menu."
+msgstr ""
+
+#: run.c:373
 #, c-format
 msgid "File doesn't exist, or I can't access it: %s"
 msgstr "Fitxategia edo ez dago edo ezin da ireki: %s"
 
-#: run.c:292
+#: run.c:378
 #, c-format
 msgid "I don't know how to open '%s'"
 msgstr "Ez dakit '%s' nola ireki"
 
-#: run.c:323
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' ya no es un enlace simb√≥lico"
+
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "'%s' direktorioa ez da eskuragarria"
+
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "Ez abiarazgarria %s"
+
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Huts kudeatzaielan (handler) %s: %s"
+
+#: run.c:465
 msgid ""
 "Application:\n"
 "This is an application directory - you can run it as a program, or open it "
@@ -2901,220 +3333,22 @@ msgstr ""
 "ireki (irekitzerakoan Shift sakatuaz). Aplikazio gehinek laguntza ematen "
 "dute hemen baina honek ez."
 
-#: run.c:407
+#: run.c:549
 #, c-format
 msgid "Could not send data to program: %s"
 msgstr "Ezin dira datuak programara bidali: %s"
 
-#: run.c:437
+#: run.c:578
 #, c-format
 msgid "Could not read link: %s"
 msgstr "Ezin izan da esteka irakurri: %s"
 
-#: run.c:465
+#: run.c:606
 #, c-format
 msgid "Broken symlink (or you don't have permission to follow it): %s"
 msgstr "apurtutako esteka sinbolikoa (edo ez duzu irakurtzeko eskubiderik): %s"
 
-#: run.c:502
-#, fuzzy, c-format
-msgid ""
-"No run action specified for files of this type (%s/%s) - you can set a run "
-"action by choosing `Set Run Action' from the File menu, or you can just drag "
-"the file to an application.%s"
-msgstr ""
-"Ez dago ekintza ezarririk fitxategi mota honentzat (%s/%s) - ekintza "
-"ezartzeko menuan`Ekintza Ezarri' aukeratu edo fixtategia aplikazio batetara "
-"arrastatzearekin ere aski da"
-
-#: run.c:508
-msgid ""
-"\n"
-"\n"
-"Note: If this is a computer program which you want to run, you need to set "
-"the execute bit by choosing Permissions from the File menu."
-msgstr ""
-
-#: support.c:272
-msgid "B"
-msgstr "B"
-
-#: support.c:351
-msgid "byte"
-msgstr "byte"
-
-#: toolbar.c:115
-msgid "Close"
-msgstr "Itxi"
-
-#: toolbar.c:115
-msgid "Close filer window"
-msgstr "Kudeatzaile leihoa itxi"
-
-#: toolbar.c:119
-msgid "Up"
-msgstr "Gora"
-
-#: toolbar.c:119
-msgid "Change to parent directory"
-msgstr "Goiko direktorioara joan"
-
-#: toolbar.c:123
-msgid "Home"
-msgstr "Etxea"
-
-#: toolbar.c:123
-msgid "Change to home directory"
-msgstr "Etxe direktoriora joan"
-
-#: toolbar.c:127
-msgid "Bookmarks"
-msgstr "Laster-markak"
-
-#: toolbar.c:127
-msgid "Bookmarks menu"
-msgstr "Laster-marka menua"
-
-#: toolbar.c:131
-msgid "Scan"
-msgstr "Berritu"
-
-#: toolbar.c:131
-msgid "Rescan directory contents"
-msgstr "Berritu  direktorio edukiak"
-
-#: toolbar.c:135
-msgid "Change icon size"
-msgstr "Ikono tamaina aldatu"
-
-#: toolbar.c:139
-msgid "Automatic size mode"
-msgstr "Tamaina automatiko modua"
-
-#: toolbar.c:143
-msgid "Show extra details"
-msgstr "Xehetasun gehiarriak bistarazi"
-
-#: toolbar.c:147
-msgid "Sort"
-msgstr "Sailkatu"
-
-#: toolbar.c:147
-msgid "Change sort criteria"
-msgstr "Sailkatze irizpideak aldatu"
-
-#: toolbar.c:151
-msgid "Hidden"
-msgstr "Eskutaturik"
-
-#: toolbar.c:151
-msgid "Show/hide hidden files"
-msgstr "Ezkutaturiko fitxategiak ezkutatu/bistarazi"
-
-#: toolbar.c:155
-msgid "Select all/invert selection"
-msgstr "Dana hautatu/Hautapena alderantzizkatu"
-
-#: toolbar.c:159
-msgid "Show ROX-Filer help"
-msgstr "ROX-Filer laguntza bistarazi"
-
-#: toolbar.c:220
-#, c-format
-msgid " (%u hidden)"
-msgstr " (%u ezkutaturik)"
-
-#: toolbar.c:228 tips:80
-msgid "items"
-msgstr "elementu"
-
-#: toolbar.c:228
-msgid "item"
-msgstr "elementu"
-
-#: toolbar.c:231
-#, c-format
-msgid "No items%s"
-msgstr "Elementurik ez%s"
-
-#: toolbar.c:250
-#, c-format
-msgid "%u selected (%s)"
-msgstr "%u hautaturik (%s)"
-
-#: toolbar.c:422
-msgid "Sort by name"
-msgstr "Izenez sailkatu"
-
-#: toolbar.c:422
-msgid "Sort by type"
-msgstr "Motaz sailkatu"
-
-#: toolbar.c:422
-msgid "Sort by date"
-msgstr "Dataz sailkatu"
-
-#: toolbar.c:423
-msgid "Sort by size"
-msgstr "Tamainaz sailkatu"
-
-#: toolbar.c:423
-msgid "Sort by owner"
-msgstr "Jabez sailkatu"
-
-#: toolbar.c:423
-msgid "Sort by group"
-msgstr "Taldez sailkatu"
-
-#: toolbar.c:457
-msgid "ascending"
-msgstr "gorantz"
-
-#: toolbar.c:457
-msgid "descending"
-msgstr "beherantz"
-
-#: type.c:203
-msgid "Sym link"
-msgstr "Esteka simb"
-
-#: type.c:205
-msgid "Mount point"
-msgstr "Muntatze puntua"
-
-#: type.c:207
-msgid "App dir"
-msgstr "Aplik Dir"
-
-#: type.c:214
-msgid "Dir"
-msgstr "Dir"
-
-#: type.c:216
-msgid "Char dev"
-msgstr "Kar gailua"
-
-#: type.c:218
-msgid "Block dev"
-msgstr "Bloke gailua"
-
-#: type.c:220
-msgid "Pipe"
-msgstr "Tutua"
-
-#: type.c:222
-msgid "Socket"
-msgstr "Socket-a"
-
-#: type.c:224
-msgid "Door"
-msgstr "Atea"
-
-#: type.c:227
-msgid "Unknown"
-msgstr "Ezezaguna"
-
-#: type.c:355
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3128,23 +3362,296 @@ msgid ""
 "Otherwise, you should check, or even just delete, all the existing run "
 "actions."
 msgstr ""
-"°El ejecutable '%s' es modificable por todos! Me niego a ejecutar. Por favor "
-"modifica los permisos ahora (Èste problema puede haber sido causado por un "
+"¬°El ejecutable '%s' es modificable por todos! Me niego a ejecutar. Por favor "
+"modifica los permisos ahora (√©ste problema puede haber sido causado por un "
 "bug en versiones anteriores del filer).\n"
 "\n"
-"Tener accions de ejecuciÛn (no enlaces simbÛlicos) modificables por todos "
+"Tener accions de ejecuci√≥n (no enlaces simb√≥licos) modificables por todos "
 "significa que otras personas que usen tu computadora pueden reemplazar tus "
-"acciones de ejecuciÛn con versiones maliciosas.\n"
+"acciones de ejecuci√≥n con versiones maliciosas.\n"
 "\n"
-"Si confÌas en todos los que puedan escribir en Èsos archivos, entonces no "
-"necesitas preocuparte. Sino, deberÌas verificar, o incluso sÛlo eliminar, "
-"todas las acciones de ejecuciÛn existentes."
+"Si conf√≠as en todos los que puedan escribir en √©sos archivos, entonces no "
+"necesitas preocuparte. Sino, deber√≠as verificar, o incluso s√≥lo eliminar, "
+"todas las acciones de ejecuci√≥n existentes."
 
-#: type.c:368
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Segurtasun arazoa konpontzend u)"
 
-#: type.c:498
+#: support.c:288
+msgid " "
+msgstr ""
+
+#: support.c:381
+msgid "byte"
+msgstr "byte"
+
+#: support.c:1531 support.c:1585
+#, fuzzy, c-format
+msgid "Failed to open and stat file '%s': %s"
+msgstr ""
+"Hust '%s' ezabatzerakoan:\n"
+"%s"
+
+#: support.c:1542 support.c:1596
+#, fuzzy, c-format
+msgid "Failed to mmap file '%s': %s"
+msgstr ""
+"Hust '%s' ezabatzerakoan:\n"
+"%s"
+
+#: toolbar.c:116
+msgid "Close"
+msgstr "Itxi"
+
+#: toolbar.c:116
+msgid "Close filer window"
+msgstr "Kudeatzaile leihoa itxi"
+
+#: toolbar.c:120
+msgid "Up"
+msgstr "Gora"
+
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
+
+#: toolbar.c:126
+msgid "Home"
+msgstr "Etxea"
+
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
+
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
+
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
+
+#: toolbar.c:138
+msgid "Scan"
+msgstr "Berritu"
+
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
+
+#: toolbar.c:143
+#, fuzzy
+msgid "Size‚îº"
+msgstr "Tamaina"
+
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ‚îò : Huge\n"
+"  ‚î§ : Large\n"
+"  ‚îê : Small\n"
+"  ‚îå, ‚îú : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automatikoa"
+
+#: toolbar.c:155
+msgid "Automatic size mode"
+msgstr "Tamaina automatiko modua"
+
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Zerrenda bistaratzea"
+
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
+msgid "Sort"
+msgstr "Sailkatu"
+
+#: toolbar.c:165
+msgid "Change sort criteria"
+msgstr "Sailkatze irizpideak aldatu"
+
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
+
+#: toolbar.c:169
+msgid ""
+"Left: Show/hide hidden files\n"
+"Right: Show/hide thumbnails"
+msgstr ""
+
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "Dana hautatu/Hautapena alderantzizkatu"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "‚óã"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ‚ñΩ: No settings\n"
+"  ‚ñº: Own settings\n"
+"  ‚ñ∂: Parent settings\n"
+"  ‚ñ∑: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
+msgid "Show ROX-Filer help"
+msgstr "ROX-Filer laguntza bistarazi"
+
+#: toolbar.c:270
+#, c-format
+msgid " (%u hidden)"
+msgstr " (%u ezkutaturik)"
+
+#: toolbar.c:276 tips:79
+msgid "items"
+msgstr "elementu"
+
+#: toolbar.c:276
+msgid "item"
+msgstr "elementu"
+
+#: toolbar.c:279
+#, c-format
+msgid "No items%s"
+msgstr "Elementurik ez%s"
+
+#: toolbar.c:298
+#, c-format
+msgid "%u selected (%s)"
+msgstr "%u hautaturik (%s)"
+
+#: toolbar.c:535
+msgid "Sort by name"
+msgstr "Izenez sailkatu"
+
+#: toolbar.c:535
+msgid "Sort by type"
+msgstr "Motaz sailkatu"
+
+#: toolbar.c:535
+msgid "Sort by date"
+msgstr "Dataz sailkatu"
+
+#: toolbar.c:535
+msgid "Sort by size"
+msgstr "Tamainaz sailkatu"
+
+#: toolbar.c:536
+msgid "Sort by owner"
+msgstr "Jabez sailkatu"
+
+#: toolbar.c:536
+msgid "Sort by group"
+msgstr "Taldez sailkatu"
+
+#: toolbar.c:568
+msgid "ascending"
+msgstr "gorantz"
+
+#: toolbar.c:568
+msgid "descending"
+msgstr "beherantz"
+
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
+msgid "Sym link"
+msgstr "Esteka simb"
+
+#: type.c:223
+msgid "Mount point"
+msgstr "Muntatze puntua"
+
+#: type.c:225
+msgid "App dir"
+msgstr "Aplik Dir"
+
+#: type.c:232
+msgid "Dir"
+msgstr "Dir"
+
+#: type.c:234
+msgid "Char dev"
+msgstr "Kar gailua"
+
+#: type.c:236
+msgid "Block dev"
+msgstr "Bloke gailua"
+
+#: type.c:238
+msgid "Pipe"
+msgstr "Tutua"
+
+#: type.c:240
+msgid "Socket"
+msgstr "Socket-a"
+
+#: type.c:242
+msgid "Door"
+msgstr "Atea"
+
+#: type.c:245
+msgid "Unknown"
+msgstr "Ezezaguna"
+
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3155,71 +3662,71 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:679
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Hau ez da programa bat! Honen ordez aplikazio bat eman behar duzu!"
 
-#: type.c:740
+#: type.c:839
 msgid "No run action defined"
 msgstr "Ez dago abiarazte ekintzarik"
 
-#: type.c:766
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Huts kudeatzaielan (handler) %s: %s"
 
-#: type.c:781
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
-msgstr "AplicaciÛn inv·lida %s (AppRun incorrecto)"
+msgstr "Aplicaci√≥n inv√°lida %s (AppRun incorrecto)"
 
-#: type.c:792
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "Ez abiarazgarria %s"
 
-#: type.c:825
+#: type.c:902
 msgid "Set run action"
 msgstr "Ekintza ezarri"
 
-#: type.c:831
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 "Mota bereziarerentzat ez badago aplikaziorik ezarririk, hau erabili "
 "lehenespen bezala."
 
-#: type.c:833
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Lehenespen bezala ezarri `%s/<zerbait>' guztietan"
 
-#: type.c:837
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "MIME mota honetako fitxategi guztiekin aplikaziio hau erabili."
 
-#: type.c:839
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "`%s' (%s/%s) motarentzat bakarrik"
 
-#: type.c:845
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Ekarri aplikazio erabilgarri bat hona"
 
-#: type.c:860
+#: type.c:963
 msgid "OR"
 msgstr "EDO"
 
-#: type.c:867
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Idatzi shell komando bat:"
 
-#: type.c:896
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Komandoa"
 
-#: type.c:926
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
@@ -3227,43 +3734,29 @@ msgstr ""
 "Ekintza bat ezarririk dago eta nahiko programa handi bat da - ezabatu nahi "
 "duzula zihur zaude?"
 
-#: type.c:937
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Ezin da %s ezabatu: %s"
 
-#: type.c:974
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "CHOICESPATH aldagaiak aukerak gordetzea ezintzen du"
 
-#: type.c:1249
-#, c-format
-msgid ""
-"Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr ""
-"'%s' ikono gaiak ez ditu MIME ikonorik. ROX-en lehenetsiriko gaia erabiltzen "
-"honen ordez."
-
-#: type.c:1263
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason)"
+"%s"
 msgstr ""
-"Huts '%s' esteka sinbolikoa sortzerakoan:\n"
-"%s\n"
-"\n"
-"(honek ROX gaia dagoeneko han dagoela baina 'mime-application:postscript' "
-"zerbaitegaik ezin izna dela kargatu esan nahi dezake)"
+"Fall√≥ la eliminaci√≥n de '%s':\n"
+"%s"
 
-#: usericons.c:181
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "Emandako bidea ez dago. Ikonoa ez da aldatu."
 
-#: usericons.c:191 usericons.c:616
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3273,12 +3766,12 @@ msgstr ""
 "edo agian baimenak gaizki al daude?\n"
 "Ikonoa ez da aldatua izango."
 
-#: usericons.c:238
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
-msgstr "ø'%s' ikonoa benetan ezabatu?"
+msgstr "¬ø'%s' ikonoa benetan ezabatu?"
 
-#: usericons.c:242
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3287,30 +3780,30 @@ msgstr ""
 "Ezin da '%s' ezabatu:\n"
 "%s"
 
-#: usericons.c:270
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Ikonoa ezarri"
 
-#: usericons.c:279
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr "Erabili irudiaren kopia bat MIME mota hauetako fitxategi guztientzat."
 
-#: usericons.c:281
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "`%s/<zerbait>' guztientzat ikonoa ezarri"
 
-#: usericons.c:286
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "Erabili irudiaren kopia bat MIME mota honetako fitxategi guztientzat."
 
-#: usericons.c:288
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Para todos los archivos de tipo `%s' (%s/%s)"
 
-#: usericons.c:294
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
@@ -3318,12 +3811,12 @@ msgstr ""
 "Gehitu fitxategi eta irudi fitxategi izenak zerrenda pertsonalera. Ezarpena "
 "galdu egingo da irudia edo fitxategia mugitzen bada."
 
-#: usericons.c:297
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "`%s' fitxategiarentzat bakarrik"
 
-#: usericons.c:305
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
@@ -3334,19 +3827,19 @@ msgstr ""
 "eta direktorioasegurtasunez mugitu ahal izango duzu. Hau normalean aukera "
 "hoberena da direktorioan idazteko aukera baduzu."
 
-#: usericons.c:311
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Kopiatu irudia direktorio barnean"
 
-#: usericons.c:317
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Askatu ikono bat hemen"
 
-#: usericons.c:587
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "CHOICESPATH aldagaiak ikonoak ezartzea ezintzen du"
 
-#: usericons.c:631
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3355,144 +3848,71 @@ msgstr ""
 "Errorea '%s' irudia sortzerakoan:\n"
 "%s"
 
-#: view_details.c:1009
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
+msgid "Mono font"
+msgstr ""
+
+#: view_details.c:1019
+msgid "Font for displaying mono-spaced text"
+msgstr ""
+
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Izena"
 
-#: view_details.c:1012
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Mota"
 
-#: view_details.c:1015
-msgid "_Permissions"
-msgstr "_Baimenak"
-
-#: view_details.c:1016
-msgid "_Owner"
-msgstr "_Jabea"
-
-#: view_details.c:1018
-msgid "_Group"
-msgstr "_Taldea"
-
-#: view_details.c:1020
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Tamaina"
 
-#: view_details.c:1022
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Baimenak"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_Jabea"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Taldea"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "Akzen _Aldaketa"
 
-#: tips:1
-msgid "Translation"
-msgstr "Itzulpena"
-
-#: tips:2
-msgid "Language"
-msgstr "Hizkuntza"
-
-#: tips:3
-msgid "Use the LANG environment variable"
-msgstr "LANG aldagaieko ingurunea erabili"
-
-#: tips:4
-msgid "Basque"
+#: view_details.c:1260
+msgid "Last _Changed"
 msgstr ""
 
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Txinatar (tradizionala)"
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
 
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Txinatar (soildua)"
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Atributu hedatuak"
 
-#: tips:7
-msgid "Czech"
-msgstr "Txekiera"
-
-#: tips:8
-msgid "Danish"
-msgstr "Daniera"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Holandarra"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Ingelesa (itzuli gabe)"
-
-#: tips:11
-#, fuzzy
-msgid "Estonian"
-msgstr "Errumaniera"
-
-#: tips:12
-msgid "Finnish"
-msgstr "Finlandiera"
-
-#: tips:13
-msgid "French"
-msgstr "Frantsesa"
-
-#: tips:14
-msgid "German"
-msgstr "Alemaniera"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Hungariera"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Japoniera"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "Norvegiera"
-
-#: tips:18
-msgid "Italian"
-msgstr "Italiera"
-
-#: tips:19
-msgid "Polish"
-msgstr "Poloniera"
-
-#: tips:20
-msgid "Portuguese (Brasil)"
-msgstr "Portugesa (Brasil)"
-
-#: tips:21
-msgid "Romanian"
-msgstr "Errumaniera"
-
-#: tips:22
-msgid "Russian"
-msgstr "Errusiera"
-
-#: tips:23
-msgid "Spanish"
-msgstr "Gaztelania"
-
-#: tips:24
-msgid "Swedish"
-msgstr "Suediera"
-
-#: tips:25
+#: tips:1
 msgid "Filer windows"
 msgstr "Kudeatzaile leihoa"
 
-#: tips:26
+#: tips:2
 msgid "Auto-resize filer windows"
 msgstr "Kudeatziale leihoak automatikoki tamainaz aldatu"
 
-#: tips:27
+#: tips:3
 msgid "Never automatically resize"
 msgstr "Inoiz ez automatikoki tamaiana aldatu "
 
-#: tips:28
+#: tips:4
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
@@ -3500,11 +3920,11 @@ msgstr ""
 "Leiho tamainak leiho kudeatzailea, `Leiho tamaina aldatu' menuaz edo leiho "
 "atzealdean klik bikoitza eginez eskuz aldatu beharko dituzu."
 
-#: tips:29
+#: tips:5
 msgid "Resize when changing the display style"
 msgstr "Tamaina aldatu bistaratze metodoa aldatzerakoan"
 
-#: tips:30
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
@@ -3512,11 +3932,11 @@ msgstr ""
 "Ikono tamaina edo bistarazitako xehetasunak aldatzean leihoa tamaina "
 "automatikoki aldatuko da."
 
-#: tips:31
+#: tips:7
 msgid "Always resize"
 msgstr "Beti tamaina aldatu"
 
-#: tips:32
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
@@ -3524,15 +3944,16 @@ msgstr ""
 "Kudeatzaileak leiho tamaina erabilgarri denean aldatuko du (hau da, "
 "direktorioa aldatu edi bistaratze estiloa aldatzean)."
 
-#: tips:33
+#: tips:9
 msgid "Largest window size:"
 msgstr "Leiho tamaina handiena:"
 
-#: tips:34
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:35
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
@@ -3540,15 +3961,29 @@ msgstr ""
 "Leiho baten tamaina aldatzean erabiliko den tamaina handiena, pantailaren "
 "tamaina ehunekotan."
 
-#: tips:36
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Leiho tamaina handiena:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Leiho baten tamaina aldatzean erabiliko den tamaina handiena, pantailaren "
+"tamaina ehunekotan."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Leihoaren Portamoldea"
 
-#: tips:37
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Izenburu etiketa laburrak"
 
-#: tips:38
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
@@ -3556,11 +3991,11 @@ msgstr ""
 "Hitzak beharrean hizkiak erabili kudeaketa, Denak eta argazkitxo "
 "erakusleentzat izenburu barran."
 
-#: tips:39
+#: tips:18
 msgid "Unique windows"
 msgstr "Leiho bakarrak"
 
-#: tips:40
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3568,11 +4003,34 @@ msgstr ""
 "Direktorio bat irekitzerakoan berau beste leiho batetan irekirik egon ezkero "
 "beste leihoa itxi egingo da."
 
-#: tips:41
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Leihoa"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Leiho berria 1 botoiaz"
 
-#: tips:42
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3582,11 +4040,11 @@ msgstr ""
 "egiteandirektorioa leiho berri batetan irekiko da. 3. botoiaz (erdikoa) "
 "egitean leihoa berdina erabiliok da."
 
-#: tips:43
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Klik bakarreko nabigatzea"
 
-#: tips:44 tips:137
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
@@ -3597,11 +4055,11 @@ msgstr ""
 "egiterakoan elementua aukeratua egingo da, irekitzeko klik bikoitza egin "
 "beharko da."
 
-#: tips:45
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Atzealdean klik-bikoitzaz tamaina aldatu"
 
-#: tips:46
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
@@ -3610,15 +4068,15 @@ msgstr ""
 "egingo da, tresnabarrako tamaina automatiko modu botoia klikatuko bazenu "
 "bezala."
 
-#: tips:47
+#: tips:30
 msgid "Sorting"
 msgstr "Sailkapena"
 
-#: tips:48
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Direktorioak lehenengo (izenezko sailkapenarentzat)"
 
-#: tips:49
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
@@ -3626,11 +4084,11 @@ msgstr ""
 "Gaiturik badago direktorioa beti lehenego bistarazik dira izenez "
 "sailkatzerakoan."
 
-#: tips:50
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Hizki larrizko izenak lehenengo (izenezko sailkapenarentzat)"
 
-#: tips:51
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
@@ -3638,15 +4096,58 @@ msgstr ""
 "Gaiturik badago hizki larri batez hasten diren fitxategiak minuskulaz hasten "
 "direnez aurretik bistaraziko dira."
 
-#: tips:53
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Direktorioak lehenengo (izenezko sailkapenarentzat)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Seg"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "Atributu hedatuak"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "Leiho berrientzako lehenetsitako ezarpenak"
 
-#: tips:54
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "Jatorrizko leihoaren aukerak erabili"
 
-#: tips:55
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
@@ -3654,27 +4155,38 @@ msgstr ""
 "Gaiturik badago leiho berri baten bistartze aukerak jatorrizko leihotik "
 "artuko dira posible bada, bestela lehenespenak erabiliko dira."
 
-#: tips:56
+#: tips:48
 msgid "View type:"
 msgstr "Ikuspegi mota:"
 
-#: tips:59
+#: tips:51
 msgid "Sort by:"
 msgstr "Sailkapena:"
 
-#: tips:61 tips:76
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Mota"
 
-#: tips:62
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Data"
 
-#: tips:64
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Data"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Data"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Ezkutaturiko fitxategiak bistarazi"
 
-#: tips:65
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
@@ -3682,7 +4194,34 @@ msgstr ""
 "Gaiturik badago izena puntu batez hasten duten fixtategiak bistarazi egingo "
 "dira, bestela ezkutatu egingo dira."
 
-#: tips:66
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Ezkutaturiko fitxategiak bistarazi"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Gaiturik badago izena puntu batez hasten duten fixtategiak bistarazi egingo "
+"dira, bestela ezkutatu egingo dira."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Ikono Itzelak"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "pixel"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "Ikono Bistaratzea"
 
@@ -3694,11 +4233,11 @@ msgstr "Lehenetsiriko tamaina:"
 msgid "Huge Icons"
 msgstr "Ikono Itzelak"
 
-#: tips:69 tips:245
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Ikono Handiak"
 
-#: tips:70 tips:244
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "Ikono Txikiak"
 
@@ -3710,15 +4249,20 @@ msgstr "Lehenetsiriko xehetasunak:"
 msgid "No details"
 msgstr "Xehetasun gabe"
 
+#: tips:74
+msgid "Sizes"
+msgstr "Tamainak"
+
+#: tips:77
+msgid "Times"
+msgstr "Data"
+
 #: tips:78
-msgid "Automatic small icons:"
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "Ikono txiki automatikoak:"
 
-#: tips:79
-msgid "Change at:"
-msgstr "Aldaketa hemen:"
-
-#: tips:81
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3728,103 +4272,227 @@ msgstr ""
 "hau edo handiago badu Ikono Txikiak erabiltzen bistaraziko dira, bestela "
 "Ikono Handiak erabiliko dira. "
 
-#: tips:82
-msgid "Max width (Large icons):"
-msgstr "Zabalera handiena (Ikono Handiak):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Ikono Handiak"
 
-#: tips:83 tips:86
-msgid "pixels"
-msgstr "pixel"
-
-#: tips:84
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "Hau baino testu luzeagoak bi lerrotan bereiziko dira Ikono Handi moduan. "
 "Ikono Itzel moduan honen erdia baino luzeagoak direnak erdibituko dira."
 
-#: tips:85
-msgid "(Small Icons):"
-msgstr "(Ikono Txikiak):"
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
 
 #: tips:87
-msgid "Maximum width for the text beside a Small Icon."
-msgstr "Ikono txiki baten alboko testuaren gehienezko zabalera."
+msgid "Wrap by characters"
+msgstr ""
 
 #: tips:88
-msgid "Order small icons vertically"
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
 msgstr ""
 
 #: tips:89
-msgid ""
-"If this option is on, then small icons are ordered vertically, not "
-"horizontally."
-msgstr ""
-
-#: tips:90
-msgid "Order large icons vertically"
-msgstr ""
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "(Ikono Txikiak):"
 
 #: tips:91
-msgid ""
-"If this option is on, then large icons are sorted vertically, not "
-"horizontally."
+msgid "Maximum width for the text beside a Small Icon."
+msgstr "Ikono txiki baten alboko testuaren gehienezko zabalera."
+
+#: tips:92
+msgid "Order small icons vertically"
 msgstr ""
 
 #: tips:93
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
+msgstr ""
+
+#: tips:94
+msgid "Order large icons vertically"
+msgstr ""
+
+#: tips:95
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
+msgstr ""
+
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Zutabe goiburuak erakutsi"
 
-#: tips:94
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr ""
 "Gaiturik badago zutabe goiburuak bistarazi egingo dira zerrenda ikuspegian."
 
-#: tips:95
+#: tips:102
 #, fuzzy
 msgid "Show full type"
 msgstr "Motaz sailkatu"
 
-#: tips:96
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr ""
 
-#: tips:97
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Ikono txiki baten alboko testuaren gehienezko zabalera."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Zutabe goiburuak erakutsi"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Gaiturik badago zutabe goiburuak bistarazi egingo dira zerrenda ikuspegian."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Gaiturik badago zutabe goiburuak bistarazi egingo dira zerrenda ikuspegian."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Gaiturik badago zutabe goiburuak bistarazi egingo dira zerrenda ikuspegian."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Gaiturik badago zutabe goiburuak bistarazi egingo dira zerrenda ikuspegian."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Gaiturik badago zutabe goiburuak bistarazi egingo dira zerrenda ikuspegian."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Gaiturik badago zutabe goiburuak bistarazi egingo dira zerrenda ikuspegian."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "Akzen _Aldaketa"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Gaiturik badago zutabe goiburuak bistarazi egingo dira zerrenda ikuspegian."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Gaiturik badago zutabe goiburuak bistarazi egingo dira zerrenda ikuspegian."
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Gaiturik badago zutabe goiburuak bistarazi egingo dira zerrenda ikuspegian."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Lanabesa/Minibuffer-a"
 
-#: tips:98
+#: tips:131
 msgid "Toolbar"
 msgstr "Tresnabarra"
 
-#: tips:99
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Tresnabarra mota:"
 
-#: tips:100
+#: tips:133
 msgid "No toolbar"
 msgstr "Tresnabarrarik ez"
 
-#: tips:101
+#: tips:134
 msgid "Icons only"
 msgstr "Ikonoak bakarrik"
 
-#: tips:102
+#: tips:135
 msgid "Text under icons"
 msgstr "Testua ikonoen azpian"
 
-#: tips:103
+#: tips:136
 msgid "Text beside icons"
 msgstr "Testua ikonoen alboan"
 
-#: tips:104
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Irudi bakarrik"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Elementu kopurua bistarazi"
 
-#: tips:105
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3834,15 +4502,15 @@ msgstr ""
 "ezkutatutako fitxategi kopurua (baleude). Hautapen bat egina badago, "
 "aukeratutako fitxategi kopurua erakutsiko da."
 
-#: tips:106
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Barran nahi dituzun botoiak hautatu:"
 
-#: tips:107
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "Tresnabarra zabalerak leihoaren gutxieneko zabalera ezartzen du"
 
-#: tips:108
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
@@ -3850,15 +4518,15 @@ msgstr ""
 "Kudeatzailearen leiho bakoitza gutzienez tresnabarra bistaratzeko bezain "
 "zabala izan behar da"
 
-#: tips:109
+#: tips:143
 msgid "Minibuffer"
 msgstr "Minibuffer-a"
 
-#: tips:110
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "beep egin tabuladore betetzeak huts egin ezkero"
 
-#: tips:111
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
@@ -3868,11 +4536,11 @@ msgstr ""
 "ez bada ezer gertatzen (adibidez aukera anitz daudelako eta hurrengo hizkia "
 "aldatzen delako)."
 
-#: tips:112
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Parekatzea asko egon ezkero beep egin"
 
-#: tips:113
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
@@ -3881,7 +4549,27 @@ msgstr ""
 "fitxategi bat baino gehiagok parekatzea betetzen badute nahiz hizki batenbat "
 "gehitu."
 
-#: tips:116
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Deskarga kudeatzailea"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Huts kudeatzaielan (handler) %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
@@ -3889,11 +4577,11 @@ msgstr ""
 "Argazkitxoak gaiturik daudenean direktorioko irudi bakoitza kargatu eta bere "
 "argazki txiki bat bistarazi egingo da."
 
-#: tips:117
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Irudien argazkitxoak bistarazi"
 
-#: tips:118
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
@@ -3901,30 +4589,104 @@ msgstr ""
 "Hau da leiho berrien lehenetsiriko konfigurazioa. Bistarazi menua erabili "
 "leiho batetan argazkitxo bistaratzea gaitu edo ezgaitzeko."
 
-#: tips:119
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Irudien argazkitxoak bistarazi"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 #, fuzzy
 msgid "Video thumbnails"
 msgstr "Argazkitxoak bistarazi"
 
-#: tips:120
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Argazkitxo katxea"
 
-#: tips:121
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "Gauzak bizkortzeko sortutako argazkitxoak ~/.thumbnails ezkutatutako "
 "direktorioan gordeko dira. Hemen klik egin katxean dauden argazkitxo guztiak "
 "ezabatzeko. Beharrezko direnean berriz sortuko dira."
 
-#: tips:122 tips:195
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
+#, fuzzy
+msgid "Manage thumbnails"
+msgstr "Irudien argazkitxoak bistarazi"
+
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Argazkitxoak bistarazi"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Seg"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Idazmahaia"
 
-#: tips:123
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
@@ -3932,47 +4694,47 @@ msgstr ""
 "Idazmahaia erabiltzen denean idazmahai atzekaldera fitxategi eta plikazioa "
 "arrastatu ditzakezu estekak sortzeko."
 
-#: tips:124 tips:241
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Itxura"
 
-#: tips:125
+#: tips:179
 msgid "Foreground:"
 msgstr "Lehen maila:"
 
-#: tips:126
+#: tips:180
 msgid "Text shadow:"
 msgstr "Testu itzala:"
 
-#: tips:127
+#: tips:181
 msgid "Background:"
 msgstr "Atzekaldea:"
 
-#: tips:128
+#: tips:182
 msgid "No shadow"
 msgstr "Testu itzala:"
 
-#: tips:129
+#: tips:183
 msgid "Thin"
 msgstr "Estua"
 
-#: tips:130
+#: tips:184
 msgid "Thick"
 msgstr "Lodia"
 
-#: tips:131
+#: tips:185
 msgid "Use custom font:"
 msgstr "Pertsonalizatutako letra-tipoa erabili:"
 
-#: tips:132
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Ikonoen azpiko testua bistaratzeko erabiliko den letra-tipoa"
 
-#: tips:133
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Irudi eskalatze azkarra"
 
-#: tips:134
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
@@ -3980,19 +4742,19 @@ msgstr ""
 "Hautatu irudi eskalatze metodo azkar eta geldoan artean. Metodo geldoak "
 "emaitza hobeak lortzen ditu."
 
-#: tips:135
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Idazmahai portamoldea"
 
-#: tips:136
+#: tips:190
 msgid "Single-click to open"
 msgstr "Klik bakarra irekitzeko"
 
-#: tips:138
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Ikonoak panatalla mugen barnean mantendu"
 
-#: tips:139
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
@@ -4000,39 +4762,39 @@ msgstr ""
 "Gaiturik dagoenean, idazmahaieko ikonoak guztiz pantailaren mugen barnean "
 "kokatuko dira, etiketa barne."
 
-#: tips:140
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Ikono arteko tartea:"
 
-#: tips:141
+#: tips:195
 msgid "Fine"
 msgstr "Fina"
 
-#: tips:142
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "2 pixel zabalerako sareta bat erabili ikonoak idazmahaiean ipintzeko."
 
-#: tips:143
+#: tips:197
 msgid "Medium"
 msgstr "Erdikoa"
 
-#: tips:144
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "16 pixel zabalerako sareta bat erabili ikonoak idazmahaiean ipintzeko."
 
-#: tips:145
+#: tips:199
 msgid "Coarse"
 msgstr "Zabala"
 
-#: tips:146
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "32 pixel zabalerako sareta bat erabili ikonoak idazmahaiean ipintzeko."
 
-#: tips:147 tips:149
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Txikituriko leihoak"
 
-#: tips:148
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
@@ -4042,11 +4804,11 @@ msgstr ""
 "eta zenbait progrmanak, ROX-Filer barne, erabili daitezke ikonoturiko "
 "leihoak ikusteko."
 
-#: tips:150
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Txikituriko leihoak bistarazi"
 
-#: tips:151
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
@@ -4056,11 +4818,11 @@ msgstr ""
 "idazmahaieko botoi bat bezala bistaraziko da. Leiho kudeatzaile bateragarri "
 "bat behar da eta idazmahaia martxan egon behar da."
 
-#: tips:152
+#: tips:206
 msgid "Show per workspace"
 msgstr ""
 
-#: tips:153
+#: tips:207
 #, fuzzy
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
@@ -4070,39 +4832,39 @@ msgstr ""
 "idazmahaieko botoi bat bezala bistaraziko da. Leiho kudeatzaile bateragarri "
 "bat behar da eta idazmahaia martxan egon behar da."
 
-#: tips:154
+#: tips:208
 msgid "Iconify to the"
 msgstr "Txikitu hemen:"
 
-#: tips:155
+#: tips:209
 msgid "top-left"
 msgstr "Ezker-goialdean"
 
-#: tips:156
+#: tips:210
 msgid "top-right"
 msgstr "Eskuin-goialdean"
 
-#: tips:157
+#: tips:211
 msgid "bottom-left"
 msgstr "Ezker-behekaldean"
 
-#: tips:158
+#: tips:212
 msgid "bottom-right"
 msgstr "Eskuin-behekaldean"
 
-#: tips:159
+#: tips:213
 msgid ", going"
 msgstr ", zentzua: "
 
-#: tips:160
+#: tips:214
 msgid "horizontally"
 msgstr "horizontala"
 
-#: tips:161
+#: tips:215
 msgid "vertically"
 msgstr "betikala"
 
-#: tips:162
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4114,180 +4876,100 @@ msgstr ""
 "edo behekaldean marjin bat ezarri dezakezu ikonoak hor ipintzea ezintzeko. "
 "Kudeatzaileak bere panela ezagutzen du."
 
-#: tips:163
+#: tips:217
 msgid "Top margin"
 msgstr "Goikaldeko marjina"
 
-#: tips:164
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Pantailaren goikaldean erabiltzea ez den nahi altuera."
 
-#: tips:165
+#: tips:219
 msgid "Bottom margin"
 msgstr "Behekaldeko marjina"
 
-#: tips:166
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "Pantailaren behekaldean erabiltzea ez den nahi altuera."
 
-#: tips:167
-msgid "Panels"
-msgstr "Panelak"
+#: tips:221
+#, fuzzy
+msgid "Left margin"
+msgstr "Goikaldeko marjina"
 
-#: tips:168
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr ""
-"Panelak pantailaren albo batetan kokaturiko ikono barrak dira. Panelen "
-"erabilerari buruz argibide gehiago jasotzeko manuala irakurri."
+#: tips:222
+#, fuzzy
+msgid "Width of no-go area at left of screen."
+msgstr "Pantailaren goikaldean erabiltzea ez den nahi altuera."
 
-#: tips:169
-msgid "Panel style"
-msgstr "Panel estiloa"
+#: tips:223
+#, fuzzy
+msgid "Right margin"
+msgstr "Behekaldeko marjina"
 
-#: tips:170
-msgid "Image and text"
-msgstr "Irudia eta testua"
+#: tips:224
+#, fuzzy
+msgid "Width of no-go area at right of screen."
+msgstr "Pantailaren goikaldean erabiltzea ez den nahi altuera."
 
-#: tips:171
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Paneleko ikono bakoitza irudi bat eta testu batez bistaratzen dira."
-
-#: tips:172
-msgid "Image only for applications"
-msgstr "Irudi bakarrik aplikazioentzat"
-
-#: tips:173
-msgid ""
-"Applications have just an image, everything else has both an image and text."
-msgstr ""
-"Aplikazioek irudia bakarrik dute, beste guztiak irudi eta testua izango dute."
-
-#: tips:174
-msgid "Image only"
-msgstr "Irudi bakarrik"
-
-#: tips:175
-msgid "Only the image is shown."
-msgstr "Irudia bakarrik bistaratzen da."
-
-#: tips:176
-msgid "Panel width (thin)"
-msgstr "Panel zabalera (estua)"
-
-#: tips:177
-msgid "(thick)"
-msgstr "(lodia)"
-
-#: tips:178
-msgid "The size of the panels."
-msgstr "Panelen tamaina."
-
-#: tips:179
-msgid "Do not cover panel"
-msgstr "Ez panela tapatu"
-
-#: tips:180
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
-msgstr ""
-"Leiho kudeatzaileari leihoan guztiz handitzerakoan panela ez estaltzeko "
-"eskatu. Leiho kudeatzaile btazuek ez dute hau errespetatzen. Gaiturik ez "
-"badago kudeatzaileak pare bat pixel bakarrik eskatzen ditu aute-erakusteak "
-"gaituaz bistarazi ahal izateko."
-
-#: tips:181
-msgid "Xinerama"
-msgstr "Xinerama"
-
-#: tips:182
-msgid "Confine to Xinerama monitor"
-msgstr "Xinerama monitorean mantendu"
-
-#: tips:183
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
-msgstr ""
-"Xinerama bidez monitore anitz konfiguraturik badituzu panela monitore "
-"batetan mantentzeko (batetik bestera pasa beharrean) aukera hau erabili."
-
-#: tips:184
-msgid ""
-"The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr "Xinerama moduan panelak mantenduko diren monitorea (0-tik zenbaturik)."
-
-#: tips:185
+#: tips:225
 msgid "Desktop"
 msgstr ""
 
-#: tips:186
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
 msgstr ""
 
-#: tips:187
+#: tips:227
 #, fuzzy
 msgid "Panel only"
 msgstr "Irudi bakarrik"
 
-#: tips:188
+#: tips:228
 #, fuzzy
 msgid "Only a panel is shown."
 msgstr "Irudia bakarrik bistaratzen da."
 
-#: tips:189
+#: tips:229
 #, fuzzy
 msgid "Pinboard only"
 msgstr "Idazmahaia"
 
-#: tips:190
+#: tips:230
 #, fuzzy
 msgid "Only the pinboard is shown."
 msgstr "Irudia bakarrik bistaratzen da."
 
-#: tips:191
+#: tips:231
 #, fuzzy
 msgid "Panel and pinboard"
 msgstr "Idazmahaia"
 
-#: tips:192
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr ""
 
-#: tips:193
-#, fuzzy
-msgid "Panel"
-msgstr "Panelak"
-
-#: tips:194
-msgid "Enter the name of the panel to show here."
-msgstr ""
-
-#: tips:196
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr ""
 
-#: tips:197
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr ""
 
-#: tips:198
+#: tips:236
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 
-#: tips:199
+#: tips:237
 msgid "Action windows"
 msgstr "Ekintza leihoak"
 
-#: tips:200
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4295,63 +4977,110 @@ msgstr ""
 "Ekintza leihoak ekintza bat atzeko planoan abiarazterakoan\n"
 " agertzen dira, fitxategiak kopiatu edo borratu bezalakoetan."
 
-#: tips:201
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Ekintza hauek auto-abiarazi (ixilpean)"
 
-#: tips:203
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Lehenik berretsi gabe kopiatu fitxategiak."
 
-#: tips:205
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Lehenik berretsi gabe mugitu fitxategiak."
 
-#: tips:207
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Lehenik berretsi gabe fitxategietara estekak sortu."
 
-#: tips:209
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Lehenik berretsi gabe ezabatu fitxategiak."
 
-#: tips:210
+#: tips:248
 msgid "Mount"
 msgstr "Muntatu"
 
-#: tips:211
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Lehenik berretsi gabe fitxategi sistemak muntatu eta desmuntatu."
 
-#: tips:212
+#: tips:250
 msgid "Default settings"
 msgstr "Lehenetsiriko aukerak"
 
-#: tips:214
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Indartu"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "Lehenik berretsi gabe ezabatu idazketa aurkako babeturiko fitxategiak."
 
-#: tips:216
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Mezu eremuan ez argibide gehiegi bistarazi."
 
-#: tips:218
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Azpidirektorioen edukia ere eraldatu."
 
-#: tips:221
+#: tips:263
+#, fuzzy
+msgid "Mount commands"
+msgstr "Muntatze puntua"
+
+#: tips:264
+#, fuzzy
+msgid "Mount command"
+msgstr "Muntatze puntua"
+
+#: tips:265
+msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
+msgstr ""
+
+#: tips:266
+#, fuzzy
+msgid "Unmount command"
+msgstr "Desmuntatu"
+
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "_Komandoa"
+
+#: tips:269
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Arrastatu eta Jaregin"
 
-#: tips:222
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Ikonoak arrastatzen"
 
-#: tips:223
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Kudeatzaile leihoetan fitxategiak arrastatzea baimendu"
 
-#: tips:224
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
@@ -4361,11 +5090,11 @@ msgstr ""
 "programa baten gainera arrastatu dezakezu, Elementu nabarmendu egingo da eta "
 "fitxategia askatzerakoan direktorio barnean sartu edo programan kargatuko da."
 
-#: tips:225
+#: tips:276
 msgid "Directories spring open"
 msgstr "Direktorioen irekiera automatikoa"
 
-#: tips:226
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
@@ -4375,15 +5104,15 @@ msgstr ""
 "fitxategi direktorioaren gainean mantendu ondoren 'automatikoki irekitzea' "
 "lortzen du."
 
-#: tips:227
+#: tips:278
 msgid "Spring delay:"
 msgstr "Irekiera automatiko atzerapena:"
 
-#: tips:228
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:229
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
@@ -4393,33 +5122,33 @@ msgstr ""
 "mantendu behar den denbora ezartzen du, ms-etan. Aurreko aukera gaiturik "
 "egon behar da honek eraginik edukitzeko."
 
-#: tips:230
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Saguaren ezkerreko botoiaz fitxategia arrastatzerakoan"
 
-#: tips:231 tips:235
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Aukera posibleen menu bat bistarazi"
 
-#: tips:232
+#: tips:283
 msgid "Copy the files"
 msgstr "Fitxategiak kopiatu"
 
-#: tips:233
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
 msgstr "Oraindik Alt tekla zanpatua mantenduaz menua agertzea lor dezakezu."
 
-#: tips:234
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Saguaren erdiko botoiaz fitxategiak arrastatzerakoan"
 
-#: tips:236
+#: tips:287
 msgid "Move the files"
 msgstr "Fitxategiak mugitu"
 
-#: tips:237
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
@@ -4427,11 +5156,11 @@ msgstr ""
 "Oraindik Alt tekla zanpatua mantenduaz eta ezkerro botoiaz menua bistaratzea "
 "lor dezakezu."
 
-#: tips:238
+#: tips:289
 msgid "Download handler"
 msgstr "Deskarga kudeatzailea"
 
-#: tips:239
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4443,35 +5172,35 @@ msgstr ""
 "arrastaturiko URI-a da, eta momentuko direktorioa helburua da. Adibidez:\n"
 "xterm -e wget $1"
 
-#: tips:240
+#: tips:291
 msgid "Menus"
 msgstr "Menuak"
 
-#: tips:242
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Menuetako ikono tamaina:"
 
-#: tips:243
+#: tips:294
 msgid "No Icons"
 msgstr "Ikono gabe"
 
-#: tips:246
+#: tips:297
 msgid "Same as current window"
 msgstr "Dagoen leihoaren berdina"
 
-#: tips:247
+#: tips:298
 msgid "Same as default"
 msgstr "Lehenetsirikoa"
 
-#: tips:248
+#: tips:299
 msgid "Behaviour"
 msgstr "Portamoldea"
 
-#: tips:249
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Fitxategi menua eskubiko-klik eginez"
 
-#: tips:250
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
@@ -4480,23 +5209,29 @@ msgstr ""
 "bistarazi menu nagusiaren ordez (menu nagusia Kontrol tekla zanpatuaz "
 "bistaraziko da)."
 
-#: tips:251
-msgid "`Xterm Here' program"
+#: tips:302
+#, fuzzy
+msgid "Terminal emulator program"
 msgstr "`Xterm Hemen' programa"
 
-#: tips:252
-msgid "The program to launch when you choose `Xterm Here' from the menu."
+#: tips:303
+#, fuzzy
+msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr "Menuan `Xterm Hemen' aukeratzean abiaraziko den programa."
 
-#: tips:253
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Laster-teklak"
 
-#: tips:255
+#: tips:305
+msgid "Types"
+msgstr "Motak"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME motak"
 
-#: tips:256
+#: tips:307
 #, fuzzy
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
@@ -4509,24 +5244,24 @@ msgstr ""
 "\n"
 "http://rox.sourceforge.net/mime_editor.html"
 
-#: tips:257
+#: tips:308
 msgid "Edit MIME rules"
 msgstr ""
 
-#: tips:258
+#: tips:309
 #, fuzzy
 msgid "Themes"
 msgstr "Data"
 
-#: tips:259
+#: tips:310
 msgid "Icon theme"
 msgstr "Ikono gaia"
 
-#: tips:260
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "Gaiak ~/.icons direktorian kokatu beharko lirateke."
 
-#: tips:261
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
@@ -4535,40 +5270,40 @@ msgstr ""
 "izan modu honetan aukeratutako ikonoak aukeratutako gaiaren ikonoak aldatuko "
 "dituztela."
 
-#: tips:262
+#: tips:313
 msgid "Colours"
 msgstr "Koloreak"
 
-#: tips:263
+#: tips:314
 msgid "File type colours"
 msgstr "Fitxategi mota koloreak"
 
-#: tips:264
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Fitxategiak moten arabera kolorezturik"
 
-#: tips:265
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr ""
 "Fitxategi izenak (eta xehetasuna) fitxategi motaren arabera koloreztuko dira."
 
-#: tips:266
+#: tips:317
 msgid "Directory:"
 msgstr "Direktorioa:"
 
-#: tips:267
+#: tips:318
 msgid "Regular file:"
 msgstr "Fitxategi arrunta:"
 
-#: tips:268
+#: tips:319
 msgid "Pipe:"
 msgstr "Tutua:"
 
-#: tips:269
+#: tips:320
 msgid "Socket:"
 msgstr "Socket-a:"
 
-#: tips:271
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
@@ -4576,19 +5311,19 @@ msgstr ""
 "Errorea, ez dagoen fitxategi batetara loturiko esteka edo kudeatzaileak "
 "ikusteko baimenik ez duen fitxategia bezala."
 
-#: tips:272
+#: tips:323
 msgid "Character device:"
 msgstr "Karaktere gailua:"
 
-#: tips:273
+#: tips:324
 msgid "Block device:"
 msgstr "Bloke gailua:"
 
-#: tips:274
+#: tips:325
 msgid "Door:"
 msgstr "Door:"
 
-#: tips:275
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
@@ -4596,33 +5331,61 @@ msgstr ""
 "Door fitxategia socket edo tutuen antzekoak dira, eta SOlaris-en bakarrik "
 "aurki daitezke."
 
-#: tips:276
+#: tips:327
 msgid "Executable file:"
 msgstr "Fitxategi abiarazgarria:"
 
-#: tips:277
+#: tips:328
 msgid "Application directory:"
 msgstr "Aplikazio direktorioa:"
 
-#: tips:278
+#: tips:329
 msgid "Unknown type:"
 msgstr "Mota ezezaguna:"
 
-#: tips:279
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Atzekaldea:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Pertsonalizatutako letra-tipoa erabili:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Bateragarritasuna"
 
-#: tips:280
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Leiho kudeatzaile arazoak"
 
-#: tips:281
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr ""
 "Leiho kudeatzaileak idazmahai eta panelen gain duen kontrola albo batetara "
 "utzi"
 
-#: tips:282
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4636,12 +5399,12 @@ msgstr ""
 "etortzen bada, izenburu barra eta beste batzu leihoen inguruan agertu edo "
 "panel edo idazmahaia leiho aukeraketan agertzen badira."
 
-#: tips:283
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr ""
 "Pantailaren atzekaldean eginiko klik guztiak leiho kudeatzaileari bidali"
 
-#: tips:284
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
@@ -4652,11 +5415,11 @@ msgstr ""
 "gaitu gertaerak leiho kudeatzailera bidaltzeko. Ikono gaineko klik-ak ez "
 "dira bidaliko."
 
-#: tips:285
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Blackbox erro menuentzat 'hack'-a"
 
-#: tips:286
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4668,27 +5431,51 @@ msgstr ""
 "gaitzen ditu. Hau beharrezko izan ez dedin leiho kudeatzaile hauek bere "
 "portamoldea hurrengo bertsioetarako aldatzea espero da."
 
-#: tips:287
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "Panela 'dock' bat da"
 
-#: tips:288
+#: tips:346
+#, fuzzy
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 "Ezgaitu aukera hau zure desioen kontra panela beste aplikazioen gainetik "
 "agertzen bada. Berrabiarazi egin behar da."
 
-#: tips:289
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Panel estiloa"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Arratratu eta jaregin"
 
-#: tips:290
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Ez erabili ostalari izenak"
 
-#: tips:291
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4699,15 +5486,11 @@ msgstr ""
 "batetara mugitzean markatzailearen gainean + ikur bat agertu baina "
 "asakatzerakoan ez badu funtzionatzen."
 
-#: tips:292
-msgid "Extended attributes"
-msgstr "Atributu hedatuak"
-
-#: tips:293
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Ez erabili atributu hedatuak"
 
-#: tips:294
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4719,6 +5502,402 @@ msgstr ""
 "Ezarri' menu sarrera ezgaiturik dago, fitxategiaren MIME mota fitxategiaren "
 "izenean bakarrik oinarrituko da eta propietate leihoak ez du aukera hedatuen "
 "argibiderik emango."
+
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Behekaldeko marjina"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+msgid "Right gap:"
+msgstr ""
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "Etxe direktorioa ireki"
+
+#: ../Templates.ui.h:4
+#, fuzzy
+msgid "Panel Options"
+msgstr "Aukerak"
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Irudia eta testua"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Paneleko ikono bakoitza irudi bat eta testu batez bistaratzen dira."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Irudi bakarrik aplikazioentzat"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"Aplikazioek irudia bakarrik dute, beste guztiak irudi eta testua izango dute."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Irudi bakarrik"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Irudia bakarrik bistaratzen da."
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Panel zabalera (estua)"
+
+#: ../Templates.ui.h:12
+#, fuzzy
+msgid "The size of this panel."
+msgstr "Panelen tamaina."
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Itzulpena"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "Ez panela tapatu"
+
+#: ../Templates.ui.h:19
+#, fuzzy
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Leiho kudeatzaileari leihoan guztiz handitzerakoan panela ez estaltzeko "
+"eskatu. Leiho kudeatzaile btazuek ez dute hau errespetatzen. Gaiturik ez "
+"badago kudeatzaileak pare bat pixel bakarrik eskatzen ditu aute-erakusteak "
+"gaituaz bistarazi ahal izateko."
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Panel estiloa"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Xinerama monitorean mantendu"
+
+#: ../Templates.ui.h:22
+#, fuzzy
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Xinerama bidez monitore anitz konfiguraturik badituzu panela monitore "
+"batetan mantentzeko (batetik bestera pasa beharrean) aukera hau erabili."
+
+#: ../Templates.ui.h:23
+#, fuzzy
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr "Xinerama moduan panelak mantenduko diren monitorea (0-tik zenbaturik)."
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "Xinerama"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr ""
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr ""
+
+#: ../Templates.ui.h:27
+#, fuzzy
+msgid "Bottom edge"
+msgstr "Behekaldeko marjina"
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr ""
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "<b>Baimenak</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<dir>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' badago - gainidatzi?"
+
+#, fuzzy
+#~ msgid "Choices migration"
+#~ msgstr "Txinatar (tradizionala)"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Errorea '%s' irakurtzerakoan:\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Direktorioa ezabatua/falta da"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "'%s' direktorioa ez da aurkitu."
+
+#~ msgid "Cancel"
+#~ msgstr "Ezeztatu"
+
+#~ msgid ""
+#~ ".\n"
+#~ "Home page (including updated versions): http://rox.sourceforge.net/\n"
+#~ msgstr ""
+#~ ".\n"
+#~ "Webgunea (eguneraturiko bertsioak barne): http://rox.sourceforge.net/\n"
+
+#~ msgid "GNOME-VFS library"
+#~ msgstr "GNOME-VFS liburutegia"
+
+#~ msgid "No (need 2.8.0 or later)"
+#~ msgstr "Ez (2.8.0 edo berriagoa behar du)"
+
+#~ msgid "Dnotify support"
+#~ msgstr "Dnotify Onarpena"
+
+#~ msgid "Open AVFS"
+#~ msgstr "AVFS ireki"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Zuk Shift zapalduri duzula fitxategiaren menuan klik egin behar duzu "
+#~ "norabait bidaltzeko"
+
+#~ msgid "Look inside ... ?"
+#~ msgstr "Bilatu barruan ... ?"
+
+#, fuzzy
+#~ msgid "Panel: %s"
+#~ msgstr "Panelak"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Archivo de traducci√≥n .gmo no v√°lido (demasiado corto): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr ""
+#~ "Archivo de traducci√≥n .gmo no v√°lido (no se encontr√≥ el n√∫mero m√°gico "
+#~ "GNU): %s"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Goiko direktorioara joan"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Etxe direktoriora joan"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Laster-markak"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Laster-marka menua"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Berritu  direktorio edukiak"
+
+#~ msgid "Change icon size"
+#~ msgstr "Ikono tamaina aldatu"
+
+#~ msgid "Show extra details"
+#~ msgstr "Xehetasun gehiarriak bistarazi"
+
+#~ msgid "Hidden"
+#~ msgstr "Eskutaturik"
+
+#~ msgid "Show/hide hidden files"
+#~ msgstr "Ezkutaturiko fitxategiak ezkutatu/bistarazi"
+
+#~ msgid ""
+#~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
+#~ "instead."
+#~ msgstr ""
+#~ "'%s' ikono gaiak ez ditu MIME ikonorik. ROX-en lehenetsiriko gaia "
+#~ "erabiltzen honen ordez."
+
+#~ msgid ""
+#~ "Failed to create symlink '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(this may mean that the ROX theme already exists there, but the 'mime-"
+#~ "application:postscript' icon couldn't be loaded for some reason)"
+#~ msgstr ""
+#~ "Huts '%s' esteka sinbolikoa sortzerakoan:\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(honek ROX gaia dagoeneko han dagoela baina 'mime-application:postscript' "
+#~ "zerbaitegaik ezin izna dela kargatu esan nahi dezake)"
+
+#~ msgid "Language"
+#~ msgstr "Hizkuntza"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "LANG aldagaieko ingurunea erabili"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Txinatar (tradizionala)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Txinatar (soildua)"
+
+#~ msgid "Czech"
+#~ msgstr "Txekiera"
+
+#~ msgid "Danish"
+#~ msgstr "Daniera"
+
+#~ msgid "Dutch"
+#~ msgstr "Holandarra"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Ingelesa (itzuli gabe)"
+
+#, fuzzy
+#~ msgid "Estonian"
+#~ msgstr "Errumaniera"
+
+#~ msgid "Finnish"
+#~ msgstr "Finlandiera"
+
+#~ msgid "French"
+#~ msgstr "Frantsesa"
+
+#~ msgid "German"
+#~ msgstr "Alemaniera"
+
+#~ msgid "Hungarian"
+#~ msgstr "Hungariera"
+
+#~ msgid "Japanese"
+#~ msgstr "Japoniera"
+
+#~ msgid "Norwegian"
+#~ msgstr "Norvegiera"
+
+#~ msgid "Italian"
+#~ msgstr "Italiera"
+
+#~ msgid "Polish"
+#~ msgstr "Poloniera"
+
+#~ msgid "Portuguese (Brasil)"
+#~ msgstr "Portugesa (Brasil)"
+
+#~ msgid "Romanian"
+#~ msgstr "Errumaniera"
+
+#~ msgid "Russian"
+#~ msgstr "Errusiera"
+
+#~ msgid "Spanish"
+#~ msgstr "Gaztelania"
+
+#~ msgid "Swedish"
+#~ msgstr "Suediera"
+
+#~ msgid "Change at:"
+#~ msgstr "Aldaketa hemen:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Zabalera handiena (Ikono Handiak):"
+
+#~ msgid "Panels"
+#~ msgstr "Panelak"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Panelak pantailaren albo batetan kokaturiko ikono barrak dira. Panelen "
+#~ "erabilerari buruz argibide gehiago jasotzeko manuala irakurri."
+
+#~ msgid "(thick)"
+#~ msgstr "(lodia)"
 
 #~ msgid ""
 #~ "Error loading MIME database:\n"

--- a/ROX-Filer/src/po/fi.po
+++ b/ROX-Filer/src/po/fi.po
@@ -6,59 +6,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-08-09 14:02+0100\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2005-01-27 14:01+0200\n"
 "Last-Translator: Jari Rahkonen <jari.rahkonen@pp1.inet.fi>\n"
 "Language-Team: Finnish\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: abox.c:127
-msgid "<dir>"
-msgstr "<hakemisto>"
+msgid "<src>"
+msgstr ""
 
-#: abox.c:219
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Hiljaa"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Quiet"
 msgstr "Hiljaa"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Älä pyydä vahvistusta jokaiselle tapahtumalle"
 
-#: abox.c:455 tips:60
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Nimi"
 
-#: abox.c:461 menu.c:232
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Hakemisto"
 
-#: abox.c:550
+#: abox.c:546
 msgid "Expression:"
 msgstr "Lauseke:"
 
-#: action.c:58
+#: action.c:57
 msgid "See the attr(5) man page for full details."
 msgstr ""
 
-#: action.c:60
+#: action.c:59
 msgid "See the fsattr(5) man page for full details."
 msgstr ""
 
-#: action.c:62
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr ""
 
-#: action.c:188
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Etsi lausekkeella"
 
-#: action.c:199
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -133,11 +138,11 @@ msgstr ""
 "%-merkki 'komennossa' korvataan nykyisen tiedoston polulla)\n"
 "<b>prune</b> (epätosi, ja jättää hakemiston sisällön haun ulkopuolelle)."
 
-#: action.c:246
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Vaihda oikeusviite"
 
-#: action.c:257
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -196,11 +201,11 @@ msgstr ""
 "\n"
 "Lisätietoja saat chmod-käskyn man-sivulta."
 
-#: action.c:298
+#: action.c:308
 msgid "Set type reference"
 msgstr "Aseta tyyppiviite"
 
-#: action.c:309
+#: action.c:319
 #, fuzzy
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
@@ -232,48 +237,55 @@ msgstr ""
 "käyttöjärjestelmä tukee niitä.\n"
 "\n"
 
-#: action.c:416
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Prosessi päätetty.\n"
 
-#: action.c:432
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Yksi virhe tapahtui.\n"
 
-#: action.c:434
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Tapahtui %d virhettä.\n"
 
-#: action.c:458
+#: action.c:516
 msgid "ERROR reading"
 msgstr "VIRHE luettaessa"
 
-#: action.c:501
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Valmis\n"
 
-#: action.c:557 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "VIRHE"
 
-#: action.c:711 main.c:674 main.c:681 main.c:688
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Kyllä"
 
-#: action.c:714 main.c:676 main.c:690
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Ei"
 
-#: action.c:732
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -281,7 +293,7 @@ msgstr ""
 "\n"
 "Pyydetään lapsiprosessia päättämään toimintansa...\n"
 
-#: action.c:739
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -289,41 +301,41 @@ msgstr ""
 "\n"
 "Yritetään tappaa karannut prosessi...\n"
 
-#: action.c:892
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Lasketaanko kohteen %s sisältö?"
 
-#: action.c:928
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Poistetaanko %s'%s'?"
 
-#: action.c:929
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "KIRJOITUSSUOJATTU"
 
-#: action.c:936
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'Poistetaan '%s'\n"
 
-#: action.c:949
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'Hakemisto '%s' poistettu\n"
 
-#: action.c:982
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?Poistetaanko media '%s'?"
 
-#: action.c:989
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Poista media '%s'\n"
 
-#: action.c:1008
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -332,80 +344,95 @@ msgstr ""
 "!%s\n"
 "Poistaminen epäonnistui\n"
 
-#: action.c:1027 action.c:1046
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Tarkistetaanko '%s'?"
 
-#: action.c:1043
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Hakuehto ei kelpaa - vaihda se ja yritä uudelleen\n"
 
-#: action.c:1053
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(kun kohdetta '%s' tarkistetaan)\n"
 
-#: action.c:1127 action.c:1152
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Vaihda oikeudet kohteelle '%s'?"
 
-#: action.c:1133
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Vaihdetaan oikeudet kohteelle '%s'\n"
 
-#: action.c:1150
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Oikeuksien muutoskomento ei kelpaa - muuta sitä ja yritä uudelleen\n"
 
-#: action.c:1207 action.c:1227
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?Vaihdetaanko tiedoston '%s' tyyppi'?"
+
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Vaihdetaanko tiedoston '%s' tyyppi'?"
 
-#: action.c:1224
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Tyyppi ei kelpaa - vaihda se ja kokeile uudelleen\n"
 
-#: action.c:1246
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Vaihdetaan tiedoston '%s' tyypiksi '%s'\n"
 
-#: action.c:1325
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'Vaihdetaan tiedoston '%s' tyypiksi '%s'\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' on jo olemassa - %s?"
 
-#: action.c:1327
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "yhdistä sisällöt"
 
-#: action.c:1328
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "korvaa"
 
-#: action.c:1344
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Yritetään kopioida siitä huolimatta...\n"
 
-#: action.c:1353
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Kopioidaanko %s kohteeseen %s?"
 
-#: action.c:1357
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Kopioidaan %s kohteeseen %s\n"
 
-#: action.c:1372
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!VIRHE: Kohde on jo olemassa, mutta ei ole hakemisto\n"
 
-#: action.c:1444
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -414,26 +441,7 @@ msgstr ""
 "!%s\n"
 "Tiedoston '%s' kopiointi epäonnistui\n"
 
-#: action.c:1488
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' on jo olemassa - korvataanko?"
-
-#: action.c:1503
-msgid "'Trying move anyway...\n"
-msgstr "'Yritetään siirtää kaikesta huolimatta...\n"
-
-#: action.c:1511
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Siirretäänkö %s kohteeseen %s?"
-
-#: action.c:1515
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Siirretään %s kohteeseen %s\n"
-
-#: action.c:1523
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -442,45 +450,59 @@ msgstr ""
 "!%s\n"
 "!VIRHE: Tiedoston %s siirto kohteeseen %s epäonnistui\n"
 
-#: action.c:1544
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Yritetään siirtää kaikesta huolimatta...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Siirretäänkö %s kohteeseen %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Siirretään %s kohteeseen %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!VIRHE: Kohdetta ei voi kopioida itseensä\n"
 
-#: action.c:1559
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!VIRHE: Kohdetta ei voi siirtää/nimetä itsensä päälle\n"
 
-#: action.c:1571
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Linkitetään %s nimellä %s\n"
 
-#: action.c:1576
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Linkitetäänkö %s nimellä %s?"
 
-#: action.c:1618
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Liitetään %s\n"
 
-#: action.c:1619
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Irrotetaan %s\n"
 
-#: action.c:1622
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?Liitetäänkö %s tiedostojärjestelmään?"
 
-#: action.c:1623
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?Irrotetaanko %s tiedostojärjestelmästä?"
 
-#: action.c:1643
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -489,7 +511,7 @@ msgstr ""
 "!%s\n"
 "Liittäminen epäonnistui\n"
 
-#: action.c:1644
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -498,11 +520,11 @@ msgstr ""
 "!%s\n"
 "Irrottaminen epäonnistui\n"
 
-#: action.c:1652
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(näyttää ainakin olevan nyt liitetty)\n"
 
-#: action.c:1698
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -511,209 +533,233 @@ msgstr ""
 "'\n"
 "Yhteensä: %s ("
 
-#: action.c:1704
+#: action.c:2108
 msgid "file"
 msgstr "tiedosto"
 
-#: action.c:1704
+#: action.c:2108
 msgid "files"
 msgstr "tiedostoa"
 
-#: action.c:1708
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "ei hakemistoja)\n"
 
-#: action.c:1712
+#: action.c:2116
 msgid "directory"
 msgstr "hakemisto"
 
-#: action.c:1713
+#: action.c:2117
 msgid "directories"
 msgstr "hakemistoa"
 
-#: action.c:1754
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Ei liitoskohtia valittuna!\n"
 
-#: action.c:1839
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Uusi haku?"
 
-#: action.c:1869 action.c:1900
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' on symbolinen linkki\n"
 
-#: action.c:1940
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "Sinun täytyy valita hakukohteet"
 
-#: action.c:1950 menu.c:223
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Etsi"
 
-#: action.c:1983
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Sinun täytyy valita laskettavat kohteet"
 
-#: action.c:1987
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Levyn Käyttö"
 
-#: action.c:2021
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Liitä / Irrota"
 
-#: action.c:2034
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr "ROX-Filer ei vielä tue liitoskohtia järjestelmässäsi. Pahoittelen."
 
-#: action.c:2048 menu.c:210 tips:208
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Poista"
 
-#: action.c:2058 tips:213
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Pakota"
 
-#: action.c:2058
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Poista kirjoitussuojatut kohteet pyytämättä vahvistusta."
 
-#: action.c:2061 action.c:2116 action.c:2175 action.c:2228 action.c:2264
-#: tips:215
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Suppea"
 
-#: action.c:2061
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Kirjaa vain poistettavat hakemistot"
 
-#: action.c:2078
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "Sinun täytyy valita kohteet, joiden oikeuksia haluat vaihtaa"
 
-#: action.c:2086
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Anna suoritus/selausoikeudet)"
 
-#: action.c:2088
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (Poista suoritus/selausoikeudet)"
 
-#: action.c:2090
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Anna omistajalle luku- ja kirjoitusoikeudet)"
 
-#: action.c:2092
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Henkilökohtainen - vain omistajan saatavilla)"
 
-#: action.c:2094
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Julkisesti saatavilla, ei kirjoitettavissa)"
 
-#: action.c:2105 menu.c:184 menu.c:221 tips:75
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Oikeudet"
 
-#: action.c:2116 action.c:2175
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Älä luettele käsiteltyjä tiedostoja"
 
-#: action.c:2119 action.c:2178 tips:217
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Rekursiivinen"
 
-#: action.c:2119
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Muuta myös alihakemistojen sisältöä"
 
-#: action.c:2123
+#: action.c:2547
 msgid "Command:"
 msgstr "Komento:"
 
-#: action.c:2151
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Sinun täytyy valita kohteet, joiden tyypin haluat vaihtaa"
 
-#: action.c:2164
+#: action.c:2590
 msgid "Set type"
 msgstr "Aseta tyyppi"
 
-#: action.c:2178
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Muuta alihakemistojen sisältöä"
 
-#: action.c:2185 infobox.c:615
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Tyyppi:"
 
-#: action.c:2214 dnd.c:124 menu.c:1999 tips:202
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Kopioi"
 
-#: action.c:2224 action.c:2260 tips:219
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Älä pyydä vahvistusta jokaiselle tapahtumalle"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Korvaa ainoastaan, jos lähdetiedosto on kohdetta uudempi."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Uudemmat"
 
-#: action.c:2225 action.c:2261 tips:220
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Korvaa ainoastaan, jos lähdetiedosto on kohdetta uudempi."
 
-#: action.c:2228
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "hakemistoa"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Kirjaa vain kopioitavat hakemistot"
 
-#: action.c:2250 dnd.c:125 tips:204
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Siirrä"
 
-#: action.c:2264
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Älä kirjaa jokaista tiedostoa siirrettäessä"
 
-#: action.c:2284 tips:206
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Luo linkki"
 
-#: action.c:2303 appmenu.c:113
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Poista media"
 
-#: action.c:2360
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Kohteiden, kuten "
 
-#: action.c:2364
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Kohteen "
 
-#: action.c:2366
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Kohteiden "
 
-#: action.c:2385
+#: action.c:2900
 msgid " and "
 msgstr " sekä "
 
-#: action.c:2394
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr ""
 " poistaminen vaikuttaa kohteisiin työpöydällä tai paneelissa - poistetaanko "
 "se varmasti?"
 
-#: action.c:2401
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr ""
 " poistaminen vaikuttaa kohteisiin työpöydällä tai paneelissa - poistetaanko "
 "ne varmasti?"
 
-#: appmenu.c:198
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<nimike puuttuu>"
 
-#: appmenu.c:295
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
@@ -722,83 +768,83 @@ msgstr ""
 "Luo tähän hakemistoon symboliset linkit haluamiisi ohjelmiin. Ne näkyvät "
 "valikossa kaikille tiedostoille, joiden tyyppi on '%s/%s'."
 
-#: appmenu.c:339 menu.c:234
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Mukauta Valikkoa..."
 
-#: appmenu.c:396 menu.c:251 toolbar.c:159
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Ohje"
 
-#: bookmarks.c:147
-msgid "Path"
-msgstr "Polku"
-
-#: bookmarks.c:155
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Otsake"
 
-#: bookmarks.c:304
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Polku"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Ei voi luoda kirjanmerkkiä etäresurssille '%s'\n"
 
-#: bookmarks.c:312 bookmarks.c:630
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' ei ole hakemisto"
 
-#: bookmarks.c:518
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Sinun pitää ensin valita rivejä poistettavaksi"
 
-#: bookmarks.c:542
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Aseta osoitin listan kohteen päälle siirtääksesi sitä"
 
-#: bookmarks.c:562
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Kohde on jo viimeisenä"
 
-#: bookmarks.c:636
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Ei voi luoda kirjanmerkkiä etäkansioille, kuten '%s'"
 
-#: bookmarks.c:778
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Lisää Kirjanmerkki"
 
-#: bookmarks.c:785
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Muokkaa Kirjanmerkkejä"
 
-#: bookmarks.c:790
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Viimeksi Avatut"
 
-#: bulk_rename.c:68
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Massanimeä tiedostoja"
 
-#: bulk_rename.c:71
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Palauta"
 
-#: bulk_rename.c:76
+#: bulk_rename.c:77
 #, fuzzy
 msgid "Make the New column a copy of Old"
 msgstr "Kopioi Ennen-sarake Jälkeen-sarakkeeseen"
 
-#: bulk_rename.c:81
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "_Nimeä"
 
-#: bulk_rename.c:94
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Korvaa:"
 
-#: bulk_rename.c:101
+#: bulk_rename.c:102
 #, fuzzy
 msgid ""
 "This is a regular expression to search for.\n"
@@ -818,18 +864,20 @@ msgid "With:"
 msgstr "Tällä:"
 
 #: bulk_rename.c:116
+#, fuzzy
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 "Ensimmäinen täsmäävä osa tiedostonimessä korvataan tällä merkkijonolla. "
 "Erikoismerkkejä ei ole."
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Käytä"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 #, fuzzy
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
@@ -838,47 +886,47 @@ msgstr ""
 "Etsi ja korvaa Jälkeen-sarakkeessa. Tiedostoja ei nimetä uudelleen, ennen "
 "kuin napsautat alla olevaa Nimeä-painiketta."
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr ""
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 #, fuzzy
 msgid "New name"
 msgstr "Nimeä uudelleen"
 
-#: bulk_rename.c:259
+#: bulk_rename.c:295
 #, fuzzy
 msgid "No strings (in the New column) matched the given expression"
 msgstr "Lauseketta vastaavaa merkkijonoa ei löytynyt (Jälkeen-sarakkeesta)"
 
-#: bulk_rename.c:264
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Yksi nimi vastasi hakua, mutta se ei muuttunut"
 
-#: bulk_rename.c:267
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d nimeä vastasi hakua, mutta yksikään niistä ei muuttunut"
 
-#: bulk_rename.c:293
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr ""
 "Syötä haettava säännöllinen lauseke sekä merkkijono, jolla vastaavuudet "
 "korvataan."
 
-#: bulk_rename.c:310
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (>> '%s')"
 
-#: bulk_rename.c:343
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr "Tiedosto nimeltään '%s' on jo olemassa. Peruutetaan massanimeäminen."
 
-#: bulk_rename.c:348
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -889,12 +937,12 @@ msgstr ""
 "%s\n"
 "Peruutetaan massanimeäminen."
 
-#: bulk_rename.c:410
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "Tiedosto nimeltä '%s' on jo olemassa"
 
-#: bulk_rename.c:421
+#: bulk_rename.c:458
 #, fuzzy, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
@@ -903,53 +951,69 @@ msgstr ""
 "Jotkin Jälkeen-sarakkeen nimistä sisältävät /-merkkejä ('%s'). Tämän vuoksi "
 "tiedostot päätyvät eri hakemistoihin. Jatketaanko?"
 
-#: bulk_rename.c:436
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Nimet eivät muuttuneet. Ei mitään tehtävää!"
 
-#: choices.c:428
-#, fuzzy
-msgid "Choices migration"
-msgstr "Kiina (perinteinen)"
+#: choices.c:434
+#, c-format
+msgid "%d directories could not be migrated"
+msgstr ""
 
 #: choices.c:436
 #, c-format
 msgid ""
 "Choices have been moved from \n"
-"<b>%s</b>\n"
+"%s\n"
 " to the new location \n"
-"<b>%s</b>\n"
+"%s\n"
+"%s"
 msgstr ""
 
-#: choices.c:447
-#, c-format
-msgid "%d directories could not be migrated"
-msgstr ""
-
-#: dir.c:982
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Hakemiston tila ei saatavilla: %s"
 
-#: dir.c:991
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Ei voi avata hakemistoa: %s"
 
-#: display.c:588
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Koko"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) epäonnistui: %s"
 
-#: dnd.c:126
-msgid "Link (relative)"
-msgstr ""
-
-#: dnd.c:127
-msgid "Link (absolute)"
-msgstr ""
-
-#: dnd.c:426
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Sisäinen virhe - epäkelpo infotyyppi"
 
@@ -1031,13 +1095,13 @@ msgid ""
 "Can't get data from remote machine (application/octet-stream not provided)"
 msgstr "Etäkoneelta ei saada tietoa (ei application/octet-stream:ia tarjolla)"
 
-#: dnd.c:1016
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
 "Jotkut tiedostoista ovat eri koneella - ne jätetään huomiotta - pahoittelen"
 
-#: dnd.c:1023
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
@@ -1045,28 +1109,44 @@ msgstr ""
 "Yksikään näistä tiedostoista ei ole tällä koneella - kohteena ei voi olla "
 "useita etätiedostoja - pahoittelen."
 
-#: dnd.c:1036
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Tuntematon toiminto pyydetty"
 
-#: dnd.c:1044
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Virhe noudettaessa tiedostolistaa: %s"
 
-#: dropbox.c:114
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr ""
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr ""
+
+#: dnd.c:1109
+msgid "Link (relative, sym path)"
+msgstr ""
+
+#: dnd.c:1110
+msgid "Link (absolute, sym path)"
+msgstr ""
+
+#: dropbox.c:112
 msgid "Show"
 msgstr "Näytä"
 
-#: dropbox.c:120
+#: dropbox.c:118
 msgid "Show the current choice in a filer window"
 msgstr "Näytä nykyinen valinta tiedostonhallintaikkunassa"
 
-#: dropbox.c:174
+#: dropbox.c:172
 msgid "<nothing>"
 msgstr "<ei mitään>"
 
-#: dropbox.c:239
+#: dropbox.c:237
 msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
@@ -1074,18 +1154,18 @@ msgstr ""
 "En voi näyttää asetettua kohdetta, koska mitään ei ole asetettu. Raahaa "
 "jotain päälleni!"
 
-#: dropbox.c:263
+#: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
 msgstr ""
 "Anteeksi, mutta sinun pitää vetää tarkalleen yksi tiedosto pudotusalueelle."
 
-#: dropbox.c:273
+#: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr ""
 "Anteeksi, mutta kohde '%s' ei kelpaa, koska se ei ole paikallinen tiedosto."
 
-#: dropbox.c:280 pinboard.c:853
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1094,7 +1174,7 @@ msgstr ""
 "Kohde '%s' ei ole saatavilla:\n"
 "%s"
 
-#: filer.c:453
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1103,16 +1183,7 @@ msgstr ""
 "Virhe lukiessa kohdetta '%s:\n"
 "%s\n"
 
-#: filer.c:457
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Virhe lukiessa kohdetta '%s:\n"
-"%s"
-
-#: filer.c:562
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1122,19 +1193,19 @@ msgstr ""
 "\n"
 "Tämä tekee tallennuslaitteen poistamisesta turvallisen."
 
-#: filer.c:566
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 msgid "No change"
 msgstr "Ei muutosta"
 
-#: filer.c:572 menu.c:862
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Irrota"
 
-#: filer.c:669
-msgid "Directory missing/deleted"
-msgstr "Hakemisto puuttuu/poistettu"
-
-#: filer.c:1031
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
@@ -1146,313 +1217,372 @@ msgstr ""
 "uudelleen.\n"
 "Varmista, että NumLock on päällä, jos käytät numeronäppäimistöä."
 
-#: filer.c:1267
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Hakemisto '%s' ei ole saatavilla"
+#: filer.c:2655
+msgid "A"
+msgstr ""
 
-#: filer.c:1419
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Hakemistoa '%s' ei löytynyt."
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
 
-#: filer.c:1713
-msgid "Cancel"
-msgstr "Peruuta"
+#: filer.c:2659 find.c:923
+msgid "G"
+msgstr "G"
 
-#: filer.c:2002
+#: filer.c:2664
 msgid "S"
 msgstr "L"
 
-#: filer.c:2004
+#: filer.c:2669
 msgid "T"
 msgstr "P"
 
-#: filer.c:2026
+#: filer.c:2670
+msgid "D"
+msgstr ""
+
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
+#, c-format
+msgid "Glob (%s), "
+msgstr ""
+
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Luetaan, "
 
-#: filer.c:2028
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Pienoiskuvat, "
 
-#: filer.c:2304
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Pienoiskuvat, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Symbolinen linkki kohteeseen"
 
-#: filer.c:2335
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "Tiedostonimen koodaus ei ole UTF-8. Se pitäisi nimetä uudelleen.\n"
 
-#: filer.c:2643 menu.c:1989
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "Kohdetta ei enää ole!"
 
-#: filer.c:3327
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Valitse tallennettavat näkymäasetukset"
 
-#: filer.c:3334
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Valitse tallennettavat näkymäasetukset"
+
+#: filer.c:4727
 msgid "Position"
 msgstr "Sijainti"
 
-#: filer.c:3339 toolbar.c:135 toolbar.c:139 tips:63
-msgid "Size"
-msgstr "Koko"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Ikkuna"
 
-#: filer.c:3344
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Näytä piilotetut"
 
-#: filer.c:3350
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Näkymä"
 
-#: filer.c:3356
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "järjestämistapa"
 
-#: filer.c:3361 toolbar.c:143
+#: filer.c:4754
 msgid "Details"
 msgstr "Tiedot"
 
-#: filer.c:3366 tips:114 tips:115
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Pienoiskuvat"
 
-#: filer.c:3372
+#: filer.c:4765
 msgid "Filter"
 msgstr "Suodatin"
 
-#: find.c:487
+#: find.c:485
 msgid "And"
 msgstr "Ja"
 
-#: find.c:511
+#: find.c:509
 msgid "Not"
 msgstr "Ei"
 
-#: find.c:554
+#: find.c:552
 msgid "system"
 msgstr "järjestelmä"
 
-#: find.c:562
+#: find.c:560
 msgid "prune"
 msgstr "karsi"
 
-#: find.c:650
+#: find.c:648
 msgid "After"
 msgstr "Jälkeen"
 
-#: find.c:652
+#: find.c:650
 msgid "Before"
 msgstr "Ennen"
 
-#: find.c:746
+#: find.c:744
 msgid "IsReg"
 msgstr "IsReg"
 
-#: find.c:748
+#: find.c:746
 msgid "IsLink"
 msgstr "IsLink"
 
-#: find.c:750
+#: find.c:748
 msgid "IsDir"
 msgstr "IsDir"
 
-#: find.c:752
+#: find.c:750
 msgid "IsChar"
 msgstr "IsChar"
 
-#: find.c:754
+#: find.c:752
 msgid "IsBlock"
 msgstr "IsBlock"
 
-#: find.c:756
+#: find.c:754
 msgid "IsDev"
 msgstr "IsDev"
 
-#: find.c:758
+#: find.c:756
 msgid "IsPipe"
 msgstr "IsPipe"
 
-#: find.c:760
+#: find.c:758
 msgid "IsSocket"
 msgstr "IsSocket"
 
-#: find.c:762
+#: find.c:760
 msgid "IsDoor"
 msgstr "IsDoor"
 
-#: find.c:764
+#: find.c:762
 msgid "IsSUID"
 msgstr "IsSUID"
 
-#: find.c:766
+#: find.c:764
 msgid "IsSGID"
 msgstr "IsSGID"
 
-#: find.c:768
+#: find.c:766
 msgid "IsSticky"
 msgstr "IsSticky"
 
-#: find.c:770
+#: find.c:768
 msgid "IsReadable"
 msgstr "IsReadable"
 
-#: find.c:772
+#: find.c:770
 msgid "IsWriteable"
 msgstr "IsWriteable"
 
-#: find.c:774
+#: find.c:772
 msgid "IsExecutable"
 msgstr "IsExecutable"
 
-#: find.c:776
+#: find.c:774
 msgid "IsEmpty"
 msgstr "IsEmpty"
 
-#: find.c:778
+#: find.c:776
 msgid "IsMine"
 msgstr "IsMine"
 
-#: find.c:906
+#: find.c:904
 msgid "Now"
 msgstr "Nyt"
 
-#: find.c:919
+#: find.c:917
 msgid "Byte"
 msgstr "Tavu"
 
-#: find.c:919
+#: find.c:917
 msgid "Bytes"
 msgstr "Tavua"
 
-#: find.c:921
+#: find.c:919
 msgid "Kb"
 msgstr "Kb"
 
-#: find.c:921
+#: find.c:919
 msgid "K"
 msgstr "K"
 
-#: find.c:923
+#: find.c:921
 msgid "Mb"
 msgstr "Mb"
 
-#: find.c:923
+#: find.c:921
 msgid "M"
 msgstr "M"
 
-#: find.c:925
+#: find.c:923
 msgid "Gb"
 msgstr "Gb"
 
 #: find.c:925
-msgid "G"
-msgstr "G"
-
-#: find.c:927
 msgid "Sec"
 msgstr "Sekunti"
 
-#: find.c:927
+#: find.c:925
 msgid "Secs"
 msgstr "Sekuntia"
 
-#: find.c:929
+#: find.c:927
 msgid "Min"
 msgstr "Minuutti"
 
-#: find.c:929
+#: find.c:927
 msgid "Mins"
 msgstr "Minuuttia"
 
-#: find.c:931
+#: find.c:929
 msgid "Hour"
 msgstr "Tunti"
 
-#: find.c:931
+#: find.c:929
 msgid "Hours"
 msgstr "Tuntia"
 
-#: find.c:933
+#: find.c:931
 msgid "Day"
 msgstr "Päivä"
 
-#: find.c:933
+#: find.c:931
 msgid "Days"
 msgstr "Päivää"
 
-#: find.c:935
+#: find.c:933
 msgid "Week"
 msgstr "Viikko"
 
-#: find.c:935
+#: find.c:933
 msgid "Weeks"
 msgstr "Viikkoa"
 
-#: find.c:937
+#: find.c:935
 msgid "Year"
 msgstr "Vuosi"
 
-#: find.c:937
+#: find.c:935
 msgid "Years"
 msgstr "Vuotta"
 
-#: find.c:946
+#: find.c:944
 msgid "Ago"
 msgstr "Sitten"
 
-#: find.c:948
+#: find.c:946
 msgid "Hence"
 msgstr "Alkaen"
 
-#: find.c:963
+#: find.c:961
 msgid "atime"
 msgstr "atime"
 
-#: find.c:965
+#: find.c:963
 msgid "ctime"
 msgstr "ctime"
 
-#: find.c:967
+#: find.c:965
 msgid "mtime"
 msgstr "mtime"
 
-#: find.c:969
+#: find.c:967
 msgid "size"
 msgstr "koko"
 
-#: find.c:971
+#: find.c:969
 msgid "inode"
 msgstr "inode"
 
-#: find.c:973
+#: find.c:971
 msgid "nlinks"
 msgstr "nlinks"
 
-#: find.c:975
+#: find.c:973
 msgid "uid"
 msgstr "uid"
 
-#: find.c:977
+#: find.c:975
 msgid "gid"
 msgstr "gid"
 
-#: find.c:979
+#: find.c:977
 msgid "blocks"
 msgstr "lohkoa"
 
-#: gtksavebox.c:251
+#: gtksavebox.c:249
 msgid "Save As:"
 msgstr "Tallenna nimellä:"
 
-#: gtksavebox.c:397
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Nimeämätön"
 
-#: gtksavebox.c:473
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
@@ -1460,7 +1590,7 @@ msgstr ""
 "Etäsovellus haluaa käyttää Direct Save-toimintoa, mutta en voi lukea "
 "XdndDirectSave0(tyyppiä text/plain) -ominaisuutta.\n"
 
-#: gtksavebox.c:598
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1468,7 +1598,7 @@ msgstr ""
 "Raahaa kuvake hakemistonäkymään\n"
 "(tai syötä täydellinen polku)"
 
-#: gui_support.c:331
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1476,20 +1606,21 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:400
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr ""
 "Yritetään lukea XML-tiedosto tekstitiedostona. Tiedosto '%s' voi olla "
 "turmeltunut."
 
-#: gui_support.c:417
-#, c-format
+#: gui_support.c:542
+#, fuzzy, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
 "This may be due to upgrading from a previous version of ROX-Filer. Open the "
-"Options window and click on Save.\n"
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
 "Virhe tiedostossa '%s' rivillä %d: \n"
@@ -1498,16 +1629,16 @@ msgstr ""
 "Asetukset-ikkuna ja paina Tallenna.\n"
 "Lisävirheet ohitetaan."
 
-#: gui_support.c:1000
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Virheellinen tai puuttuva rivinvaihto text/uri-list -datassa"
 
-#: gui_support.c:1332
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "Tiedoston '%s' avaus epäonnistui: %s"
 
-#: gui_support.c:1376
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
@@ -1515,15 +1646,16 @@ msgstr ""
 "Kuvan '%s' lataaminen epäonnistui: syy tuntematon, luultavasti turmeltunut "
 "kuvatiedosto"
 
-#: gui_support.c:1427
+#: gui_support.c:1583
+#, c-format
 msgid ""
-"This program cannot be run, as the 0launch command is not available. It can "
-"be downloaded from here:\n"
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
 
-#: i18n.c:38
+#: i18n.c:39
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
@@ -1532,154 +1664,177 @@ msgstr ""
 "tiedostonhallinta uudelleen, jotta uusia kieliasetuksia käytetään joka "
 "paikassa."
 
-#: icon.c:78
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(napsauta asettaaksesi)"
 
-#: icon.c:133
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:134 menu.c:252
-msgid "About ROX-Filer..."
-msgstr "Tietoja ROX-Fileristä..."
-
-#: icon.c:135 menu.c:253
-msgid "Show Help Files"
-msgstr "Näytä Ohjetiedostot"
-
-#: icon.c:136 menu.c:254
-msgid "Manual"
-msgstr "Käsikirja"
-
-#: icon.c:138 menu.c:230
-msgid "Options..."
-msgstr "Asetukset..."
-
-#: icon.c:139 menu.c:239
-msgid "Home Directory"
-msgstr "Kotihakemisto"
-
-#: icon.c:140 icon.c:1340 menu.c:206 type.c:212
-msgid "File"
-msgstr "Tiedosto"
-
-#: icon.c:141 menu.c:212 menu.c:875
-msgid "Shift Open"
-msgstr "Shift+Avaa"
-
-#: icon.c:142 menu.c:218
-msgid "Properties"
-msgstr "Ominaisuudet"
-
-#: icon.c:143 menu.c:216
-msgid "Set Run Action..."
-msgstr "Aseta Suoritustoiminto..."
-
-#: icon.c:144 menu.c:217
-msgid "Set Icon..."
-msgstr "Aseta Kuvake..."
-
-#: icon.c:145 icon.c:806
-msgid "Edit Item"
-msgstr "Muokkaa kohdetta"
-
-#: icon.c:146
-msgid "Show Location"
-msgstr "Näytä Sijainti"
-
-#: icon.c:147
-msgid "Remove Item(s)"
-msgstr "Poista kohde/kohteet"
-
-#: icon.c:278 menu.c:764
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:291
+#: icon.c:311
 msgid "Nothing"
 msgstr "Ei mitään"
 
-#: icon.c:547
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "Sijainnissa täytyy olla vähintään yksi merkki!"
 
-#: icon.c:613
+#: icon.c:641
+#, c-format
+msgid "You must unlock '%s' before removing it"
+msgstr ""
+
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Valitse ensin kohteita poistettavaksi"
 
-#: icon.c:627
+#: icon.c:657
+msgid "An item must be unlocked before it can be removed."
+msgstr ""
+
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Valikko täytyy avata kohteen yläpuolella"
 
-#: icon.c:652 menu.c:1260
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "Voit asettaa suoritustoiminnon ainoastaan tavalliselle tiedostolle"
 
-#: icon.c:738
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Paina haluamiasi pikanäppäimiä (esim. Ctrl+F1)"
 
-#: icon.c:760
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Näppäimistön kaappaus epäonnistui!"
 
-#: icon.c:809
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Muokkaa kohdetta"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Kuvakkeen napsauttaminen avaa:"
 
-#: icon.c:819
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Annettavat argumentit (käynnistystiedostoille):"
 
-#: icon.c:833
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "Kuvakkeen alla näytettävä teksti on:"
 
-#: icon.c:846
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "Pikanäppäin on:"
 
-#: infobox.c:112
+#: icon.c:910
+#, fuzzy
+msgid "Locked"
+msgstr "Vastake"
+
+#: icon.c:915
+msgid "Locking an item prevents it from being accidentally removed"
+msgstr ""
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Tietoja ROX-Fileristä..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Näytä Ohjetiedostot"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Käsikirja"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Asetukset..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Kotihakemisto"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Tiedosto"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Shift+Avaa"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Ominaisuudet"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Aseta Suoritustoiminto..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Aseta Kuvake..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Näytä Sijainti"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Poista kohde/kohteet"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
 msgstr "Haluatko varmasti avata %d ikkunaa?"
 
-#: infobox.c:113
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Näytä tiedot"
 
-#: infobox.c:135 menu.c:769
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(epäkelpo utf-8)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Näytä _Ohjetiedostot"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Oikeudet</b>"
 
-#: infobox.c:286
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>Sisältö viittaa...</b>"
 
-#: infobox.c:423 infobox.c:560 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Kirjaa vain kopioitavat hakemistot"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "tavua"
 
-#: infobox.c:446
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Koon lukeminen epäonnistui"
 
-#: infobox.c:504
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' ei ole enää symbolinen linkki"
 
-#: infobox.c:511
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1688,7 +1843,7 @@ msgstr ""
 "Kohteen '%s' poisto epäonnistui:\n"
 "%s"
 
-#: infobox.c:516
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1699,145 +1854,194 @@ msgstr ""
 "%s\n"
 "(huomaa: vanha linkki on poistettu)"
 
-#: infobox.c:539 tips:270
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Virhe:"
 
-#: infobox.c:546
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Todellinen hakemisto:"
 
-#: infobox.c:549
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Omistaja, Ryhmä:"
 
-#: infobox.c:556 infobox.c:571 infobox.c:580
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Koko:"
 
-#: infobox.c:581
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Luetaan"
 
-#: infobox.c:602
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Lukeminen epäonnistui"
 
-#: infobox.c:609
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Muutettu:"
 
-#: infobox.c:611
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Muokattu:"
 
-#: infobox.c:613
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Käytetty:"
 
-#: infobox.c:621
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Lisäattribuutit:"
 
-#: infobox.c:623
+#: infobox.c:667
 msgid "Present"
 msgstr "Paikalla"
 
-#: infobox.c:624
+#: infobox.c:668
 msgid "None"
 msgstr "Ei mitään"
 
-#: infobox.c:625
+#: infobox.c:669
 msgid "Not supported"
 msgstr "Ei tueta"
 
-#: infobox.c:637
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Linkin kohde:"
 
-#: infobox.c:649 infobox.c:652
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Suoritustoiminto:"
 
-#: infobox.c:649
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Suorita tiedosto"
 
-#: infobox.c:744
+#: infobox.c:805
+#, fuzzy
+msgid "Comment"
+msgstr "Komento:"
+
+#: infobox.c:807
+#, fuzzy
+msgid "Execute"
+msgstr "Suorita tiedosto"
+
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<ei vielä mitään>"
 
-#: infobox.c:814
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "file(1) kertoo... %s"
 
-#: infobox.c:871
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Oikeuksien muuttaminen epäonnistui: %s"
 
-#: infobox.c:889
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Omistaja"
 
-#: infobox.c:891
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Ryhmä"
 
-#: infobox.c:893
+#: infobox.c:974
 msgid "World"
 msgstr "Muut"
 
-#: infobox.c:896
+#: infobox.c:977
 msgid "Read"
 msgstr "Luku"
 
-#: infobox.c:898
+#: infobox.c:980
 msgid "Write"
 msgstr "Kirjoitus"
 
-#: infobox.c:900
+#: infobox.c:983
 msgid "Exec"
 msgstr "Suoritus"
 
-#: infobox.c:917
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:924
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:931
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Kiinnitetty"
 
-#: infobox.c:953
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<ei mitään>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Symbolinen linkki"
 
-#: infobox.c:956
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX-sovellus"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "mounted"
 msgstr "liitetty"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "irrotettu"
 
-#: infobox.c:968
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Liitoskohta kohteelle %s (%s)"
 
-#: infobox.c:971
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Liitoskohta (%s) "
+
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d kohdetta"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Kopioi..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "Muokkaa kohdetta"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Ajat"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Asetukset"
 
 #: main.c:95
 msgid ""
@@ -1873,7 +2077,7 @@ msgstr ""
 "sinun täytyy käyttää niiden lyhyitä muotoja.\n"
 
 #: main.c:115
-#, fuzzy
+#, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Open each directory or file listed, or the current working\n"
@@ -1895,10 +2099,12 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
-"Report bugs to "
+"Report bugs to %s.\n"
+"Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
 "Käyttö: ROX-Filer/AppRun [VALITSIN]... [TIEDOSTO]...\n"
 "Avaa jokainen lueteltu kansio tai tiedosto, tai nykyinen\n"
@@ -1923,15 +2129,7 @@ msgstr ""
 "\n"
 "Ilmoita viat osoitteessa "
 
-#: main.c:136
-msgid ""
-".\n"
-"Home page (including updated versions): http://rox.sourceforge.net/\n"
-msgstr ""
-".\n"
-"Kotisivu (myös päivitetyt versiot): http://rox.sourceforge.net/\n"
-
-#: main.c:234
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1939,7 +2137,7 @@ msgid ""
 "Trying to continue..."
 msgstr ""
 
-#: main.c:382
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
@@ -1947,280 +2145,376 @@ msgstr ""
 "'-o'-argumenttia ei enää käytetä. Voit kytkeä uudelleenohjauksen "
 "syrjäyttämisen päälle Asetukset-ikkunasta."
 
-#: main.c:489
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Suoritetaan käyttäjänä '%s'"
 
-#: main.c:666
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Käännettäessä GTK:n versio oli %s\n"
 
-#: main.c:667
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Suoritetaan GTK:n versiolla %d.%d.%d\n"
 
-#: main.c:671
+#: main.c:693
 msgid "features set at compile time"
 msgstr "kääntäessä asetetut ominaisuudet"
 
-#: main.c:672
+#: main.c:694
 msgid "Large File Support"
 msgstr "Suurten Tiedostojen Tuki"
 
-#: main.c:679
-msgid "GNOME-VFS library"
-msgstr "GNOME-VFS-kirjasto"
-
-#: main.c:683
-msgid "No (need 2.8.0 or later)"
-msgstr "Ei (vaaditaan vähintään 2.8.0)"
-
-#: main.c:686
-msgid "Dnotify support"
-msgstr "Dnotify-tuki"
-
-#: main.c:693
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Binaarinen yhteensopivuus"
 
-#: main.c:695
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Kyllä (toimii vanhempien glibc:n versioiden kanssa)"
 
-#: main.c:697
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Ei (tiedostoa apsymbols.h ei löydy)"
 
-#: menu.c:180 tips:52
+#: main.c:709
+#, fuzzy
+msgid "Extended attribute support"
+msgstr "Lisäattribuutit"
+
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr "Tiedoston '%s' avaus epäonnistui: %s"
+
+#: main.c:895
+#, c-format
+msgid ""
+"Left-click to run %s.\n"
+"Right-click for a list of versions."
+msgstr ""
+
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Virhe luotaessa kohdetta '%s': %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Tallenna nimellä:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Näytä"
 
-#: menu.c:181 tips:57
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "Kuvakenäkymä"
 
-#: menu.c:182
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "Kuvakkeet, sekä..."
 
-#: menu.c:183 tips:74
-msgid "Sizes"
-msgstr "Koot"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Kuvaketeema"
 
-#: menu.c:185 tips:254
-msgid "Types"
-msgstr "Tyypit"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Oikeudet"
 
-#: menu.c:186 tips:77
-msgid "Times"
-msgstr "Ajat"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Kuvakkeet, sekä..."
 
-#: menu.c:187 tips:58 tips:92
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "Listanäkymä"
 
-#: menu.c:189
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "Suuremmat Kuvakkeet"
 
-#: menu.c:190
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "Pienemmät Kuvakkeet"
 
-#: menu.c:191 tips:71
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Automaattinen"
 
-#: menu.c:193
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Järjestä Nimen mukaan"
 
-#: menu.c:194
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Järjestä Tyypin mukaan"
 
-#: menu.c:195
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Järjestä Päivämäärän mukaan"
 
-#: menu.c:196
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Järjestä Päivämäärän mukaan"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Järjestä Päivämäärän mukaan"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Järjestä Koon mukaan"
 
-#: menu.c:197
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Oikeudet"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "Järjestä Omistajan mukaan"
 
-#: menu.c:198
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "Järjestä Ryhmän mukaan"
 
-#: menu.c:199
+#: menu.c:671
 msgid "Reversed"
 msgstr "Käänteinen"
 
-#: menu.c:201
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "Näytä Piilotetut"
 
-#: menu.c:202
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Näytä Ohjetiedostot"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "ei hakemistoja)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "Suodata Tiedostot..."
 
-#: menu.c:203
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Suodata Tiedostot..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "Näytä Pienoiskuvat"
 
-#: menu.c:204
+#: menu.c:683
 msgid "Refresh"
 msgstr "Virkistä"
 
-#: menu.c:205
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Virkistä"
+
+#: menu.c:686
 msgid "Save Display Settings..."
 msgstr "Tallenna Näkymäasetukset..."
 
-#: menu.c:207
-msgid "Copy..."
-msgstr "Kopioi..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Tallenna Näkymäasetukset..."
 
-#: menu.c:208
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Laske"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "Nimeä Uudelleen..."
 
-#: menu.c:209
+#: menu.c:700
 msgid "Link..."
 msgstr "Luo Linkki..."
 
-#: menu.c:213
-msgid "Open AVFS"
-msgstr "Avaa AVFS:llä"
-
-#: menu.c:214
+#: menu.c:708
 msgid "Send To..."
 msgstr "Lähetä..."
 
-#: menu.c:219
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Lisäattribuutit"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Laske"
 
-#: menu.c:220
+#: menu.c:723
 msgid "Set Type..."
 msgstr "Aseta Tyyppi..."
 
-#: menu.c:224 toolbar.c:155
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Valitse"
 
-#: menu.c:225
+#: menu.c:733
 msgid "Select All"
 msgstr "Valitse Kaikki"
 
-#: menu.c:226
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "Poista Valinta"
 
-#: menu.c:227
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "Käänteinen Valinta"
 
-#: menu.c:228
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "Valitse Nimen perusteella..."
 
-#: menu.c:229
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Valitse Jos..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Valitse Jos..."
 
-#: menu.c:231
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Uusi"
 
-#: menu.c:233
+#: menu.c:752
 msgid "Blank file"
 msgstr "Tyhjä tiedosto"
 
-#: menu.c:235 tasklist.c:308
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Ikkuna"
 
-#: menu.c:236
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "Ylätaso, Uusi Ikkuna"
 
-#: menu.c:237
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "Ylätaso, Sama Ikkuna"
 
-#: menu.c:238
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "Uusi Ikkuna"
 
-#: menu.c:240
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "Näytä Kirjanmerkit"
 
-#: menu.c:241
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Näytä tiedot"
+
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "Seuraa Symbolisia Linkkejä"
 
-#: menu.c:242
+#: menu.c:769
 msgid "Resize Window"
 msgstr "Muuta Ikkunan Kokoa"
 
-#: menu.c:245
+#: menu.c:771
 msgid "Close Window"
 msgstr "Sulje Ikkuna"
 
-#: menu.c:247
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Syötä Polku..."
 
-#: menu.c:248
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Komentotulkin komento..."
 
-#: menu.c:249
-msgid "Xterm Here"
+#: menu.c:780
+#, fuzzy
+msgid "Terminal Here"
 msgstr "Pääte Tähän"
 
-#: menu.c:250
-msgid "Switch to xterm"
+#: menu.c:782
+#, fuzzy
+msgid "Switch to Terminal"
 msgstr "Vaihda päättesovellukseen"
 
-#: menu.c:718
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr ""
-"Paina Shift+Menupainike tiedoston yläpuolella lähettääksesi sen jonnekin"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Mukauta Valikkoa..."
 
-#: menu.c:754
+#: menu.c:976
 msgid "Next Click"
 msgstr "Seuraava Napsautus"
 
-#: menu.c:776
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d kohdetta"
 
-#: menu.c:864
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "Avaa irrotettu"
 
-#: menu.c:867
+#: menu.c:1097
 msgid "Show Target"
 msgstr "Näytä Kohde"
 
-#: menu.c:869
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "Katso Sisään"
 
-#: menu.c:871
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "Avaa Tekstinä"
 
-#: menu.c:1031
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2234,15 +2528,15 @@ msgstr ""
 "ehkäpä tiedostojärjestelmää liittäessä täytyy yksinkertaisesti antaa "
 "vaadittava valitsin. (Linux-järjestelmissä 'user_xattr')."
 
-#: menu.c:1037
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr "Osa tiedostoista ei tue tyypin asettamista."
 
-#: menu.c:1072
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "_Suhteellinen linkki"
 
-#: menu.c:1078
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2254,45 +2548,58 @@ msgstr ""
 "Muussa tapauksessa tallennetaan polku juurihakemistosta - käytä tätä, jos "
 "linkkiä voidaan siirtää, mutta kohde pysyy paikallaan."
 
-#: menu.c:1148
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "Uusi polku ei ole absoluuttinen"
 
-#: menu.c:1214
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr ""
-"Symbolinen linkki kohteesta '%s' on jo olemassa. Korvataanko se kohteeseen '%"
-"s' osoittavalla linkillä?"
+"Symbolinen linkki kohteesta '%s' on jo olemassa. Korvataanko se kohteeseen "
+"'%s' osoittavalla linkillä?"
 
-#: menu.c:1220
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Korvaa"
 
-#: menu.c:1351 menu.c:1392 menu.c:1452
-msgid "Create"
-msgstr "Luo"
-
-#: menu.c:1352
+#: menu.c:1704
 msgid "NewDir"
 msgstr "UusiHakemisto"
 
-#: menu.c:1366 menu.c:1372
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Virhe luotaessa kohdetta '%s': %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Luo"
 
-#: menu.c:1393
+#: menu.c:1755
 msgid "NewFile"
 msgstr "UusiTiedosto"
 
-#: menu.c:1411
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "Virhe luotaessa tiedostoa: muodolle %s ei löytynyt pohjaa"
 
-#: menu.c:1482
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Luo tähän hakemistoon symboliset linkit haluamiisi ohjelmiin. Ne näkyvät "
+"valikossa kaikille tiedostoille, joiden tyyppi on '%s/%s'."
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2304,8 +2611,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "'Lähetä'-valikko tarjoaa nopean keinon lähettää tiedostoja sovellukselle. "
 "Listattavat sovellukset löytyvät seuraavista hakemistoista:\n"
@@ -2319,7 +2627,7 @@ msgstr ""
 "näytetään ainoastaan kyseisille tiedostotyypeille. '.group' näytetään, kun "
 "useita tiedostoja on valittuna."
 
-#: menu.c:1493
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
@@ -2327,11 +2635,11 @@ msgstr ""
 "Näytän nyt SendTo-hakemistosi; sinun pitäisi luoda tänne symboliset linkit "
 "(Ctrl+Shift ja raahata) haluamillesi sovelluksille."
 
-#: menu.c:1496 menu.c:1536
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr "CHOICESPATH-muuttujasi asetus estää mukauttamisen - pahoittelen."
 
-#: menu.c:1529
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2343,7 +2651,7 @@ msgid ""
 "%s\n"
 msgstr ""
 
-#: menu.c:1534
+#: menu.c:1936
 #, fuzzy
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
@@ -2352,15 +2660,21 @@ msgstr ""
 "Näytän nyt SendTo-hakemistosi; sinun pitäisi luoda tänne symboliset linkit "
 "(Ctrl+Shift ja raahata) haluamillesi sovelluksille."
 
-#: menu.c:1651
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Mukauta"
 
-#: menu.c:1717
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Mukauta Valikkoa..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Tämä on jo hakemiston kanoninen nimi."
 
-#: menu.c:1748
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2368,75 +2682,103 @@ msgstr ""
 "Et voi avata toista näkymää tähän hakemistoon, koska `Ainutkertaiset "
 "Ikkunat'-asetus on valittuna Asetukset-ikkunassa."
 
-#: menu.c:1869
-msgid "Copy ... ?"
-msgstr "Kopioidaanko ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1872
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Kopioidaanko %s kohteeseen %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Kopioidaanko %s kohteeseen %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Nimetäänkö uudelleen ... ?"
 
-#: menu.c:1875
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Luodaanko Symbolinen Linkki ... ?"
 
-#: menu.c:1878
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Shift+Avataanko ... ?"
 
-#: menu.c:1881
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Näytetäänkö tiedot ... ?"
 
-#: menu.c:1884
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Lisäattribuutit"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Asetetaanko tyyppi ... ?"
 
-#: menu.c:1887
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Asetetaanko Suoritustoiminto kohteelle ... ?"
 
-#: menu.c:1890
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Asetetaanko kuvake kohteelle ... ?"
 
-#: menu.c:1893
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Lähetetäänkö ... kohteeseen ... ?"
 
-#: menu.c:1896
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "POISTETAANKO ... ?"
 
-#: menu.c:1899
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Lasketaanko koko kohteelle ... ?"
 
-#: menu.c:1902
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Asetetaanko oikeudet kohteelle ... ?"
 
-#: menu.c:1905
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Etsitäänkö kohteesta ... ?"
 
-#: menu.c:1908
-msgid "Look inside ... ?"
-msgstr "Katsotaanko sisään kohteeseen ... ?"
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Kopioidaanko ... ?"
 
-#: menu.c:1972
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Et voi tehdä tätä kuin yhdelle kohteelle kerrallaan"
 
-#: menu.c:2004
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Nimeä uudelleen"
 
-#: menu.c:2009
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Luo symbolinen linkki"
 
-#: menu.c:2041
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2457,7 +2799,7 @@ msgstr ""
 "\tgtk-can-change-accels = 1\n"
 "\t(tämä toimii vain, kun XSETTINGS EI ole käytössä)"
 
-#: menu.c:2052
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2477,31 +2819,40 @@ msgstr ""
 "Pikanäppäin ilmestyy kohteen viereen, ja voit jatkossa vain painaa "
 "pikanäppäintä avaamatta valikkoa."
 
-#: menu.c:2067
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Aseta pikanäppäimet"
 
-#: minibuffer.c:131
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Siirry:"
 
-#: minibuffer.c:132
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Komentotulkki:"
 
-#: minibuffer.c:133
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Valitse Jos:"
 
-#: minibuffer.c:134
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Valitse Nimellä:"
 
-#: minibuffer.c:135
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Valitse Jos:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Kaava:"
 
-#: minibuffer.c:264
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
@@ -2509,14 +2860,34 @@ msgstr ""
 "Kirjoita tiedoston nimi ja näytän sen sinulle. Paina Tab täyttääksesi "
 "pisimmän vastaavuuden. Esc-näppäin sulkee minipuskurin."
 
-#: minibuffer.c:270
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
 "Syötä suoritettava komentotulkin komento. Napsauta tiedostoa lisätäksesi sen "
 "puskuriin."
 
-#: minibuffer.c:275
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Syötä tiedostojen valinnassa käytettävä kaava:\n"
+"\n"
+"? vastaa mitä tahansa merkkiä\n"
+"* tarkoittaa nollaa tai useampaa merkkiä\n"
+"[aA] vastaa merkkejä 'a' tai 'A'\n"
+"[a-z] vastaa mitä tahansa merkkiä väliltä a-z (pienaakkoset)\n"
+"*.png vastaa mitä tahansa '.png'-päätteellistä nimeä"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2534,7 +2905,7 @@ msgstr ""
 "[a-z] vastaa mitä tahansa merkkiä väliltä a-z (pienaakkoset)\n"
 "*.png vastaa mitä tahansa '.png'-päätteellistä nimeä"
 
-#: minibuffer.c:287
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
@@ -2542,43 +2913,57 @@ msgstr ""
 "Syötä näytettävien tiedostojen valintaan käytettävä kaava. Tyhjä suodatin "
 "poistaa suodattimen käytöstä."
 
-#: minibuffer.c:895
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Syötä näytettävien tiedostojen valintaan käytettävä kaava. Tyhjä suodatin "
+"poistaa suodattimen käytöstä."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Hakuehto ei kelpaa"
 
-#: mount.c:374
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s yhteensä, %s käytössä, %s vapaana (%.1f %%)"
 
-#: options.c:277
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "ROX-Filer on muuttanut Asetustiedostosi uuteen XML-muotoon."
 
-#: options.c:535 options.c:1258
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(käytä oletusta)"
 
-#: options.c:806
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Sisäinen virhe: %s lukukelvoton"
 
-#: options.c:917
+#: options.c:929
 msgid "Options"
 msgstr "Asetukset"
 
-#: options.c:962
+#: options.c:974
 msgid "_Revert"
 msgstr "_Palauta"
 
-#: options.c:968
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr ""
 "Palauta kaikki valinnat siihen tilaan, kun ne olivat avatessasi Asetukset-"
 "ikkunan."
 
-#: options.c:983
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2587,24 +2972,34 @@ msgstr ""
 "Asetukset tallennetaan kohteeseen:\n"
 "%s"
 
-#: options.c:991
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(tallentaminen estetty CHOICESPATH-muuttujalla)"
 
-#: options.c:1164 usericons.c:450
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Virhe tallennettaessa kohdetta %s: %s"
 
-#: options.c:1794
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Puuttuva '='"
 
-#: panel.c:439
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr "Tiedoston '%s' avaus epäonnistui: %s"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "Vanha paneelitiedostosi on muutettu uuteen XML-muotoon."
 
-#: panel.c:546
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
@@ -2613,20 +3008,20 @@ msgstr ""
 "tarkoituksellista... suljetaanko?You have tried to close a panel via the "
 "window manager - I usually find that this is accidental... really close?"
 
-#: panel.c:639
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Puuttuva < tai > paneelin asetustiedostossa"
 
-#: panel.c:1519
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Virhe tallennettaessa paneelia %s: %s"
 
-#: panel.c:1835
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "Sovelma lopetti luomatta graafista elementtiä!"
 
-#: panel.c:1934
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2635,68 +3030,58 @@ msgstr ""
 "Virhe suoritettaessa sovelmaa:\n"
 "%s"
 
-#: panel.c:2335
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "Haluatko varmasti avata %d ikkunaa?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Poista kohde/kohteet"
+
+#: panel.c:2777
 #, fuzzy
 msgid "Panel Options..."
 msgstr "Asetukset..."
 
-#: panel.c:2427
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Xinerama-näyttö %d ei ole saatavilla"
 
-#: panel.c:2502
+#: panel.c:2897
+msgid "Top"
+msgstr ""
+
+#: panel.c:2899
 #, fuzzy
-msgid "Panel Options"
-msgstr "Asetukset"
-
-#: panel.c:2517
-#, fuzzy, c-format
-msgid "Panel: %s"
-msgstr "Paneelit"
-
-#: panel.c:2525
-msgid "Select the panel's position:"
-msgstr ""
-
-#: panel.c:2531
-msgid "Top-edge panel"
-msgstr ""
-
-#: panel.c:2532
-msgid "Top edge"
-msgstr ""
-
-#: panel.c:2533
-msgid "Bottom edge panel"
-msgstr ""
-
-#: panel.c:2534
-#, fuzzy
-msgid "Bottom edge"
+msgid "Bottom"
 msgstr "Alamarginaali"
 
-#: panel.c:2535
-msgid "Left edge panel"
+#: panel.c:2901
+msgid "Left"
 msgstr ""
 
-#: panel.c:2536
-msgid "Left edge"
+#: panel.c:2903
+msgid "Right"
 msgstr ""
 
-#: panel.c:2537
-msgid "Right-edge panel"
-msgstr ""
+#: panel.c:2905
+#, fuzzy
+msgid "Default"
+msgstr "Oletuskoko:"
 
-#: panel.c:2538
-msgid "Right edge"
-msgstr ""
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "Tuntematon"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
 msgstr "Vanha työpöytätiedostosi on muutettu uuteen XML-muotoon."
 
-#: pinboard.c:635
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
@@ -2706,7 +3091,7 @@ msgstr ""
 "Aseta Taustakuva-ikkunaan, tai (ohjelmoijille) ohjaa se SOAP SetBackdropApp-"
 "metodille."
 
-#: pinboard.c:654
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2720,51 +3105,63 @@ msgstr ""
 "Ohjelmoijat: sovelluksen AppInfo.xml-tiedoston täytyy sisältää "
 "CanSetBackdrop-elementti, kuten ROX-Filerin käsikirja kertoo."
 
-#: pinboard.c:674
+#: pinboard.c:750
 msgid "Set backdrop"
 msgstr "Aseta taustakuva"
 
-#: pinboard.c:685
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
 msgstr "Valitse tyyli, ja raahaa tähän kuva:"
 
-#: pinboard.c:698
+#: pinboard.c:774
 msgid "Centre the image without scaling it"
 msgstr "Keskitä kuva skaalaamatta sitä"
 
-#: pinboard.c:699
+#: pinboard.c:775
 msgid "Centre"
 msgstr "Keskitetty"
 
-#: pinboard.c:700
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr "Skaalaa kuva siten, että se sopii taustan alueelle säilyttäen muotonsa"
 
-#: pinboard.c:702
+#: pinboard.c:778
 msgid "Scale"
 msgstr "Skaalattu"
 
-#: pinboard.c:703
+#: pinboard.c:779
+#, fuzzy
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr "Skaalaa kuva siten, että se sopii taustan alueelle säilyttäen muotonsa"
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Suodatin"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
 msgstr "Venytä kuva täyttämään taustan alue"
 
-#: pinboard.c:704
+#: pinboard.c:783
 msgid "Stretch"
 msgstr "Venytetty"
 
-#: pinboard.c:705
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr "Toista kuvaa rinnakkain taustalla"
 
-#: pinboard.c:706
+#: pinboard.c:785
 msgid "Tile"
 msgstr "Rinnakkain"
 
-#: pinboard.c:711
+#: pinboard.c:790
 msgid "Drop an image here"
 msgstr "Pudota tähän kuva"
 
-#: pinboard.c:772
+#: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
@@ -2772,31 +3169,36 @@ msgstr ""
 "Työpöytää ei ollut käytössä... 'Default'-työpöytä valittiin. Käytä komentoa "
 "'rox -p=Default' käyttääksesi sitä jatkossa."
 
-#: pinboard.c:866
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
 msgstr ""
 "Vain tiedostoja (ja eräitä ohjelmia) voi käyttää taustakuvan asettamiseen."
 
-#: pinboard.c:1471
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Puuttuva '>' kuvakkeen nimikkeessä"
 
-#: pinboard.c:1480
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Puuttuva ',' kuvakkeen nimikkeen jälkeen"
 
-#: pinboard.c:1565
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Virhe tallennettaessa työpöytää %s: %s"
 
-#: pinboard.c:2109
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Taustakuva..."
 
-#: pinboard.c:2202
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Paneelit"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2807,7 +3209,7 @@ msgstr ""
 "%s\n"
 "Taustakuva poistettu."
 
-#: pixmaps.c:991
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2816,60 +3218,89 @@ msgstr ""
 "Ei voi poistaa pienoiskuvia kohteesta %s:\n"
 "%s"
 
-#: pixmaps.c:1012
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Ei pienoiskuvia poistettavaksi"
 
-#: pixmaps.c:1025
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Tyhjennä pienoiskuvat levyvälimuistista"
 
-#: remote.c:624
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Tuntematon tyyli '%s'"
 
-#: remote.c:646
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Tuntematon yksityiskohtatyyppi '%s'"
 
-#: remote.c:674
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Tuntematon lajittelutyyppi '%s'"
 
-#: remote.c:1117
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Kutsuttu epäkelpoa SOAP-metodia '%s'"
 
-#: rox_gettext.c:95
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Epäkelpo .gmo-käännöstiedosto (liian lyhyt): %s"
-
-#: rox_gettext.c:108
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Epäkelpo .gmo-käännöstiedosto (GNU 'taikanumeroa' ei löydy): %s"
-
-#: run.c:96 run.c:141
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "Ohjelmaa %s ei löydy - poistettu?"
 
-#: run.c:287
+#: run.c:359
+#, fuzzy, c-format
+msgid ""
+"No run action specified for files of this type (%s/%s) - you can set a run "
+"action by choosing `Set Run Action' from the File menu, or you can just drag "
+"the file to an application.%s"
+msgstr ""
+"Suoritustoimintoa ei ole asetettu tälle tiedostotyypille (%s/%s) - voit "
+"asettaa suoritustoiminnon valitsemalla `Aseta Suoritustoiminto' Tiedosto-"
+"valikosta, tai voit raahata tiedoston sovelluksen päälle"
+
+#: run.c:365
+msgid ""
+"\n"
+"\n"
+"Note: If this is a computer program which you want to run, you need to set "
+"the execute bit by choosing Permissions from the File menu."
+msgstr ""
+
+#: run.c:373
 #, c-format
 msgid "File doesn't exist, or I can't access it: %s"
 msgstr "Tiedostoa ei ole olemassa, tai en pääse siihen käsiksi: %s"
 
-#: run.c:292
+#: run.c:378
 #, c-format
 msgid "I don't know how to open '%s'"
 msgstr "En osaa avata kohdetta '%s'"
 
-#: run.c:323
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' ei ole enää symbolinen linkki"
+
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "Hakemisto '%s' ei ole saatavilla"
+
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "%s ei ole suoritettava tiedosto"
+
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Virhe käsittelijässä %s: %s"
+
+#: run.c:465
 msgid ""
 "Application:\n"
 "This is an application directory - you can run it as a program, or open it "
@@ -2881,222 +3312,24 @@ msgstr ""
 "(pidä Shift painettuna napsauttaessasi sitä). Useimpien sovellusten mukana "
 "tulee omat ohjeensa, mutta tämän ei."
 
-#: run.c:407
+#: run.c:549
 #, c-format
 msgid "Could not send data to program: %s"
 msgstr "Tiedon lähetys epäonnistui sovellukselle: %s"
 
-#: run.c:437
+#: run.c:578
 #, c-format
 msgid "Could not read link: %s"
 msgstr "Linkin luku epäonnistui: %s"
 
-#: run.c:465
+#: run.c:606
 #, c-format
 msgid "Broken symlink (or you don't have permission to follow it): %s"
 msgstr ""
-"Symbolinen linkki ei toimi (tai sinulla ei ole oikeuksia sen käyttämiseen): %"
-"s"
+"Symbolinen linkki ei toimi (tai sinulla ei ole oikeuksia sen käyttämiseen): "
+"%s"
 
-#: run.c:502
-#, fuzzy, c-format
-msgid ""
-"No run action specified for files of this type (%s/%s) - you can set a run "
-"action by choosing `Set Run Action' from the File menu, or you can just drag "
-"the file to an application.%s"
-msgstr ""
-"Suoritustoimintoa ei ole asetettu tälle tiedostotyypille (%s/%s) - voit "
-"asettaa suoritustoiminnon valitsemalla `Aseta Suoritustoiminto' Tiedosto-"
-"valikosta, tai voit raahata tiedoston sovelluksen päälle"
-
-#: run.c:508
-msgid ""
-"\n"
-"\n"
-"Note: If this is a computer program which you want to run, you need to set "
-"the execute bit by choosing Permissions from the File menu."
-msgstr ""
-
-#: support.c:272
-msgid "B"
-msgstr "T"
-
-#: support.c:351
-msgid "byte"
-msgstr "tavu"
-
-#: toolbar.c:115
-msgid "Close"
-msgstr "Sulje"
-
-#: toolbar.c:115
-msgid "Close filer window"
-msgstr "Sulje tiedostonhallintaikkuna"
-
-#: toolbar.c:119
-msgid "Up"
-msgstr "Ylös"
-
-#: toolbar.c:119
-msgid "Change to parent directory"
-msgstr "Vaihda ylähakemistoon"
-
-#: toolbar.c:123
-msgid "Home"
-msgstr "Koti"
-
-#: toolbar.c:123
-msgid "Change to home directory"
-msgstr "Siirry kotihakemistoon"
-
-#: toolbar.c:127
-msgid "Bookmarks"
-msgstr "Kirjanmerkit"
-
-#: toolbar.c:127
-msgid "Bookmarks menu"
-msgstr "Kirjanmerkkivalikko"
-
-#: toolbar.c:131
-msgid "Scan"
-msgstr "Lue"
-
-#: toolbar.c:131
-msgid "Rescan directory contents"
-msgstr "Lue uudelleen hakemiston sisältö"
-
-#: toolbar.c:135
-msgid "Change icon size"
-msgstr "Muuta kuvakekokoa"
-
-#: toolbar.c:139
-msgid "Automatic size mode"
-msgstr "Automaattinen koko"
-
-#: toolbar.c:143
-msgid "Show extra details"
-msgstr "Näytä lisätietoja"
-
-#: toolbar.c:147
-msgid "Sort"
-msgstr "Järjestä"
-
-#: toolbar.c:147
-msgid "Change sort criteria"
-msgstr "Muuta järjestysperusteita"
-
-#: toolbar.c:151
-msgid "Hidden"
-msgstr "Piilotettu"
-
-#: toolbar.c:151
-msgid "Show/hide hidden files"
-msgstr "Näytä/piilota piilotiedostot"
-
-#: toolbar.c:155
-msgid "Select all/invert selection"
-msgstr "Valitse kaikki/käänteinen valinta"
-
-#: toolbar.c:159
-msgid "Show ROX-Filer help"
-msgstr "Näytä ROX-Filerin ohje"
-
-#: toolbar.c:220
-#, c-format
-msgid " (%u hidden)"
-msgstr " (%u piilotettua)"
-
-#: toolbar.c:228 tips:80
-msgid "items"
-msgstr "kohdetta"
-
-#: toolbar.c:228
-msgid "item"
-msgstr "kohde"
-
-#: toolbar.c:231
-#, c-format
-msgid "No items%s"
-msgstr "Ei kohteita%s"
-
-#: toolbar.c:250
-#, c-format
-msgid "%u selected (%s)"
-msgstr "%u valittu (%s)"
-
-#: toolbar.c:422
-msgid "Sort by name"
-msgstr "Järjestä nimen mukaan"
-
-#: toolbar.c:422
-msgid "Sort by type"
-msgstr "Järjestä tyypin mukaan"
-
-#: toolbar.c:422
-msgid "Sort by date"
-msgstr "Järjestä päivämäärän mukaan"
-
-#: toolbar.c:423
-msgid "Sort by size"
-msgstr "Järjestä koon mukaan"
-
-#: toolbar.c:423
-msgid "Sort by owner"
-msgstr "Järjestä omistajan mukaan"
-
-#: toolbar.c:423
-msgid "Sort by group"
-msgstr "Järjestä ryhmän mukaan"
-
-#: toolbar.c:457
-msgid "ascending"
-msgstr "nouseva"
-
-#: toolbar.c:457
-msgid "descending"
-msgstr "laskeva"
-
-#: type.c:203
-msgid "Sym link"
-msgstr "Symbolinen linkki"
-
-#: type.c:205
-msgid "Mount point"
-msgstr "Liitoskohta"
-
-#: type.c:207
-msgid "App dir"
-msgstr "Sovelluskansio"
-
-#: type.c:214
-msgid "Dir"
-msgstr "Hakemisto"
-
-#: type.c:216
-msgid "Char dev"
-msgstr "Merkkilaite"
-
-#: type.c:218
-msgid "Block dev"
-msgstr "Lohkolaite"
-
-#: type.c:220
-msgid "Pipe"
-msgstr "Putki"
-
-#: type.c:222
-msgid "Socket"
-msgstr "Vastake"
-
-#: type.c:224
-msgid "Door"
-msgstr "Ovi"
-
-#: type.c:227
-msgid "Unknown"
-msgstr "Tuntematon"
-
-#: type.c:355
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3122,11 +3355,280 @@ msgstr ""
 "huolestua. Muussa tapauksessa sinun pitäisi tarkistaa, tai jopa poistaa "
 "kaikki nykyiset suoritustoiminnot."
 
-#: type.c:368
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Korjaa turvallisuusongelma)"
 
-#: type.c:498
+#: support.c:288
+msgid " "
+msgstr ""
+
+#: support.c:381
+msgid "byte"
+msgstr "tavu"
+
+#: support.c:1531 support.c:1585
+#, fuzzy, c-format
+msgid "Failed to open and stat file '%s': %s"
+msgstr "Tiedoston '%s' avaus epäonnistui: %s"
+
+#: support.c:1542 support.c:1596
+#, fuzzy, c-format
+msgid "Failed to mmap file '%s': %s"
+msgstr "Tiedoston '%s' avaus epäonnistui: %s"
+
+#: toolbar.c:116
+msgid "Close"
+msgstr "Sulje"
+
+#: toolbar.c:116
+msgid "Close filer window"
+msgstr "Sulje tiedostonhallintaikkuna"
+
+#: toolbar.c:120
+msgid "Up"
+msgstr "Ylös"
+
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
+
+#: toolbar.c:126
+msgid "Home"
+msgstr "Koti"
+
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
+
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
+
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
+
+#: toolbar.c:138
+msgid "Scan"
+msgstr "Lue"
+
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
+
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Koko"
+
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automaattinen"
+
+#: toolbar.c:155
+msgid "Automatic size mode"
+msgstr "Automaattinen koko"
+
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Listanäkymä"
+
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
+msgid "Sort"
+msgstr "Järjestä"
+
+#: toolbar.c:165
+msgid "Change sort criteria"
+msgstr "Muuta järjestysperusteita"
+
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
+
+#: toolbar.c:169
+msgid ""
+"Left: Show/hide hidden files\n"
+"Right: Show/hide thumbnails"
+msgstr ""
+
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "Valitse kaikki/käänteinen valinta"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
+msgid "Show ROX-Filer help"
+msgstr "Näytä ROX-Filerin ohje"
+
+#: toolbar.c:270
+#, c-format
+msgid " (%u hidden)"
+msgstr " (%u piilotettua)"
+
+#: toolbar.c:276 tips:79
+msgid "items"
+msgstr "kohdetta"
+
+#: toolbar.c:276
+msgid "item"
+msgstr "kohde"
+
+#: toolbar.c:279
+#, c-format
+msgid "No items%s"
+msgstr "Ei kohteita%s"
+
+#: toolbar.c:298
+#, c-format
+msgid "%u selected (%s)"
+msgstr "%u valittu (%s)"
+
+#: toolbar.c:535
+msgid "Sort by name"
+msgstr "Järjestä nimen mukaan"
+
+#: toolbar.c:535
+msgid "Sort by type"
+msgstr "Järjestä tyypin mukaan"
+
+#: toolbar.c:535
+msgid "Sort by date"
+msgstr "Järjestä päivämäärän mukaan"
+
+#: toolbar.c:535
+msgid "Sort by size"
+msgstr "Järjestä koon mukaan"
+
+#: toolbar.c:536
+msgid "Sort by owner"
+msgstr "Järjestä omistajan mukaan"
+
+#: toolbar.c:536
+msgid "Sort by group"
+msgstr "Järjestä ryhmän mukaan"
+
+#: toolbar.c:568
+msgid "ascending"
+msgstr "nouseva"
+
+#: toolbar.c:568
+msgid "descending"
+msgstr "laskeva"
+
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
+msgid "Sym link"
+msgstr "Symbolinen linkki"
+
+#: type.c:223
+msgid "Mount point"
+msgstr "Liitoskohta"
+
+#: type.c:225
+msgid "App dir"
+msgstr "Sovelluskansio"
+
+#: type.c:232
+msgid "Dir"
+msgstr "Hakemisto"
+
+#: type.c:234
+msgid "Char dev"
+msgstr "Merkkilaite"
+
+#: type.c:236
+msgid "Block dev"
+msgstr "Lohkolaite"
+
+#: type.c:238
+msgid "Pipe"
+msgstr "Putki"
+
+#: type.c:240
+msgid "Socket"
+msgstr "Vastake"
+
+#: type.c:242
+msgid "Door"
+msgstr "Ovi"
+
+#: type.c:245
+msgid "Unknown"
+msgstr "Tuntematon"
+
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3137,70 +3639,70 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:679
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Tämä ei ole ohjelmatiedosto! Tarvitsen sovelluksen!"
 
-#: type.c:740
+#: type.c:839
 msgid "No run action defined"
 msgstr "Suoritustoimintoa ei ole määritetty"
 
-#: type.c:766
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Virhe käsittelijässä %s: %s"
 
-#: type.c:781
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Epäkelpo sovellus %s (virheellinen AppRun)"
 
-#: type.c:792
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "%s ei ole suoritettava tiedosto"
 
-#: type.c:825
+#: type.c:902
 msgid "Set run action"
 msgstr "Aseta suoritustoiminto"
 
-#: type.c:831
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 "Jos tiedostotyypille ei ole asetettu käsittelijää, käytä tätä oletusarvona."
 
-#: type.c:833
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Aseta oletus tyypeille `%s/<mikä tahansa>'"
 
-#: type.c:837
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Käytä sovellusta kaikille tiedostoille, joiden MIME-tyyppi on tämä."
 
-#: type.c:839
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Ainoastaan tyypille `%s' (%s/%s)"
 
-#: type.c:845
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Raahaa sopiva sovellus tähän"
 
-#: type.c:860
+#: type.c:963
 msgid "OR"
 msgstr "TAI"
 
-#: type.c:867
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Syötä komentotulkin komento:"
 
-#: type.c:896
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Käytä komentoa"
 
-#: type.c:926
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
@@ -3208,42 +3710,29 @@ msgstr ""
 "Suoritustoiminto on jo olemassa, ja on melko kookas ohjelma - haluatko "
 "varmasti poistaa sen?"
 
-#: type.c:937
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Ei voi poistaa kohdetta %s: %s"
 
-#: type.c:974
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "Asetusten tallentaminen estetty CHOICESPATH-muuttujalla"
 
-#: type.c:1249
-#, c-format
-msgid ""
-"Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr ""
-"Kuvaketeema '%s' ei sisällä MIME-kuvakkeita. Käytetään ROX:in oletusteemaa."
-
-#: type.c:1263
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason)"
+"%s"
 msgstr ""
-"Symbolisen linkin '%s' luominen epäonnistui:\n"
-"%s\n"
-"\n"
-"(tämä saattaa tarkoittaa, että kohteessa on jo ROX-teema, mutta 'mime-"
-"application:postscript'-kuvaketta ei voitu ladata jostain syystä)"
+"Kohteen '%s' poisto epäonnistui:\n"
+"%s"
 
-#: usericons.c:181
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "Antamaasi polkua ei ole olemassa. Kuvaketta ei vaihdettu."
 
-#: usericons.c:191 usericons.c:616
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3253,12 +3742,12 @@ msgstr ""
 "muodossa, tai ehkä oikeuksissa on virhe?\n"
 "Kuvaketta ei vaihdettu."
 
-#: usericons.c:238
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Poistetaanko varmasti kuvake '%s'?"
 
-#: usericons.c:242
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3267,31 +3756,31 @@ msgstr ""
 "Ei voi poistaa kohdetta '%s':\n"
 "%s"
 
-#: usericons.c:270
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Aseta kuvake"
 
-#: usericons.c:279
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr ""
 "Käytä kuvan kopiota oletuksena kaikille näiden MIME-tyyppien tiedostoille."
 
-#: usericons.c:281
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Aseta kuvake tyypeille `%s/<mikä tahansa>'"
 
-#: usericons.c:286
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "Käytä kuvan kopiota kaikille tämän MIME-tyypin tiedostoille."
 
-#: usericons.c:288
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Kaikille tyypin `%s' tiedostoille (%s/%s)"
 
-#: usericons.c:294
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
@@ -3299,12 +3788,12 @@ msgstr ""
 "Lisää tiedoston ja kuvatiedoston nimet henkilökohtaiselle listallesi. Asetus "
 "katoaa jos kuvaa tai tiedostoa siirretään."
 
-#: usericons.c:297
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Vain tiedostolle `%s'"
 
-#: usericons.c:305
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
@@ -3314,19 +3803,19 @@ msgstr ""
 "näkevät silloin kuvakkeen ja voit siirtää hakemistoa turvallisesti. Tämä on "
 "yleensä paras vaihtoehto, jos sinulla on kirjoitusoikeudet hakemistoon."
 
-#: usericons.c:311
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Kopioi kuva hakemistoon"
 
-#: usericons.c:317
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Raahaa tähän kuvaketiedosto"
 
-#: usericons.c:587
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "Kuvakkeen asettaminen estetty CHOICESPATH-muuttujalla"
 
-#: usericons.c:631
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3335,144 +3824,71 @@ msgstr ""
 "Virhe luotaessa kuvaa '%s':\n"
 "%s"
 
-#: view_details.c:1009
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
+msgid "Mono font"
+msgstr ""
+
+#: view_details.c:1019
+msgid "Font for displaying mono-spaced text"
+msgstr ""
+
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Nimi"
 
-#: view_details.c:1012
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Tyyppi"
 
-#: view_details.c:1015
-msgid "_Permissions"
-msgstr "O_ikeudet"
-
-#: view_details.c:1016
-msgid "_Owner"
-msgstr "_Omistaja"
-
-#: view_details.c:1018
-msgid "_Group"
-msgstr "_Ryhmä"
-
-#: view_details.c:1020
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Koko"
 
-#: view_details.c:1022
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "O_ikeudet"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_Omistaja"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Ryhmä"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "Viimeksi _Muokattu"
 
-#: tips:1
-msgid "Translation"
-msgstr "Käännös"
-
-#: tips:2
-msgid "Language"
-msgstr "Kieli"
-
-#: tips:3
-msgid "Use the LANG environment variable"
-msgstr "Käytä LANG-ympäristömuuttujaa"
-
-#: tips:4
-msgid "Basque"
+#: view_details.c:1260
+msgid "Last _Changed"
 msgstr ""
 
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Kiina (perinteinen)"
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
 
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Kiina (yksinkertaistettu)"
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Lisäattribuutit"
 
-#: tips:7
-msgid "Czech"
-msgstr "Tšekki"
-
-#: tips:8
-msgid "Danish"
-msgstr "Tanska"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Hollanti"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Englanti (ei käännöstä)"
-
-#: tips:11
-#, fuzzy
-msgid "Estonian"
-msgstr "Romania"
-
-#: tips:12
-msgid "Finnish"
-msgstr "Suomi"
-
-#: tips:13
-msgid "French"
-msgstr "Ranska"
-
-#: tips:14
-msgid "German"
-msgstr "Saksa"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Unkari"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Japani"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "Norja"
-
-#: tips:18
-msgid "Italian"
-msgstr "Italia"
-
-#: tips:19
-msgid "Polish"
-msgstr "Puola"
-
-#: tips:20
-msgid "Portuguese (Brasil)"
-msgstr "Portugali (Brasilia)"
-
-#: tips:21
-msgid "Romanian"
-msgstr "Romania"
-
-#: tips:22
-msgid "Russian"
-msgstr "Venäjä"
-
-#: tips:23
-msgid "Spanish"
-msgstr "Espanja"
-
-#: tips:24
-msgid "Swedish"
-msgstr "Ruotsi"
-
-#: tips:25
+#: tips:1
 msgid "Filer windows"
 msgstr "Tiedostonhallintaikkunat"
 
-#: tips:26
+#: tips:2
 msgid "Auto-resize filer windows"
 msgstr "Ikkunoiden koon automaattinen muuttaminen"
 
-#: tips:27
+#: tips:3
 msgid "Never automatically resize"
 msgstr "Älä koskaan muuta kokoa automaattisesti"
 
-#: tips:28
+#: tips:4
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
@@ -3481,11 +3897,11 @@ msgstr ""
 "valikon 'Muuta Ikkunan Kokoa' -valintaa tai kaksoisnapsauttamalla ikkunan "
 "taustaa."
 
-#: tips:29
+#: tips:5
 msgid "Resize when changing the display style"
 msgstr "Muuta kokoa, kun vaihdetaan näkymätyyppiä"
 
-#: tips:30
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
@@ -3493,11 +3909,11 @@ msgstr ""
 "Kuvakkeiden koon tai näytettävien tietojen vaihtaminen muuttaa ikkunan kokoa "
 "puolestasi."
 
-#: tips:31
+#: tips:7
 msgid "Always resize"
 msgstr "Muuta aina kokoa"
 
-#: tips:32
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
@@ -3505,15 +3921,16 @@ msgstr ""
 "Tiedostonhallinta muuttaa ikkunoiden kokoa aina, kun se näyttää "
 "tarpeelliselta (eli vaihtaessasi hakemistoa tai näkymätyyppiä)."
 
-#: tips:33
+#: tips:9
 msgid "Largest window size:"
 msgstr "Ikkunan suurin koko:"
 
-#: tips:34
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:35
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
@@ -3521,15 +3938,29 @@ msgstr ""
 "Suurin koko prosentteina ruudun koosta, johon automaattinen koon muuttaja "
 "voi ikkunaa venyttää."
 
-#: tips:36
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Ikkunan suurin koko:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Suurin koko prosentteina ruudun koosta, johon automaattinen koon muuttaja "
+"voi ikkunaa venyttää."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Ikkunan toimintatapa"
 
-#: tips:37
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Lyhyet otsakepalkin liput"
 
-#: tips:38
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
@@ -3537,11 +3968,11 @@ msgstr ""
 "Käytä yksittäisiä kirjaimia otsakepalkin 'Luetaan', 'Kaikki' ja "
 "'Pienoiskuvat'-ilmaisimien sijasta."
 
-#: tips:39
+#: tips:18
 msgid "Unique windows"
 msgstr "Ainutkertaiset ikkunat"
 
-#: tips:40
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3549,11 +3980,34 @@ msgstr ""
 "Jos avaat hakemiston, joka näytetään jo toisessa ikkunassa, tämä valinta "
 "aiheuttaa toisen ikkunan sulkemisen."
 
-#: tips:41
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Ikkuna"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Uusi ikkuna 1-painikkeella"
 
-#: tips:42
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3563,11 +4017,11 @@ msgstr ""
 "napsauttaminen avaa hakemiston uudessa ikkunassa. 2-painikkeen "
 "(keskimmäinen) napsauttaminen käyttää nykyistä ikkunaa."
 
-#: tips:43
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Kertapainallusnavigaatio"
 
-#: tips:44 tips:137
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
@@ -3577,11 +4031,11 @@ msgstr ""
 "painettuna valitaksesi kohteen. Muussa tapauksessa kertapainallus valitsee "
 "kohteen; avaaminen tapahtuu kaksoisnapsauttamalla."
 
-#: tips:45
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Kaksoisnapsautus taustalla muuttaa kokoa"
 
-#: tips:46
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
@@ -3589,15 +4043,15 @@ msgstr ""
 "Tämän ollessa valittuna ikkunan taustan kaksoisnapsautus muuttaa ikkunan "
 "kokoa samoin, kuin työkalupalkin Automaattinen koko-painike."
 
-#: tips:47
+#: tips:30
 msgid "Sorting"
 msgstr "Järjestäminen"
 
-#: tips:48
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Kansiot ensin (nimen mukaan järjestettäessä)"
 
-#: tips:49
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
@@ -3605,11 +4059,11 @@ msgstr ""
 "Tämän ollessa valittuna kansiot näytetään aina ensimmäisenä järjestettäessä "
 "nimen mukaan."
 
-#: tips:50
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Suuraakkosilla kirjoitetut ensin (nimen mukaan järjestettäessä)"
 
-#: tips:51
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
@@ -3617,15 +4071,58 @@ msgstr ""
 "Tämän ollessa valittuna kaikki suuraakkosella alkavat tiedostonimet "
 "esitetään ennen pienaakkosella alkavia."
 
-#: tips:53
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Kansiot ensin (nimen mukaan järjestettäessä)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sekunti"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "Lisäattribuutit"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "Oletusasetukset uusille ikkunoille"
 
-#: tips:54
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "Peri asetukset lähdeikkunalta"
 
-#: tips:55
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
@@ -3634,27 +4131,38 @@ msgstr ""
 "lähdeikkunalta silloin, kun se on mahdollista. Muussa tapauksessa ne "
 "asetetaan allaoleviin oletusarvoihin."
 
-#: tips:56
+#: tips:48
 msgid "View type:"
 msgstr "Näkymätyyppi:"
 
-#: tips:59
+#: tips:51
 msgid "Sort by:"
 msgstr "Järjestysperuste:"
 
-#: tips:61 tips:76
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Tyyppi"
 
-#: tips:62
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Päivämäärä"
 
-#: tips:64
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Päivämäärä"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Päivämäärä"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Näytä piilotetut tiedostot"
 
-#: tips:65
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
@@ -3662,7 +4170,34 @@ msgstr ""
 "Tämän ollessa valittuna myös .-alkuiset tiedostot näytetään, muussa "
 "tapauksessa ne piilotetaan."
 
-#: tips:66
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Näytä piilotetut tiedostot"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Tämän ollessa valittuna myös .-alkuiset tiedostot näytetään, muussa "
+"tapauksessa ne piilotetaan."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Jättimäiset kuvakkeet"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "pistettä"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "Kuvakenäkymä"
 
@@ -3674,11 +4209,11 @@ msgstr "Oletuskoko:"
 msgid "Huge Icons"
 msgstr "Jättimäiset kuvakkeet"
 
-#: tips:69 tips:245
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Suuret kuvakkeet"
 
-#: tips:70 tips:244
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "Pienet kuvakkeet"
 
@@ -3690,15 +4225,20 @@ msgstr "Oletustiedot:"
 msgid "No details"
 msgstr "Ei tietoja"
 
+#: tips:74
+msgid "Sizes"
+msgstr "Koot"
+
+#: tips:77
+msgid "Times"
+msgstr "Ajat"
+
 #: tips:78
-msgid "Automatic small icons:"
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "Automaattiset pienet kuvakkeet:"
 
-#: tips:79
-msgid "Change at:"
-msgstr "Muutosraja:"
-
-#: tips:81
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3708,104 +4248,228 @@ msgstr ""
 "sisältää näin monta kohdetta, se näytetään käyttäen Pieniä kuvakkeita. "
 "Muussa tapauksessa käytetään Suuria kuvakkeita."
 
-#: tips:82
-msgid "Max width (Large icons):"
-msgstr "Enimmäiskoko (Suuret kuvakkeet):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Suuret kuvakkeet"
 
-#: tips:83 tips:86
-msgid "pixels"
-msgstr "pistettä"
-
-#: tips:84
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "Tätä leveämpi teksti jaetaan kahdelle riville Suuret kuvakkeet-tilassa. "
 "Jättimäiset kuvakkeet-tilassa teksti kierrätetään, kun se on 50% tätä "
 "leveämpi."
 
-#: tips:85
-msgid "(Small Icons):"
-msgstr "(Pienet kuvakkeet):"
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
 
 #: tips:87
-msgid "Maximum width for the text beside a Small Icon."
-msgstr "Pienten kuvakkeiden vieressä olevan tekstin enimmäisleveys."
+msgid "Wrap by characters"
+msgstr ""
 
 #: tips:88
-msgid "Order small icons vertically"
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
 msgstr ""
 
 #: tips:89
-msgid ""
-"If this option is on, then small icons are ordered vertically, not "
-"horizontally."
-msgstr ""
-
-#: tips:90
-msgid "Order large icons vertically"
-msgstr ""
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "(Pienet kuvakkeet):"
 
 #: tips:91
-msgid ""
-"If this option is on, then large icons are sorted vertically, not "
-"horizontally."
+msgid "Maximum width for the text beside a Small Icon."
+msgstr "Pienten kuvakkeiden vieressä olevan tekstin enimmäisleveys."
+
+#: tips:92
+msgid "Order small icons vertically"
 msgstr ""
 
 #: tips:93
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
+msgstr ""
+
+#: tips:94
+msgid "Order large icons vertically"
+msgstr ""
+
+#: tips:95
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
+msgstr ""
+
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Näytä sarakkeiden otsakkeet"
 
-#: tips:94
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr ""
 "Tämän ollessa valittuna sarakkeiden otsakkeet näytetään listanäkymässä."
 
-#: tips:95
+#: tips:102
 #, fuzzy
 msgid "Show full type"
 msgstr "Järjestä tyypin mukaan"
 
-#: tips:96
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr ""
 
-#: tips:97
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Pienten kuvakkeiden vieressä olevan tekstin enimmäisleveys."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Näytä sarakkeiden otsakkeet"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Tämän ollessa valittuna sarakkeiden otsakkeet näytetään listanäkymässä."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Tämän ollessa valittuna sarakkeiden otsakkeet näytetään listanäkymässä."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Tämän ollessa valittuna sarakkeiden otsakkeet näytetään listanäkymässä."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Tämän ollessa valittuna sarakkeiden otsakkeet näytetään listanäkymässä."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Tämän ollessa valittuna sarakkeiden otsakkeet näytetään listanäkymässä."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Tämän ollessa valittuna sarakkeiden otsakkeet näytetään listanäkymässä."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "Viimeksi _Muokattu"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Tämän ollessa valittuna sarakkeiden otsakkeet näytetään listanäkymässä."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Tämän ollessa valittuna sarakkeiden otsakkeet näytetään listanäkymässä."
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Tämän ollessa valittuna sarakkeiden otsakkeet näytetään listanäkymässä."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Työkalut/Minipuskuri"
 
-#: tips:98
+#: tips:131
 msgid "Toolbar"
 msgstr "Työkalupalkki"
 
-#: tips:99
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Työkalupalkin tyyppi:"
 
-#: tips:100
+#: tips:133
 msgid "No toolbar"
 msgstr "Ei työkalupalkkia"
 
-#: tips:101
+#: tips:134
 msgid "Icons only"
 msgstr "Vain kuvakkeet"
 
-#: tips:102
+#: tips:135
 msgid "Text under icons"
 msgstr "Teksti kuvakkeiden alla"
 
-#: tips:103
+#: tips:136
 msgid "Text beside icons"
 msgstr "Teksti kuvakkeiden vieressä"
 
-#: tips:104
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Vain kuva"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Näytä kohteiden yhteismäärä"
 
-#: tips:105
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3815,15 +4479,15 @@ msgstr ""
 "samoin kuin piilotettujen kohteiden määrä (jos yhtään). Kun on tehty "
 "valinta, näytä valittujen kohteiden lukumäärä ja yhteiskoko."
 
-#: tips:106
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Valitse palkkiin haluamasi painikkeet:"
 
-#: tips:107
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "Työkalupalkin leveys määrää ikkunan vähimmäisleveyden"
 
-#: tips:108
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
@@ -3831,15 +4495,15 @@ msgstr ""
 "Jokainen tiedostonhallintaikkuna pakotetaan vähintään niin leveäksi, että "
 "koko työkalupalkki mahtuu näkyviin"
 
-#: tips:109
+#: tips:143
 msgid "Minibuffer"
 msgstr "Minipuskuri"
 
-#: tips:110
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Piippaa, jos Tab-täydennys epäonnistuu"
 
-#: tips:111
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
@@ -3849,11 +4513,11 @@ msgstr ""
 "piippaa, jos mitään ei tapahdu (esim. koska on useita vaihtoehtoja ja "
 "seuraava merkki vaihtelee)."
 
-#: tips:112
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Piippaa, jos vastaavuuksia on useita"
 
-#: tips:113
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
@@ -3862,7 +4526,27 @@ msgstr ""
 "piippaa, jos vastaavia kohteita on enemmän kuin yksi, vaikka merkkejä "
 "olisikin lisätty."
 
-#: tips:116
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Latauksenkäsittelijä"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Virhe käsittelijässä %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
@@ -3870,11 +4554,11 @@ msgstr ""
 "Pienoiskuvien ollessa käytössä hakemiston jokainen kuvatiedosto ladataan ja "
 "siitä esitetään pieni pienoiskuva."
 
-#: tips:117
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Näytä pienoiskuvat"
 
-#: tips:118
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
@@ -3882,30 +4566,104 @@ msgstr ""
 "Tämä on oletusasetus uusille ikkunoille. Voit ottaa pienoiskuvat käyttöön "
 "yksittäisissä ikkunoissa Näytä-valikon kautta."
 
-#: tips:119
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Näytä pienoiskuvat"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 #, fuzzy
 msgid "Video thumbnails"
 msgstr "Näytä Pienoiskuvat"
 
-#: tips:120
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Pienoiskuvavälimuisti"
 
-#: tips:121
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "Toiminnan nopeuttamiseksi luodut pienoiskuvat tallennetaan piilotettuun ~/."
 "thumbnails-hakemistoon. Paina tästä poistaaksesi kaikki pienoiskuvat "
 "välimuistista. Ne luodaan uudelleen tarvittaessa."
 
-#: tips:122 tips:195
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
+#, fuzzy
+msgid "Manage thumbnails"
+msgstr "Näytä pienoiskuvat"
+
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Näytä Pienoiskuvat"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sekunti"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Työpöytä"
 
-#: tips:123
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
@@ -3913,47 +4671,47 @@ msgstr ""
 "Työpöydän ollessa käytössä voit vetää tiedostoja ja sovelluksia työpöydän "
 "taustalle luodaksesi niihin pikakuvakkeet."
 
-#: tips:124 tips:241
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Ulkoasu"
 
-#: tips:125
+#: tips:179
 msgid "Foreground:"
 msgstr "Etuala:"
 
-#: tips:126
+#: tips:180
 msgid "Text shadow:"
 msgstr "Tekstin varjo:"
 
-#: tips:127
+#: tips:181
 msgid "Background:"
 msgstr "Tausta:"
 
-#: tips:128
+#: tips:182
 msgid "No shadow"
 msgstr "Ei varjoa"
 
-#: tips:129
+#: tips:183
 msgid "Thin"
 msgstr "Ohut"
 
-#: tips:130
+#: tips:184
 msgid "Thick"
 msgstr "Paksu"
 
-#: tips:131
+#: tips:185
 msgid "Use custom font:"
 msgstr "Mukautettu kirjasin:"
 
-#: tips:132
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Kirjasin, jota käytetään kuvakkeiden alla olevassa tekstissä"
 
-#: tips:133
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Kuvien nopea skaalaus"
 
-#: tips:134
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
@@ -3961,19 +4719,19 @@ msgstr ""
 "Valitse nopean ja hitaan taustakuvien skaalausmenetelmän väliltä. Hidas "
 "menetelmä saattaa antaa paremman tuloksen."
 
-#: tips:135
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Työpöydän toiminta"
 
-#: tips:136
+#: tips:190
 msgid "Single-click to open"
 msgstr "Kertanapsautus avaa"
 
-#: tips:138
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Pidä kuvakkeet ruudun alueella"
 
-#: tips:139
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
@@ -3981,39 +4739,39 @@ msgstr ""
 "Tämän ollessa valittuna työpöydän kuvakkeet pidetään aina kokonaan ruudun "
 "rajojen sisäpuolella nimikettä myöten."
 
-#: tips:140
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Kuvakeruudukon askelväli:"
 
-#: tips:141
+#: tips:195
 msgid "Fine"
 msgstr "Hieno"
 
-#: tips:142
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "Käytä 2 kuvapisteen ruudukkoa kuvakkeiden sijoitteluun työpöydällä."
 
-#: tips:143
+#: tips:197
 msgid "Medium"
 msgstr "Kohtalainen"
 
-#: tips:144
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "Käytä 16 kuvapisteen ruudukkoa kuvakkeiden sijoitteluun työpöydällä."
 
-#: tips:145
+#: tips:199
 msgid "Coarse"
 msgstr "Karkea"
 
-#: tips:146
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "Käytä 32 kuvapisteen ruudukkoa kuvakkeiden sijoitteluun työpöydällä."
 
-#: tips:147 tips:149
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Pienennetyt ikkunat"
 
-#: tips:148
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
@@ -4023,11 +4781,11 @@ msgstr ""
 "ikkunoita, ja useat ohjelmat, ROX-Filer mukaanluettuna, kykenevät näyttämään "
 "nämä pienennetyt ikkunat."
 
-#: tips:150
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Näytä pienennetyt ikkunat"
 
-#: tips:151
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
@@ -4037,11 +4795,11 @@ msgstr ""
 "ikkunan pienenä kuvakkeena työpöydällä. Vaatii yhteensopivan "
 "ikkunanmanagerin ja ROX-työpöydän pitää olla käytössä."
 
-#: tips:152
+#: tips:206
 msgid "Show per workspace"
 msgstr ""
 
-#: tips:153
+#: tips:207
 #, fuzzy
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
@@ -4051,39 +4809,39 @@ msgstr ""
 "ikkunan pienenä kuvakkeena työpöydällä. Vaatii yhteensopivan "
 "ikkunanmanagerin ja ROX-työpöydän pitää olla käytössä."
 
-#: tips:154
+#: tips:208
 msgid "Iconify to the"
 msgstr "Pienennä"
 
-#: tips:155
+#: tips:209
 msgid "top-left"
 msgstr "ylävasemmalle"
 
-#: tips:156
+#: tips:210
 msgid "top-right"
 msgstr "yläoikealle"
 
-#: tips:157
+#: tips:211
 msgid "bottom-left"
 msgstr "alavasemmalle"
 
-#: tips:158
+#: tips:212
 msgid "bottom-right"
 msgstr "alaoikealle"
 
-#: tips:159
+#: tips:213
 msgid ", going"
 msgstr ", lisäten"
 
-#: tips:160
+#: tips:214
 msgid "horizontally"
 msgstr "vaakasuuntaisesti"
 
-#: tips:161
+#: tips:215
 msgid "vertically"
 msgstr "pystysuuntaisesti"
 
-#: tips:162
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4095,182 +4853,100 @@ msgstr ""
 "ylä- ja alamarginaalit välttääksesi kuvakkeiden sijoittelua näille alueille. "
 "Tiedostonhallinta tietää kyllä oman paneelinsa sijainnin."
 
-#: tips:163
+#: tips:217
 msgid "Top margin"
 msgstr "Ylämarginaali"
 
-#: tips:164
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Luoksepääsemättömän alueen korkeus ruudun yläreunassa."
 
-#: tips:165
+#: tips:219
 msgid "Bottom margin"
 msgstr "Alamarginaali"
 
-#: tips:166
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "Luoksepääsemättömän alueen korkeus ruudun alareunassa."
 
-#: tips:167
-msgid "Panels"
-msgstr "Paneelit"
+#: tips:221
+#, fuzzy
+msgid "Left margin"
+msgstr "Ylämarginaali"
 
-#: tips:168
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr ""
-"Paneelit ovat kuvakepalkkeja, jotka sijaitsevat näytön reunalla. "
-"Käsikirjasta löydät tietoa paneelien käyttämisestä."
+#: tips:222
+#, fuzzy
+msgid "Width of no-go area at left of screen."
+msgstr "Luoksepääsemättömän alueen korkeus ruudun yläreunassa."
 
-#: tips:169
-msgid "Panel style"
-msgstr "Paneelin tyyli"
+#: tips:223
+#, fuzzy
+msgid "Right margin"
+msgstr "Alamarginaali"
 
-#: tips:170
-msgid "Image and text"
-msgstr "Kuvat ja teksti"
+#: tips:224
+#, fuzzy
+msgid "Width of no-go area at right of screen."
+msgstr "Luoksepääsemättömän alueen korkeus ruudun yläreunassa."
 
-#: tips:171
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Jokainen paneelin kuvake näytetään kuvana ja tekstinä."
-
-#: tips:172
-msgid "Image only for applications"
-msgstr "Pelkkä kuvake sovelluksille"
-
-#: tips:173
-msgid ""
-"Applications have just an image, everything else has both an image and text."
-msgstr ""
-"Sovelluksille näytetään vain kuva, kaikelle muulle näytetään kuva ja teksti."
-
-#: tips:174
-msgid "Image only"
-msgstr "Vain kuva"
-
-#: tips:175
-msgid "Only the image is shown."
-msgstr "Vain kuva näytetään."
-
-#: tips:176
-msgid "Panel width (thin)"
-msgstr "Paneelin leveys (ohut)"
-
-#: tips:177
-msgid "(thick)"
-msgstr "(paksu)"
-
-#: tips:178
-msgid "The size of the panels."
-msgstr "Paneelien koko."
-
-#: tips:179
-msgid "Do not cover panel"
-msgstr "Älä peitä paneelia"
-
-#: tips:180
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
-msgstr ""
-"Pyydä ikkunamanageria välttämään paneelien peittämistä suurentaessasi "
-"ikkunoita. Jotkin ikkunamanagerit eivät noudata tätä. Tämän ollessa pois "
-"käytöstä tiedostonhallinta pyytää jättämään peittämättä vain pari pikseliä "
-"ruudun reunalta, jotta automaattinostaminen toimisi."
-
-#: tips:181
-msgid "Xinerama"
-msgstr "Xinerama"
-
-#: tips:182
-msgid "Confine to Xinerama monitor"
-msgstr "Rajoita Xinerama-näytölle"
-
-#: tips:183
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
-msgstr ""
-"Jos käytät useampaa näyttöä Xineraman kautta, käytä tätä asetusta "
-"rajoittaaksesi paneelit yhden näytön alueelle venyttämisen sijaan."
-
-#: tips:184
-msgid ""
-"The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr ""
-"Näyttö, jonka alueelle paneelit pakotetaan Xinerama-tilassa (numerointi "
-"alkaen 0:sta)."
-
-#: tips:185
+#: tips:225
 msgid "Desktop"
 msgstr ""
 
-#: tips:186
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
 msgstr ""
 
-#: tips:187
+#: tips:227
 #, fuzzy
 msgid "Panel only"
 msgstr "Vain kuva"
 
-#: tips:188
+#: tips:228
 #, fuzzy
 msgid "Only a panel is shown."
 msgstr "Vain kuva näytetään."
 
-#: tips:189
+#: tips:229
 #, fuzzy
 msgid "Pinboard only"
 msgstr "Työpöytä"
 
-#: tips:190
+#: tips:230
 #, fuzzy
 msgid "Only the pinboard is shown."
 msgstr "Vain kuva näytetään."
 
-#: tips:191
+#: tips:231
 #, fuzzy
 msgid "Panel and pinboard"
 msgstr "Työpöytä"
 
-#: tips:192
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr ""
 
-#: tips:193
-#, fuzzy
-msgid "Panel"
-msgstr "Paneelit"
-
-#: tips:194
-msgid "Enter the name of the panel to show here."
-msgstr ""
-
-#: tips:196
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr ""
 
-#: tips:197
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr ""
 
-#: tips:198
+#: tips:236
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 
-#: tips:199
+#: tips:237
 msgid "Action windows"
 msgstr "Toimintaikkunat"
 
-#: tips:200
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4278,63 +4954,110 @@ msgstr ""
 "Toimintaikkuna avautuu, kun aloitat taustatoiminnon,\n"
 "kuten tiedostojen kopioinnin tai poiston."
 
-#: tips:201
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Kännistä automaattisesti (hiljaisena) nämä toiminnot"
 
-#: tips:203
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Kopioi tiedostot pyytämättä vahvistusta."
 
-#: tips:205
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Siirrä tiedostot pyytämättä vahvistusta."
 
-#: tips:207
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Luo linkit tiedostoihin pyytämättä vahvistusta."
 
-#: tips:209
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Poista tiedostot pyytämättä vahvistusta.."
 
-#: tips:210
+#: tips:248
 msgid "Mount"
 msgstr "Liitä"
 
-#: tips:211
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Liitä ja irrota tiedostojärjestelmät pyytämättä vahvistusta."
 
-#: tips:212
+#: tips:250
 msgid "Default settings"
 msgstr "Oletusasetukset"
 
-#: tips:214
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Pakota"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "Poista kirjoitussuojatut tiedostot pyytämättä vahvistusta."
 
-#: tips:216
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Näytä vähemmän tietoa viestialueella."
 
-#: tips:218
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Muuta myös alihakemistojen sisältöä."
 
-#: tips:221
+#: tips:263
+#, fuzzy
+msgid "Mount commands"
+msgstr "Liitoskohta"
+
+#: tips:264
+#, fuzzy
+msgid "Mount command"
+msgstr "Liitoskohta"
+
+#: tips:265
+msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
+msgstr ""
+
+#: tips:266
+#, fuzzy
+msgid "Unmount command"
+msgstr "Irrota"
+
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "_Käytä komentoa"
+
+#: tips:269
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Vetäminen ja Pudottaminen"
 
-#: tips:222
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Kuvakkeisiin raahaaminen"
 
-#: tips:223
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Salli tiedostonhallintaikkunoiden kuvakkeisiin raahaaminen"
 
-#: tips:224
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
@@ -4344,11 +5067,11 @@ msgstr ""
 "päälle tiedostonhallintaikkunassa. Tällöin kohde korostetaan ja "
 "pudottaessasi tiedosto lisätään hakemistoon tai ladataan sovellukseen."
 
-#: tips:225
+#: tips:276
 msgid "Directories spring open"
 msgstr "Hakemistot ponnahtavat auki"
 
-#: tips:226
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
@@ -4358,15 +5081,15 @@ msgstr ""
 "korostetun hakemiston 'ponnahtamaan auki' pidettyäsi tiedostoa sen "
 "yläpuolella hetken aikaa."
 
-#: tips:227
+#: tips:278
 msgid "Spring delay:"
 msgstr "Ponnahdusviive:"
 
-#: tips:228
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:229
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
@@ -4376,19 +5099,19 @@ msgstr ""
 "tiedostoa hakemiston päällä, ennen kuin se ponnahtaa auki. Myös ylläoleva "
 "asetus täytyy olla valittuna, jotta tämä vaikuttaisi."
 
-#: tips:230
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Raahattaessa tiedostoja hiiren vasemmalla painikkeella"
 
-#: tips:231 tips:235
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Näytä mahdolliset toiminnot valikkona"
 
-#: tips:232
+#: tips:283
 msgid "Copy the files"
 msgstr "Kopioi tiedostot"
 
-#: tips:233
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
@@ -4396,15 +5119,15 @@ msgstr ""
 "Huomaa, että saat yhä valikon esiin raahaamalla, kun Alt-näppäin on "
 "painettuna."
 
-#: tips:234
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Raahattaessa tiedostoja hiiren keskipainikkeella"
 
-#: tips:236
+#: tips:287
 msgid "Move the files"
 msgstr "Siirrä tiedostot"
 
-#: tips:237
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
@@ -4412,11 +5135,11 @@ msgstr ""
 "Huomaa, että saat yhä valikon esiin raahaamalla vasemmalla painikkeella, kun "
 "Alt-näppäin on painettuna."
 
-#: tips:238
+#: tips:289
 msgid "Download handler"
 msgstr "Latauksenkäsittelijä"
 
-#: tips:239
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4428,35 +5151,35 @@ msgstr ""
 "raahaamasi URI, ja kohde on nykyinen hakemisto. Esim:\n"
 "xterm -e wget $1"
 
-#: tips:240
+#: tips:291
 msgid "Menus"
 msgstr "Valikot"
 
-#: tips:242
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Valikkojen kuvakkeiden koko:"
 
-#: tips:243
+#: tips:294
 msgid "No Icons"
 msgstr "Ei Kuvakkeita"
 
-#: tips:246
+#: tips:297
 msgid "Same as current window"
 msgstr "Sama kuin nykyisessä ikkunassa"
 
-#: tips:247
+#: tips:298
 msgid "Same as default"
 msgstr "Sama kuin oletus"
 
-#: tips:248
+#: tips:299
 msgid "Behaviour"
 msgstr "Toimintatapa"
 
-#: tips:249
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Tiedostovalikko oikealla painikkeella"
 
-#: tips:250
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
@@ -4465,24 +5188,30 @@ msgstr ""
 "hiiren painiketta, kun valittuna on tiedostoja (päävalikon saat pitämällä "
 "Ctrl-näppäinta painettuna)."
 
-#: tips:251
-msgid "`Xterm Here' program"
+#: tips:302
+#, fuzzy
+msgid "Terminal emulator program"
 msgstr "'Pääte Tähän'-sovellus"
 
-#: tips:252
-msgid "The program to launch when you choose `Xterm Here' from the menu."
+#: tips:303
+#, fuzzy
+msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr ""
 "Sovellus, joka käynnistetään valitessasi valikosta toiminnon 'Pääte Tähän'."
 
-#: tips:253
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Pikanäppäimet"
 
-#: tips:255
+#: tips:305
+msgid "Types"
+msgstr "Tyypit"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME-tyypit"
 
-#: tips:256
+#: tips:307
 #, fuzzy
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
@@ -4495,24 +5224,24 @@ msgstr ""
 "\n"
 "http://rox.sourceforge.net/mime_editor.html"
 
-#: tips:257
+#: tips:308
 msgid "Edit MIME rules"
 msgstr ""
 
-#: tips:258
+#: tips:309
 #, fuzzy
 msgid "Themes"
 msgstr "Ajat"
 
-#: tips:259
+#: tips:310
 msgid "Icon theme"
 msgstr "Kuvaketeema"
 
-#: tips:260
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "Teemat pitäisi sijoittaa ~/.icons-hakemistoon"
 
-#: tips:261
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
@@ -4520,39 +5249,39 @@ msgstr ""
 "Käytä 'Aseta Kuvake...'-ikkunaa asettaaksesi kuvakkeet eri MIME-tyypeille. "
 "Huomaa, että näin valitut kuvakkeet syrjäyttävät valitun teeman kuvakkeet."
 
-#: tips:262
+#: tips:313
 msgid "Colours"
 msgstr "Värit"
 
-#: tips:263
+#: tips:314
 msgid "File type colours"
 msgstr "Tiedostotyyppien värit"
 
-#: tips:264
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Väritä tiedostot tyyppien mukaan"
 
-#: tips:265
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr "Tiedostonimet (ja tiedot) väritetään tiedoston tyypin mukaan."
 
-#: tips:266
+#: tips:317
 msgid "Directory:"
 msgstr "Hakemisto:"
 
-#: tips:267
+#: tips:318
 msgid "Regular file:"
 msgstr "Tavallinen tiedosto:"
 
-#: tips:268
+#: tips:319
 msgid "Pipe:"
 msgstr "Putki:"
 
-#: tips:269
+#: tips:320
 msgid "Socket:"
 msgstr "Vastake:"
 
-#: tips:271
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
@@ -4560,19 +5289,19 @@ msgstr ""
 "Virhe, kuten symbolinen linkki olemattomaan tiedostoon tai tiedosto, jonka "
 "tarkasteluun tiedostonhallinnalla ei ole oikeuksia."
 
-#: tips:272
+#: tips:323
 msgid "Character device:"
 msgstr "Merkkilaite:"
 
-#: tips:273
+#: tips:324
 msgid "Block device:"
 msgstr "Lohkolaite:"
 
-#: tips:274
+#: tips:325
 msgid "Door:"
 msgstr "Ovi:"
 
-#: tips:275
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
@@ -4580,31 +5309,59 @@ msgstr ""
 "Ovitiedostot muistuttavat hieman vastakkeita ja putkia, mutta niitä on nähty "
 "vain Solaris-järjestelmissä."
 
-#: tips:276
+#: tips:327
 msgid "Executable file:"
 msgstr "Käynnistystiedosto:"
 
-#: tips:277
+#: tips:328
 msgid "Application directory:"
 msgstr "Sovellushakemisto:"
 
-#: tips:278
+#: tips:329
 msgid "Unknown type:"
 msgstr "Tuntematon tyyppi:"
 
-#: tips:279
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Tausta:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Mukautettu kirjasin:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Yhteensopivuus"
 
-#: tips:280
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Ikkunamanagerin ongelmat"
 
-#: tips:281
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "Syrjäytä ikkunamanagerin hallinta työpöydältä ja paneeleista."
 
-#: tips:282
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4619,12 +5376,12 @@ msgstr ""
 "reunusten ilmestyminen ikkunoiden ympärille tai niiden esiintyminen "
 "ikkunanvalintalistoissa."
 
-#: tips:283
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr ""
 "Ohjaa taustakuvan päällä tapahtuvat hiiren napsautukset ikkunamanagerille"
 
-#: tips:284
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
@@ -4635,11 +5392,11 @@ msgstr ""
 "tapahtumat sen sijaan ikkunamanagerillesi. Kuvakkeen napsauttamisia ei "
 "ohjata eteenpäin."
 
-#: tips:285
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Blackboxin juurivalikon korjaus"
 
-#: tips:286
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4651,27 +5408,51 @@ msgstr ""
 "kiertokeinoja. Näiden ikkunamanagerien odotetaan muuttavan käytöstään "
 "uudemmissa versioissaan, jolloin tämä ei ole enää tarpeellista."
 
-#: tips:287
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "Paneeli on 'telakka'"
 
-#: tips:288
+#: tips:346
+#, fuzzy
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 "Poista tämä valinta, jos paneeli pysyy haluamattasi aina päällimmäisenä. "
 "Vaatii ohjelman uudelleenkäynnistyksen."
 
-#: tips:289
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Paneelin tyyli"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Raahaaminen ja pudottaminen"
 
-#: tips:290
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Älä käytä isäntänimiä"
 
-#: tips:291
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4681,15 +5462,11 @@ msgstr ""
 "vaatia tämän asetuksen valitsemista. Käytä, jos raahatessasi tiedoston "
 "sovelluksen päälle osoittimeen ilmestyy +-merkki, mutta pudotus ei toimi."
 
-#: tips:292
-msgid "Extended attributes"
-msgstr "Lisäattribuutit"
-
-#: tips:293
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Älä käytä lisäattribuutteja"
 
-#: tips:294
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4701,6 +5478,401 @@ msgstr ""
 "ollessa valittuna 'Aseta Tyyppi'-kohta on valikossa passiivinen, tiedoston "
 "MIME-tyyppi päätellään ainoastaan tiedostonimen perusteella ja ominaisuudet-"
 "ikkuna ei näytä lisäattribuutteja."
+
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Alamarginaali"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+msgid "Right gap:"
+msgstr ""
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "Kotihakemisto"
+
+#: ../Templates.ui.h:4
+#, fuzzy
+msgid "Panel Options"
+msgstr "Asetukset"
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Kuvat ja teksti"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Jokainen paneelin kuvake näytetään kuvana ja tekstinä."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Pelkkä kuvake sovelluksille"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"Sovelluksille näytetään vain kuva, kaikelle muulle näytetään kuva ja teksti."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Vain kuva"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Vain kuva näytetään."
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Paneelin leveys (ohut)"
+
+#: ../Templates.ui.h:12
+#, fuzzy
+msgid "The size of this panel."
+msgstr "Paneelien koko."
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Käännös"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "Älä peitä paneelia"
+
+#: ../Templates.ui.h:19
+#, fuzzy
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Pyydä ikkunamanageria välttämään paneelien peittämistä suurentaessasi "
+"ikkunoita. Jotkin ikkunamanagerit eivät noudata tätä. Tämän ollessa pois "
+"käytöstä tiedostonhallinta pyytää jättämään peittämättä vain pari pikseliä "
+"ruudun reunalta, jotta automaattinostaminen toimisi."
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Paneelin tyyli"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Rajoita Xinerama-näytölle"
+
+#: ../Templates.ui.h:22
+#, fuzzy
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Jos käytät useampaa näyttöä Xineraman kautta, käytä tätä asetusta "
+"rajoittaaksesi paneelit yhden näytön alueelle venyttämisen sijaan."
+
+#: ../Templates.ui.h:23
+#, fuzzy
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+"Näyttö, jonka alueelle paneelit pakotetaan Xinerama-tilassa (numerointi "
+"alkaen 0:sta)."
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "Xinerama"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr ""
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr ""
+
+#: ../Templates.ui.h:27
+#, fuzzy
+msgid "Bottom edge"
+msgstr "Alamarginaali"
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr ""
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "<b>Oikeudet</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<hakemisto>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' on jo olemassa - korvataanko?"
+
+#, fuzzy
+#~ msgid "Choices migration"
+#~ msgstr "Kiina (perinteinen)"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Virhe lukiessa kohdetta '%s:\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Hakemisto puuttuu/poistettu"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Hakemistoa '%s' ei löytynyt."
+
+#~ msgid "Cancel"
+#~ msgstr "Peruuta"
+
+#~ msgid ""
+#~ ".\n"
+#~ "Home page (including updated versions): http://rox.sourceforge.net/\n"
+#~ msgstr ""
+#~ ".\n"
+#~ "Kotisivu (myös päivitetyt versiot): http://rox.sourceforge.net/\n"
+
+#~ msgid "GNOME-VFS library"
+#~ msgstr "GNOME-VFS-kirjasto"
+
+#~ msgid "No (need 2.8.0 or later)"
+#~ msgstr "Ei (vaaditaan vähintään 2.8.0)"
+
+#~ msgid "Dnotify support"
+#~ msgstr "Dnotify-tuki"
+
+#~ msgid "Open AVFS"
+#~ msgstr "Avaa AVFS:llä"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Paina Shift+Menupainike tiedoston yläpuolella lähettääksesi sen jonnekin"
+
+#~ msgid "Look inside ... ?"
+#~ msgstr "Katsotaanko sisään kohteeseen ... ?"
+
+#, fuzzy
+#~ msgid "Panel: %s"
+#~ msgstr "Paneelit"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Epäkelpo .gmo-käännöstiedosto (liian lyhyt): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr "Epäkelpo .gmo-käännöstiedosto (GNU 'taikanumeroa' ei löydy): %s"
+
+#~ msgid "B"
+#~ msgstr "T"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Vaihda ylähakemistoon"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Siirry kotihakemistoon"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Kirjanmerkit"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Kirjanmerkkivalikko"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Lue uudelleen hakemiston sisältö"
+
+#~ msgid "Change icon size"
+#~ msgstr "Muuta kuvakekokoa"
+
+#~ msgid "Show extra details"
+#~ msgstr "Näytä lisätietoja"
+
+#~ msgid "Hidden"
+#~ msgstr "Piilotettu"
+
+#~ msgid "Show/hide hidden files"
+#~ msgstr "Näytä/piilota piilotiedostot"
+
+#~ msgid ""
+#~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
+#~ "instead."
+#~ msgstr ""
+#~ "Kuvaketeema '%s' ei sisällä MIME-kuvakkeita. Käytetään ROX:in "
+#~ "oletusteemaa."
+
+#~ msgid ""
+#~ "Failed to create symlink '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(this may mean that the ROX theme already exists there, but the 'mime-"
+#~ "application:postscript' icon couldn't be loaded for some reason)"
+#~ msgstr ""
+#~ "Symbolisen linkin '%s' luominen epäonnistui:\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(tämä saattaa tarkoittaa, että kohteessa on jo ROX-teema, mutta 'mime-"
+#~ "application:postscript'-kuvaketta ei voitu ladata jostain syystä)"
+
+#~ msgid "Language"
+#~ msgstr "Kieli"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "Käytä LANG-ympäristömuuttujaa"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Kiina (perinteinen)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Kiina (yksinkertaistettu)"
+
+#~ msgid "Czech"
+#~ msgstr "Tšekki"
+
+#~ msgid "Danish"
+#~ msgstr "Tanska"
+
+#~ msgid "Dutch"
+#~ msgstr "Hollanti"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Englanti (ei käännöstä)"
+
+#, fuzzy
+#~ msgid "Estonian"
+#~ msgstr "Romania"
+
+#~ msgid "Finnish"
+#~ msgstr "Suomi"
+
+#~ msgid "French"
+#~ msgstr "Ranska"
+
+#~ msgid "German"
+#~ msgstr "Saksa"
+
+#~ msgid "Hungarian"
+#~ msgstr "Unkari"
+
+#~ msgid "Japanese"
+#~ msgstr "Japani"
+
+#~ msgid "Norwegian"
+#~ msgstr "Norja"
+
+#~ msgid "Italian"
+#~ msgstr "Italia"
+
+#~ msgid "Polish"
+#~ msgstr "Puola"
+
+#~ msgid "Portuguese (Brasil)"
+#~ msgstr "Portugali (Brasilia)"
+
+#~ msgid "Romanian"
+#~ msgstr "Romania"
+
+#~ msgid "Russian"
+#~ msgstr "Venäjä"
+
+#~ msgid "Spanish"
+#~ msgstr "Espanja"
+
+#~ msgid "Swedish"
+#~ msgstr "Ruotsi"
+
+#~ msgid "Change at:"
+#~ msgstr "Muutosraja:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Enimmäiskoko (Suuret kuvakkeet):"
+
+#~ msgid "Panels"
+#~ msgstr "Paneelit"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Paneelit ovat kuvakepalkkeja, jotka sijaitsevat näytön reunalla. "
+#~ "Käsikirjasta löydät tietoa paneelien käyttämisestä."
+
+#~ msgid "(thick)"
+#~ msgstr "(paksu)"
 
 #~ msgid ""
 #~ "Error loading MIME database:\n"

--- a/ROX-Filer/src/po/fr.po
+++ b/ROX-Filer/src/po/fr.po
@@ -1,64 +1,69 @@
 # French messages for ROX-Filer
-# Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007 Vincent Lefèvre <vincent@vinc17.org>
+# Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007 Vincent LefÃ¨vre <vincent@vinc17.org>
 # Copyright 2001, 2002, 2003, 2004, 2005, 2006, 2007 Thierry Godefroy <godefroy@imaginet.fr>
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: ROX-Filer 2.5-20070224\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2007-02-24 22:38+0100\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2007-02-24 22:40+0100\n"
 "Last-Translator: Vincent Lefevre <vincent@vinc17.org>\n"
 "Language-Team: ROX Mailing List <rox-devel@lists.sourceforge.net>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=iso-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: abox.c:125
-msgid "<dir>"
-msgstr "<rép>"
+#: abox.c:127
+msgid "<src>"
+msgstr ""
 
-#: abox.c:218
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Silencieux"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Quiet"
 msgstr "Silencieux"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Don't confirm every operation"
-msgstr "Ne pas confirmer chaque opération"
+msgstr "Ne pas confirmer chaque opÃ©ration"
 
-#: abox.c:454 infobox.c:771 tips:63
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Nom"
 
-#: abox.c:460 menu.c:231
+#: abox.c:447 menu.c:751
 msgid "Directory"
-msgstr "Répertoire"
+msgstr "RÃ©pertoire"
 
-#: abox.c:549
+#: abox.c:546
 msgid "Expression:"
-msgstr "Expression :"
+msgstr "ExpressionÂ :"
 
-#: action.c:56
+#: action.c:57
 msgid "See the attr(5) man page for full details."
-msgstr "Voir la page man attr(5) pour les détails complets."
+msgstr "Voir la page man attr(5) pour les dÃ©tails complets."
 
-#: action.c:58
+#: action.c:59
 msgid "See the fsattr(5) man page for full details."
-msgstr "Voir la page man fsattr(5) pour les détails complets."
+msgstr "Voir la page man fsattr(5) pour les dÃ©tails complets."
 
-#: action.c:60
+#: action.c:61
 msgid "You do not appear to have OS support."
-msgstr "Vous ne semblez pas avoir de support par le système d'exploitation."
+msgstr "Vous ne semblez pas avoir de support par le systÃ¨me d'exploitation."
 
-#: action.c:190
+#: action.c:198
 msgid "Find expression reference"
-msgstr "Référence de la recherche par expression"
+msgstr "RÃ©fÃ©rence de la recherche par expression"
 
-#: action.c:201
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -96,51 +101,51 @@ msgid ""
 "a % in 'command' is replaced with the path of the current file)\n"
 "<b>prune</b> (false, and prevents searching the contents of a directory)."
 msgstr ""
-"<u>Si vous êtes pressé</u>\n"
+"<u>Si vous Ãªtes pressÃ©</u>\n"
 "Mettez simplement le nom du fichier que vous recherchez entre apostrophes "
-"(single quotes) :\n"
-"<b>'index.html'</b> (pour trouver un fichier appelé 'index.html')\n"
+"(single quotes)Â :\n"
+"<b>'index.html'</b> (pour trouver un fichier appelÃ© 'index.html')\n"
 "\n"
 "<u>Exemples</u>\n"
 "<b>'*.htm', '*.html'</b> (trouve les fichiers HTML)\n"
-"<b>EstRép 'lib'</b> (trouve les répertoires nommés 'lib')\n"
-"<b>EstOrd 'core'</b> (trouve un fichier ordinaire nommé 'core')\n"
-"<b>! (EstRép, EstOrd)</b> (n'est ni un répertoire, ni un fichier ordinaire)\n"
-"<b>mtime après 1 jour passé et taille > 1Mo</b> (gros, et récemment "
-"modifié)\n"
-"<b>'CVS' prune, estrép</b> (un fichier ordinaire pas dans CVS)\n"
+"<b>EstRÃ©p 'lib'</b> (trouve les rÃ©pertoires nommÃ©s 'lib')\n"
+"<b>EstOrd 'core'</b> (trouve un fichier ordinaire nommÃ© 'core')\n"
+"<b>! (EstRÃ©p, EstOrd)</b> (n'est ni un rÃ©pertoire, ni un fichier ordinaire)\n"
+"<b>mtime aprÃ¨s 1 jour passÃ© et taille > 1Mo</b> (gros, et rÃ©cemment "
+"modifiÃ©)\n"
+"<b>'CVS' prune, estrÃ©p</b> (un fichier ordinaire pas dans CVS)\n"
 "<b>EstOrd system(grep -q fred \\\"%\\\")</b> (contient le mot 'fred')\n"
 "\n"
 "<u>Tests simples</u>\n"
-"<b>EstOrd, EstLien, EstRép, EstCar, EstBloc, EstPér, EstTube, EstSocket, "
+"<b>EstOrd, EstLien, EstRÃ©p, EstCar, EstBloc, EstPÃ©r, EstTube, EstSocket, "
 "EstPorte</b> (types)\n"
-"<b>EstSUID, EstSGID, EstSticky, EstLisible, EstInscriptible, EstExécutable</"
+"<b>EstSUID, EstSGID, EstSticky, EstLisible, EstInscriptible, EstExÃ©cutable</"
 "b> (permissions)\n"
-"<b>EstVide, EstÀMoi</b>\n"
-"Un motif entre apostrophes est un motif style shell avec métacaractères. "
+"<b>EstVide, EstÃ€Moi</b>\n"
+"Un motif entre apostrophes est un motif style shell avec mÃ©tacaractÃ¨res. "
 "S'il\n"
 "contient un slash (barre de fraction), alors la correspondance se fait avec "
 "le\n"
-"chemin complet ; sinon elle se fait seulement avec le nom de fichier "
+"chemin completÂ ; sinon elle se fait seulement avec le nom de fichier "
 "(feuille).\n"
 "\n"
 "<u>Comparaisons</u>\n"
-"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, Après, Avant</b> (compare deux valeurs)\n"
+"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, AprÃ¨s, Avant</b> (compare deux valeurs)\n"
 "<b>5 octets, 1Ko, 2Mo, 3Go</b> (tailles de fichiers)\n"
-"<b>2 sec|min|heures|jours|semaines|ans  passé|futur</b> (dates)\n"
+"<b>2 sec|min|heures|jours|semaines|ans  passÃ©|futur</b> (dates)\n"
 "<b>atime, ctime, mtime, maintenant, taille, inode, nliens, uid, gid, blocs</"
 "b> (valeurs)\n"
 "\n"
-"<u>Fonctions spéciales</u>\n"
-"<b>system(commande)</b> (vrai si 'commande' se termine avec un code nul ;\n"
-"un % dans 'commande' est remplacé par le chemin du fichier courant)\n"
-"<b>prune</b> (faux, et empêche de chercher dans un répertoire)."
+"<u>Fonctions spÃ©ciales</u>\n"
+"<b>system(commande)</b> (vrai si 'commande' se termine avec un code nulÂ ;\n"
+"un % dans 'commande' est remplacÃ© par le chemin du fichier courant)\n"
+"<b>prune</b> (faux, et empÃªche de chercher dans un rÃ©pertoire)."
 
-#: action.c:248
+#: action.c:256
 msgid "Change permissions reference"
-msgstr "Référence du changement des permissions"
+msgstr "RÃ©fÃ©rence du changement des permissions"
 
-#: action.c:259
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -170,46 +175,46 @@ msgid ""
 "\n"
 "See the chmod(1) man page for full details."
 msgstr ""
-"Normalement, il suffit de sélectionner une commande à partir du menu "
+"Normalement, il suffit de sÃ©lectionner une commande Ã  partir du menu "
 "(cliquer\n"
-"sur la flèche à côté de la boîte de commande). Parfois, il vous faut "
+"sur la flÃ¨che Ã  cÃ´tÃ© de la boÃ®te de commande). Parfois, il vous faut "
 "plus...\n"
 "\n"
-"Le format d'une commande est : <b>CHANGEMENT, CHANGEMENT, ...</b>\n"
-"Chaque <b>CHANGEMENT</b> a la forme : <b>QUI COMMENT PERMISSIONS</b>\n"
+"Le format d'une commande estÂ : <b>CHANGEMENT, CHANGEMENT, ...</b>\n"
+"Chaque <b>CHANGEMENT</b> a la formeÂ : <b>QUI COMMENT PERMISSIONS</b>\n"
 "<b>QUI</b> est une combinaison de <b>u</b>, <b>g</b> et <b>o</b> qui "
-"détermine s'il faut changer les\n"
-"permissions pour le propriétaire (User), le groupe (Group) ou les autres "
+"dÃ©termine s'il faut changer les\n"
+"permissions pour le propriÃ©taire (User), le groupe (Group) ou les autres "
 "(Others).\n"
 "<b>COMMENT</b> est <b>+</b>, <b>-</b> ou <b>=</b> pour ajouter, enlever ou "
 "mettre exactement les permissions.\n"
 "<b>PERMISSIONS</b> est une combinaison des lettres <b>rwxXstugo</b>\n"
 "\n"
-"Du texte entre parenthèses et les espaces sont ignorés.\n"
+"Du texte entre parenthÃ¨ses et les espaces sont ignorÃ©s.\n"
 "\n"
 "<u>Exemples</u>\n"
-"<b>u+rw</b> : le propriétaire du fichier obtient la permission de lire et "
-"d'écrire\n"
-"<b>g=u</b> : les permissions du groupe sont mises comme celles du "
-"propriétaire\n"
-"<b>o=u-w</b> : les autres obtiennent les mêmes permissions que le "
-"propriétaire, mais sans la permission d'écrire\n"
-"<b>a+x</b> : tout le monde obtient la permission d'exécuter/accéder - "
-"identique à <b>ugo+x</b>\n"
-"<b>a+X</b> : les répertoires deviennent accessibles à tout le monde ; les "
+"<b>u+rw</b>Â : le propriÃ©taire du fichier obtient la permission de lire et "
+"d'Ã©crire\n"
+"<b>g=u</b>Â : les permissions du groupe sont mises comme celles du "
+"propriÃ©taire\n"
+"<b>o=u-w</b>Â : les autres obtiennent les mÃªmes permissions que le "
+"propriÃ©taire, mais sans la permission d'Ã©crire\n"
+"<b>a+x</b>Â : tout le monde obtient la permission d'exÃ©cuter/accÃ©der - "
+"identique Ã  <b>ugo+x</b>\n"
+"<b>a+X</b>Â : les rÃ©pertoires deviennent accessibles Ã  tout le monde ; les "
 "fichiers\n"
-"qui étaient exécutables par quelqu'un le deviennent par tout le monde\n"
-"<b>u+rw, go+r</b> : deux commandes à la fois !\n"
-"<b>u+s</b> : mettre le bit SetUID - n'a souvent aucun effet sur les scripts\n"
-"<b>755</b> : mettre directement les permissions\n"
+"qui Ã©taient exÃ©cutables par quelqu'un le deviennent par tout le monde\n"
+"<b>u+rw, go+r</b>Â : deux commandes Ã  la fois !\n"
+"<b>u+s</b>Â : mettre le bit SetUID - n'a souvent aucun effet sur les scripts\n"
+"<b>755</b>Â : mettre directement les permissions\n"
 "\n"
-"Voir la page man chmod(1) pour tous les détails."
+"Voir la page man chmod(1) pour tous les dÃ©tails."
 
-#: action.c:300
+#: action.c:308
 msgid "Set type reference"
-msgstr "Référence de « fixer le type »"
+msgstr "RÃ©fÃ©rence de Â«Â fixer le typeÂ Â»"
 
-#: action.c:311
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -224,62 +229,69 @@ msgid ""
 "directories, devices, pipes or sockets, and then only\n"
 "on certain file systems and where the OS implements them.\n"
 msgstr ""
-"Normalement ROX-Filer détermine le type d'un fichier ordinaire en\n"
-"comparant son nom à un motif. Pour changer le type du fichier, vous\n"
+"Normalement ROX-Filer dÃ©termine le type d'un fichier ordinaire en\n"
+"comparant son nom Ã  un motif. Pour changer le type du fichier, vous\n"
 "devez le renommer.\n"
 "\n"
-"De nouveaux systèmes de fichiers peuvent supporter quelque chose appelé\n"
-"« attributs étendus » qui peut être utilisé pour stocker des données\n"
-"supplémentaires pour chaque fichier en paramètres nommés. ROX-Filer\n"
-"utilise l'attribut « user.mime_type » pour stocker les types de fichier.\n"
+"De nouveaux systÃ¨mes de fichiers peuvent supporter quelque chose appelÃ©\n"
+"Â«Â attributs Ã©tendusÂ Â» qui peut Ãªtre utilisÃ© pour stocker des donnÃ©es\n"
+"supplÃ©mentaires pour chaque fichier en paramÃ¨tres nommÃ©s. ROX-Filer\n"
+"utilise l'attribut Â«Â user.mime_typeÂ Â» pour stocker les types de fichier.\n"
 "\n"
-"Les types de fichier ne sont supportés que pour des fichiers ordinaires,\n"
-"pas pour des répertoires, fichiers de périphérique, tubes ou sockets,\n"
-"et seulement sur certains systèmes de fichiers et où c'est implémenté\n"
-"par le système d'exploitation.\n"
+"Les types de fichier ne sont supportÃ©s que pour des fichiers ordinaires,\n"
+"pas pour des rÃ©pertoires, fichiers de pÃ©riphÃ©rique, tubes ou sockets,\n"
+"et seulement sur certains systÃ¨mes de fichiers et oÃ¹ c'est implÃ©mentÃ©\n"
+"par le systÃ¨me d'exploitation.\n"
 
-#: action.c:418
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
-"Processus terminé.\n"
+"Processus terminÃ©.\n"
 
-#: action.c:434
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Il y a eu une erreur.\n"
 
-#: action.c:436
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Il y a eu %d erreurs.\n"
 
-#: action.c:460
+#: action.c:516
 msgid "ERROR reading"
 msgstr "ERREUR de lecture"
 
-#: action.c:503
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
-"Terminé\n"
+"TerminÃ©\n"
 
-#: action.c:559 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "ERREUR"
 
-#: action.c:713 main.c:690 main.c:697 main.c:711
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Oui"
 
-#: action.c:716 main.c:692 main.c:699 main.c:711
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Non"
 
-#: action.c:734
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -287,146 +299,146 @@ msgstr ""
 "\n"
 "Demande au processus fils de terminer...\n"
 
-#: action.c:741
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
 msgstr ""
 "\n"
-"Tentative de tuer (KILL) le processus résistant...\n"
+"Tentative de tuer (KILL) le processus rÃ©sistant...\n"
 
-#: action.c:894
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
-msgstr "?Compter le contenu de %s ?"
+msgstr "?Compter le contenu de %sÂ ?"
 
-#: action.c:930
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
-msgstr "?Supprimer %s'%s' ?"
+msgstr "?Supprimer %s'%s'Â ?"
 
-#: action.c:931
+#: action.c:1047
 msgid "WRITE-PROTECTED "
-msgstr "PROTÉGÉ CONTRE L'ÉCRITURE "
+msgstr "PROTÃ‰GÃ‰ CONTRE L'Ã‰CRITURE "
 
-#: action.c:938
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'Suppression de '%s'\n"
 
-#: action.c:951
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
-msgstr "'Répertoire '%s' supprimé\n"
+msgstr "'RÃ©pertoire '%s' supprimÃ©\n"
 
-#: action.c:984
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
-msgstr "?Éjecter '%s' ?"
+msgstr "?Ã‰jecter '%s'Â ?"
 
-#: action.c:991
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
-msgstr "'Éjection de '%s'\n"
+msgstr "'Ã‰jection de '%s'\n"
 
-#: action.c:1010
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
 "eject failed\n"
 msgstr ""
 "!%s\n"
-"L'éjection a échoué\n"
+"L'Ã©jection a Ã©chouÃ©\n"
 
-#: action.c:1029 action.c:1048
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
-msgstr "?Vérifier '%s' ?"
+msgstr "?VÃ©rifier '%s'Â ?"
 
-#: action.c:1045
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
-msgstr "!Condition de recherche invalide - changez-la et réessayez\n"
+msgstr "!Condition de recherche invalide - changez-la et rÃ©essayez\n"
 
-#: action.c:1055
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
-msgstr "'(lors de la vérification de '%s')\n"
+msgstr "'(lors de la vÃ©rification de '%s')\n"
 
-#: action.c:1129 action.c:1154
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
-msgstr "?Changer les permissions de '%s' ?"
+msgstr "?Changer les permissions de '%s'Â ?"
 
-#: action.c:1135
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Changement des permissions de '%s'\n"
 
-#: action.c:1152
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
-msgstr "!Commande de mode invalide - changez-la et réessayez\n"
+msgstr "!Commande de mode invalide - changez-la et rÃ©essayez\n"
 
-#: action.c:1210
+#: action.c:1332
 #, c-format
 msgid "?Change contents of '%s'?"
-msgstr "?Changer le contenu de '%s' ?"
+msgstr "?Changer le contenu de '%s'Â ?"
 
-#: action.c:1213 action.c:1233
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
-msgstr "?Changer le type de '%s' ?"
+msgstr "?Changer le type de '%s'Â ?"
 
-#: action.c:1230
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
-msgstr "!Type invalide - changez-le et réessayez\n"
+msgstr "!Type invalide - changez-le et rÃ©essayez\n"
 
-#: action.c:1252
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Changement du type de '%s' en '%s'\n"
 
-#: action.c:1275
+#: action.c:1397
 #, c-format
 msgid "'Not changing type of directory '%s'\n"
-msgstr "'Pas de changement du type du répertoire '%s'\n"
+msgstr "'Pas de changement du type du rÃ©pertoire '%s'\n"
 
-#: action.c:1281
+#: action.c:1403
 #, c-format
 msgid "'Non-regular file '%s' not changed\n"
-msgstr "'Fichier non ordinaire '%s' non changé\n"
+msgstr "'Fichier non ordinaire '%s' non changÃ©\n"
 
-#: action.c:1341
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
-msgstr "?'%s' existe déjà - %s ?"
+msgstr "?'%s' existe dÃ©jÃ  - %sÂ ?"
 
-#: action.c:1343
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "fusionner les contenus"
 
-#: action.c:1344
+#: action.c:1551 action.c:1860
 msgid "overwrite"
-msgstr "écraser"
+msgstr "Ã©craser"
 
-#: action.c:1360
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
-msgstr "'On essaie quand même de copier...\n"
+msgstr "'On essaie quand mÃªme de copier...\n"
 
-#: action.c:1369
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
-msgstr "?Copier %s vers %s ?"
+msgstr "?Copier %s vers %sÂ ?"
 
-#: action.c:1373
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Copie de %s vers %s\n"
 
-#: action.c:1388
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
-msgstr "!ERREUR : la destination existe déjà, mais n'est pas un répertoire\n"
+msgstr "!ERREURÂ : la destination existe dÃ©jÃ , mais n'est pas un rÃ©pertoire\n"
 
-#: action.c:1460
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -435,393 +447,412 @@ msgstr ""
 "!%s\n"
 "Impossible de copier '%s'\n"
 
-#: action.c:1504
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' existe déjà - écraser ?"
-
-#: action.c:1519
-msgid "'Trying move anyway...\n"
-msgstr "'On essaie quand même de déplacer...\n"
-
-#: action.c:1527
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Déplacer %s vers %s ?"
-
-#: action.c:1531
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Déplacement de %s vers %s\n"
-
-#: action.c:1539
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
 "Failed to move %s as %s\n"
 msgstr ""
 "!%s\n"
-"Impossible de déplacer %s vers %s\n"
+"Impossible de dÃ©placer %s vers %s\n"
 
-#: action.c:1560
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'On essaie quand mÃªme de dÃ©placer...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?DÃ©placer %s vers %sÂ ?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'DÃ©placement de %s vers %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
-msgstr "!ERREUR : on ne peut pas copier d'objet dans lui-même\n"
+msgstr "!ERREURÂ : on ne peut pas copier d'objet dans lui-mÃªme\n"
 
-#: action.c:1575
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
-msgstr "!ERREUR : on ne peut pas déplacer/renommer d'objet dans lui-même\n"
+msgstr "!ERREURÂ : on ne peut pas dÃ©placer/renommer d'objet dans lui-mÃªme\n"
 
-#: action.c:1587
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Lien de %s vers %s\n"
 
-#: action.c:1592
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
-msgstr "?Lier %s vers %s ?"
+msgstr "?Lier %s vers %sÂ ?"
 
-#: action.c:1635
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Montage de %s\n"
 
-#: action.c:1636
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
-msgstr "'Démontage de %s\n"
+msgstr "'DÃ©montage de %s\n"
 
-#: action.c:1639
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
-msgstr "?Monter %s ?"
+msgstr "?Monter %sÂ ?"
 
-#: action.c:1640
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
-msgstr "?Démonter %s ?"
+msgstr "?DÃ©monter %sÂ ?"
 
-#: action.c:1661
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
 "Mount failed\n"
 msgstr ""
 "!%s\n"
-"Le montage a échoué\n"
+"Le montage a Ã©chouÃ©\n"
 
-#: action.c:1662
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
 "Unmount failed\n"
 msgstr ""
 "!%s\n"
-"Le démontage a échoué\n"
+"Le dÃ©montage a Ã©chouÃ©\n"
 
-#: action.c:1670
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
-msgstr "'(semble maintenant être monté de toute façon)\n"
+msgstr "'(semble maintenant Ãªtre montÃ© de toute faÃ§on)\n"
 
-#: action.c:1716
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
 "Total: %s ("
 msgstr ""
 "'\n"
-"Total : %s ("
+"TotalÂ : %s ("
 
-#: action.c:1722
+#: action.c:2108
 msgid "file"
 msgstr "fichier"
 
-#: action.c:1722
+#: action.c:2108
 msgid "files"
 msgstr "fichiers"
 
-#: action.c:1726
+#: action.c:2112
 msgid "no directories)\n"
-msgstr "pas de répertoires)\n"
+msgstr "pas de rÃ©pertoires)\n"
 
-#: action.c:1730
+#: action.c:2116
 msgid "directory"
-msgstr "répertoire"
+msgstr "rÃ©pertoire"
 
-#: action.c:1731
+#: action.c:2117
 msgid "directories"
-msgstr "répertoires"
+msgstr "rÃ©pertoires"
 
-#: action.c:1772
+#: action.c:2155
 msgid "!No mount points selected!\n"
-msgstr "!Pas de point de montage sélectionné !\n"
+msgstr "!Pas de point de montage sÃ©lectionnÃ© !\n"
 
-#: action.c:1857
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Chercher encore?"
 
-#: action.c:1887 action.c:1918
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' est un lien symbolique\n"
 
-#: action.c:1958
+#: action.c:2342
 msgid "You need to select some items to search through"
-msgstr "Vous devez sélectionner des objets pour la recherche"
+msgstr "Vous devez sÃ©lectionner des objets pour la recherche"
 
-#: action.c:1968 menu.c:222
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Chercher"
 
-#: action.c:2001
+#: action.c:2387
 msgid "You need to select some items to count"
-msgstr "Vous devez sélectionner des objets à compter"
+msgstr "Vous devez sÃ©lectionner des objets Ã  compter"
 
-#: action.c:2005
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Occupation du disque"
 
-#: action.c:2041
+#: action.c:2429
 msgid "Mount / Unmount"
-msgstr "Monter / Démonter"
+msgstr "Monter / DÃ©monter"
 
-#: action.c:2056
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr ""
-"ROX-Filer ne supporte pas encore les points de montage sur votre système. "
-"Désolé."
+"ROX-Filer ne supporte pas encore les points de montage sur votre systÃ¨me. "
+"DÃ©solÃ©."
 
-#: action.c:2070 menu.c:210 tips:218
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Supprimer"
 
-#: action.c:2082 tips:223
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Forcer"
 
-#: action.c:2082
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
-msgstr "Ne pas confirmer la suppression d'objets protégés contre l'écriture"
+msgstr "Ne pas confirmer la suppression d'objets protÃ©gÃ©s contre l'Ã©criture"
 
-#: action.c:2085 action.c:2142 action.c:2203 action.c:2258 action.c:2296
-#: tips:225
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Bref"
 
-#: action.c:2085
+#: action.c:2479
 msgid "Only log directories being deleted"
-msgstr "Ne lister que les répertoires supprimés"
+msgstr "Ne lister que les rÃ©pertoires supprimÃ©s"
 
-#: action.c:2102
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr ""
-"Vous devez sélectionner les objets dont vous voulez changer les permissions"
+"Vous devez sÃ©lectionner les objets dont vous voulez changer les permissions"
 
-#: action.c:2110
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
-msgstr "a+x (Rendre exécutable/cherchable)"
+msgstr "a+x (Rendre exÃ©cutable/cherchable)"
 
-#: action.c:2112
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
-msgstr "a-x (Rendre non-exécutable/non-cherchable)"
+msgstr "a-x (Rendre non-exÃ©cutable/non-cherchable)"
 
-#: action.c:2114
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
-msgstr "u+rw (Donner au propriétaire lecture+écriture)"
+msgstr "u+rw (Donner au propriÃ©taire lecture+Ã©criture)"
 
-#: action.c:2116
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
-msgstr "go-rwx (Privé - accès par le propriétaire uniquement)"
+msgstr "go-rwx (PrivÃ© - accÃ¨s par le propriÃ©taire uniquement)"
 
-#: action.c:2118
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
-msgstr "go=u-w (Accès public, sauf écriture)"
+msgstr "go=u-w (AccÃ¨s public, sauf Ã©criture)"
 
-#: action.c:2129 menu.c:183 menu.c:220 tips:80
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Permissions"
 
-#: action.c:2142 action.c:2203
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
-msgstr "Ne pas lister les fichiers traités"
+msgstr "Ne pas lister les fichiers traitÃ©s"
 
-#: action.c:2145 action.c:2206 tips:227
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
-msgstr "Récursif"
+msgstr "RÃ©cursif"
 
-#: action.c:2145
+#: action.c:2543
 msgid "Also change contents of subdirectories"
-msgstr "Changer aussi le contenu des sous-répertoires"
+msgstr "Changer aussi le contenu des sous-rÃ©pertoires"
 
-#: action.c:2149
+#: action.c:2547
 msgid "Command:"
-msgstr "Commande :"
+msgstr "CommandeÂ :"
 
-#: action.c:2177
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
-msgstr "Vous devez sélectionner les objets dont vous voulez changer le type"
+msgstr "Vous devez sÃ©lectionner les objets dont vous voulez changer le type"
 
-#: action.c:2190
+#: action.c:2590
 msgid "Set type"
 msgstr "Fixer le type"
 
-#: action.c:2206
+#: action.c:2608
 msgid "Change contents of subdirectories"
-msgstr "Changer le contenu des sous-répertoires"
+msgstr "Changer le contenu des sous-rÃ©pertoires"
 
-#: action.c:2213 infobox.c:627
+#: action.c:2615 infobox.c:659
 msgid "Type:"
-msgstr "Type :"
+msgstr "TypeÂ :"
 
-#: action.c:2242 dnd.c:122 menu.c:2004 tips:212
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Copier"
 
-#: action.c:2254 action.c:2292 tips:229
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Ne pas confirmer chaque opÃ©ration"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Ã‰craser seulement si la source est plus rÃ©cente que la destination."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
-msgstr "Plus récent"
+msgstr "Plus rÃ©cent"
 
-#: action.c:2255 action.c:2293 tips:230
-msgid "Only over-write if source is newer than destination."
-msgstr "Écraser seulement si la source est plus récente que la destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
+msgstr "Ã‰craser seulement si la source est plus rÃ©cente que la destination."
 
-#: action.c:2258
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "rÃ©pertoires"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
-msgstr "Ne lister que les répertoires copiés"
+msgstr "Ne lister que les rÃ©pertoires copiÃ©s"
 
-#: action.c:2280 dnd.c:123 tips:214
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
-msgstr "Déplacer"
+msgstr "DÃ©placer"
 
-#: action.c:2296
+#: action.c:2752
 msgid "Don't log each file as it is moved"
-msgstr "Ne pas lister chaque fichier déplacé"
+msgstr "Ne pas lister chaque fichier dÃ©placÃ©"
 
-#: action.c:2316 tips:216
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Lier"
 
-#: action.c:2337 appmenu.c:111 filer.c:593
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
-msgstr "Éjecter"
+msgstr "Ã‰jecter"
 
-#: action.c:2403
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "La suppression d'objets comme "
 
-#: action.c:2407
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "La suppression de l'objet "
 
-#: action.c:2409
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "La suppression des objets "
 
-#: action.c:2428
+#: action.c:2900
 msgid " and "
 msgstr " et "
 
-#: action.c:2437
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr ""
 " affectera des objets sur le punaiseur ou le panneau - voulez-vous vraiment "
-"le supprimer ?"
+"le supprimerÂ ?"
 
-#: action.c:2444
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr ""
 " affectera des objets sur le punaiseur ou le panneau - voulez-vous vraiment "
-"les supprimer ?"
+"les supprimerÂ ?"
 
-#: appmenu.c:197
+#: appmenu.c:206
 msgid "<missing label>"
-msgstr "<étiquette manquante>"
+msgstr "<Ã©tiquette manquante>"
 
-#: appmenu.c:320
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
 "menu for all items of this type (%s/%s)."
 msgstr ""
-"Faites un lien symbolique des programmes que vous voulez dans ce répertoire. "
-"Ils apparaîtront dans le menu pour tous les objets de ce type (%s/%s)."
+"Faites un lien symbolique des programmes que vous voulez dans ce rÃ©pertoire. "
+"Ils apparaÃ®tront dans le menu pour tous les objets de ce type (%s/%s)."
 
-#: appmenu.c:364 menu.c:233
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Personnaliser le menu..."
 
-#: appmenu.c:421 menu.c:250 toolbar.c:158
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Aide"
 
-#: bookmarks.c:145
-msgid "Path"
-msgstr "Chemin"
-
-#: bookmarks.c:153
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Titre"
 
-#: bookmarks.c:302
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Chemin"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Impossible de mettre en signet la ressource non locale '%s'\n"
 
-#: bookmarks.c:310 bookmarks.c:628
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
-msgstr "'%s' n'est pas un répertoire"
+msgstr "'%s' n'est pas un rÃ©pertoire"
 
-#: bookmarks.c:516
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
-msgstr "Vous devez d'abord sélectionner des rangées à supprimer"
+msgstr "Vous devez d'abord sÃ©lectionner des rangÃ©es Ã  supprimer"
 
-#: bookmarks.c:540
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
-msgstr "Placez le curseur sur une entrée de la liste pour la déplacer"
+msgstr "Placez le curseur sur une entrÃ©e de la liste pour la dÃ©placer"
 
-#: bookmarks.c:560
+#: bookmarks.c:755
 msgid "This item is already at the end"
-msgstr "Cet objet est déjà à la fin"
+msgstr "Cet objet est dÃ©jÃ  Ã  la fin"
 
-#: bookmarks.c:634
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
-msgstr "Impossible de mettre en signets des répertoires non locaux comme '%s'"
+msgstr "Impossible de mettre en signets des rÃ©pertoires non locaux comme '%s'"
 
-#: bookmarks.c:776
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Ajouter un nouveau signet"
 
-#: bookmarks.c:783
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
-msgstr "Éditer les signets"
+msgstr "Ã‰diter les signets"
 
-#: bookmarks.c:788
+#: bookmarks.c:1010
 msgid "Recently Visited"
-msgstr "Récemment visités"
+msgstr "RÃ©cemment visitÃ©s"
 
-#: bulk_rename.c:66
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Renommage en masse de fichiers"
 
-#: bulk_rename.c:69
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Revenir"
 
-#: bulk_rename.c:74
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "Faire de la colonne Nouveau une copie de Ancien"
 
-#: bulk_rename.c:79
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "_Renommer"
 
-#: bulk_rename.c:92
+#: bulk_rename.c:95
 msgid "Replace:"
-msgstr "Remplacer :"
+msgstr "RemplacerÂ :"
 
-#: bulk_rename.c:99
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -829,110 +860,112 @@ msgid ""
 "\\. matches a dot\n"
 "\\.htm$ matches the '.htm' in 'index.htm', etc"
 msgstr ""
-"Ceci est une expression rationnelle à rechercher.\n"
-"^ désigne le début d'un nom de fichier\n"
-"$ désigne la fin\n"
-"\\. désigne un point\n"
-"\\.htm$ correspond à « .htm » dans « index.htm », etc."
+"Ceci est une expression rationnelle Ã  rechercher.\n"
+"^ dÃ©signe le dÃ©but d'un nom de fichier\n"
+"$ dÃ©signe la fin\n"
+"\\. dÃ©signe un point\n"
+"\\.htm$ correspond Ã  Â«Â .htmÂ Â» dans Â«Â index.htmÂ Â», etc."
 
-#: bulk_rename.c:107
+#: bulk_rename.c:109
 msgid "With:"
-msgstr "par :"
+msgstr "parÂ :"
 
-#: bulk_rename.c:114
+#: bulk_rename.c:116
+#, fuzzy
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
-"La première correspondance dans chaque fichier sera remplacé par la chaîne. "
-"Il n'y a pas de caractères spéciaux."
+"La premiÃ¨re correspondance dans chaque fichier sera remplacÃ© par la chaÃ®ne. "
+"Il n'y a pas de caractÃ¨res spÃ©ciaux."
 
-#: bulk_rename.c:118
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Appliquer"
 
-#: bulk_rename.c:121
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
 msgstr ""
 "Faire un chercher-remplacer dans la colonne Nouveau. Les fichiers ne sont "
-"pas réellement renommés jursqu'à ce que vous cliquiez sur le bouton Renommer "
+"pas rÃ©ellement renommÃ©s jursqu'Ã  ce que vous cliquiez sur le bouton Renommer "
 "ci-dessous."
 
-#: bulk_rename.c:140
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Ancien nom"
 
-#: bulk_rename.c:149
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Nouveau nom"
 
-#: bulk_rename.c:257
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr ""
-"Aucune chaîne (dans la colonne Nouveau) ne correspond à l'expression donnée"
+"Aucune chaÃ®ne (dans la colonne Nouveau) ne correspond Ã  l'expression donnÃ©e"
 
-#: bulk_rename.c:262
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
-msgstr "Un nom correspond, mais le résultat est le même"
+msgstr "Un nom correspond, mais le rÃ©sultat est le mÃªme"
 
-#: bulk_rename.c:265
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
-msgstr "%d noms correspondent, mais les résultats sont tous les mêmes"
+msgstr "%d noms correspondent, mais les rÃ©sultats sont tous les mÃªmes"
 
-#: bulk_rename.c:291
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr ""
-"Donnez une expression rationnelle et une chaîne de remplacement "
+"Donnez une expression rationnelle et une chaÃ®ne de remplacement "
 "correspondante."
 
-#: bulk_rename.c:308
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (pour '%s')"
 
-#: bulk_rename.c:341
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
-msgstr "Un fichier nommé '%s' existe déjà. Renommage en masse abandonné."
+msgstr "Un fichier nommÃ© '%s' existe dÃ©jÃ . Renommage en masse abandonnÃ©."
 
-#: bulk_rename.c:346
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
 "%s\n"
 "Aborting bulk rename."
 msgstr ""
-"Impossible de renommer '%s' en '%s' :\n"
+"Impossible de renommer '%s' en '%s'Â :\n"
 "%s\n"
-"Renommage en masse abandonné."
+"Renommage en masse abandonnÃ©."
 
-#: bulk_rename.c:408
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
-msgstr "Un fichier nommé '%s' existe déjà"
+msgstr "Un fichier nommÃ© '%s' existe dÃ©jÃ "
 
-#: bulk_rename.c:419
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
 "files to end up in different directories. Continue?"
 msgstr ""
-"Certains des noms de « Nouveau » contiennent des caractères / (e.g. '%s'). "
-"Ceci causera le déplacement des fichiers dans des répertoires différents. "
-"Continuer ?"
+"Certains des noms de Â«Â NouveauÂ Â» contiennent des caractÃ¨res / (e.g. '%s'). "
+"Ceci causera le dÃ©placement des fichiers dans des rÃ©pertoires diffÃ©rents. "
+"ContinuerÂ ?"
 
-#: bulk_rename.c:434
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
-msgstr "Aucun des noms n'a changé. Rien à faire !"
+msgstr "Aucun des noms n'a changÃ©. Rien Ã  faireÂ !"
 
 #: choices.c:434
 #, c-format
 msgid "%d directories could not be migrated"
-msgstr "%d répertoires n'ont pas pu être migrés"
+msgstr "%d rÃ©pertoires n'ont pas pu Ãªtre migrÃ©s"
 
 #: choices.c:436
 #, c-format
@@ -943,48 +976,68 @@ msgid ""
 "%s\n"
 "%s"
 msgstr ""
-"Les choix ont été déplacés de \n"
+"Les choix ont Ã©tÃ© dÃ©placÃ©s de \n"
 "%s\n"
-" à leur nouvel emplacement \n"
+" Ã  leur nouvel emplacement \n"
 "%s\n"
 "%s"
 
-#: dir.c:980
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
-msgstr "Impossible de faire un stat du répertoire : %s"
+msgstr "Impossible de faire un stat du rÃ©pertoireÂ : %s"
 
-#: dir.c:989
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
-msgstr "Impossible d'ouvrir le répertoire : %s"
+msgstr "Impossible d'ouvrir le rÃ©pertoireÂ : %s"
 
-#: display.c:629
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Taille"
+
+#: display.c:705
+msgid "â”¤"
+msgstr ""
+
+#: display.c:706
+msgid "â”"
+msgstr ""
+
+#: display.c:707
+msgid "â”˜"
+msgstr ""
+
+#: display.c:709
+msgid "â”œ"
+msgstr ""
+
+#: display.c:709
+msgid "â”Œ"
+msgstr ""
+
+#: display.c:710
+msgid "â”¼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
-msgstr "lstat(2) a échoué : %s"
+msgstr "lstat(2) a Ã©chouÃ©Â : %s"
 
-#: dnd.c:124
-msgid "Link (relative)"
-msgstr "Lien (relatif)"
-
-#: dnd.c:125
-msgid "Link (absolute)"
-msgstr "Lien (absolu)"
-
-#: dnd.c:424
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Erreur interne - mauvais type d'info"
 
-#: dnd.c:563
+#: dnd.c:565
 msgid "Drag a directory here to bookmark it."
-msgstr "Faites glisser ici un répertoire pour le mettre en signet."
+msgstr "Faites glisser ici un rÃ©pertoire pour le mettre en signet."
 
-#: dnd.c:578
+#: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
-msgstr "Erreur de protocole XDS : le nom de fichier ne doit pas contenir '/'\n"
+msgstr "Erreur de protocole XDSÂ : le nom de fichier ne doit pas contenir '/'\n"
 
-#: dnd.c:603
+#: dnd.c:605
 msgid ""
 "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
 "plain) did not contain a leafname\n"
@@ -992,18 +1045,18 @@ msgstr ""
 "Cible XdndDirectSave0 fournie, mais l'atome XdndDirectSave0 (type text/"
 "plain) ne contenait pas de nom de fichier (feuille)\n"
 
-#: dnd.c:616
+#: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
-msgstr "Désolé - j'ai besoin d'un type cible text/uri-list ou XdndDirectSave0."
+msgstr "DÃ©solÃ© - j'ai besoin d'un type cible text/uri-list ou XdndDirectSave0."
 
-#: dnd.c:619
+#: dnd.c:621
 msgid ""
 "Sorry - I require a target type of text/uri-list or application/octet-stream."
 msgstr ""
-"Désolé - j'ai besoin d'un type cible text/uri-list ou application/octet-"
+"DÃ©solÃ© - j'ai besoin d'un type cible text/uri-list ou application/octet-"
 "stream."
 
-#: dnd.c:689
+#: dnd.c:691
 #, c-format
 msgid ""
 "Failed to add some items to the pinboard, because they are on a remote "
@@ -1012,74 +1065,92 @@ msgid ""
 "%s"
 msgstr ""
 "Impossible d'ajouter certains objets sur le punaiseur, parce qu'ils sont sur "
-"une machine distante. Par exemple :\n"
+"une machine distante. Par exempleÂ :\n"
 "\n"
 "%s"
 
-#: dnd.c:764
+#: dnd.c:766
 msgid "Unknown target"
 msgstr "Cible inconnue"
 
-#: dnd.c:797
+#: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
 msgstr ""
-"L'application distante ne peut pas ou ne veut pas m'envoyer les données - "
-"désolé"
+"L'application distante ne peut pas ou ne veut pas m'envoyer les donnÃ©es - "
+"dÃ©solÃ©"
 
-#: dnd.c:810
+#: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
 msgstr ""
-"Erreur de protocole XDS : le code de retour devrait être 'S', 'F' ou 'E'\n"
+"Erreur de protocole XDSÂ : le code de retour devrait Ãªtre 'S', 'F' ou 'E'\n"
 
-#: dnd.c:843
+#: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
 msgstr ""
-"Désolé, impossible d'afficher un menu des actions pour un fichier distant / "
-"des données brutes."
+"DÃ©solÃ©, impossible d'afficher un menu des actions pour un fichier distant / "
+"des donnÃ©es brutes."
 
-#: dnd.c:859
+#: dnd.c:861
 msgid "UntitledData"
 msgstr "UntitledData"
 
-#: dnd.c:886
+#: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
-msgstr "Erreur lors de la sauvegarde du fichier : %s"
+msgstr "Erreur lors de la sauvegarde du fichierÂ : %s"
 
-#: dnd.c:959
+#: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
-msgstr "Pas d'URI dans le text/uri-list (il n'y a rien à faire !)"
+msgstr "Pas d'URI dans le text/uri-list (il n'y a rien Ã  faire !)"
 
-#: dnd.c:991
+#: dnd.c:993
 msgid ""
 "Can't get data from remote machine (application/octet-stream not provided)"
 msgstr ""
-"Impossible d'obtenir les données de la machine distante (application/octet-"
+"Impossible d'obtenir les donnÃ©es de la machine distante (application/octet-"
 "stream non fourni)"
 
-#: dnd.c:1014
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
-"Certains de ces fichiers sont sur une machine différente - ils seront "
-"ignorés - désolé"
+"Certains de ces fichiers sont sur une machine diffÃ©rente - ils seront "
+"ignorÃ©s - dÃ©solÃ©"
 
-#: dnd.c:1021
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
 msgstr ""
 "Aucun de ces fichiers n'est sur la machine locale - je ne peux pas traiter "
-"de multiples fichiers distants - désolé."
+"de multiples fichiers distants - dÃ©solÃ©."
 
-#: dnd.c:1034
+#: dnd.c:1040
 msgid "Unknown action requested"
-msgstr "Action demandée inconnue"
+msgstr "Action demandÃ©e inconnue"
 
-#: dnd.c:1042
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
-msgstr "Erreur lors du chargement de la liste des fichiers : %s"
+msgstr "Erreur lors du chargement de la liste des fichiersÂ : %s"
+
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Lien (relatif)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Lien (absolu)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Lien (relatif)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Lien (absolu)"
 
 #: dropbox.c:112
 msgid "Show"
@@ -1087,7 +1158,7 @@ msgstr "Montrer"
 
 #: dropbox.c:118
 msgid "Show the current choice in a filer window"
-msgstr "Montrer le choix courant dans une fenêtre du filer"
+msgstr "Montrer le choix courant dans une fenÃªtre du filer"
 
 #: dropbox.c:172
 msgid "<nothing>"
@@ -1098,176 +1169,213 @@ msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
 msgstr ""
-"Je ne peux pas vous montrer l'objet actuellement fixé, parce que rien n'est "
-"fixé actuellement. Faites glisser quelque chose ici !"
+"Je ne peux pas vous montrer l'objet actuellement fixÃ©, parce que rien n'est "
+"fixÃ© actuellement. Faites glisser quelque chose iciÂ !"
 
 #: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
 msgstr ""
-"Désolé, vous devez faire glisser exactement un seul fichier sur la zone de "
-"dépôt."
+"DÃ©solÃ©, vous devez faire glisser exactement un seul fichier sur la zone de "
+"dÃ©pÃ´t."
 
 #: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr ""
-"Désolé, je ne peux pas utiliser '%s' parce que ce n'est pas un fichier local."
+"DÃ©solÃ©, je ne peux pas utiliser '%s' parce que ce n'est pas un fichier local."
 
-#: dropbox.c:278 pinboard.c:858
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
 "%s"
 msgstr ""
-"Impossible d'accéder à '%s' :\n"
+"Impossible d'accÃ©der Ã  '%s'Â :\n"
 "%s"
 
-#: filer.c:456
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
 "%s\n"
 msgstr ""
-"Erreur lors de la lecture de '%s' :\n"
+"Erreur lors de la lecture de '%s'Â :\n"
 "%s\n"
 
-#: filer.c:460
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Erreur lors de la lecture de '%s' :\n"
-"%s"
-
-#: filer.c:576
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
 "Unmounting a device makes it safe to remove the disk."
 msgstr ""
-"Voulez-vous démonter ce fichier de périphérique (« device ») ?\n"
+"Voulez-vous dÃ©monter ce fichier de pÃ©riphÃ©rique (Â«Â deviceÂ Â»)Â ?\n"
 "\n"
-"Démonter un fichier de périphérique permet d'enlever le disque de manière "
+"DÃ©monter un fichier de pÃ©riphÃ©rique permet d'enlever le disque de maniÃ¨re "
 "sure."
 
-#: filer.c:580
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 msgid "No change"
 msgstr "Pas de changement"
 
-#: filer.c:586 menu.c:865
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
-msgstr "Démonter"
+msgstr "DÃ©monter"
 
-#: filer.c:690
-msgid "Directory missing/deleted"
-msgstr "Répertoire manquant/supprimé"
-
-#: filer.c:1054
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
 "Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"Le groupe %s n'est pas défini. Sélectionnez des fichiers et appuyez sur "
-"<Ctrl>+%s pour le définir. Appuyez seulement sur %s pour resélectionner ces "
-"fichiers à l'avenir.\n"
-"Assurez-vous que NumLock est activé si vous utilisez le pavé numérique."
+"Le groupe %s n'est pas dÃ©fini. SÃ©lectionnez des fichiers et appuyez sur "
+"<Ctrl>+%s pour le dÃ©finir. Appuyez seulement sur %s pour resÃ©lectionner ces "
+"fichiers Ã  l'avenir.\n"
+"Assurez-vous que NumLock est activÃ© si vous utilisez le pavÃ© numÃ©rique."
 
-#: filer.c:1290
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Le répertoire '%s' n'est pas accessible"
-
-#: filer.c:1442
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Répertoire '%s' non trouvé."
-
-#: filer.c:1742
-msgid "Cancel"
-msgstr "Annuler"
-
-#: filer.c:2023
+#: filer.c:2655
 msgid "A"
 msgstr "T"
 
-#: filer.c:2025 find.c:923
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr "G"
 
-#: filer.c:2030
+#: filer.c:2664
 msgid "S"
 msgstr "L"
 
-#: filer.c:2032
+#: filer.c:2669
 msgid "T"
 msgstr "V"
 
-#: filer.c:2042
-msgid "All, "
-msgstr "Tous, "
+#: filer.c:2670
+msgid "D"
+msgstr ""
 
-#: filer.c:2045
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
 msgstr "Glob (%s), "
 
-#: filer.c:2053
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Lecture, "
 
-#: filer.c:2055
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Vignettes, "
 
-#: filer.c:2331
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Vignettes, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Lien symbolique vers "
 
-#: filer.c:2373
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr ""
 "Ce nom de fichier n'est pas en UTF-8 valide. Vous devriez le renommer.\n"
 
-#: filer.c:2684 menu.c:1994
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
-msgstr "L'objet n'existe plus !"
+msgstr "L'objet n'existe plusÂ !"
 
-#: filer.c:3411
+#: filer.c:4451
+msgid "â–¼"
+msgstr ""
+
+#: filer.c:4451
+msgid "â–½"
+msgstr ""
+
+#: filer.c:4462
+msgid "â–·"
+msgstr ""
+
+#: filer.c:4462
+msgid "â–¶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
-msgstr "Sélectionnez des propriétés d'affichage à sauver"
+msgstr "SÃ©lectionnez des propriÃ©tÃ©s d'affichage Ã  sauver"
 
-#: filer.c:3418
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "SÃ©lectionnez des propriÃ©tÃ©s d'affichage Ã  sauver"
+
+#: filer.c:4727
 msgid "Position"
 msgstr "Position"
 
-#: filer.c:3423 toolbar.c:133 toolbar.c:137 tips:66
-msgid "Size"
-msgstr "Taille"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "FenÃªtre"
 
-#: filer.c:3428
+#: filer.c:4737
 msgid "Show hidden"
-msgstr "Montrer les fichiers cachés"
+msgstr "Montrer les fichiers cachÃ©s"
 
-#: filer.c:3434
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Style d'affichage"
 
-#: filer.c:3440
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Type de tri et ordre"
 
-#: filer.c:3445 toolbar.c:141
+#: filer.c:4754
 msgid "Details"
-msgstr "Détails"
+msgstr "DÃ©tails"
 
-#: filer.c:3450 tips:119 tips:120
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Vignettes"
 
-#: filer.c:3456
+#: filer.c:4765
 msgid "Filter"
 msgstr "Filtre"
 
@@ -1289,7 +1397,7 @@ msgstr "prune"
 
 #: find.c:648
 msgid "After"
-msgstr "Après"
+msgstr "AprÃ¨s"
 
 #: find.c:650
 msgid "Before"
@@ -1305,7 +1413,7 @@ msgstr "EstLien"
 
 #: find.c:748
 msgid "IsDir"
-msgstr "EstRép"
+msgstr "EstRÃ©p"
 
 #: find.c:750
 msgid "IsChar"
@@ -1317,7 +1425,7 @@ msgstr "EstBloc"
 
 #: find.c:754
 msgid "IsDev"
-msgstr "EstPér"
+msgstr "EstPÃ©r"
 
 #: find.c:756
 msgid "IsPipe"
@@ -1353,7 +1461,7 @@ msgstr "EstInscriptible"
 
 #: find.c:772
 msgid "IsExecutable"
-msgstr "EstExécutable"
+msgstr "EstExÃ©cutable"
 
 #: find.c:774
 msgid "IsEmpty"
@@ -1361,7 +1469,7 @@ msgstr "EstVide"
 
 #: find.c:776
 msgid "IsMine"
-msgstr "EstÀMoi"
+msgstr "EstÃ€Moi"
 
 #: find.c:904
 msgid "Now"
@@ -1445,7 +1553,7 @@ msgstr "Ans"
 
 #: find.c:944
 msgid "Ago"
-msgstr "Passé"
+msgstr "PassÃ©"
 
 #: find.c:946
 msgid "Hence"
@@ -1489,29 +1597,29 @@ msgstr "blocs"
 
 #: gtksavebox.c:249
 msgid "Save As:"
-msgstr "Sauver sous :"
+msgstr "Sauver sousÂ :"
 
-#: gtksavebox.c:395
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "SansNom"
 
-#: gtksavebox.c:471
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
 msgstr ""
-"L'application distante veut utiliser « Direct Save », mais je ne peux pas "
-"lire la propriété XdndDirectSave0 (type text/plain).\n"
+"L'application distante veut utiliser Â«Â Direct SaveÂ Â», mais je ne peux pas "
+"lire la propriÃ©tÃ© XdndDirectSave0 (type text/plain).\n"
 
-#: gtksavebox.c:596
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
 msgstr ""
-"Faites glisser l'icône vers une fenêtre répertoire\n"
+"Faites glisser l'icÃ´ne vers une fenÃªtre rÃ©pertoire\n"
 "(ou entrez un chemin complet)"
 
-#: gui_support.c:329
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1519,14 +1627,14 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:398
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr ""
 "Tentative de lecture d'un fichier XML en tant que fichier texte. Le fichier "
-"'%s' est peut-être altéré."
+"'%s' est peut-Ãªtre altÃ©rÃ©."
 
-#: gui_support.c:415
+#: gui_support.c:542
 #, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
@@ -1536,31 +1644,31 @@ msgid ""
 "the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
-"Erreur dans le fichier '%s' à la ligne %d : \n"
+"Erreur dans le fichier '%s' Ã  la ligne %dÂ : \n"
 "\"%s\"\n"
-"Cela peut être dû à la mise à jour depuis une version antérieure de ROX-"
-"Filer. Ouvrez la fenêtre « Options » et essayez de changer quelque chose "
-"puis de le remettre à la valeur voulue (pour que le fichier soit resauvé).\n"
-"Les erreurs suivantes seront ignorées."
+"Cela peut Ãªtre dÃ» Ã  la mise Ã  jour depuis une version antÃ©rieure de ROX-"
+"Filer. Ouvrez la fenÃªtre Â«Â OptionsÂ Â» et essayez de changer quelque chose "
+"puis de le remettre Ã  la valeur voulue (pour que le fichier soit resauvÃ©).\n"
+"Les erreurs suivantes seront ignorÃ©es."
 
-#: gui_support.c:1007
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
-msgstr "Fin de ligne incorrecte ou manquante dans les données text/uri-list"
+msgstr "Fin de ligne incorrecte ou manquante dans les donnÃ©es text/uri-list"
 
-#: gui_support.c:1339
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
-msgstr "Impossible d'ouvrir le fichier '%s' : %s"
+msgstr "Impossible d'ouvrir le fichier '%s'Â : %s"
 
-#: gui_support.c:1383
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
 msgstr ""
-"Impossible de charger l'image '%s' : raison inconnue, probablement un "
+"Impossible de charger l'image '%s'Â : raison inconnue, probablement un "
 "fichier d'image corrompu"
 
-#: gui_support.c:1434
+#: gui_support.c:1583
 #, c-format
 msgid ""
 "This program (%s) cannot be run, as the 0launch command is not available. It "
@@ -1569,352 +1677,396 @@ msgid ""
 "http://0install.net/injector.html"
 msgstr ""
 "Ce programme (%s) ne peut pas tourner, car la commande 0launch n'est pas "
-"disponible. Elle peut être téléchargée d'ici :\n"
+"disponible. Elle peut Ãªtre tÃ©lÃ©chargÃ©e d'iciÂ :\n"
 "\n"
 "http://0install.net/injector.html"
 
-#: i18n.c:36
+#: i18n.c:39
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
 msgstr ""
 "Noter que vous devez sauver vos choix et relancer le filer pour que la "
-"nouvelle langue soit entièrement supportée."
+"nouvelle langue soit entiÃ¨rement supportÃ©e."
 
-#: icon.c:76
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(cliquer pour fixer)"
 
-#: icon.c:131
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:132 menu.c:251
-msgid "About ROX-Filer..."
-msgstr "Au sujet de ROX-Filer..."
-
-#: icon.c:133 menu.c:252
-msgid "Show Help Files"
-msgstr "Voir les fichiers d'aide"
-
-#: icon.c:134 menu.c:253
-msgid "Manual"
-msgstr "Manuel"
-
-#: icon.c:136 menu.c:229
-msgid "Options..."
-msgstr "Options..."
-
-#: icon.c:137 menu.c:238
-msgid "Home Directory"
-msgstr "Répertoire personnel"
-
-#: icon.c:138 icon.c:1389 menu.c:206 type.c:221
-msgid "File"
-msgstr "Fichier"
-
-#: icon.c:139 menu.c:212 menu.c:878
-msgid "Shift Open"
-msgstr "Shift Ouvrir"
-
-#: icon.c:140 menu.c:217
-msgid "Properties"
-msgstr "Propriétés"
-
-#: icon.c:141 menu.c:215
-msgid "Set Run Action..."
-msgstr "Fixer l'action d'exécution..."
-
-#: icon.c:142 menu.c:216
-msgid "Set Icon..."
-msgstr "Fixer l'icône..."
-
-#: icon.c:143 icon.c:846
-msgid "Edit Item"
-msgstr "Éditer l'objet"
-
-#: icon.c:144
-msgid "Show Location"
-msgstr "Voir l'emplacement"
-
-#: icon.c:145
-msgid "Remove Item(s)"
-msgstr "Enlever le(s) objet(s)"
-
-#: icon.c:297 menu.c:767
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:310
+#: icon.c:311
 msgid "Nothing"
 msgstr "Rien"
 
-#: icon.c:571
+#: icon.c:576
 msgid "The location must contain at least one character!"
-msgstr "L'emplacement doit contenir au moins un caractère !"
+msgstr "L'emplacement doit contenir au moins un caractÃ¨re !"
 
-#: icon.c:636
+#: icon.c:641
 #, c-format
 msgid "You must unlock '%s' before removing it"
-msgstr "Vous devez déverrouiller '%s' avant de l'enlever"
+msgstr "Vous devez dÃ©verrouiller '%s' avant de l'enlever"
 
-#: icon.c:646
+#: icon.c:651
 msgid "You must first select some items to remove"
-msgstr "Vous devez d'abord sélectionner des objets à enlever"
+msgstr "Vous devez d'abord sÃ©lectionner des objets Ã  enlever"
 
-#: icon.c:652
+#: icon.c:657
 msgid "An item must be unlocked before it can be removed."
-msgstr "Un objet doit être déverrouillé avant qu'il puisse être enlevé."
+msgstr "Un objet doit Ãªtre dÃ©verrouillÃ© avant qu'il puisse Ãªtre enlevÃ©."
 
-#: icon.c:666
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Vous devez ouvrir le menu au-dessus d'un objet"
 
-#: icon.c:691 menu.c:1274
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr ""
-"Vous ne pouvez fixer l'action d'exécution que pour un fichier ordinaire"
+"Vous ne pouvez fixer l'action d'exÃ©cution que pour un fichier ordinaire"
 
-#: icon.c:777
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
-msgstr "Appuyer sur le raccourci désiré (e.g. Control+F1)"
+msgstr "Appuyer sur le raccourci dÃ©sirÃ© (e.g. Control+F1)"
 
-#: icon.c:799
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
-msgstr "Impossible de récupérer l'événement clavier !"
+msgstr "Impossible de rÃ©cupÃ©rer l'Ã©vÃ©nement clavierÂ !"
 
-#: icon.c:849
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Ã‰diter l'objet"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
-msgstr "Un clic sur l'icône ouvre :"
+msgstr "Un clic sur l'icÃ´ne ouvreÂ :"
 
-#: icon.c:859
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
-msgstr "Arguments à passer (pour les exécutables) :"
+msgstr "Arguments Ã  passer (pour les exÃ©cutables)Â :"
 
-#: icon.c:873
+#: icon.c:877
 msgid "The text displayed under the icon is:"
-msgstr "Le texte affiché au-dessous de l'icône est :"
+msgstr "Le texte affichÃ© au-dessous de l'icÃ´ne estÂ :"
 
-#: icon.c:886
+#: icon.c:890
 msgid "The keyboard shortcut is:"
-msgstr "Le raccourci clavier est :"
+msgstr "Le raccourci clavier estÂ :"
 
-#: icon.c:906
+#: icon.c:910
 msgid "Locked"
-msgstr "Verrouillé"
+msgstr "VerrouillÃ©"
 
-#: icon.c:911
+#: icon.c:915
 msgid "Locking an item prevents it from being accidentally removed"
-msgstr "Verrouiller un objet l'empêche d'être accidentellement enlevé"
+msgstr "Verrouiller un objet l'empÃªche d'Ãªtre accidentellement enlevÃ©"
 
-#: infobox.c:111
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Au sujet de ROX-Filer..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Voir les fichiers d'aide"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Manuel"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Options..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "RÃ©pertoire personnel"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Fichier"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Shift Ouvrir"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "PropriÃ©tÃ©s"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Fixer l'action d'exÃ©cution..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Fixer l'icÃ´ne..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Voir l'emplacement"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Enlever le(s) objet(s)"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
-msgstr "Êtes-vous sûr de vouloir ouvrir %d fenêtres ?"
+msgstr "ÃŠtes-vous sÃ»r de vouloir ouvrir %d fenÃªtresÂ ?"
 
-#: infobox.c:112
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Montrer"
 
-#: infobox.c:134 menu.c:772
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(utf-8 incorrect)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Voir les fichiers d'_aide"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Permissions</b>"
 
-#: infobox.c:290
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>Le contenu indique...</b>"
 
-#: infobox.c:427 infobox.c:568 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Ne lister que les rÃ©pertoires copiÃ©s"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "octets"
 
-#: infobox.c:450
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Impossible de lire la taille"
 
-#: infobox.c:511
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' n'est plus un lien symbolique"
 
-#: infobox.c:518
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
 "%s"
 msgstr ""
-"Impossible de supprimer le lien '%s' :\n"
+"Impossible de supprimer le lien '%s'Â :\n"
 "%s"
 
-#: infobox.c:523
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
 "%s\n"
 "(note: old link has been deleted)"
 msgstr ""
-"Impossible de créer le lien symbolique depuis '%s' :\n"
+"Impossible de crÃ©er le lien symbolique depuis '%s'Â :\n"
 "%s\n"
-"(note: l'ancien lien a été supprimé)"
+"(note: l'ancien lien a Ã©tÃ© supprimÃ©)"
 
-#: infobox.c:547 tips:287
+#: infobox.c:579 tips:321
 msgid "Error:"
-msgstr "Erreur :"
+msgstr "ErreurÂ :"
 
-#: infobox.c:554
+#: infobox.c:586
 msgid "Real directory:"
-msgstr "Vrai répertoire :"
-
-#: infobox.c:557
-msgid "Owner, Group:"
-msgstr "Propriétaire, groupe :"
-
-#: infobox.c:564 infobox.c:579 infobox.c:588
-msgid "Size:"
-msgstr "Taille :"
+msgstr "Vrai rÃ©pertoireÂ :"
 
 #: infobox.c:589
+msgid "Owner, Group:"
+msgstr "PropriÃ©taire, groupeÂ :"
+
+#: infobox.c:596 infobox.c:611 infobox.c:620
+msgid "Size:"
+msgstr "TailleÂ :"
+
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Lecture"
 
-#: infobox.c:614
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Impossible de lire"
 
-#: infobox.c:621
+#: infobox.c:653
 msgid "Change time:"
-msgstr "Date de changement :"
+msgstr "Date de changementÂ :"
 
-#: infobox.c:623
+#: infobox.c:655
 msgid "Modify time:"
-msgstr "Date de modification :"
+msgstr "Date de modificationÂ :"
 
-#: infobox.c:625
+#: infobox.c:657
 msgid "Access time:"
-msgstr "Date d'accès :"
+msgstr "Date d'accÃ¨sÂ :"
 
-#: infobox.c:633
+#: infobox.c:665
 msgid "Extended attributes:"
-msgstr "Attributs étendus :"
+msgstr "Attributs Ã©tendusÂ :"
 
-#: infobox.c:635
+#: infobox.c:667
 msgid "Present"
-msgstr "Présents"
+msgstr "PrÃ©sents"
 
-#: infobox.c:636
+#: infobox.c:668
 msgid "None"
 msgstr "Aucun"
 
-#: infobox.c:637
+#: infobox.c:669
 msgid "Not supported"
-msgstr "Non supportés"
+msgstr "Non supportÃ©s"
 
-#: infobox.c:649
+#: infobox.c:681
 msgid "Link target:"
-msgstr "Cible du lien :"
+msgstr "Cible du lienÂ :"
 
-#: infobox.c:661 infobox.c:664
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
-msgstr "Exécuter l'action :"
+msgstr "ExÃ©cuter l'actionÂ :"
 
-#: infobox.c:661
+#: infobox.c:693
 msgid "Execute file"
-msgstr "Exécuter le fichier"
+msgstr "ExÃ©cuter le fichier"
 
-#: infobox.c:773
+#: infobox.c:805
 msgid "Comment"
 msgstr "Commentaire"
 
-#: infobox.c:775
+#: infobox.c:807
 msgid "Execute"
-msgstr "Exécuter"
+msgstr "ExÃ©cuter"
 
-#: infobox.c:789
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<encore rien>"
 
-#: infobox.c:859
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "file(1) dit... %s"
 
-#: infobox.c:916
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
-msgstr "Impossible de changer les permissions : %s"
+msgstr "Impossible de changer les permissionsÂ : %s"
 
-#: infobox.c:934
+#: infobox.c:970 tips:120
 msgid "Owner"
-msgstr "Propriétaire"
+msgstr "PropriÃ©taire"
 
-#: infobox.c:936
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Groupe"
 
-#: infobox.c:938
+#: infobox.c:974
 msgid "World"
 msgstr "Monde"
 
-#: infobox.c:941
+#: infobox.c:977
 msgid "Read"
 msgstr "Lecture"
 
-#: infobox.c:943
+#: infobox.c:980
 msgid "Write"
-msgstr "Écriture"
+msgstr "Ã‰criture"
 
-#: infobox.c:945
+#: infobox.c:983
 msgid "Exec"
-msgstr "Exécution"
+msgstr "ExÃ©cution"
 
-#: infobox.c:962
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:969
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:976
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky"
 
-#: infobox.c:998
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<rien>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Lien symbolique"
 
-#: infobox.c:1001
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "Application ROX"
 
-#: infobox.c:1009
+#: infobox.c:1100
 msgid "mounted"
-msgstr "monté"
+msgstr "montÃ©"
 
-#: infobox.c:1009
+#: infobox.c:1100
 msgid "unmounted"
-msgstr "démonté"
+msgstr "dÃ©montÃ©"
 
-#: infobox.c:1013
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Point de montage pour %s (%s)"
 
-#: infobox.c:1016
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Point de montage (%s)"
 
-#: main.c:93
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d objets"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Copier..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "Ã‰diter l'objet"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Dates & heures"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Options"
+
+#: main.c:95
 msgid ""
 "Copyright (C) 2005 Thomas Leonard.\n"
 "ROX-Filer comes with ABSOLUTELY NO WARRANTY,\n"
@@ -1925,30 +2077,30 @@ msgid ""
 msgstr ""
 "Copyright (C) 2005 Thomas Leonard.\n"
 "ROX-Filer est fourni SANS GARANTIE AUCUNE,\n"
-"sans préjudice des termes prévus par la loi.\n"
+"sans prÃ©judice des termes prÃ©vus par la loi.\n"
 "Vous pouvez redistribuer des copies de ROX-Filer\n"
 "selon les termes de la GNU General Public License.\n"
-"Pour plus d'information à ce sujet, voir le fichier « COPYING ».\n"
+"Pour plus d'information Ã  ce sujet, voir le fichier Â«Â COPYINGÂ Â».\n"
 
-#: main.c:102
+#: main.c:104
 msgid "Try `ROX-Filer/AppRun --help' for more information.\n"
 msgstr "Essayer `ROX-Filer/AppRun --help' pour plus d'information.\n"
 
-#: main.c:105
+#: main.c:107
 msgid "Try `ROX-Filer/AppRun -h' for more information.\n"
 msgstr "Essayer `ROX-Filer/AppRun -h' pour plus d'information.\n"
 
-#: main.c:107
+#: main.c:109
 msgid ""
 "NOTE: Your system does not support long options - \n"
 "you must use the short versions instead.\n"
 "\n"
 msgstr ""
-"NOTE : votre système ne supporte pas les options longues - \n"
-"vous devez utiliser les versions courtes à la place.\n"
+"NOTEÂ : votre systÃ¨me ne supporte pas les options longues - \n"
+"vous devez utiliser les versions courtes Ã  la place.\n"
 "\n"
 
-#: main.c:113
+#: main.c:115
 #, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
@@ -1978,97 +2130,98 @@ msgid ""
 "Report bugs to %s.\n"
 "Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
-"Syntaxe : ROX-Filer/AppRun [OPTION]... [FICHIER]...\n"
-"Ouvre chaque répertoire ou fichier listé, ou le répertoire de travail\n"
-"courant si aucun argument n'est donné.\n"
+"SyntaxeÂ : ROX-Filer/AppRun [OPTION]... [FICHIER]...\n"
+"Ouvre chaque rÃ©pertoire ou fichier listÃ©, ou le rÃ©pertoire de travail\n"
+"courant si aucun argument n'est donnÃ©.\n"
 "\n"
 "  -b, --border=PANNEAU\touvre PANNEAU comme panneau (sur un bord)\n"
 "  -B, --bottom=PANNEAU\touvre PANNEAU en bas comme panneau\n"
-"  -c, --client-id=ID\tutilisé pour la gestion de sessions\n"
-"  -d, --dir=RÉPERTOIRE\touvre RÉPERTOIRE comme répertoire (pas application)\n"
-"  -D, --close=RÉP\tferme RÉPERTOIRE et ses sous-répertoires\n"
+"  -c, --client-id=ID\tutilisÃ© pour la gestion de sessions\n"
+"  -d, --dir=RÃ‰PERTOIRE\touvre RÃ‰PERTOIRE comme rÃ©pertoire (pas application)\n"
+"  -D, --close=RÃ‰P\tferme RÃ‰PERTOIRE et ses sous-rÃ©pertoires\n"
 "  -h, --help\t\taffiche cette aide et quitte\n"
-"  -l, --left=PANNEAU\touvre PANNEAU à gauche comme panneau\n"
+"  -l, --left=PANNEAU\touvre PANNEAU Ã  gauche comme panneau\n"
 "  -m, --mime-type=FICH\taffiche le type MIME de FICHIER et quitte\n"
-"  -n, --new\t\tlance une nouvelle copie ; pour débugger le filer\n"
+"  -n, --new\t\tlance une nouvelle copieÂ ; pour dÃ©bugger le filer\n"
 "  -p, --pinboard=PUN\tutilise le punaiseur PUN comme punaiseur\n"
-"  -r, --right=PANNEAU\touvre PANNEAU à droite comme panneau\n"
-"  -R, --RPC\t\tinvoque la méthode d'appel lue sur stdin\n"
-"  -s, --show=FICHIER\touvre un répertoire montrant FICHIER\n"
-"  -S, --rox-session\toptions par défaut de panneau et punaiseur, et -n\n"
+"  -r, --right=PANNEAU\touvre PANNEAU Ã  droite comme panneau\n"
+"  -R, --RPC\t\tinvoque la mÃ©thode d'appel lue sur stdin\n"
+"  -s, --show=FICHIER\touvre un rÃ©pertoire montrant FICHIER\n"
+"  -S, --rox-session\toptions par dÃ©faut de panneau et punaiseur, et -n\n"
 "  -t, --top=PANNEAU\touvre PANNEAU en haut comme panneau\n"
-"  -u, --user\t\taffiche le nom de l'utilisateur dans chaque fenêtre\n"
-"  -U, --url=URL\t\touvre un fichier ou répertoire donné sous forme d'URI\n"
+"  -u, --user\t\taffiche le nom de l'utilisateur dans chaque fenÃªtre\n"
+"  -U, --url=URL\t\touvre un fichier ou rÃ©pertoire donnÃ© sous forme d'URI\n"
 "  -v, --version\t\taffiche les info concernant cette version et quitte\n"
-"  -x, --examine=FICH\tFICHIER a changé - le ré-examiner\n"
+"  -x, --examine=FICH\tFICHIER a changÃ© - le rÃ©-examiner\n"
 "\n"
-"Rendre compte des bugs à %s.\n"
-"Page web (dont les versions mises à jour): http://rox.sourceforge.net/\n"
+"Rendre compte des bugs Ã  %s.\n"
+"Page web (dont les versions mises Ã  jour): http://rox.sourceforge.net/\n"
 
-#: main.c:235
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Trying to continue..."
 msgstr ""
-"Nous avons eu une erreur BadWindow du serveur X. Ceci peut être dû au bug de "
-"GTK (pendant le glisser-déposer ?) :\n"
+"Nous avons eu une erreur BadWindow du serveur X. Ceci peut Ãªtre dÃ» au bug de "
+"GTK (pendant le glisser-dÃ©poserÂ ?)Â :\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Essayons de continuer..."
 
-#: main.c:394
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
 msgstr ""
-"L'argument -o n'est plus utilisé. Vous pouvez activer cette option "
-"« override » de la boîte Options."
+"L'argument -o n'est plus utilisÃ©. Vous pouvez activer cette option "
+"Â«Â overrideÂ Â» de la boÃ®te Options."
 
-#: main.c:522
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
-msgstr "Exécution en tant qu'utilisateur '%s'"
+msgstr "ExÃ©cution en tant qu'utilisateur '%s'"
 
-#: main.c:682
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
-msgstr "Compilé avec GTK version %s\n"
+msgstr "CompilÃ© avec GTK version %s\n"
 
-#: main.c:683
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Tournant avec GTK version %d.%d.%d\n"
 
-#: main.c:687
+#: main.c:693
 msgid "features set at compile time"
-msgstr "fonctionnalités fixées à la compilation"
+msgstr "fonctionnalitÃ©s fixÃ©es Ã  la compilation"
 
-#: main.c:688
+#: main.c:694
 msgid "Large File Support"
 msgstr "Support des fichiers longs"
 
-#: main.c:695
-msgid "Dnotify support"
-msgstr "Support dnotify"
-
-#: main.c:702
+#: main.c:701
 msgid "Binary compatibility"
-msgstr "Compatibilité binaire"
+msgstr "CompatibilitÃ© binaire"
 
-#: main.c:704
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Oui (peut tourner avec des versions plus anciennes de la glibc)"
 
-#: main.c:706
+#: main.c:705
 msgid "No (apsymbols.h not found)"
-msgstr "Non (apsymbols.h non trouvé)"
+msgstr "Non (apsymbols.h non trouvÃ©)"
 
-#: main.c:710
+#: main.c:709
 msgid "Extended attribute support"
-msgstr "Support des attributs étendus"
+msgstr "Support des attributs Ã©tendus"
 
-#: main.c:867
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr "Impossible d'ouvrir le fichier '%s'Â : %s"
+
+#: main.c:895
 #, c-format
 msgid ""
 "Left-click to run %s.\n"
@@ -2077,234 +2230,323 @@ msgstr ""
 "Cliquer avec le bouton gauche pour lancer %s.\n"
 "Cliquer avec le bouton droit pour obtenir une liste de versions."
 
-#: menu.c:179 tips:55
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Erreur lors de la crÃ©ation de '%s'Â : %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Sauver sousÂ :"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Affichage"
 
-#: menu.c:180 tips:60
+#: menu.c:641 tips:49
 msgid "Icons View"
-msgstr "Icônes"
+msgstr "IcÃ´nes"
 
-#: menu.c:181
-msgid "Icons, With..."
-msgstr "Icônes, avec..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
+msgstr "IcÃ´nes, avec..."
 
-#: menu.c:182 tips:79
-msgid "Sizes"
-msgstr "Tailles"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "ThÃ¨me d'icÃ´nes"
 
-#: menu.c:184 tips:271
-msgid "Types"
-msgstr "Types"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Permissions"
 
-#: menu.c:185 tips:82
-msgid "Times"
-msgstr "Dates & heures"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "IcÃ´nes, avec..."
 
-#: menu.c:186 tips:61 tips:97
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "Liste"
 
-#: menu.c:188
+#: menu.c:651
 msgid "Bigger Icons"
-msgstr "Icônes plus grandes"
+msgstr "IcÃ´nes plus grandes"
 
-#: menu.c:189
+#: menu.c:653
 msgid "Smaller Icons"
-msgstr "Icônes plus petites"
+msgstr "IcÃ´nes plus petites"
 
-#: menu.c:190 tips:76
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Automatique"
 
-#: menu.c:192
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Trier par nom"
 
-#: menu.c:193
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Trier par type"
 
-#: menu.c:194
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Trier par date"
 
-#: menu.c:195
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Trier par date"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Trier par date"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Trier par taille"
 
-#: menu.c:196
-msgid "Sort by Owner"
-msgstr "Trier par propriétaire"
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Permissions"
 
-#: menu.c:197
+#: menu.c:668
+msgid "Sort by Owner"
+msgstr "Trier par propriÃ©taire"
+
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "Trier par groupe"
 
-#: menu.c:198
+#: menu.c:671
 msgid "Reversed"
-msgstr "Inversé"
+msgstr "InversÃ©"
 
-#: menu.c:200
+#: menu.c:675
 msgid "Show Hidden"
-msgstr "Montrer les fichiers cachés"
+msgstr "Montrer les fichiers cachÃ©s"
 
-#: menu.c:201
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Voir les fichiers d'aide"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "pas de rÃ©pertoires)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "Filtrer des fichiers..."
 
-#: menu.c:202
-msgid "Filter Directories With Files"
-msgstr "Filtrer les répertoires avec les fichiers"
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Filtrer des fichiers..."
 
-#: menu.c:203
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr "Filtrer les rÃ©pertoires avec les fichiers"
+
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "Montrer les vignettes"
 
-#: menu.c:204
+#: menu.c:683
 msgid "Refresh"
-msgstr "Rafraîchir"
+msgstr "RafraÃ®chir"
 
-#: menu.c:205
-msgid "Save Current Display Settings..."
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "RafraÃ®chir"
+
+#: menu.c:686
+#, fuzzy
+msgid "Save Display Settings..."
 msgstr "Sauver les options d'affichage courantes..."
 
-#: menu.c:207
-msgid "Copy..."
-msgstr "Copier..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Sauver les options d'affichage courantes..."
 
-#: menu.c:208
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Compter"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "Renommer..."
 
-#: menu.c:209
+#: menu.c:700
 msgid "Link..."
 msgstr "Lier..."
 
-#: menu.c:213
+#: menu.c:708
 msgid "Send To..."
-msgstr "Envoyer à..."
+msgstr "Envoyer Ã ..."
 
-#: menu.c:218
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Attributs Ã©tendus"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Compter"
 
-#: menu.c:219
+#: menu.c:723
 msgid "Set Type..."
 msgstr "Fixer le type..."
 
-#: menu.c:223 toolbar.c:154
+#: menu.c:731 toolbar.c:179
 msgid "Select"
-msgstr "Sélectionner"
+msgstr "SÃ©lectionner"
 
-#: menu.c:224
+#: menu.c:733
 msgid "Select All"
-msgstr "Tout sélectionner"
+msgstr "Tout sÃ©lectionner"
 
-#: menu.c:225
+#: menu.c:735
 msgid "Clear Selection"
-msgstr "Oublier la sélection"
+msgstr "Oublier la sÃ©lection"
 
-#: menu.c:226
+#: menu.c:736
 msgid "Invert Selection"
-msgstr "Inverser la sélection"
+msgstr "Inverser la sÃ©lection"
 
-#: menu.c:227
+#: menu.c:737
 msgid "Select by Name..."
-msgstr "Sélectionner par nom..."
+msgstr "SÃ©lectionner par nom..."
 
-#: menu.c:228
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "SÃ©lectionner si..."
+
+#: menu.c:741
 msgid "Select If..."
-msgstr "Sélectionner si..."
+msgstr "SÃ©lectionner si..."
 
-#: menu.c:230
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Nouveau"
 
-#: menu.c:232
+#: menu.c:752
 msgid "Blank file"
 msgstr "Fichier vide"
 
-#: menu.c:234 tasklist.c:306
+#: menu.c:756 tasklist.c:305
 msgid "Window"
-msgstr "Fenêtre"
+msgstr "FenÃªtre"
 
-#: menu.c:235
+#: menu.c:758
 msgid "Parent, New Window"
-msgstr "Père, nouvelle fenêtre"
+msgstr "PÃ¨re, nouvelle fenÃªtre"
 
-#: menu.c:236
+#: menu.c:759
 msgid "Parent, Same Window"
-msgstr "Père, même fenêtre"
+msgstr "PÃ¨re, mÃªme fenÃªtre"
 
-#: menu.c:237
+#: menu.c:761 tips:44
 msgid "New Window"
-msgstr "Nouvelle fenêtre"
+msgstr "Nouvelle fenÃªtre"
 
-#: menu.c:239
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "Montrer les signets"
 
-#: menu.c:240
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Montrer"
+
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "Suivre les liens symboliques"
 
-#: menu.c:241
+#: menu.c:769
 msgid "Resize Window"
-msgstr "Changer taille de la fenêtre"
+msgstr "Changer taille de la fenÃªtre"
 
-#: menu.c:244
+#: menu.c:771
 msgid "Close Window"
-msgstr "Fermer la fenêtre"
+msgstr "Fermer la fenÃªtre"
 
-#: menu.c:246
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Entrer un chemin..."
 
-#: menu.c:247
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Commande shell..."
 
-#: menu.c:248
+#: menu.c:780
 msgid "Terminal Here"
 msgstr "Terminal ici"
 
-#: menu.c:249
+#: menu.c:782
 msgid "Switch to Terminal"
 msgstr "Remplacer par un terminal"
 
-#: menu.c:718
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr ""
-"Vous devez cliquer avec Menu, touche Shift enfoncée, au-dessus d'un fichier "
-"pour l'envoyer quelque part"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Personnaliser le menu..."
 
-#: menu.c:757
+#: menu.c:976
 msgid "Next Click"
 msgstr "Clic suivant"
 
-#: menu.c:779
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d objets"
 
-#: menu.c:867
+#: menu.c:1094
 msgid "Open unmounted"
-msgstr "Ouvrir démonté"
+msgstr "Ouvrir dÃ©montÃ©"
 
-#: menu.c:870
+#: menu.c:1097
 msgid "Show Target"
 msgstr "Voir la cible"
 
-#: menu.c:872
+#: menu.c:1099
 msgid "Look Inside"
-msgstr "Voir à l'intérieur"
+msgstr "Voir Ã  l'intÃ©rieur"
 
-#: menu.c:874
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "Ouvrir en texte"
 
-#: menu.c:1045
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2312,71 +2554,84 @@ msgid ""
 "it may simply be that the filesystem needs to be mounted with the right "
 "mount option ('user_xattr' on Linux)."
 msgstr ""
-"Les attributs étendus, utilisés pour stocker des types, ne sont pas "
-"supportés pour ce ou ces fichiers.\n"
-"Ceci peut être dû à l'absence de support pour le système de fichiers ou la "
-"bibliothèque C, ou bien le système de fichiers doit simplement être monté "
-"avec la bonne option (« user_xattr » sous Linux)."
+"Les attributs Ã©tendus, utilisÃ©s pour stocker des types, ne sont pas "
+"supportÃ©s pour ce ou ces fichiers.\n"
+"Ceci peut Ãªtre dÃ» Ã  l'absence de support pour le systÃ¨me de fichiers ou la "
+"bibliothÃ¨que C, ou bien le systÃ¨me de fichiers doit simplement Ãªtre montÃ© "
+"avec la bonne option (Â«Â user_xattrÂ Â» sous Linux)."
 
-#: menu.c:1051
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
-msgstr "Choix du type non supporté pour certains de ces fichiers"
+msgstr "Choix du type non supportÃ© pour certains de ces fichiers"
 
-#: menu.c:1086
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "_Lien relatif"
 
-#: menu.c:1092
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
 "If off, the path from the root directory is stored - use this if the symlink "
 "may move but the target will stay put."
 msgstr ""
-"Si activée, le lien symbolique sera relatif au répertoire du fichier cible. "
-"Utiliser ceci si le lien et la cible seront déplacés ensemble.\n"
-"Si désactivée, le lien symbolique est absolu - utiliser ceci si le lien peut "
-"être déplacé sans que la cible bouge."
+"Si activÃ©e, le lien symbolique sera relatif au rÃ©pertoire du fichier cible. "
+"Utiliser ceci si le lien et la cible seront dÃ©placÃ©s ensemble.\n"
+"Si dÃ©sactivÃ©e, le lien symbolique est absolu - utiliser ceci si le lien peut "
+"Ãªtre dÃ©placÃ© sans que la cible bouge."
 
-#: menu.c:1162
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "Le nouveau chemin n'est pas absolu"
 
-#: menu.c:1228
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
-msgstr "Un lien depuis '%s' existe déjà. Le remplacer par un lien vers '%s' ?"
+msgstr "Un lien depuis '%s' existe dÃ©jÃ . Le remplacer par un lien vers '%s'Â ?"
 
-#: menu.c:1234
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Remplacer"
 
-#: menu.c:1354 menu.c:1395 menu.c:1455
-msgid "Create"
-msgstr "Créer"
-
-#: menu.c:1355
+#: menu.c:1704
 msgid "NewDir"
 msgstr "NouveauRep"
 
-#: menu.c:1369 menu.c:1375
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Erreur lors de la création de '%s' : %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "CrÃ©er"
 
-#: menu.c:1396
+#: menu.c:1755
 msgid "NewFile"
 msgstr "NouveauFichier"
 
-#: menu.c:1414
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr ""
-"Erreur lors de la création du fichier : impossible de trouver le modèle pour "
+"Erreur lors de la crÃ©ation du fichierÂ : impossible de trouver le modÃ¨le pour "
 "%s"
 
-#: menu.c:1485
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Faites un lien symbolique des programmes que vous voulez dans ce rÃ©pertoire. "
+"Ils apparaÃ®tront dans le menu pour tous les objets de ce type (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2388,39 +2643,40 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
-"Le menu `Envoyer à' fournit une manière rapide d'envoyer des fichiers à une "
-"application. Les applications listées sont celles contenues dans les "
-"répertoires suivants :\n"
+"Le menu `Envoyer Ã ' fournit une maniÃ¨re rapide d'envoyer des fichiers Ã  une "
+"application. Les applications listÃ©es sont celles contenues dans les "
+"rÃ©pertoires suivantsÂ :\n"
 "\n"
 "%s\n"
 "%s\n"
-"Le menu `Envoyer à' peut être ouvert par <Shift>+<clic Menu> au-dessus d'un "
+"Le menu `Envoyer Ã ' peut Ãªtre ouvert par <Shift>+<clic Menu> au-dessus d'un "
 "fichier.\n"
 "\n"
-"Utilisation avancée :\n"
-"Vous pouvez aussi créer des sous-répertoires appelés `.text_html', `.text', "
-"etc. qui n'apparaîtront que pour des fichiers de ce type. `.group' n'est "
-"montré que si plusieurs fichiers sont sélectionnés."
+"Utilisation avancÃ©eÂ :\n"
+"Vous pouvez aussi crÃ©er des sous-rÃ©pertoires appelÃ©s `.text_html', `.text', "
+"etc. qui n'apparaÃ®tront que pour des fichiers de ce type. `.group' n'est "
+"montrÃ© que si plusieurs fichiers sont sÃ©lectionnÃ©s."
 
-#: menu.c:1496
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
 msgstr ""
-"Je vais maintenant vous montrer votre répertoire SendTo (« envoyer à ») ; "
-"vous devez y lier (faire glisser avec <Ctrl> et <Shift> enfoncées) les "
+"Je vais maintenant vous montrer votre rÃ©pertoire SendTo (Â«Â envoyer Ã Â Â»)Â ; "
+"vous devez y lier (faire glisser avec <Ctrl> et <Shift> enfoncÃ©es) les "
 "applications voulues."
 
-#: menu.c:1499 menu.c:1539
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr ""
 "Le contenu de votre variable CHOICESPATH ne permet pas la personnalisation - "
-"désolé."
+"dÃ©solÃ©."
 
-#: menu.c:1532
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2431,103 +2687,141 @@ msgid ""
 "%s\n"
 "%s\n"
 msgstr ""
-"Chaque fichier placé dans vos répertoires Templates apparaîtra dans le menu "
-"« Nouveau ». Choisir l'un d'eux en fera une copie comme nouveau fichier.\n"
+"Chaque fichier placÃ© dans vos rÃ©pertoires Templates apparaÃ®tra dans le menu "
+"Â«Â NouveauÂ Â». Choisir l'un d'eux en fera une copie comme nouveau fichier.\n"
 "\n"
-"Les répertoires suivants contiennent des patrons :\n"
+"Les rÃ©pertoires suivants contiennent des patronsÂ :\n"
 "\n"
 "%s\n"
 "%s\n"
 
-#: menu.c:1537
+#: menu.c:1936
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
 msgstr ""
-"Je vais maintenant vous montrer votre répertoire Templates ; vous devez y "
+"Je vais maintenant vous montrer votre rÃ©pertoire TemplatesÂ ; vous devez y "
 "placer les fichiers patrons voulus."
 
-#: menu.c:1654
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Personnaliser"
 
-#: menu.c:1720
-msgid "This is already the canonical name for this directory."
-msgstr "C'est déjà le nom canonique de ce répertoire."
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Personnaliser le menu..."
 
-#: menu.c:1751
+#: menu.c:2169
+msgid "This is already the canonical name for this directory."
+msgstr "C'est dÃ©jÃ  le nom canonique de ce rÃ©pertoire."
+
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
 msgstr ""
-"Vous ne pouvez pas ouvrir une seconde vue de ce répertoire parce que "
-"l'option « Fenêtres Uniques » est activée dans la fenêtre « Options »."
+"Vous ne pouvez pas ouvrir une seconde vue de ce rÃ©pertoire parce que "
+"l'option Â«Â FenÃªtres UniquesÂ Â» est activÃ©e dans la fenÃªtre Â«Â OptionsÂ Â»."
 
-#: menu.c:1877
-msgid "Copy ... ?"
-msgstr "Copier ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1880
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Copier %s vers %sÂ ?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Copier %s vers %sÂ ?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Renommer ... ?"
 
-#: menu.c:1883
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Lien symbolique ... ?"
 
-#: menu.c:1886
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Shift Ouvrir ... ?"
 
-#: menu.c:1889
+#: menu.c:2468
 msgid "Properties of ... ?"
-msgstr "Propriétés de ... ?"
+msgstr "PropriÃ©tÃ©s de ... ?"
 
-#: menu.c:1892
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Attributs Ã©tendus"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Fixer le type de ... ?"
 
-#: menu.c:1895
+#: menu.c:2479
 msgid "Set run action for ... ?"
-msgstr "Fixer l'action d'exécution pour ... ?"
+msgstr "Fixer l'action d'exÃ©cution pour ... ?"
 
-#: menu.c:1898
+#: menu.c:2482
 msgid "Set icon for ... ?"
-msgstr "Fixer l'icône pour ... ?"
+msgstr "Fixer l'icÃ´ne pour ... ?"
 
-#: menu.c:1901
+#: menu.c:2485
 msgid "Send ... to ... ?"
-msgstr "Envoyer ... à ... ?"
+msgstr "Envoyer ... Ã  ... ?"
 
-#: menu.c:1904
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "SUPPRIMER ... ?"
 
-#: menu.c:1907
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Calculer la taille de ... ?"
 
-#: menu.c:1910
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Fixer les permissions de ... ?"
 
-#: menu.c:1913
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Chercher dans ... ?"
 
-#: menu.c:1977
-msgid "You cannot do this to more than one item at a time"
-msgstr "Vous ne pouvez pas appliquer cette action à plus d'un objet à la fois"
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Copier ... ?"
 
-#: menu.c:2009
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
+msgid "You cannot do this to more than one item at a time"
+msgstr "Vous ne pouvez pas appliquer cette action Ã  plus d'un objet Ã  la fois"
+
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Renommer"
 
-#: menu.c:2014
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Lien symbolique"
 
-#: menu.c:2043
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2539,17 +2833,17 @@ msgid ""
 "\tgtk-can-change-accels = 1\n"
 "\t(this only works if NOT using XSETTINGS)"
 msgstr ""
-"Les raccourcis utilisateur sont désactivés par défaut dans Gtk2 et vous ne "
-"les avez pas activés. Vous pouvez activer cette fonctionnalité :\n"
+"Les raccourcis utilisateur sont dÃ©sactivÃ©s par dÃ©faut dans Gtk2 et vous ne "
+"les avez pas activÃ©s. Vous pouvez activer cette fonctionnalitÃ©Â :\n"
 "\n"
 "1) en utilisant un gestionnaire XSettings, comme ROX-Session ou gnome-"
 "settings-daemon ou\n"
 "\n"
-"2) en ajoutant cette ligne à ~/.gtkrc-2.0 :\n"
+"2) en ajoutant cette ligne Ã  ~/.gtkrc-2.0Â :\n"
 "\tgtk-can-change-accels = 1\n"
-"\t(ceci ne marche que si XSETTINGS n'est PAS utilisé)"
+"\t(ceci ne marche que si XSETTINGS n'est PAS utilisÃ©)"
 
-#: menu.c:2054
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2560,55 +2854,85 @@ msgid ""
 "The key will appear next to the menu item and you can just press that key "
 "without opening the menu in future."
 msgstr ""
-"Pour affecter un raccourci clavier à une entrée d'un menu :\n"
+"Pour affecter un raccourci clavier Ã  une entrÃ©e d'un menuÂ :\n"
 "\n"
-"- ouvrir le menu au-dessus d'une fenêtre du filer,\n"
-"- déplacer le pointeur au-dessus de l'entrée voulue,\n"
-"- appuyer sur la touche que vous voulez attacher à l'entrée.\n"
+"- ouvrir le menu au-dessus d'une fenÃªtre du filer,\n"
+"- dÃ©placer le pointeur au-dessus de l'entrÃ©e voulue,\n"
+"- appuyer sur la touche que vous voulez attacher Ã  l'entrÃ©e.\n"
 "\n"
-"La touche apparaîtra à côté de l'entrée du menu et vous pourrez à l'avenir "
-"juste appuyer sur cette touche, sans avoir à ouvrir le menu."
+"La touche apparaÃ®tra Ã  cÃ´tÃ© de l'entrÃ©e du menu et vous pourrez Ã  l'avenir "
+"juste appuyer sur cette touche, sans avoir Ã  ouvrir le menu."
 
-#: menu.c:2069
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Fixer les raccourcis clavier"
 
-#: minibuffer.c:129
+#: minibuffer.c:140
 msgid "Goto:"
-msgstr "Aller à :"
+msgstr "Aller Ã Â :"
 
-#: minibuffer.c:130
+#: minibuffer.c:141
 msgid "Shell:"
-msgstr "Shell :"
+msgstr "ShellÂ :"
 
-#: minibuffer.c:131
+#: minibuffer.c:142
 msgid "Select If:"
-msgstr "Sélectionner si :"
+msgstr "SÃ©lectionner siÂ :"
 
-#: minibuffer.c:132
+#: minibuffer.c:143
 msgid "Select Named:"
-msgstr "Sélectionner le nom :"
+msgstr "SÃ©lectionner le nomÂ :"
 
-#: minibuffer.c:133
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "SÃ©lectionner siÂ :"
+
+#: minibuffer.c:145
 msgid "Pattern:"
-msgstr "Motif :"
+msgstr "MotifÂ :"
 
-#: minibuffer.c:262
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
 msgstr ""
-"Entrez le nom d'un fichier à afficher. Appuyez sur <Tab> pour compléter avec "
+"Entrez le nom d'un fichier Ã  afficher. Appuyez sur <Tab> pour complÃ©ter avec "
 "la plus longue correspondance. <Escape> pour fermer le minibuffer."
 
-#: minibuffer.c:268
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
-"Entrez une commande shell à exécuter. Cliquez sur un fichier pour l'ajouter "
+"Entrez une commande shell Ã  exÃ©cuter. Cliquez sur un fichier pour l'ajouter "
 "au buffer."
 
-#: minibuffer.c:273
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Entrez un motif de nom de fichier pour sÃ©lectionner tous les fichiers "
+"correspondantsÂ :\n"
+"\n"
+"? pour n'importe quel caractÃ¨re\n"
+"* pour n'importe quelle sÃ©quence de caractÃ¨res (0 ou plus)\n"
+"[aA] pour Â«Â aÂ Â» ou Â«Â AÂ Â»\n"
+"[a-z] pour n'importe quel caractÃ¨re de a Ã  z (minuscule)\n"
+"*.png pour n'importe quel nom se terminant par Â«Â .pngÂ Â»"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2618,186 +2942,204 @@ msgid ""
 "[a-z] means any character from a to z (lowercase)\n"
 "*.png means any name ending in '.png'"
 msgstr ""
-"Entrez un motif de nom de fichier pour sélectionner tous les fichiers "
-"correspondants :\n"
+"Entrez un motif de nom de fichier pour sÃ©lectionner tous les fichiers "
+"correspondantsÂ :\n"
 "\n"
-"? pour n'importe quel caractère\n"
-"* pour n'importe quelle séquence de caractères (0 ou plus)\n"
-"[aA] pour « a » ou « A »\n"
-"[a-z] pour n'importe quel caractère de a à z (minuscule)\n"
-"*.png pour n'importe quel nom se terminant par « .png »"
+"? pour n'importe quel caractÃ¨re\n"
+"* pour n'importe quelle sÃ©quence de caractÃ¨res (0 ou plus)\n"
+"[aA] pour Â«Â aÂ Â» ou Â«Â AÂ Â»\n"
+"[a-z] pour n'importe quel caractÃ¨re de a Ã  z (minuscule)\n"
+"*.png pour n'importe quel nom se terminant par Â«Â .pngÂ Â»"
 
-#: minibuffer.c:285
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
 msgstr ""
-"Entrez un motif correspondant aux fichiers à montrer. Un filtre vide "
-"désactive le filtrage."
+"Entrez un motif correspondant aux fichiers Ã  montrer. Un filtre vide "
+"dÃ©sactive le filtrage."
 
-#: minibuffer.c:905
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Entrez un motif correspondant aux fichiers Ã  montrer. Un filtre vide "
+"dÃ©sactive le filtrage."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Condition de recherche invalide"
 
-#: mount.c:372
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
-msgstr "%s total, %s utilisés, %s libres (%.1f %%)"
+msgstr "%s total, %s utilisÃ©s, %s libres (%.1f %%)"
 
-#: options.c:275
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "ROX-Filer a converti votre fichier Options au nouveau format XML"
 
-#: options.c:535 options.c:1260
+#: options.c:560 options.c:1250
 msgid "(use default)"
-msgstr "(utiliser le choix par défaut)"
+msgstr "(utiliser le choix par dÃ©faut)"
 
-#: options.c:805
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
-msgstr "Erreur interne : %s illisible"
+msgstr "Erreur interneÂ : %s illisible"
 
-#: options.c:916
+#: options.c:929
 msgid "Options"
 msgstr "Options"
 
-#: options.c:961
+#: options.c:974
 msgid "_Revert"
 msgstr "_Revenir"
 
-#: options.c:967
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr ""
-"Récupérer tous les choix tels qu'ils étaient lorsque la boîte Options a été "
+"RÃ©cupÃ©rer tous les choix tels qu'ils Ã©taient lorsque la boÃ®te Options a Ã©tÃ© "
 "ouverte."
 
-#: options.c:982
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
 "%s"
 msgstr ""
-"Les choix seront sauvés sous :\n"
+"Les choix seront sauvÃ©s sousÂ :\n"
 "%s"
 
-#: options.c:990
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
-msgstr "(sauvegarde désactivée par CHOICESPATH)"
+msgstr "(sauvegarde dÃ©sactivÃ©e par CHOICESPATH)"
 
-#: options.c:1163 usericons.c:452
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
-msgstr "Erreur lors de la sauvegarde de %s : %s"
+msgstr "Erreur lors de la sauvegarde de %sÂ : %s"
 
-#: options.c:1797
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Symbole '=' manquant"
 
-#: panel.c:438
-msgid "Your old panel file has been converted to the new XML format."
-msgstr "Votre vieux fichier de panneau a été converti au nouveau format XML."
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr "Impossible d'ouvrir le fichier '%s'Â : %s"
 
-#: panel.c:546
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
+msgid "Your old panel file has been converted to the new XML format."
+msgstr "Votre vieux fichier de panneau a Ã©tÃ© converti au nouveau format XML."
+
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
 msgstr ""
-"Vous avez essayé de fermer un panneau avec le gestionnaire de fenêtres - je "
-"considère généralement cette action comme accidentelle... Voulez-vous "
-"vraiment le fermer ?"
+"Vous avez essayÃ© de fermer un panneau avec le gestionnaire de fenÃªtres - je "
+"considÃ¨re gÃ©nÃ©ralement cette action comme accidentelle... Voulez-vous "
+"vraiment le fermerÂ ?"
 
-#: panel.c:648
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "'<' ou '>' manquant dans le fichier de config du panneau"
 
-#: panel.c:1533
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
-msgstr "Erreur lors de la sauvegarde du panneau %s : %s"
+msgstr "Erreur lors de la sauvegarde du panneau %sÂ : %s"
 
-#: panel.c:1849
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
-msgstr "L'appliquette a quitté sans avoir créé de widget !"
+msgstr "L'appliquette a quittÃ© sans avoir crÃ©Ã© de widgetÂ !"
 
-#: panel.c:1948
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
 "%s"
 msgstr ""
-"Erreur lors de l'exécution de l'appliquette :\n"
+"Erreur lors de l'exÃ©cution de l'appliquetteÂ :\n"
 "%s"
 
-#: panel.c:2358
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "ÃŠtes-vous sÃ»r de vouloir ouvrir %d fenÃªtresÂ ?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Enlever le(s) objet(s)"
+
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Options du panneau..."
 
-#: panel.c:2450
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Moniteur Xinerama %d non disponible"
 
-#: panel.c:2525
-msgid "Panel Options"
-msgstr "Options du panneau"
+#: panel.c:2897
+msgid "Top"
+msgstr ""
 
-#: panel.c:2540
-#, c-format
-msgid "Panel: %s"
-msgstr "Panneau : %s"
-
-#: panel.c:2548
-msgid "Select the panel's position:"
-msgstr "Sélectionnez la position du panneau :"
-
-#: panel.c:2554
-msgid "Top-edge panel"
-msgstr "Panneau situé sur le bord supérieur"
-
-#: panel.c:2555
-msgid "Top edge"
-msgstr "En haut"
-
-#: panel.c:2556
-msgid "Bottom edge panel"
-msgstr "Panneau situé sur le bord inférieur"
-
-#: panel.c:2557
-msgid "Bottom edge"
+#: panel.c:2899
+#, fuzzy
+msgid "Bottom"
 msgstr "En bas"
 
-#: panel.c:2558
-msgid "Left edge panel"
-msgstr "Panneau situé sur le bord gauche"
+#: panel.c:2901
+#, fuzzy
+msgid "Left"
+msgstr "Ã€ gauche"
 
-#: panel.c:2559
-msgid "Left edge"
-msgstr "À gauche"
+#: panel.c:2903
+#, fuzzy
+msgid "Right"
+msgstr "Ã€ droite"
 
-#: panel.c:2560
-msgid "Right-edge panel"
-msgstr "Panneau situé sur le bord droit"
+#: panel.c:2905
+#, fuzzy
+msgid "Default"
+msgstr "Taille par dÃ©fautÂ :"
 
-#: panel.c:2561
-msgid "Right edge"
-msgstr "À droite"
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "Inconnu"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
-msgstr "Votre vieux fichier de punaiseur a été converti au nouveau format XML."
+msgstr "Votre vieux fichier de punaiseur a Ã©tÃ© converti au nouveau format XML."
 
-#: pinboard.c:637
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
 "the SOAP SetBackdropApp method."
 msgstr ""
-"Le gestionnaire d'image de fond doit être un répertoire application. Faites "
-"glisser un répertoire application dans la boîte de dialogue « Fixer l'image "
-"de fond » ou (pour les programmeurs) passez-le à la méthode SOAP "
+"Le gestionnaire d'image de fond doit Ãªtre un rÃ©pertoire application. Faites "
+"glisser un rÃ©pertoire application dans la boÃ®te de dialogue Â«Â Fixer l'image "
+"de fondÂ Â» ou (pour les programmeurs) passez-le Ã  la mÃ©thode SOAP "
 "SetBackdropApp."
 
-#: pinboard.c:656
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2808,235 +3150,171 @@ msgstr ""
 "Vous ne pouvez fixer l'image de fond que sur une image ou sur un programme "
 "qui sait comment manier l'image de fond de ROX-Filer.\n"
 "\n"
-"Programmeurs : le fichier AppInfo.xml de l'application doit contenir "
-"l'élément CanSetBackdrop, comme indiqué dans le manuel de ROX-Filer."
+"ProgrammeursÂ : le fichier AppInfo.xml de l'application doit contenir "
+"l'Ã©lÃ©ment CanSetBackdrop, comme indiquÃ© dans le manuel de ROX-Filer."
 
-#: pinboard.c:676
+#: pinboard.c:750
 msgid "Set backdrop"
 msgstr "Fixer l'image de fond"
 
-#: pinboard.c:687
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
-msgstr "Choisissez un style et faites glisser une image dans :"
+msgstr "Choisissez un style et faites glisser une image dansÂ :"
 
-#: pinboard.c:700
+#: pinboard.c:774
 msgid "Centre the image without scaling it"
 msgstr "Centrer l'image sans changer sa taille"
 
-#: pinboard.c:701
+#: pinboard.c:775
 msgid "Centre"
 msgstr "Centrer"
 
-#: pinboard.c:702
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr ""
-"Changer la taille de l'image sans la déformer pour l'ajuster à la zone de "
+"Changer la taille de l'image sans la dÃ©former pour l'ajuster Ã  la zone de "
 "fond"
 
-#: pinboard.c:704
+#: pinboard.c:778
 msgid "Scale"
 msgstr "Redimensionner"
 
-#: pinboard.c:705
+#: pinboard.c:779
 msgid ""
 "Scale the image to fit the backdrop area, regardless of image dimensions - "
 "overscale"
 msgstr ""
-"Changer la taille de l'image pour l'ajuster à la zone de fond, sans tenir "
+"Changer la taille de l'image pour l'ajuster Ã  la zone de fond, sans tenir "
 "compte des dimensions de l'image - surdimensionnement"
 
-#: pinboard.c:707
+#: pinboard.c:781
 msgid "Fit"
 msgstr "Ajuster"
 
-#: pinboard.c:708
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
-msgstr "Étirer l'image pour remplir la zone de fond"
+msgstr "Ã‰tirer l'image pour remplir la zone de fond"
 
-#: pinboard.c:709
+#: pinboard.c:783
 msgid "Stretch"
-msgstr "Étirer"
+msgstr "Ã‰tirer"
 
-#: pinboard.c:710
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr "Paver la zone de fond avec l'image"
 
-#: pinboard.c:711
+#: pinboard.c:785
 msgid "Tile"
 msgstr "Paver"
 
-#: pinboard.c:716
+#: pinboard.c:790
 msgid "Drop an image here"
 msgstr "Faites glisser ici une image"
 
-#: pinboard.c:777
+#: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
 msgstr ""
-"Aucun punaiseur n'était utilisé... le punaiseur 'Default' a été sélectionné. "
-"Utilisez 'rox -p=Default' pour le choisir à l'avenir."
+"Aucun punaiseur n'Ã©tait utilisÃ©... le punaiseur 'Default' a Ã©tÃ© sÃ©lectionnÃ©. "
+"Utilisez 'rox -p=Default' pour le choisir Ã  l'avenir."
 
-#: pinboard.c:871
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
 msgstr ""
-"Seuls des fichiers (et certaines applications) peuvent être utilisés pour "
+"Seuls des fichiers (et certaines applications) peuvent Ãªtre utilisÃ©s pour "
 "fixer l'image de fond."
 
-#: pinboard.c:1496
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
-msgstr "'>' manquant dans l'étiquette de l'icône"
+msgstr "'>' manquant dans l'Ã©tiquette de l'icÃ´ne"
 
-#: pinboard.c:1505
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
-msgstr "',' manquant après l'étiquette de l'icône"
+msgstr "',' manquant aprÃ¨s l'Ã©tiquette de l'icÃ´ne"
 
-#: pinboard.c:1593
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
-msgstr "Erreur lors de la sauvegarde du punaiseur %s : %s"
+msgstr "Erreur lors de la sauvegarde du punaiseur %sÂ : %s"
 
-#: pinboard.c:2137
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Image de fond..."
 
-#: pinboard.c:2230
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Panneau"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
 "%s\n"
 "Backdrop removed."
 msgstr ""
-"Erreur lors du chargement de l'image de fond :\n"
+"Erreur lors du chargement de l'image de fondÂ :\n"
 "%s\n"
-"Image de fond enlevée."
+"Image de fond enlevÃ©e."
 
-#: pixmaps.c:971
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
 "%s"
 msgstr ""
-"Impossible de supprimer les vignettes dans %s :\n"
+"Impossible de supprimer les vignettes dans %sÂ :\n"
 "%s"
 
-#: pixmaps.c:992
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
-msgstr "Il n'y a pas de vignette à supprimer"
+msgstr "Il n'y a pas de vignette Ã  supprimer"
 
-#: pixmaps.c:1005
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Vider le cache disque des vignettes"
 
-#: remote.c:722
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Style inconnu '%s'"
 
-#: remote.c:744
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
-msgstr "Type de détails inconnu '%s'"
+msgstr "Type de dÃ©tails inconnu '%s'"
 
-#: remote.c:772
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Type de tri inconnu '%s'"
 
-#: remote.c:1245
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
-msgstr "Tentative d'invoquer la méthode SOAP inconnue '%s'"
+msgstr "Tentative d'invoquer la mÃ©thode SOAP inconnue '%s'"
 
-#: rox_gettext.c:93
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Fichier de traduction .gmo invalide (trop court) : %s"
-
-#: rox_gettext.c:106
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr ""
-"Fichier de traduction .gmo invalide (nombre magique GNU non trouvé) : %s"
-
-#: run.c:99 run.c:152
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
-msgstr "Programme %s non trouvé - supprimé ?"
+msgstr "Programme %s non trouvÃ© - supprimÃ©Â ?"
 
-#: run.c:302
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "Ce fichier est inexistant ou inaccessible : %s"
-
-#: run.c:307
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "Je ne sais pas comment ouvrir '%s'"
-
-#: run.c:338
-#, c-format
-msgid "'%s' is not a valid URI"
-msgstr "'%s' n'est pas un URI valide"
-
-#: run.c:349
-#, c-format
-msgid "%s not accessable"
-msgstr "%s inaccessible"
-
-#: run.c:357
-#, c-format
-msgid "Non-local URL %s"
-msgstr "URL %s non locale"
-
-#: run.c:374
-#, c-format
-msgid "%s: no handler for %s"
-msgstr "%s : pas de gestionnaire pour %s"
-
-#: run.c:394
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"Application :\n"
-"C'est un répertoire application - vous pouvez l'exécuter en tant que "
-"programme ou l'ouvrir (maintenez la touche Shift enfoncée pendant "
-"l'ouverture). La plupart des applications fournissent leur propre aide ici, "
-"mais ce n'est pas le cas de celle-ci."
-
-#: run.c:478
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "Impossible d'envoyer les données au programme : %s"
-
-#: run.c:508
-#, c-format
-msgid "Could not read link: %s"
-msgstr "Impossible de lire le lien : %s"
-
-#: run.c:536
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr "Lien symbolique incorrect (ou pas de permission pour le suivre) : %s"
-
-#: run.c:573
+#: run.c:359
 #, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
 "action by choosing `Set Run Action' from the File menu, or you can just drag "
 "the file to an application.%s"
 msgstr ""
-"Aucune action d'exécution spécifiée pour les fichiers de ce type (%s/%s) - "
-"vous pouvez fixer une action d'exécution en choisissant « Fixer l'action "
-"d'exécution » depuis le menu « Fichier », ou vous pouvez juste faire glisser "
+"Aucune action d'exÃ©cution spÃ©cifiÃ©e pour les fichiers de ce type (%s/%s) - "
+"vous pouvez fixer une action d'exÃ©cution en choisissant Â«Â Fixer l'action "
+"d'exÃ©cutionÂ Â» depuis le menu Â«Â FichierÂ Â», ou vous pouvez juste faire glisser "
 "le fichier sur une application.%s"
 
-#: run.c:579
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -3045,10 +3323,68 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"Note : si c'est un programme que vous voulez lancer, vous devez positionner "
-"le bit d'exécution en choisissant « Permissions » dans le menu « Fichier »."
+"NoteÂ : si c'est un programme que vous voulez lancer, vous devez positionner "
+"le bit d'exÃ©cution en choisissant Â«Â PermissionsÂ Â» dans le menu Â«Â FichierÂ Â»."
 
-#: run.c:746
+#: run.c:373
+#, c-format
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "Ce fichier est inexistant ou inaccessibleÂ : %s"
+
+#: run.c:378
+#, c-format
+msgid "I don't know how to open '%s'"
+msgstr "Je ne sais pas comment ouvrir '%s'"
+
+#: run.c:409
+#, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' n'est pas un URI valide"
+
+#: run.c:420
+#, c-format
+msgid "%s not accessable"
+msgstr "%s inaccessible"
+
+#: run.c:428
+#, c-format
+msgid "Non-local URL %s"
+msgstr "URL %s non locale"
+
+#: run.c:445
+#, c-format
+msgid "%s: no handler for %s"
+msgstr "%sÂ : pas de gestionnaire pour %s"
+
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
+msgstr ""
+"ApplicationÂ :\n"
+"C'est un rÃ©pertoire application - vous pouvez l'exÃ©cuter en tant que "
+"programme ou l'ouvrir (maintenez la touche Shift enfoncÃ©e pendant "
+"l'ouverture). La plupart des applications fournissent leur propre aide ici, "
+"mais ce n'est pas le cas de celle-ci."
+
+#: run.c:549
+#, c-format
+msgid "Could not send data to program: %s"
+msgstr "Impossible d'envoyer les donnÃ©es au programmeÂ : %s"
+
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "Impossible de lire le lienÂ : %s"
+
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
+msgstr "Lien symbolique incorrect (ou pas de permission pour le suivre)Â : %s"
+
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3062,647 +3398,634 @@ msgid ""
 "Otherwise, you should check, or even just delete, all the existing run "
 "actions."
 msgstr ""
-"L'exécutable '%s' a un accès en écriture pour tout le monde ! Je refuse de "
-"le lancer. Veuillez changer les droits d'accès dès maintenant (ce problème a "
-"pu être causé par un bug dans d'anciennes versions du filer).\n"
+"L'exÃ©cutable '%s' a un accÃ¨s en Ã©criture pour tout le monde ! Je refuse de "
+"le lancer. Veuillez changer les droits d'accÃ¨s dÃ¨s maintenant (ce problÃ¨me a "
+"pu Ãªtre causÃ© par un bug dans d'anciennes versions du filer).\n"
 "\n"
-"Avoir des actions d'exécution (qui ne sont pas des liens symboliques) à "
-"accès en écriture pour tout le monde signifie que d'autres utilisateurs de "
-"votre ordinateur peuvent remplacer vos actions d'exécution par des versions "
+"Avoir des actions d'exÃ©cution (qui ne sont pas des liens symboliques) Ã  "
+"accÃ¨s en Ã©criture pour tout le monde signifie que d'autres utilisateurs de "
+"votre ordinateur peuvent remplacer vos actions d'exÃ©cution par des versions "
 "malveillantes.\n"
 "\n"
-"Si vous faites confiance à tous ceux qui peuvent écrire dans ces fichiers, "
-"vous n'avez pas à vous inquiéter. Dans le cas contraire, vous devez "
-"vérifier, ou même juste supprimer, toutes les actions d'exécution existantes."
+"Si vous faites confiance Ã  tous ceux qui peuvent Ã©crire dans ces fichiers, "
+"vous n'avez pas Ã  vous inquiÃ©ter. Dans le cas contraire, vous devez "
+"vÃ©rifier, ou mÃªme juste supprimer, toutes les actions d'exÃ©cution existantes."
 
-#: run.c:759
+#: run.c:798
 msgid "go-w (Fix security problem)"
-msgstr "go-w (corriger un problème de sécurité)"
+msgstr "go-w (corriger un problÃ¨me de sÃ©curitÃ©)"
 
-#: support.c:272
-msgid "B"
-msgstr "O"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:351
+#: support.c:381
 msgid "byte"
 msgstr "octet"
 
-#: support.c:1589 support.c:1643
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
-msgstr "Impossible d'ouvrir et de faire un stat sur le fichier '%s' : %s"
+msgstr "Impossible d'ouvrir et de faire un stat sur le fichier '%s'Â : %s"
 
-#: support.c:1600 support.c:1654
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
-msgstr "Impossible de faire un mmap du fichier '%s' : %s"
+msgstr "Impossible de faire un mmap du fichier '%s'Â : %s"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close"
 msgstr "Fermer"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close filer window"
-msgstr "Fermer la fenêtre du filer"
+msgstr "Fermer la fenÃªtre du filer"
 
-#: toolbar.c:117
+#: toolbar.c:120
 msgid "Up"
-msgstr "Père"
+msgstr "PÃ¨re"
 
-#: toolbar.c:117
-msgid "Change to parent directory"
-msgstr "Aller au répertoire père"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:121
+#: toolbar.c:126
 msgid "Home"
 msgstr "Perso"
 
-#: toolbar.c:121
-msgid "Change to home directory"
-msgstr "Aller au répertoire personnel"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks"
-msgstr "Signets"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks menu"
-msgstr "Menu des signets"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:129
+#: toolbar.c:138
 msgid "Scan"
 msgstr "Lire"
 
-#: toolbar.c:129
-msgid "Rescan directory contents"
-msgstr "Relire le contenu du répertoire"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:133
-msgid "Change icon size"
-msgstr "Changer la taille des icônes"
+#: toolbar.c:143
+#, fuzzy
+msgid "Sizeâ”¼"
+msgstr "Taille"
 
-#: toolbar.c:137
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  â”˜ : Huge\n"
+"  â”¤ : Large\n"
+"  â” : Small\n"
+"  â”Œ, â”œ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automatique"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
 msgstr "Mode taille automatique"
 
-#: toolbar.c:141
-msgid "Show extra details"
-msgstr "Montrer tous les détails"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Liste"
 
-#: toolbar.c:145
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
 msgstr "Trier"
 
-#: toolbar.c:145
+#: toolbar.c:165
 msgid "Change sort criteria"
-msgstr "Changer le critère de tri"
+msgstr "Changer le critÃ¨re de tri"
 
-#: toolbar.c:149
-msgid "Hidden"
-msgstr "Cachés"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:149
+#: toolbar.c:169
 msgid ""
 "Left: Show/hide hidden files\n"
 "Right: Show/hide thumbnails"
 msgstr ""
-"Gauche: montrer/cacher les fichiers cachés\n"
+"Gauche: montrer/cacher les fichiers cachÃ©s\n"
 "Droit: montrer/cacher les vignettes"
 
-#: toolbar.c:154
-msgid "Select all/invert selection"
-msgstr "Tout sélectionner/inverser la sélection"
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
 
-#: toolbar.c:158
+#: toolbar.c:174
+#, fuzzy
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+"Gauche: montrer/cacher les fichiers cachÃ©s\n"
+"Droit: montrer/cacher les vignettes"
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "Tout sÃ©lectionner/inverser la sÃ©lection"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "â—‹"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  â–½: No settings\n"
+"  â–¼: Own settings\n"
+"  â–¶: Parent settings\n"
+"  â–·: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
 msgstr "Montrer l'aide de ROX-Filer"
 
-#: toolbar.c:221
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
-msgstr " (%u caché(s))"
+msgstr " (%u cachÃ©(s))"
 
-#: toolbar.c:229 tips:85
+#: toolbar.c:276 tips:79
 msgid "items"
 msgstr "objets"
 
-#: toolbar.c:229
+#: toolbar.c:276
 msgid "item"
 msgstr "objet"
 
-#: toolbar.c:232
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
 msgstr "Pas d'objet%s"
 
-#: toolbar.c:251
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
-msgstr "%u sélectionné(s) (%s)"
+msgstr "%u sÃ©lectionnÃ©(s) (%s)"
 
-#: toolbar.c:423
+#: toolbar.c:535
 msgid "Sort by name"
 msgstr "Tri par nom"
 
-#: toolbar.c:423
+#: toolbar.c:535
 msgid "Sort by type"
 msgstr "Tri par type"
 
-#: toolbar.c:423
+#: toolbar.c:535
 msgid "Sort by date"
 msgstr "Tri par date"
 
-#: toolbar.c:424
+#: toolbar.c:535
 msgid "Sort by size"
 msgstr "Tri par taille"
 
-#: toolbar.c:424
+#: toolbar.c:536
 msgid "Sort by owner"
-msgstr "Tri par propriétaire"
+msgstr "Tri par propriÃ©taire"
 
-#: toolbar.c:424
+#: toolbar.c:536
 msgid "Sort by group"
 msgstr "Tri par groupe"
 
-#: toolbar.c:458
+#: toolbar.c:568
 msgid "ascending"
 msgstr "croissant"
 
-#: toolbar.c:458
+#: toolbar.c:568
 msgid "descending"
-msgstr "décroissant"
+msgstr "dÃ©croissant"
 
-#: type.c:212
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
 msgid "Sym link"
 msgstr "Lien symb."
 
-#: type.c:214
+#: type.c:223
 msgid "Mount point"
 msgstr "Point de montage"
 
-#: type.c:216
-msgid "App dir"
-msgstr "Rép. App."
-
-#: type.c:223
-msgid "Dir"
-msgstr "Rép."
-
 #: type.c:225
+msgid "App dir"
+msgstr "RÃ©p. App."
+
+#: type.c:232
+msgid "Dir"
+msgstr "RÃ©p."
+
+#: type.c:234
 msgid "Char dev"
-msgstr "Périph. car."
+msgstr "PÃ©riph. car."
 
-#: type.c:227
+#: type.c:236
 msgid "Block dev"
-msgstr "Périph. bloc"
+msgstr "PÃ©riph. bloc"
 
-#: type.c:229
+#: type.c:238
 msgid "Pipe"
 msgstr "Tube"
 
-#: type.c:231
+#: type.c:240
 msgid "Socket"
 msgstr "Socket"
 
-#: type.c:233
+#: type.c:242
 msgid "Door"
 msgstr "Porte"
 
-#: type.c:236
+#: type.c:245
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: type.c:511
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
 "gimp \"$@\""
 msgstr ""
-"Entrez une commande shell qui chargera \"$@\" dans un programme approprié. "
-"Ex. :\n"
+"Entrez une commande shell qui chargera \"$@\" dans un programme appropriÃ©. "
+"Ex.Â :\n"
 "\n"
 "gimp \"$@\""
 
-#: type.c:692
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
-msgstr "Ce n'est pas un programme ! Donnez-moi une application à la place !"
+msgstr "Ce n'est pas un programme ! Donnez-moi une application Ã  la place !"
 
-#: type.c:752
+#: type.c:839
 msgid "No run action defined"
-msgstr "Pas d'action d'exécution de définie"
+msgstr "Pas d'action d'exÃ©cution de dÃ©finie"
 
-#: type.c:756
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
-msgstr "Erreur dans le gestionnaire %s : %s"
+msgstr "Erreur dans le gestionnaire %sÂ : %s"
 
-#: type.c:771
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Application %s invalide (mauvais AppRun)"
 
-#: type.c:782
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
-msgstr "%s non exécutable"
+msgstr "%s non exÃ©cutable"
 
-#: type.c:815
+#: type.c:902
 msgid "Set run action"
-msgstr "Fixer l'action d'exécution"
+msgstr "Fixer l'action d'exÃ©cution"
 
-#: type.c:821
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
-"Si un gestionnaire n'est pas fixé pour le type spécifique, utiliser celui-ci "
-"par défaut."
+"Si un gestionnaire n'est pas fixÃ© pour le type spÃ©cifique, utiliser celui-ci "
+"par dÃ©faut."
 
-#: type.c:823
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
-msgstr "Fixer en tant que défaut pour tout `%s/<quelconque>'"
+msgstr "Fixer en tant que dÃ©faut pour tout `%s/<quelconque>'"
 
-#: type.c:827
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Utiliser cette application pour tous les fichiers ayant ce type MIME."
 
-#: type.c:829
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Seulement pour le type `%s' (%s/%s)"
 
-#: type.c:835
+#: type.c:922
 msgid "Drop a suitable application here"
-msgstr "Faites glisser ici une application adéquate"
+msgstr "Faites glisser ici une application adÃ©quate"
 
-#: type.c:850
+#: type.c:963
 msgid "OR"
 msgstr "OU"
 
-#: type.c:857
+#: type.c:971
 msgid "Enter a shell command:"
-msgstr "Entrez une commande shell :"
+msgstr "Entrez une commande shellÂ :"
 
-#: type.c:886
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Utiliser la commande"
 
-#: type.c:916
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
 msgstr ""
-"Une action d'exécution existe déjà et est un assez gros programme - êtes-"
-"vous sûr de vouloir la supprimer ?"
+"Une action d'exÃ©cution existe dÃ©jÃ  et est un assez gros programme - Ãªtes-"
+"vous sÃ»r de vouloir la supprimerÂ ?"
 
-#: type.c:927
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
-msgstr "Impossible de supprimer %s : %s"
+msgstr "Impossible de supprimer %sÂ : %s"
 
-#: type.c:964
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
-msgstr "La sauvegarde des choix est désactivée par la variable CHOICESPATH"
+msgstr "La sauvegarde des choix est dÃ©sactivÃ©e par la variable CHOICESPATH"
 
-#: type.c:1239
-#, c-format
-msgid ""
-"Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr ""
-"Le thème d'icônes '%s' ne contient pas d'icônes MIME. Utilisation du thème "
-"par défaut de ROX."
-
-#: type.c:1254
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason, or %s is a "
-"link to an invalid directory; try deleting it)"
+"%s"
 msgstr ""
-"Impossible de créer le lien symbolique '%s' :\n"
-"%s\n"
-"\n"
-"(ceci peut vouloir dire que le thème ROX existe déjà ici, mais que l'icône "
-"« mime-application:postscript » n'a pas pu être chargée pour une raison "
-"quelconque, ou %s est un lien vers un répertoire invalide; essayez de le "
-"supprimer)"
+"Impossible de supprimer le lien '%s'Â :\n"
+"%s"
 
-#: usericons.c:179
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr ""
-"Le chemin que vous avez donné n'existe pas. L'icône n'a pas été changée."
+"Le chemin que vous avez donnÃ© n'existe pas. L'icÃ´ne n'a pas Ã©tÃ© changÃ©e."
 
-#: usericons.c:189 usericons.c:618
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
 "The icon has not been changed."
 msgstr ""
-"Impossible de charger l'image -- peut-être est-ce un format que je ne "
-"comprends pas, ou peut-être que les permissions sont incorrectes ?\n"
-"L'icône n'a pas été changée."
+"Impossible de charger l'image -- peut-Ãªtre est-ce un format que je ne "
+"comprends pas, ou peut-Ãªtre que les permissions sont incorrectesÂ ?\n"
+"L'icÃ´ne n'a pas Ã©tÃ© changÃ©e."
 
-#: usericons.c:235
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
-msgstr "Voulez-vous vraiment supprimer l'icône '%s' ?"
+msgstr "Voulez-vous vraiment supprimer l'icÃ´ne '%s'Â ?"
 
-#: usericons.c:239
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
 "%s"
 msgstr ""
-"Impossible de supprimer '%s' :\n"
+"Impossible de supprimer '%s'Â :\n"
 "%s"
 
-#: usericons.c:272
-msgid "Set icon"
-msgstr "Fixer l'icône"
-
 #: usericons.c:281
+msgid "Set icon"
+msgstr "Fixer l'icÃ´ne"
+
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr ""
-"Utiliser une copie de l'image comme choix par défaut pour tous les fichiers "
+"Utiliser une copie de l'image comme choix par dÃ©faut pour tous les fichiers "
 "de ces types MIME."
 
-#: usericons.c:283
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
-msgstr "Fixer l'icône pour tout `%s/<quelconque>'"
+msgstr "Fixer l'icÃ´ne pour tout `%s/<quelconque>'"
 
-#: usericons.c:288
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "Utiliser une copie de l'image pour tous les fichiers de ce type MIME."
 
-#: usericons.c:290
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Pour tous les fichiers de type `%s' (%s/%s)"
 
-#: usericons.c:296
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
 msgstr ""
-"Ajoutez les noms du fichier et de l'image à votre liste personnelle. Ce "
-"choix sera perdu si l'image ou le fichier est déplacé."
+"Ajoutez les noms du fichier et de l'image Ã  votre liste personnelle. Ce "
+"choix sera perdu si l'image ou le fichier est dÃ©placÃ©."
 
-#: usericons.c:299
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Seulement pour le fichier `%s'"
 
-#: usericons.c:307
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
 "This is usually the best option if you can write to the directory."
 msgstr ""
-"Copier l'image dans le répertoire comme fichier caché '.DirIcon'. Tous les "
-"utilisateurs verront alors l'icône et vous pourrez déplacer le répertoire "
-"sans risque. C'est généralement la meilleure option si vous avez le droit "
-"d'écrire dans le répertoire."
+"Copier l'image dans le rÃ©pertoire comme fichier cachÃ© '.DirIcon'. Tous les "
+"utilisateurs verront alors l'icÃ´ne et vous pourrez dÃ©placer le rÃ©pertoire "
+"sans risque. C'est gÃ©nÃ©ralement la meilleure option si vous avez le droit "
+"d'Ã©crire dans le rÃ©pertoire."
 
-#: usericons.c:313
+#: usericons.c:322
 msgid "Copy image into directory"
-msgstr "Copier l'image dans le répertoire"
+msgstr "Copier l'image dans le rÃ©pertoire"
 
-#: usericons.c:319
+#: usericons.c:328
 msgid "Drop an icon file here"
-msgstr "Faites glisser ici un fichier d'icône"
+msgstr "Faites glisser ici un fichier d'icÃ´ne"
 
-#: usericons.c:589
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
-msgstr "Le choix des icônes est désactivé par CHOICESPATH"
+msgstr "Le choix des icÃ´nes est dÃ©sactivÃ© par CHOICESPATH"
 
-#: usericons.c:633
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
 "%s"
 msgstr ""
-"Erreur lors de la création de l'image '%s' :\n"
+"Erreur lors de la crÃ©ation de l'image '%s'Â :\n"
 "%s"
 
-#: view_details.c:942
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
 msgid "Mono font"
 msgstr "Fonte mono"
 
-#: view_details.c:943
+#: view_details.c:1019
 msgid "Font for displaying mono-spaced text"
-msgstr "Fonte pour afficher du texte à chasse fixe (monospace)"
+msgstr "Fonte pour afficher du texte Ã  chasse fixe (monospace)"
 
-#: view_details.c:1044
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Nom"
 
-#: view_details.c:1047
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Type"
 
-#: view_details.c:1050
-msgid "_Permissions"
-msgstr "_Droits d'accès"
-
-#: view_details.c:1055
-msgid "_Owner"
-msgstr "_Propriétaire"
-
-#: view_details.c:1057
-msgid "_Group"
-msgstr "_Groupe"
-
-#: view_details.c:1059
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Taille"
 
-#: view_details.c:1065
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Droits d'accÃ¨s"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_PropriÃ©taire"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Groupe"
+
+#: view_details.c:1254
 msgid "Last _Modified"
-msgstr "Dernière _Modification"
+msgstr "DerniÃ¨re _Modification"
+
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Attributs Ã©tendus"
 
 #: tips:1
-msgid "Translation"
-msgstr "Traduction"
+msgid "Filer windows"
+msgstr "FenÃªtres du filer"
 
 #: tips:2
-msgid "Language"
-msgstr "Langue"
+msgid "Auto-resize filer windows"
+msgstr "Changement de taille automatique des fenÃªtres du filer"
 
 #: tips:3
-msgid "Use the LANG environment variable"
-msgstr "Utiliser la variable d'environnement LANG"
-
-#: tips:4
-msgid "Basque"
-msgstr "Basque"
-
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Chinois (traditionnel)"
-
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Chinois (simplifié)"
-
-#: tips:7
-msgid "Czech"
-msgstr "Tchèque"
-
-#: tips:8
-msgid "Danish"
-msgstr "Danois"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Néerlandais"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Anglais (pas de traduction)"
-
-#: tips:11
-msgid "Estonian"
-msgstr "Estonien"
-
-#: tips:12
-msgid "Finnish"
-msgstr "Finnois"
-
-#: tips:13
-msgid "French"
-msgstr "Français"
-
-#: tips:14
-msgid "German"
-msgstr "Allemand"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Hongrois"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Japonais"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "Norvégien"
-
-#: tips:18
-msgid "Italian"
-msgstr "Italien"
-
-#: tips:19
-msgid "Polish"
-msgstr "Polonais"
-
-#: tips:20
-msgid "Portuguese (Portugal)"
-msgstr "Portugais (Portugal)"
-
-#: tips:21
-msgid "Portuguese (Brasil)"
-msgstr "Portugais (Brésil)"
-
-#: tips:22
-msgid "Romanian"
-msgstr "Roumain"
-
-#: tips:23
-msgid "Russian"
-msgstr "Russe"
-
-#: tips:24
-msgid "Spanish"
-msgstr "Espagnol"
-
-#: tips:25
-msgid "Swedish"
-msgstr "Suédois"
-
-#: tips:26
-msgid "Ukrainian"
-msgstr "Ukrainien"
-
-#: tips:27
-msgid "Vietnamese"
-msgstr "Vietnamien"
-
-#: tips:28
-msgid "Filer windows"
-msgstr "Fenêtres du filer"
-
-#: tips:29
-msgid "Auto-resize filer windows"
-msgstr "Changement de taille automatique des fenêtres du filer"
-
-#: tips:30
 msgid "Never automatically resize"
 msgstr "Ne jamais changer de taille automatiquement"
 
-#: tips:31
+#: tips:4
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
 msgstr ""
-"Vous devrez changer manuellement la taille des fenêtres, via le gestionnaire "
-"de fenêtres, l'entrée du menu « Changer taille de la fenêtre » ou en double-"
-"cliquant sur le fond de la fenêtre."
+"Vous devrez changer manuellement la taille des fenÃªtres, via le gestionnaire "
+"de fenÃªtres, l'entrÃ©e du menu Â«Â Changer taille de la fenÃªtreÂ Â» ou en double-"
+"cliquant sur le fond de la fenÃªtre."
 
-#: tips:32
+#: tips:5
 msgid "Resize when changing the display style"
 msgstr "Changer de taille quand vous changez le style d'affichage"
 
-#: tips:33
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
 msgstr ""
-"Le fait de changer la taille des icônes ou les détails à afficher provoquera "
-"un changement automatique de la taille de la fenêtre."
+"Le fait de changer la taille des icÃ´nes ou les dÃ©tails Ã  afficher provoquera "
+"un changement automatique de la taille de la fenÃªtre."
 
-#: tips:34
+#: tips:7
 msgid "Always resize"
 msgstr "Toujours changer la taille"
 
-#: tips:35
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
 msgstr ""
-"Le filer changera la taille des fenêtres à chaque fois qu'il lui semblera "
-"utile (c'est-à-dire quand le répertoire ou le style d'affichage est changé)."
+"Le filer changera la taille des fenÃªtres Ã  chaque fois qu'il lui semblera "
+"utile (c'est-Ã -dire quand le rÃ©pertoire ou le style d'affichage est changÃ©)."
 
-#: tips:36
+#: tips:9
 msgid "Largest window size:"
-msgstr "Plus grande taille de fenêtre :"
+msgstr "Plus grande taille de fenÃªtreÂ :"
 
-#: tips:37
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:38
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
 msgstr ""
-"La plus grande taille, en pourcentage de la taille de l'écran, que pourra "
-"prendre une fenêtre après changement de taille automatique."
+"La plus grande taille, en pourcentage de la taille de l'Ã©cran, que pourra "
+"prendre une fenÃªtre aprÃ¨s changement de taille automatique."
 
-#: tips:39
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Plus grande taille de fenÃªtreÂ :"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"La plus grande taille, en pourcentage de la taille de l'Ã©cran, que pourra "
+"prendre une fenÃªtre aprÃ¨s changement de taille automatique."
+
+#: tips:15
 msgid "Window behaviour"
-msgstr "Comportement relatif aux fenêtres"
+msgstr "Comportement relatif aux fenÃªtres"
 
-#: tips:40
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Drapeaux de barre de titre courts"
 
-#: tips:41
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
@@ -3710,968 +4033,1205 @@ msgstr ""
 "Utiliser des lettres simples au lieu de mots pour les indicateurs Lecture, "
 "Tous et Vignettes dans la barre de titre."
 
-#: tips:42
+#: tips:18
 msgid "Unique windows"
-msgstr "Fenêtres uniques"
+msgstr "FenÃªtres uniques"
 
-#: tips:43
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
 msgstr ""
-"Lorsque vous ouvrez un répertoire et que ce répertoire est déjà affiché dans "
-"une autre fenêtre, cette option provoque la fermeture de cette autre fenêtre."
+"Lorsque vous ouvrez un rÃ©pertoire et que ce rÃ©pertoire est dÃ©jÃ  affichÃ© dans "
+"une autre fenÃªtre, cette option provoque la fermeture de cette autre fenÃªtre."
 
-#: tips:44
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "FenÃªtre"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
-msgstr "Nouvelle fenêtre avec le bouton 1"
+msgstr "Nouvelle fenÃªtre avec le bouton 1"
 
-#: tips:45
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
 "reuse the current window."
 msgstr ""
 "Cliquer avec le bouton 1 (habituellement le bouton de gauche) ouvre un "
-"répertoire dans une nouvelle fenêtre avec ceci activé. Cliquer avec le "
-"bouton 2 (milieu) réutilisera la fenêtre courante."
+"rÃ©pertoire dans une nouvelle fenÃªtre avec ceci activÃ©. Cliquer avec le "
+"bouton 2 (milieu) rÃ©utilisera la fenÃªtre courante."
 
-#: tips:46
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Navigation en simple clic"
 
-#: tips:47 tips:143
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
 "things."
 msgstr ""
 "Cliquer sur un objet l'ouvre si cette option est choisie. Enfoncez Control "
-"pour sélectionner l'objet à la place. Si option non choisie, cliquer une "
-"fois sélectionne l'objet; double-cliquez pour ouvrir des choses."
+"pour sÃ©lectionner l'objet Ã  la place. Si option non choisie, cliquer une "
+"fois sÃ©lectionne l'objet; double-cliquez pour ouvrir des choses."
 
-#: tips:48
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Un double-clic sur le fond change la taille"
 
-#: tips:49
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
 msgstr ""
-"Si activée, un double-clic sur le fond d'une fenêtre change la taille de la "
-"fenêtre, exactement comme un clic sur le bouton Mode taille automatique de "
+"Si activÃ©e, un double-clic sur le fond d'une fenÃªtre change la taille de la "
+"fenÃªtre, exactement comme un clic sur le bouton Mode taille automatique de "
 "la barre d'outils."
 
-#: tips:50
+#: tips:30
 msgid "Sorting"
 msgstr "Tri"
 
-#: tips:51
+#: tips:31
 msgid "Directories come first (for sort by name)"
-msgstr "Les répertoires sont listés en premier (pour le tri par nom)"
+msgstr "Les rÃ©pertoires sont listÃ©s en premier (pour le tri par nom)"
 
-#: tips:52
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
 msgstr ""
-"Si cette option est choisie, alors les répertoires apparaîtront toujours "
+"Si cette option est choisie, alors les rÃ©pertoires apparaÃ®tront toujours "
 "avant les autres objets quand le tri se fait par nom."
 
-#: tips:53
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Noms avec majuscule en premier (pour le tri par nom)"
 
-#: tips:54
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
 msgstr ""
-"Si activée, tous les noms de fichier commençant par une lettre majuscule "
-"viennent avant ceux commençant par une minuscule."
+"Si activÃ©e, tous les noms de fichier commenÃ§ant par une lettre majuscule "
+"viennent avant ceux commenÃ§ant par une minuscule."
 
-#: tips:56
-msgid "Default settings for new windows"
-msgstr "Options par défaut pour les nouvelles fenêtres"
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Les rÃ©pertoires sont listÃ©s en premier (pour le tri par nom)"
 
-#: tips:57
-msgid "Inherit options from source window"
-msgstr "Hériter les options de la fenêtre source"
-
-#: tips:58
-msgid ""
-"If this is on then display options for a new window are inherited from the "
-"source window if possible, otherwise they are set to the defaults below."
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
 msgstr ""
-"Lorsque cette option est activée, les options d'affichage de chaque nouvelle "
-"fenêtre sont héritées de la fenêtre source si possible, sinon elles sont "
-"fixées aux valeurs par défaut données ci-dessous."
 
-#: tips:59
-msgid "View type:"
-msgstr "Type de vue :"
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sec"
 
-#: tips:62
-msgid "Sort by:"
-msgstr "Trier par :"
-
-#: tips:64 tips:81
-msgid "Type"
-msgstr "Type"
-
-#: tips:65
-msgid "Date"
-msgstr "Date"
-
-#: tips:67
-msgid "Show hidden files"
-msgstr "Montrer les fichiers cachés"
-
-#: tips:68
-msgid ""
-"If this is on then files whose names start with a dot are shown too, "
-"otherwise they are hidden."
-msgstr ""
-"Lorsque cette option est activée, les fichiers dont le nom commence par un "
-"point sont aussi montrés, sinon ils sont cachés."
-
-#: tips:69
+#: tips:38
 msgid "Show extended attribute indicator"
-msgstr "Montrer l'indicateur des attributs étendus"
+msgstr "Montrer l'indicateur des attributs Ã©tendus"
 
-#: tips:70
+#: tips:39
 msgid ""
 "If this is on then files which have one or more extended attributes set will "
 "have an emblem added to indicate this."
 msgstr ""
-"Lorsque cette option est activée, les fichiers qui ont un ou plusieurs "
-"attributs étendus auront un emblème pour indiquer cela."
+"Lorsque cette option est activÃ©e, les fichiers qui ont un ou plusieurs "
+"attributs Ã©tendus auront un emblÃ¨me pour indiquer cela."
 
-#: tips:71
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
+msgid "Default settings for new windows"
+msgstr "Options par dÃ©faut pour les nouvelles fenÃªtres"
+
+#: tips:46
+msgid "Inherit options from source window"
+msgstr "HÃ©riter les options de la fenÃªtre source"
+
+#: tips:47
+msgid ""
+"If this is on then display options for a new window are inherited from the "
+"source window if possible, otherwise they are set to the defaults below."
+msgstr ""
+"Lorsque cette option est activÃ©e, les options d'affichage de chaque nouvelle "
+"fenÃªtre sont hÃ©ritÃ©es de la fenÃªtre source si possible, sinon elles sont "
+"fixÃ©es aux valeurs par dÃ©faut donnÃ©es ci-dessous."
+
+#: tips:48
+msgid "View type:"
+msgstr "Type de vueÂ :"
+
+#: tips:51
+msgid "Sort by:"
+msgstr "Trier parÂ :"
+
+#: tips:53 tips:76 tips:114
+msgid "Type"
+msgstr "Type"
+
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
+msgstr "Date"
+
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Date"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Date"
+
+#: tips:58
+msgid "Show hidden files"
+msgstr "Montrer les fichiers cachÃ©s"
+
+#: tips:59
+msgid ""
+"If this is on then files whose names start with a dot are shown too, "
+"otherwise they are hidden."
+msgstr ""
+"Lorsque cette option est activÃ©e, les fichiers dont le nom commence par un "
+"point sont aussi montrÃ©s, sinon ils sont cachÃ©s."
+
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Montrer les fichiers cachÃ©s"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Lorsque cette option est activÃ©e, les fichiers dont le nom commence par un "
+"point sont aussi montrÃ©s, sinon ils sont cachÃ©s."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Ã‰normes icÃ´nes"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "pixels"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
-msgstr "Vue « icônes »"
+msgstr "Vue Â«Â icÃ´nesÂ Â»"
+
+#: tips:67
+msgid "Default size:"
+msgstr "Taille par dÃ©fautÂ :"
+
+#: tips:68
+msgid "Huge Icons"
+msgstr "Ã‰normes icÃ´nes"
+
+#: tips:69 tips:296
+msgid "Large Icons"
+msgstr "Grandes icÃ´nes"
+
+#: tips:70 tips:295
+msgid "Small Icons"
+msgstr "Petites icÃ´nes"
 
 #: tips:72
-msgid "Default size:"
-msgstr "Taille par défaut :"
+msgid "Default details:"
+msgstr "DÃ©tails par dÃ©fautÂ :"
 
 #: tips:73
-msgid "Huge Icons"
-msgstr "Énormes icônes"
+msgid "No details"
+msgstr "Pas de dÃ©tails"
 
-#: tips:74 tips:262
-msgid "Large Icons"
-msgstr "Grandes icônes"
-
-#: tips:75 tips:261
-msgid "Small Icons"
-msgstr "Petites icônes"
+#: tips:74
+msgid "Sizes"
+msgstr "Tailles"
 
 #: tips:77
-msgid "Default details:"
-msgstr "Détails par défaut :"
+msgid "Times"
+msgstr "Dates & heures"
 
 #: tips:78
-msgid "No details"
-msgstr "Pas de détails"
+#, fuzzy
+msgid "Automatic small icons: Change at:"
+msgstr "Petites icÃ´nes autoÂ :"
 
-#: tips:83
-msgid "Automatic small icons:"
-msgstr "Petites icônes auto :"
-
-#: tips:84
-msgid "Change at:"
-msgstr "Changer à :"
-
-#: tips:86
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
 "used."
 msgstr ""
-"Quand le choix automatique de la taille des icônes est sélectionné : si le "
-"répertoire contient au moins autant d'objets, alors il sera affiché avec de "
-"petites icônes, sinon de grandes icônes seront utilisées."
+"Quand le choix automatique de la taille des icÃ´nes est sÃ©lectionnÃ©Â : si le "
+"rÃ©pertoire contient au moins autant d'objets, alors il sera affichÃ© avec de "
+"petites icÃ´nes, sinon de grandes icÃ´nes seront utilisÃ©es."
+
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Grandes icÃ´nes"
+
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
+msgstr ""
+"Le texte plus large que spÃ©cifiÃ© ici est dÃ©coupÃ© en deux lignes en mode "
+"Â«Â Grandes icÃ´nesÂ Â». En mode Â«Â Ã‰normes icÃ´nesÂ Â», le texte est passÃ© Ã  la "
+"ligne quand il est 50% plus large que ce qui est fixÃ© ici."
+
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
 
 #: tips:87
-msgid "Max width (Large icons):"
-msgstr "Largeur maxi (grandes icônes) :"
+msgid "Wrap by characters"
+msgstr ""
 
-#: tips:88 tips:91
-msgid "pixels"
-msgstr "pixels"
+#: tips:88
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr ""
+"Si cette option est choisie, alors les grandes icÃ´nes sont arrangÃ©es en "
+"colonnes, et non en lignes."
 
 #: tips:89
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
-msgstr ""
-"Le texte plus large que spécifié ici est découpé en deux lignes en mode "
-"« Grandes icônes ». En mode « Énormes icônes », le texte est passé à la "
-"ligne quand il est 50% plus large que ce qui est fixé ici."
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "(petites icÃ´nes)Â :"
 
-#: tips:90
-msgid "(Small Icons):"
-msgstr "(petites icônes) :"
+#: tips:91
+msgid "Maximum width for the text beside a Small Icon."
+msgstr "Largeur maximale du texte affichÃ© Ã  cÃ´tÃ© d'une petite icÃ´ne."
 
 #: tips:92
-msgid "Maximum width for the text beside a Small Icon."
-msgstr "Largeur maximale du texte affiché à côté d'une petite icône."
+msgid "Order small icons vertically"
+msgstr "Ordonner les petites icÃ´nes verticalement"
 
 #: tips:93
-msgid "Order small icons vertically"
-msgstr "Ordonner les petites icônes verticalement"
-
-#: tips:94
 msgid ""
 "If this option is on, then small icons are arranged in columns, not rows."
 msgstr ""
-"Si cette option est choisie, alors les petites icônes sont arrangées en "
+"Si cette option est choisie, alors les petites icÃ´nes sont arrangÃ©es en "
 "colonnes, et non en lignes."
 
-#: tips:95
+#: tips:94
 msgid "Order large icons vertically"
-msgstr "Ordonner les grandes icônes verticalement"
+msgstr "Ordonner les grandes icÃ´nes verticalement"
 
-#: tips:96
+#: tips:95
 msgid ""
 "If this option is on, then large icons are arranged in columns, not rows."
 msgstr ""
-"Si cette option est choisie, alors les grandes icônes sont arrangées en "
+"Si cette option est choisie, alors les grandes icÃ´nes sont arrangÃ©es en "
 "colonnes, et non en lignes."
 
-#: tips:98
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Montrer les titres des colonnes"
 
-#: tips:99
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr ""
-"Si cette option est choisie, alors les titres des colonnes seront montrés "
+"Si cette option est choisie, alors les titres des colonnes seront montrÃ©s "
 "lors de l'affichage sous forme de liste."
 
-#: tips:100
+#: tips:102
 msgid "Show full type"
 msgstr "Montrer le type complet"
 
-#: tips:101
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr ""
-"Si cette option est choisie, alors la description complète du type de chaque "
-"objet sera montrée au lieu d'un résumé du type de base."
+"Si cette option est choisie, alors la description complÃ¨te du type de chaque "
+"objet sera montrÃ©e au lieu d'un rÃ©sumÃ© du type de base."
 
-#: tips:102
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Largeur maximale du texte affichÃ© Ã  cÃ´tÃ© d'une petite icÃ´ne."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Montrer les titres des colonnes"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Si cette option est choisie, alors les titres des colonnes seront montrÃ©s "
+"lors de l'affichage sous forme de liste."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Si cette option est choisie, alors les titres des colonnes seront montrÃ©s "
+"lors de l'affichage sous forme de liste."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Si cette option est choisie, alors les titres des colonnes seront montrÃ©s "
+"lors de l'affichage sous forme de liste."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Si cette option est choisie, alors les titres des colonnes seront montrÃ©s "
+"lors de l'affichage sous forme de liste."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Si cette option est choisie, alors les titres des colonnes seront montrÃ©s "
+"lors de l'affichage sous forme de liste."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Si cette option est choisie, alors les titres des colonnes seront montrÃ©s "
+"lors de l'affichage sous forme de liste."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "DerniÃ¨re _Modification"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Si cette option est choisie, alors les titres des colonnes seront montrÃ©s "
+"lors de l'affichage sous forme de liste."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Si cette option est choisie, alors les titres des colonnes seront montrÃ©s "
+"lors de l'affichage sous forme de liste."
+
+#: tips:128
+#, fuzzy
+msgid "Last Accessed"
+msgstr "%s inaccessible"
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Si cette option est choisie, alors les titres des colonnes seront montrÃ©s "
+"lors de l'affichage sous forme de liste."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Outils/minibuffer"
 
-#: tips:103
+#: tips:131
 msgid "Toolbar"
 msgstr "Barre d'outils"
 
-#: tips:104
+#: tips:132
 msgid "Toolbar type:"
-msgstr "Type de barre d'outils :"
+msgstr "Type de barre d'outilsÂ :"
 
-#: tips:105
+#: tips:133
 msgid "No toolbar"
 msgstr "Pas de barre"
 
-#: tips:106
+#: tips:134
 msgid "Icons only"
-msgstr "Icônes seulement"
+msgstr "IcÃ´nes seulement"
 
-#: tips:107
+#: tips:135
 msgid "Text under icons"
-msgstr "Texte sous les icônes"
+msgstr "Texte sous les icÃ´nes"
 
-#: tips:108
+#: tips:136
 msgid "Text beside icons"
-msgstr "Texte à côté des icônes"
+msgstr "Texte Ã  cÃ´tÃ© des icÃ´nes"
 
-#: tips:109
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Image seule"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Afficher les nombres d'objets"
 
-#: tips:110
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
 "selected items and their combined size."
 msgstr ""
-"Montrer le nombre d'objets affichés dans une fenêtre du filer, ainsi que le "
-"nombre d'objets cachés (s'il y en a). Quand il y a une sélection, montrer le "
-"nombre d'objets sélectionnés et leur taille combinée."
+"Montrer le nombre d'objets affichÃ©s dans une fenÃªtre du filer, ainsi que le "
+"nombre d'objets cachÃ©s (s'il y en a). Quand il y a une sÃ©lection, montrer le "
+"nombre d'objets sÃ©lectionnÃ©s et leur taille combinÃ©e."
 
-#: tips:111
+#: tips:140
 msgid "Select the buttons you want on the bar:"
-msgstr "Sélectionnez les boutons que vous voulez sur la barre :"
+msgstr "SÃ©lectionnez les boutons que vous voulez sur la barreÂ :"
 
-#: tips:112
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
-msgstr "La largeur de la barre d'outils fixe la largeur minimale de la fenêtre"
+msgstr "La largeur de la barre d'outils fixe la largeur minimale de la fenÃªtre"
 
-#: tips:113
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
 msgstr ""
-"Chaque fenêtre du filer est contrainte à être suffisamment large pour que la "
+"Chaque fenÃªtre du filer est contrainte Ã  Ãªtre suffisamment large pour que la "
 "barre d'outils apparaisse en entier"
 
-#: tips:114
+#: tips:143
 msgid "Minibuffer"
 msgstr "Minibuffer"
 
-#: tips:115
+#: tips:144
 msgid "Beep if Tab-completion fails"
-msgstr "Bip si la complétion par <Tab> échoue"
+msgstr "Bip si la complÃ©tion par <Tab> Ã©choue"
 
-#: tips:116
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
 "letter varies)."
 msgstr ""
-"Quand vous utilisez le minibuffer « Entrer un chemin... » et que vous "
+"Quand vous utilisez le minibuffer Â«Â Entrer un chemin...Â Â» et que vous "
 "appuyez sur <Tab>, bip si rien ne se passe (e.g., parce qu'il y a plusieurs "
-"possibilités et que la lettre suivante varie)."
+"possibilitÃ©s et que la lettre suivante varie)."
 
-#: tips:117
+#: tips:146
 msgid "Beep if there are several matches"
-msgstr "Bip s'il y a plusieurs complétions"
+msgstr "Bip s'il y a plusieurs complÃ©tions"
 
-#: tips:118
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
 msgstr ""
-"Quand vous utilisez le minibuffer « Entrer un chemin... » et que vous "
-"appuyez sur <Tab>, un bip est émis s'il y a plusieurs fichiers qui "
-"conviennent, même si des lettres ont été ajoutées."
+"Quand vous utilisez le minibuffer Â«Â Entrer un chemin...Â Â» et que vous "
+"appuyez sur <Tab>, un bip est Ã©mis s'il y a plusieurs fichiers qui "
+"conviennent, mÃªme si des lettres ont Ã©tÃ© ajoutÃ©es."
 
-#: tips:121
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Gestionnaire de tÃ©lÃ©chargement"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Erreur dans le gestionnaire %sÂ : %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
 msgstr ""
-"Quand les vignettes sont activées, chaque fichier image dans un répertoire "
-"est chargé et une image réduite est affichée."
+"Quand les vignettes sont activÃ©es, chaque fichier image dans un rÃ©pertoire "
+"est chargÃ© et une image rÃ©duite est affichÃ©e."
 
-#: tips:122
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Montrer les vignettes"
 
-#: tips:123
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
 msgstr ""
-"Il s'agit du choix par défaut pour les nouvelles fenêtres. Utilisez le menu "
-"Affichage pour activer ou désactiver les vignettes pour des fenêtres "
-"particulières."
+"Il s'agit du choix par dÃ©faut pour les nouvelles fenÃªtres. Utilisez le menu "
+"Affichage pour activer ou dÃ©sactiver les vignettes pour des fenÃªtres "
+"particuliÃ¨res."
 
-#: tips:124
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Montrer les vignettes"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
-msgstr "Vignettes vidéo"
+msgstr "Vignettes vidÃ©o"
 
-#: tips:125
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Cache des vignettes"
 
-#: tips:126
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
-"Pour accélérer les choses, les vignettes générées sont stockées dans le "
-"répertoire caché « ~/.thumbnails ». Cliquez ici pour enlever toutes les "
-"vignettes du cache. Elles seront recréées lorsque cela sera nécessaire."
+"Pour accÃ©lÃ©rer les choses, les vignettes gÃ©nÃ©rÃ©es sont stockÃ©es dans le "
+"rÃ©pertoire cachÃ© Â«Â ~/.thumbnailsÂ Â». Cliquez ici pour enlever toutes les "
+"vignettes du cache. Elles seront recrÃ©Ã©es lorsque cela sera nÃ©cessaire."
 
-#: tips:127
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
 msgid "Manage thumbnails"
 msgstr "Manipuler les vignettes"
 
-#: tips:128 tips:205
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Vignettes vidÃ©o"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sec"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Punaiseur"
 
-#: tips:129
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
 msgstr ""
 "Quand vous utilisez un punaiseur, vous pouvez faire glisser des fichiers et "
-"des applications sur le fond du bureau pour créer des raccourcis vers eux."
+"des applications sur le fond du bureau pour crÃ©er des raccourcis vers eux."
 
-#: tips:130 tips:258
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Apparence"
 
-#: tips:131
+#: tips:179
 msgid "Foreground:"
-msgstr "Encre :"
+msgstr "EncreÂ :"
 
-#: tips:132
+#: tips:180
 msgid "Text shadow:"
-msgstr "Ombre du texte :"
+msgstr "Ombre du texteÂ :"
 
-#: tips:133
+#: tips:181
 msgid "Background:"
-msgstr "Fond :"
+msgstr "FondÂ :"
 
-#: tips:134
+#: tips:182
 msgid "No shadow"
 msgstr "Pas d'ombre"
 
-#: tips:135
+#: tips:183
 msgid "Thin"
 msgstr "Fine"
 
-#: tips:136
+#: tips:184
 msgid "Thick"
-msgstr "Épaisse"
+msgstr "Ã‰paisse"
 
-#: tips:137
+#: tips:185
 msgid "Use custom font:"
-msgstr "Utiliser la fonte :"
+msgstr "Utiliser la fonteÂ :"
 
-#: tips:138
+#: tips:186
 msgid "The font used for the text displayed under the icons"
-msgstr "La fonte utilisée pour le texte affiché au-dessous des icônes"
+msgstr "La fonte utilisÃ©e pour le texte affichÃ© au-dessous des icÃ´nes"
 
-#: tips:139
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Changement rapide de la taille des images"
 
-#: tips:140
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
 msgstr ""
-"Choisir entre la méthode rapide et la lente pour redimensionner les images "
-"de fond. La méthode lente peut donner de meilleurs résultats."
+"Choisir entre la mÃ©thode rapide et la lente pour redimensionner les images "
+"de fond. La mÃ©thode lente peut donner de meilleurs rÃ©sultats."
 
-#: tips:141
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Comportement du punaiseur"
 
-#: tips:142
+#: tips:190
 msgid "Single-click to open"
 msgstr "Simple clic pour ouvrir"
 
-#: tips:144
+#: tips:192
 msgid "Keep icons within screen limits"
-msgstr "Garder les icônes à l'intérieur des limites de l'écran"
+msgstr "Garder les icÃ´nes Ã  l'intÃ©rieur des limites de l'Ã©cran"
 
-#: tips:145
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
 msgstr ""
-"Si cette option est active, les icônes du punaiseur sont toujours gardées "
-"complètement à l'intérieur des limites de l'écran, étiquette comprise."
+"Si cette option est active, les icÃ´nes du punaiseur sont toujours gardÃ©es "
+"complÃ¨tement Ã  l'intÃ©rieur des limites de l'Ã©cran, Ã©tiquette comprise."
 
-#: tips:146
+#: tips:194
 msgid "Icon grid step:"
-msgstr "Pas de la grille pour les icônes :"
+msgstr "Pas de la grille pour les icÃ´nesÂ :"
 
-#: tips:147
+#: tips:195
 msgid "Fine"
 msgstr "Fin"
 
-#: tips:148
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr ""
-"Utiliser une grille avec pas de 2 pixels pour le positionnement des icônes "
+"Utiliser une grille avec pas de 2 pixels pour le positionnement des icÃ´nes "
 "sur le bureau."
 
-#: tips:149
+#: tips:197
 msgid "Medium"
 msgstr "Moyen"
 
-#: tips:150
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr ""
-"Utiliser une grille avec pas de 16 pixels pour le positionnement des icônes "
+"Utiliser une grille avec pas de 16 pixels pour le positionnement des icÃ´nes "
 "sur le bureau."
 
-#: tips:151
+#: tips:199
 msgid "Coarse"
 msgstr "Large"
 
-#: tips:152
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr ""
-"Utiliser une grille avec pas de 32 pixels pour le positionnement des icônes "
+"Utiliser une grille avec pas de 32 pixels pour le positionnement des icÃ´nes "
 "sur le bureau."
 
-#: tips:153 tips:155
+#: tips:201 tips:203
 msgid "Iconified windows"
-msgstr "Fenêtres iconifiées"
+msgstr "FenÃªtres iconifiÃ©es"
 
-#: tips:154
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
 "windows."
 msgstr ""
-"La plupart des gestionnaires de fenêtres fournissent une méthode pour "
-"iconifier (ou « minimiser ») les fenêtres, et divers programmes, dont ROX-"
-"Filer, peuvent servir à afficher les fenêtres iconifiées."
+"La plupart des gestionnaires de fenÃªtres fournissent une mÃ©thode pour "
+"iconifier (ou Â«Â minimiserÂ Â») les fenÃªtres, et divers programmes, dont ROX-"
+"Filer, peuvent servir Ã  afficher les fenÃªtres iconifiÃ©es."
 
-#: tips:156
+#: tips:204
 msgid "Show iconified windows"
-msgstr "Montrer les fenêtres iconifiées"
+msgstr "Montrer les fenÃªtres iconifiÃ©es"
 
-#: tips:157
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
 "pinboard must be in use."
 msgstr ""
-"Si cette option est choisie, le filer montrera chaque fenêtre iconifiée sous "
-"forme d'un petit bouton sur le punaiseur. Cela nécessite un gestionnaire de "
-"fenêtres compatible, et le punaiseur doit être actif."
+"Si cette option est choisie, le filer montrera chaque fenÃªtre iconifiÃ©e sous "
+"forme d'un petit bouton sur le punaiseur. Cela nÃ©cessite un gestionnaire de "
+"fenÃªtres compatible, et le punaiseur doit Ãªtre actif."
 
-#: tips:158
+#: tips:206
 msgid "Show per workspace"
 msgstr "Montrer par espace de travail"
 
-#: tips:159
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
 msgstr ""
-"Si cette option est choisie, le filer ne montrera que les fenêtres "
-"iconifiées associées à l'espace de travail courant."
+"Si cette option est choisie, le filer ne montrera que les fenÃªtres "
+"iconifiÃ©es associÃ©es Ã  l'espace de travail courant."
 
-#: tips:160
+#: tips:208
 msgid "Iconify to the"
 msgstr "Iconifier en"
 
-#: tips:161
+#: tips:209
 msgid "top-left"
-msgstr "haut à gauche"
+msgstr "haut Ã  gauche"
 
-#: tips:162
+#: tips:210
 msgid "top-right"
-msgstr "haut à droite"
+msgstr "haut Ã  droite"
 
-#: tips:163
+#: tips:211
 msgid "bottom-left"
-msgstr "bas à gauche"
+msgstr "bas Ã  gauche"
 
-#: tips:164
+#: tips:212
 msgid "bottom-right"
-msgstr "bas à droite"
+msgstr "bas Ã  droite"
 
-#: tips:165
+#: tips:213
 msgid ", going"
 msgstr ", en allant"
 
-#: tips:166
+#: tips:214
 msgid "horizontally"
 msgstr "horizontalement"
 
-#: tips:167
+#: tips:215
 msgid "vertically"
 msgstr "verticalement"
 
-#: tips:168
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
 "or bottom margin to avoid placing the icons there. The filer already knows "
 "about its own panel."
 msgstr ""
-"Parfois le filer ne connaît pas vos accessoires de bureau et place les "
-"fenêtres iconifiées sous le panneau de Gnome (par exemple). Vous pouvez "
-"définir une marge en haut ou en bas pour éviter d'y placer des icônes. Le "
-"filer connaît déjà son propre panneau."
+"Parfois le filer ne connaÃ®t pas vos accessoires de bureau et place les "
+"fenÃªtres iconifiÃ©es sous le panneau de Gnome (par exemple). Vous pouvez "
+"dÃ©finir une marge en haut ou en bas pour Ã©viter d'y placer des icÃ´nes. Le "
+"filer connaÃ®t dÃ©jÃ  son propre panneau."
 
-#: tips:169
+#: tips:217
 msgid "Top margin"
 msgstr "Marge haute"
 
-#: tips:170
+#: tips:218
 msgid "Height of no-go area at top of screen."
-msgstr "Hauteur de l'aire interdite en haut de l'écran."
+msgstr "Hauteur de l'aire interdite en haut de l'Ã©cran."
 
-#: tips:171
+#: tips:219
 msgid "Bottom margin"
 msgstr "Marge basse"
 
-#: tips:172
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
-msgstr "Hauteur de l'aire interdite en bas de l'écran."
+msgstr "Hauteur de l'aire interdite en bas de l'Ã©cran."
 
-#: tips:173
+#: tips:221
 msgid "Left margin"
 msgstr "Marge gauche"
 
-#: tips:174
+#: tips:222
 msgid "Width of no-go area at left of screen."
-msgstr "Largeur de l'aire interdite à gauche de l'écran."
+msgstr "Largeur de l'aire interdite Ã  gauche de l'Ã©cran."
 
-#: tips:175
+#: tips:223
 msgid "Right margin"
 msgstr "Marge droite"
 
-#: tips:176
+#: tips:224
 msgid "Width of no-go area at right of screen."
-msgstr "Largeur de l'aire interdite à droite de l'écran."
+msgstr "Largeur de l'aire interdite Ã  droite de l'Ã©cran."
 
-#: tips:177
-msgid "Panels"
-msgstr "Panneaux"
-
-#: tips:178
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr ""
-"Les panneaux sont des barres d'icônes situées sur les côtés de l'écran. Voir "
-"le manuel pour toute information sur l'utilisation des panneaux."
-
-#: tips:179
-msgid "Panel style"
-msgstr "Style du panneau"
-
-#: tips:180
-msgid "Image and text"
-msgstr "Image et texte"
-
-#: tips:181
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Chaque icône du panneau comporte une image et du texte."
-
-#: tips:182
-msgid "Image only for applications"
-msgstr "Image seule pour les applications"
-
-#: tips:183
-msgid ""
-"Applications have just an image, everything else has both an image and text."
-msgstr ""
-"Les applications comportent juste une image, le reste comporte une image et "
-"du texte."
-
-#: tips:184
-msgid "Image only"
-msgstr "Image seule"
-
-#: tips:185
-msgid "Only the image is shown."
-msgstr "Seule l'image est affichée."
-
-#: tips:186
-msgid "Panel width (thin)"
-msgstr "Largeur de panneau (fine)"
-
-#: tips:187
-msgid "(thick)"
-msgstr "(épaisse)"
-
-#: tips:188
-msgid "The size of the panels."
-msgstr "Taille des panneaux."
-
-#: tips:189
-msgid "Do not cover panel"
-msgstr "Ne pas couvrir le panneau"
-
-#: tips:190
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
-msgstr ""
-"Demande au gestionnaire de fenêtres de ne pas couvrir du tout les panneaux "
-"quand vous maximisez des fenêtres. Certains gestionnaires de fenêtres "
-"peuvent ne pas honorer cette fonctionnalité. Si désactivée, le filer demande "
-"que seules deux rangées de pixels au bord de l'écran restent visibles, de "
-"façon à ce que le passage au premier plan automatique fonctionne."
-
-#: tips:191
-msgid "Xinerama"
-msgstr "Xinerama"
-
-#: tips:192
-msgid "Confine to Xinerama monitor"
-msgstr "Confiner à un moniteur Xinerama"
-
-#: tips:193
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
-msgstr ""
-"Si vous avez une configuration multimoniteur Xinerama, utilisez cette option "
-"pour confiner les panneaux à un seul moniteur au lieu de les répartir."
-
-#: tips:194
-msgid ""
-"The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr ""
-"Le moniteur auquel les panneaux sont confinés en mode Xinerama (numéroté à "
-"partir de 0)."
-
-#: tips:195
+#: tips:225
 msgid "Desktop"
 msgstr "Bureau"
 
-#: tips:196
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
 msgstr ""
-"Lorsqu'il est lancé par un gestionnaire de session (comme ROX-Session), le "
+"Lorsqu'il est lancÃ© par un gestionnaire de session (comme ROX-Session), le "
 "filer peut ouvrir un panneau et/ou le punaiseur. Vous devez configurer cela "
 "ici."
 
-#: tips:197
+#: tips:227
 msgid "Panel only"
 msgstr "Panneau seul"
 
-#: tips:198
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Seul un panneau est visible."
 
-#: tips:199
+#: tips:229
 msgid "Pinboard only"
 msgstr "Punaiseur seul"
 
-#: tips:200
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "Seul le punaiseur est visible."
 
-#: tips:201
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "Panneau et punaiseur"
 
-#: tips:202
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "Un panneau et le punaiseur sont tous deux visibles."
 
-#: tips:203
-msgid "Panel"
-msgstr "Panneau"
-
-#: tips:204
-msgid "Enter the name of the panel to show here."
-msgstr "Entrez le nom du panneau à montrer."
-
-#: tips:206
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
-msgstr "Entrez le nom du punaiseur à montrer."
+msgstr "Entrez le nom du punaiseur Ã  montrer."
 
-#: tips:207
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr ""
-"Les changements prendront effet la prochaine fois que le filer sera lancé."
+"Les changements prendront effet la prochaine fois que le filer sera lancÃ©."
 
-#: tips:208
+#: tips:236
+#, fuzzy
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
-"Le gestionnaire de session active ces options à l'aide de l'argument -S ou --"
+"Le gestionnaire de session active ces options Ã  l'aide de l'argument -S ou --"
 "rox-session de rox."
 
-#: tips:209
+#: tips:237
 msgid "Action windows"
-msgstr "Fenêtres d'action"
+msgstr "FenÃªtres d'action"
 
-#: tips:210
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
 msgstr ""
-"Les fenêtres d'action apparaissent quand vous lancez\n"
-"une opération en arrière-plan, comme une copie ou\n"
+"Les fenÃªtres d'action apparaissent quand vous lancez\n"
+"une opÃ©ration en arriÃ¨re-plan, comme une copie ou\n"
 "suppression de fichiers."
 
-#: tips:211
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
-msgstr "Commencer immédiatement (silencieusement) ces actions"
+msgstr "Commencer immÃ©diatement (silencieusement) ces actions"
 
-#: tips:213
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Copier des fichiers sans confirmation."
 
-#: tips:215
+#: tips:243
 msgid "Move files without confirming first."
-msgstr "Déplacer des fichiers sans confirmation."
+msgstr "DÃ©placer des fichiers sans confirmation."
 
-#: tips:217
+#: tips:245
 msgid "Create links to files without confirming first."
-msgstr "Créer des liens vers des fichiers sans confirmation."
+msgstr "CrÃ©er des liens vers des fichiers sans confirmation."
 
-#: tips:219
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Supprimer des fichiers sans confirmation."
 
-#: tips:220
+#: tips:248
 msgid "Mount"
 msgstr "Monter"
 
-#: tips:221
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
-msgstr "Monter et démonter des systèmes de fichiers sans confirmation."
+msgstr "Monter et dÃ©monter des systÃ¨mes de fichiers sans confirmation."
 
-#: tips:222
+#: tips:250
 msgid "Default settings"
-msgstr "Options par défaut"
+msgstr "Options par dÃ©faut"
 
-#: tips:224
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Forcer"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
-msgstr "Ne pas confirmer la suppression d'objets protégés contre l'écriture."
+msgstr "Ne pas confirmer la suppression d'objets protÃ©gÃ©s contre l'Ã©criture."
 
-#: tips:226
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Afficher le minimum d'informations dans la zone des messages."
 
-#: tips:228
+#: tips:256
 msgid "Also change contents of subdirectories."
-msgstr "Changer aussi le contenu des sous-répertoires."
+msgstr "Changer aussi le contenu des sous-rÃ©pertoires."
 
-#: tips:231
+#: tips:263
 msgid "Mount commands"
 msgstr "Commandes de montage"
 
-#: tips:232
+#: tips:264
 msgid "Mount command"
 msgstr "Commande de montage"
 
-#: tips:233
+#: tips:265
 msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
 msgstr ""
-"Commande utilisée pour monter un système de fichiers. En cas de doute, "
-"choisissez « mount »."
+"Commande utilisÃ©e pour monter un systÃ¨me de fichiers. En cas de doute, "
+"choisissez Â«Â mountÂ Â»."
 
-#: tips:234
+#: tips:266
 msgid "Unmount command"
-msgstr "Commande de démontage"
+msgstr "Commande de dÃ©montage"
 
-#: tips:235
+#: tips:267
 msgid ""
 "The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
 "without the first \"n\")."
 msgstr ""
-"Commande utilisée pour démonter un système de fichiers. En cas de doute, "
-"choisissez « umount » (sans « n » avant le « m »)."
+"Commande utilisÃ©e pour dÃ©monter un systÃ¨me de fichiers. En cas de doute, "
+"choisissez Â«Â umountÂ Â» (sans Â«Â nÂ Â» avant le Â«Â mÂ Â»)."
 
-#: tips:236
+#: tips:268
 msgid "Eject command"
-msgstr "Commande d'éjection"
+msgstr "Commande d'Ã©jection"
 
-#: tips:237
+#: tips:269
 msgid "The command used to eject removable media. If unsure, use \"eject\"."
 msgstr ""
-"Commande utilisée pour éjecter des médias amovibles. En cas de doute, "
-"choisissez « eject »."
+"Commande utilisÃ©e pour Ã©jecter des mÃ©dias amovibles. En cas de doute, "
+"choisissez Â«Â ejectÂ Â»."
 
-#: tips:238
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
-msgstr "Glisser-déposer"
+msgstr "Glisser-dÃ©poser"
 
-#: tips:239
+#: tips:273
 msgid "Dragging to icons"
-msgstr "Glisser vers icônes"
+msgstr "Glisser vers icÃ´nes"
 
-#: tips:240
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr ""
-"Autoriser le glisser-déposer vers des icônes dans les fenêtres du filer"
+"Autoriser le glisser-dÃ©poser vers des icÃ´nes dans les fenÃªtres du filer"
 
-#: tips:241
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
 "will put it into that directory, or load it into the program."
 msgstr ""
-"Quand cette option est activée, vous pouvez faire glisser un fichier au-"
-"dessus d'un sous-répertoire ou programme dans une fenêtre du filer. La cible "
-"sera mise en valeur et lâcher le fichier dessus le mettra dans ce "
-"répertoire, ou le chargera dans ce programme."
+"Quand cette option est activÃ©e, vous pouvez faire glisser un fichier au-"
+"dessus d'un sous-rÃ©pertoire ou programme dans une fenÃªtre du filer. La cible "
+"sera mise en valeur et lÃ¢cher le fichier dessus le mettra dans ce "
+"rÃ©pertoire, ou le chargera dans ce programme."
 
-#: tips:242
+#: tips:276
 msgid "Directories spring open"
-msgstr "Les répertoires surgissent"
+msgstr "Les rÃ©pertoires surgissent"
 
-#: tips:243
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
 "short while."
 msgstr ""
 "Cette option, qui requiert que l'option ci-dessus soit aussi active, permet "
-"au répertoire mis en valeur de « surgir » lorsque le fichier a été maintenu "
+"au rÃ©pertoire mis en valeur de Â«Â surgirÂ Â» lorsque le fichier a Ã©tÃ© maintenu "
 "au-dessus pendant un instant."
 
-#: tips:244
+#: tips:278
 msgid "Spring delay:"
-msgstr "Délai de surgissement :"
+msgstr "DÃ©lai de surgissementÂ :"
 
-#: tips:245
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:246
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
 "have any effect."
 msgstr ""
 "Cette option fixe le temps, en ms, pendant lequel vous devez laisser un "
-"fichier au-dessus d'un répertoire avant que ce dernier ne surgisse. L'option "
-"ci-dessus doit être active pour que ce réglage ait un effet."
+"fichier au-dessus d'un rÃ©pertoire avant que ce dernier ne surgisse. L'option "
+"ci-dessus doit Ãªtre active pour que ce rÃ©glage ait un effet."
 
-#: tips:247
+#: tips:281
 msgid "When dragging files with the left mouse button"
-msgstr "Quand vous glissez-déposez des fichiers avec le bouton gauche"
+msgstr "Quand vous glissez-dÃ©posez des fichiers avec le bouton gauche"
 
-#: tips:248 tips:252
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
-msgstr "Faire apparaître un menu des actions possibles"
+msgstr "Faire apparaÃ®tre un menu des actions possibles"
 
-#: tips:249
+#: tips:283
 msgid "Copy the files"
 msgstr "Copier les fichiers"
 
-#: tips:250
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
 msgstr ""
-"Notez que vous pouvez toujours faire apparaître le menu par glisser-déposer "
-"tout en maintenant <Alt> enfoncée."
+"Notez que vous pouvez toujours faire apparaÃ®tre le menu par glisser-dÃ©poser "
+"tout en maintenant <Alt> enfoncÃ©e."
 
-#: tips:251
+#: tips:285
 msgid "When dragging files with the middle mouse button"
-msgstr "Quand vous glissez-déposez des fichiers avec le bouton du milieu"
+msgstr "Quand vous glissez-dÃ©posez des fichiers avec le bouton du milieu"
 
-#: tips:253
+#: tips:287
 msgid "Move the files"
-msgstr "Déplacer les fichiers"
+msgstr "DÃ©placer les fichiers"
 
-#: tips:254
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
 msgstr ""
-"Notez que vous pouvez toujours faire apparaître le menu en glissant-déposant "
+"Notez que vous pouvez toujours faire apparaÃ®tre le menu en glissant-dÃ©posant "
 "avec le bouton gauche tout en appuyant sur la touche <Alt>."
 
-#: tips:255
+#: tips:289
 msgid "Download handler"
-msgstr "Gestionnaire de téléchargement"
+msgstr "Gestionnaire de tÃ©lÃ©chargement"
 
-#: tips:256
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4679,133 +5239,137 @@ msgid ""
 "xterm -e wget $1"
 msgstr ""
 "Lorsque vous faites glisser un fichier depuis un navigateur web ou autre "
-"source distante, ce programme sera exécuté pour le télécharger. $1 est l'URI "
-"glissé sur le filer, et le répertoire courant est la destination. Par "
-"exemple :\n"
+"source distante, ce programme sera exÃ©cutÃ© pour le tÃ©lÃ©charger. $1 est l'URI "
+"glissÃ© sur le filer, et le rÃ©pertoire courant est la destination. Par "
+"exempleÂ :\n"
 "xterm -e wget $1"
 
-#: tips:257
+#: tips:291
 msgid "Menus"
 msgstr "Menus"
 
-#: tips:259
+#: tips:293
 msgid "Size of icons in menus:"
-msgstr "Taille des icônes dans les menus :"
+msgstr "Taille des icÃ´nes dans les menusÂ :"
 
-#: tips:260
+#: tips:294
 msgid "No Icons"
-msgstr "Pas d'icônes"
+msgstr "Pas d'icÃ´nes"
 
-#: tips:263
+#: tips:297
 msgid "Same as current window"
-msgstr "Comme la fenêtre courante"
+msgstr "Comme la fenÃªtre courante"
 
-#: tips:264
+#: tips:298
 msgid "Same as default"
-msgstr "Comme le choix par défaut"
+msgstr "Comme le choix par dÃ©faut"
 
-#: tips:265
+#: tips:299
 msgid "Behaviour"
 msgstr "Comportement"
 
-#: tips:266
+#: tips:300
 msgid "File menu on right-click"
-msgstr "Menu « Fichier » par clic droit"
+msgstr "Menu Â«Â FichierÂ Â» par clic droit"
 
-#: tips:267
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
 msgstr ""
-"Montrer le menu « Fichier » au lieu du menu principal quand vous cliquez "
-"avec le bouton droit alors que des fichiers sont sélectionnés (le menu "
-"principal peut être obtenu en appuyant sur la touche « Control »)."
+"Montrer le menu Â«Â FichierÂ Â» au lieu du menu principal quand vous cliquez "
+"avec le bouton droit alors que des fichiers sont sÃ©lectionnÃ©s (le menu "
+"principal peut Ãªtre obtenu en appuyant sur la touche Â«Â ControlÂ Â»)."
 
-#: tips:268
+#: tips:302
 msgid "Terminal emulator program"
-msgstr "Programme d'émulateur de terminal"
+msgstr "Programme d'Ã©mulateur de terminal"
 
-#: tips:269
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr ""
-"Le programme à lancer quand vous choisissez « Terminal ici » dans le menu."
+"Le programme Ã  lancer quand vous choisissez Â«Â Terminal iciÂ Â» dans le menu."
 
-#: tips:270
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Raccourcis clavier"
 
-#: tips:272
+#: tips:305
+msgid "Types"
+msgstr "Types"
+
+#: tips:306
 msgid "MIME types"
 msgstr "Types MIME"
 
-#: tips:273
+#: tips:307
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
 msgstr ""
-"Le filer utilise un ensemble de règles pour deviner le type MIME correct de "
-"chaque fichier ordinaire et choisit ensuite une icône adéquate pour ce type."
+"Le filer utilise un ensemble de rÃ¨gles pour deviner le type MIME correct de "
+"chaque fichier ordinaire et choisit ensuite une icÃ´ne adÃ©quate pour ce type."
 
-#: tips:274
+#: tips:308
 msgid "Edit MIME rules"
-msgstr "Éditer les règles MIME"
+msgstr "Ã‰diter les rÃ¨gles MIME"
 
-#: tips:275
+#: tips:309
 msgid "Themes"
-msgstr "Thèmes"
+msgstr "ThÃ¨mes"
 
-#: tips:276
+#: tips:310
 msgid "Icon theme"
-msgstr "Thème d'icônes"
+msgstr "ThÃ¨me d'icÃ´nes"
 
-#: tips:277
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
-msgstr "Les thèmes doivent être placés dans le répertoire « ~/.icons »."
+msgstr "Les thÃ¨mes doivent Ãªtre placÃ©s dans le rÃ©pertoire Â«Â ~/.iconsÂ Â»."
 
-#: tips:278
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
 msgstr ""
-"Utilisez la boîte de dialogue « Fixer l'icône... » pour fixer l'icône pour "
-"chaque type MIME. Notez que les icônes fixées de cette façon ont la priorité "
-"sur celles du thème sélectionné."
+"Utilisez la boÃ®te de dialogue Â«Â Fixer l'icÃ´ne...Â Â» pour fixer l'icÃ´ne pour "
+"chaque type MIME. Notez que les icÃ´nes fixÃ©es de cette faÃ§on ont la prioritÃ© "
+"sur celles du thÃ¨me sÃ©lectionnÃ©."
 
-#: tips:279
+#: tips:313
 msgid "Colours"
 msgstr "Couleurs"
 
-#: tips:280
+#: tips:314
 msgid "File type colours"
 msgstr "Couleurs des types de fichier"
 
-#: tips:281
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Mettre les fichiers en couleur en fonction de leur type"
 
-#: tips:282
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr ""
-"Les noms de fichier (et les détails) sont mis en couleur en fonction du type "
+"Les noms de fichier (et les dÃ©tails) sont mis en couleur en fonction du type "
 "du fichier."
 
-#: tips:283
+#: tips:317
 msgid "Directory:"
-msgstr "Répertoire :"
+msgstr "RÃ©pertoireÂ :"
 
-#: tips:284
+#: tips:318
 msgid "Regular file:"
-msgstr "Fichier ordinaire :"
+msgstr "Fichier ordinaireÂ :"
 
-#: tips:285
+#: tips:319
 msgid "Pipe:"
-msgstr "Tube :"
+msgstr "TubeÂ :"
 
-#: tips:286
+#: tips:320
 msgid "Socket:"
-msgstr "Socket :"
+msgstr "SocketÂ :"
 
-#: tips:288
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
@@ -4813,51 +5377,79 @@ msgstr ""
 "Erreur, comme un lien qui pointe vers un fichier inexistant, ou un fichier "
 "que le filer n'a pas la permission d'examiner."
 
-#: tips:289
+#: tips:323
 msgid "Character device:"
-msgstr "Périphérique caractère :"
+msgstr "PÃ©riphÃ©rique caractÃ¨reÂ :"
 
-#: tips:290
+#: tips:324
 msgid "Block device:"
-msgstr "Périphérique bloc :"
+msgstr "PÃ©riphÃ©rique blocÂ :"
 
-#: tips:291
+#: tips:325
 msgid "Door:"
-msgstr "Porte :"
+msgstr "PorteÂ :"
 
-#: tips:292
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
 msgstr ""
-"Les portes sont un peu comme les sockets ou les tubes, et n'ont été vues que "
+"Les portes sont un peu comme les sockets ou les tubes, et n'ont Ã©tÃ© vues que "
 "sous Solaris."
 
-#: tips:293
+#: tips:327
 msgid "Executable file:"
-msgstr "Fichier exécutable :"
+msgstr "Fichier exÃ©cutableÂ :"
 
-#: tips:294
+#: tips:328
 msgid "Application directory:"
-msgstr "Répertoire application :"
+msgstr "RÃ©pertoire applicationÂ :"
 
-#: tips:295
+#: tips:329
 msgid "Unknown type:"
-msgstr "Type inconnu :"
+msgstr "Type inconnuÂ :"
 
-#: tips:296
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "FondÂ :"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Utiliser la fonteÂ :"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
-msgstr "Compatibilité"
+msgstr "CompatibilitÃ©"
 
-#: tips:297
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
-msgstr "Problèmes de WM (gestionnaires de fenêtres)"
+msgstr "ProblÃ¨mes de WM (gestionnaires de fenÃªtres)"
 
-#: tips:298
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
-msgstr "Outrepasser le contrôle du punaiseur et des panneaux par le WM"
+msgstr "Outrepasser le contrÃ´le du punaiseur et des panneaux par le WM"
 
-#: tips:299
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4865,94 +5457,523 @@ msgid ""
 "on it, titlebars and other decorations appearing around windows, or having "
 "them appear in window-select lists."
 msgstr ""
-"Certains gestionnaires de fenêtres (WM) ne supportent pas le nouveau système "
-"« Extended Window Manager Hints » et traitent ainsi le punaiseur et les "
-"panneaux comme des fenêtres normales. Activer cette option pour corriger les "
-"problèmes comme : le punaiseur passe au premier plan quand vous cliquez "
-"dessus, des barres de titre et autres décorations apparaissent autour des "
-"fenêtres, ou ces fenêtres apparaissent dans les listes de sélection de "
-"fenêtres."
+"Certains gestionnaires de fenÃªtres (WM) ne supportent pas le nouveau systÃ¨me "
+"Â«Â Extended Window Manager HintsÂ Â» et traitent ainsi le punaiseur et les "
+"panneaux comme des fenÃªtres normales. Activer cette option pour corriger les "
+"problÃ¨mes commeÂ : le punaiseur passe au premier plan quand vous cliquez "
+"dessus, des barres de titre et autres dÃ©corations apparaissent autour des "
+"fenÃªtres, ou ces fenÃªtres apparaissent dans les listes de sÃ©lection de "
+"fenÃªtres."
 
-#: tips:300
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
-msgstr "Passer tous les clics sur l'image de fond au gestionnaire de fenêtres"
+msgstr "Passer tous les clics sur l'image de fond au gestionnaire de fenÃªtres"
 
-#: tips:301
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
 "events to your window manager instead. Clicks on icons will not be forwarded."
 msgstr ""
 "Normalement, cliquer sur le fond du bureau avec le bouton droit ouvre le "
-"menu du punaiseur et cliquer avec le bouton gauche efface la sélection. "
-"Activez cette option pour transmettre à la place les événements à votre "
-"gestionnaire de fenêtres. Les clics sur les icônes ne seront pas transmis."
+"menu du punaiseur et cliquer avec le bouton gauche efface la sÃ©lection. "
+"Activez cette option pour transmettre Ã  la place les Ã©vÃ©nements Ã  votre "
+"gestionnaire de fenÃªtres. Les clics sur les icÃ´nes ne seront pas transmis."
 
-#: tips:302
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Hack des menus racine de Blackbox"
 
-#: tips:303
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
 "managers are expected to change their behaviour in new versions so that this "
 "isn't necessary."
 msgstr ""
-"Blackbox, Fluxbox et les gestionnaires de fenêtres similaires ne "
+"Blackbox, Fluxbox et les gestionnaires de fenÃªtres similaires ne "
 "fonctionnent pas encore bien avec le punaiseur de ROX-Filer. Ces "
-"gestionnaires de fenêtres devraient changer leur comportement dans leurs "
-"nouvelles versions de manière à ce que ceci ne soit pas nécessaire."
+"gestionnaires de fenÃªtres devraient changer leur comportement dans leurs "
+"nouvelles versions de maniÃ¨re Ã  ce que ceci ne soit pas nÃ©cessaire."
 
-#: tips:304
+#: tips:345
 msgid "Panel is a 'dock'"
-msgstr "Le panneau est un « dock »"
+msgstr "Le panneau est un Â«Â dockÂ Â»"
 
-#: tips:305
+#: tips:346
+#, fuzzy
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
-"Désactivez cette option si le panneau reste au-dessus des autres fenêtres "
-"contre votre volonté. Demande un redémarrage pour prendre effet."
+"DÃ©sactivez cette option si le panneau reste au-dessus des autres fenÃªtres "
+"contre votre volontÃ©. Demande un redÃ©marrage pour prendre effet."
 
-#: tips:306
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Style du panneau"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
-msgstr "Glisser-déposer"
+msgstr "Glisser-dÃ©poser"
 
-#: tips:307
+#: tips:352
 msgid "Don't use hostnames"
-msgstr "Ne pas utiliser de nom d'hôte"
+msgstr "Ne pas utiliser de nom d'hÃ´te"
 
-#: tips:308
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
 "sign on the pointer but the drop doesn't work."
 msgstr ""
 "Quelques applications parmi les plus anciennes ne supportent pas "
-"complètement le protocole XDND et peuvent nécessiter l'activation de cette "
-"option. Utilisez-la si le « glisser » de fichiers vers une application "
+"complÃ¨tement le protocole XDND et peuvent nÃ©cessiter l'activation de cette "
+"option. Utilisez-la si le Â«Â glisserÂ Â» de fichiers vers une application "
 "provoque bien l'apparition d'un signe '+' sur le pointeur mais que le "
-"« déposer » ne fonctionne pas."
+"Â«Â dÃ©poserÂ Â» ne fonctionne pas."
 
-#: tips:309
-msgid "Extended attributes"
-msgstr "Attributs étendus"
-
-#: tips:310
+#: tips:355
 msgid "Don't use extended attributes"
-msgstr "Ne pas utiliser les attributs étendus"
+msgstr "Ne pas utiliser les attributs Ã©tendus"
 
-#: tips:311
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
 "disabled, the MIME type of the file is only derived from the file name and "
 "the properties window does not report extended attributes."
 msgstr ""
-"Ceci désactive l'utilisation des attributs étendus disponibles dans les "
-"nouveaux systèmes d'exploitation et systèmes de fichiers. Si cette option "
-"est choisie, l'entrée « Fixer le type » du menu est désactivée, le type MIME "
-"du fichier est seulement dérivé du nom du fichier et la fenêtre des "
-"propriétés ne rapporte pas les attributs étendus."
+"Ceci dÃ©sactive l'utilisation des attributs Ã©tendus disponibles dans les "
+"nouveaux systÃ¨mes d'exploitation et systÃ¨mes de fichiers. Si cette option "
+"est choisie, l'entrÃ©e Â«Â Fixer le typeÂ Â» du menu est dÃ©sactivÃ©e, le type MIME "
+"du fichier est seulement dÃ©rivÃ© du nom du fichier et la fenÃªtre des "
+"propriÃ©tÃ©s ne rapporte pas les attributs Ã©tendus."
+
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "En bas"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "Ã€ droite"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "RÃ©pertoire personnel"
+
+#: ../Templates.ui.h:4
+msgid "Panel Options"
+msgstr "Options du panneau"
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Image et texte"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Chaque icÃ´ne du panneau comporte une image et du texte."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Image seule pour les applications"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"Les applications comportent juste une image, le reste comporte une image et "
+"du texte."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Image seule"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Seule l'image est affichÃ©e."
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Largeur de panneau (fine)"
+
+#: ../Templates.ui.h:12
+#, fuzzy
+msgid "The size of this panel."
+msgstr "Taille des panneaux."
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Traduction"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "Ne pas couvrir le panneau"
+
+#: ../Templates.ui.h:19
+#, fuzzy
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Demande au gestionnaire de fenÃªtres de ne pas couvrir du tout les panneaux "
+"quand vous maximisez des fenÃªtres. Certains gestionnaires de fenÃªtres "
+"peuvent ne pas honorer cette fonctionnalitÃ©. Si dÃ©sactivÃ©e, le filer demande "
+"que seules deux rangÃ©es de pixels au bord de l'Ã©cran restent visibles, de "
+"faÃ§on Ã  ce que le passage au premier plan automatique fonctionne."
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Style du panneau"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Confiner Ã  un moniteur Xinerama"
+
+#: ../Templates.ui.h:22
+#, fuzzy
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Si vous avez une configuration multimoniteur Xinerama, utilisez cette option "
+"pour confiner les panneaux Ã  un seul moniteur au lieu de les rÃ©partir."
+
+#: ../Templates.ui.h:23
+#, fuzzy
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+"Le moniteur auquel les panneaux sont confinÃ©s en mode Xinerama (numÃ©rotÃ© Ã  "
+"partir de 0)."
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "Xinerama"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr "Ã€ droite"
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr "Ã€ gauche"
+
+#: ../Templates.ui.h:27
+msgid "Bottom edge"
+msgstr "En bas"
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr "En haut"
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "<b>Permissions</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<rÃ©p>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' existe dÃ©jÃ  - Ã©craserÂ ?"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Erreur lors de la lecture de '%s'Â :\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "RÃ©pertoire manquant/supprimÃ©"
+
+#~ msgid "Directory '%s' is not accessible"
+#~ msgstr "Le rÃ©pertoire '%s' n'est pas accessible"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "RÃ©pertoire '%s' non trouvÃ©."
+
+#~ msgid "Cancel"
+#~ msgstr "Annuler"
+
+#~ msgid "All, "
+#~ msgstr "Tous, "
+
+#~ msgid "Dnotify support"
+#~ msgstr "Support dnotify"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Vous devez cliquer avec Menu, touche Shift enfoncÃ©e, au-dessus d'un "
+#~ "fichier pour l'envoyer quelque part"
+
+#~ msgid "Panel: %s"
+#~ msgstr "PanneauÂ : %s"
+
+#~ msgid "Select the panel's position:"
+#~ msgstr "SÃ©lectionnez la position du panneauÂ :"
+
+#~ msgid "Top-edge panel"
+#~ msgstr "Panneau situÃ© sur le bord supÃ©rieur"
+
+#~ msgid "Bottom edge panel"
+#~ msgstr "Panneau situÃ© sur le bord infÃ©rieur"
+
+#~ msgid "Left edge panel"
+#~ msgstr "Panneau situÃ© sur le bord gauche"
+
+#~ msgid "Right-edge panel"
+#~ msgstr "Panneau situÃ© sur le bord droit"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Fichier de traduction .gmo invalide (trop court)Â : %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr ""
+#~ "Fichier de traduction .gmo invalide (nombre magique GNU non trouvÃ©)Â : %s"
+
+#~ msgid "B"
+#~ msgstr "O"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Aller au rÃ©pertoire pÃ¨re"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Aller au rÃ©pertoire personnel"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Signets"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Menu des signets"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Relire le contenu du rÃ©pertoire"
+
+#~ msgid "Change icon size"
+#~ msgstr "Changer la taille des icÃ´nes"
+
+#~ msgid "Show extra details"
+#~ msgstr "Montrer tous les dÃ©tails"
+
+#~ msgid "Hidden"
+#~ msgstr "CachÃ©s"
+
+#~ msgid ""
+#~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
+#~ "instead."
+#~ msgstr ""
+#~ "Le thÃ¨me d'icÃ´nes '%s' ne contient pas d'icÃ´nes MIME. Utilisation du "
+#~ "thÃ¨me par dÃ©faut de ROX."
+
+#~ msgid ""
+#~ "Failed to create symlink '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(this may mean that the ROX theme already exists there, but the 'mime-"
+#~ "application:postscript' icon couldn't be loaded for some reason, or %s is "
+#~ "a link to an invalid directory; try deleting it)"
+#~ msgstr ""
+#~ "Impossible de crÃ©er le lien symbolique '%s'Â :\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(ceci peut vouloir dire que le thÃ¨me ROX existe dÃ©jÃ  ici, mais que "
+#~ "l'icÃ´ne Â«Â mime-application:postscriptÂ Â» n'a pas pu Ãªtre chargÃ©e pour une "
+#~ "raison quelconque, ou %s est un lien vers un rÃ©pertoire invalide; essayez "
+#~ "de le supprimer)"
+
+#~ msgid "Language"
+#~ msgstr "Langue"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "Utiliser la variable d'environnement LANG"
+
+#~ msgid "Basque"
+#~ msgstr "Basque"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Chinois (traditionnel)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Chinois (simplifiÃ©)"
+
+#~ msgid "Czech"
+#~ msgstr "TchÃ¨que"
+
+#~ msgid "Danish"
+#~ msgstr "Danois"
+
+#~ msgid "Dutch"
+#~ msgstr "NÃ©erlandais"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Anglais (pas de traduction)"
+
+#~ msgid "Estonian"
+#~ msgstr "Estonien"
+
+#~ msgid "Finnish"
+#~ msgstr "Finnois"
+
+#~ msgid "French"
+#~ msgstr "FranÃ§ais"
+
+#~ msgid "German"
+#~ msgstr "Allemand"
+
+#~ msgid "Hungarian"
+#~ msgstr "Hongrois"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonais"
+
+#~ msgid "Norwegian"
+#~ msgstr "NorvÃ©gien"
+
+#~ msgid "Italian"
+#~ msgstr "Italien"
+
+#~ msgid "Polish"
+#~ msgstr "Polonais"
+
+#~ msgid "Portuguese (Portugal)"
+#~ msgstr "Portugais (Portugal)"
+
+#~ msgid "Portuguese (Brasil)"
+#~ msgstr "Portugais (BrÃ©sil)"
+
+#~ msgid "Romanian"
+#~ msgstr "Roumain"
+
+#~ msgid "Russian"
+#~ msgstr "Russe"
+
+#~ msgid "Spanish"
+#~ msgstr "Espagnol"
+
+#~ msgid "Swedish"
+#~ msgstr "SuÃ©dois"
+
+#~ msgid "Ukrainian"
+#~ msgstr "Ukrainien"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamien"
+
+#~ msgid "Change at:"
+#~ msgstr "Changer Ã Â :"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Largeur maxi (grandes icÃ´nes)Â :"
+
+#~ msgid "Panels"
+#~ msgstr "Panneaux"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Les panneaux sont des barres d'icÃ´nes situÃ©es sur les cÃ´tÃ©s de l'Ã©cran. "
+#~ "Voir le manuel pour toute information sur l'utilisation des panneaux."
+
+#~ msgid "(thick)"
+#~ msgstr "(Ã©paisse)"
+
+#~ msgid "Enter the name of the panel to show here."
+#~ msgstr "Entrez le nom du panneau Ã  montrer."

--- a/ROX-Filer/src/po/gl.po
+++ b/ROX-Filer/src/po/gl.po
@@ -2,44 +2,46 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rox-filer-2.9 galego\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-09-16 08:51+0200\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2009-10-22 19:59+0100\n"
 "Last-Translator: Miguel Anxo Bouzada <mbouzada@gmail.com>\n"
 "Language-Team: Galician <proxecto@trasno.net>\n"
+"Language: gl\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-Language: Galician\n"
 "X-Poedit-Country: SPAIN\n"
 
-#: abox.c:125
-msgid "<dir>"
-msgstr "<dir>"
+#: abox.c:127
+msgid "<src>"
+msgstr ""
 
-#: abox.c:218
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Silencioso"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Quiet"
 msgstr "Silencioso"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Non confirme cada operación"
 
-#: abox.c:454
-#: infobox.c:782
-#: tips:36
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Nome"
 
-#: abox.c:460
-#: menu.c:237
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Directorio"
 
-#: abox.c:549
+#: abox.c:546
 msgid "Expression:"
 msgstr "Expresión:"
 
@@ -55,11 +57,11 @@ msgstr "Vexa a páxina do manual fsattr(5) para máis detalles."
 msgid "You do not appear to have OS support."
 msgstr "Parece que non ten compatibilidade para S.O."
 
-#: action.c:191
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Referéncia para expresións de busca"
 
-#: action.c:202
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -75,10 +77,13 @@ msgid ""
 "<b>IsReg system(grep -q fred \"%\")</b> (contains the word 'fred')\n"
 "\n"
 "<u>Simple Tests</u>\n"
-"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</b> (types)\n"
-"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> (permissions)\n"
+"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
+"b> (types)\n"
+"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
+"(permissions)\n"
 "<b>IsEmpty, IsMine</b>\n"
-"A pattern in single quotes is a shell-style wildcard pattern to match. If it\n"
+"A pattern in single quotes is a shell-style wildcard pattern to match. If "
+"it\n"
 "contains a slash then the match is against the full path; otherwise it is\n"
 "against the leafname only.\n"
 "\n"
@@ -86,7 +91,8 @@ msgid ""
 "<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (compare two values)\n"
 "<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (file sizes)\n"
 "<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (times)\n"
-"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> (values)\n"
+"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
+"(values)\n"
 "\n"
 "<u>Specials</u>\n"
 "<b>system(command)</b> (true if 'command' returns with a zero exit status;\n"
@@ -102,43 +108,50 @@ msgstr ""
 "<b>IsDIr 'lib'</b> (Atopa directorios 'lib')\n"
 "<b>IsReg 'core'</b> (atopa un ficheiro regular chamado 'core')\n"
 "<b>! (IsDir, IsReg)</b> (Non é un directorio ou ficheiro regular)\n"
-"<b>mtime after 1 day ago and size > 1Mb</b> (Con 1 mb e modificado recentemente)\n"
+"<b>mtime after 1 day ago and size > 1Mb</b> (Con 1 mb e modificado "
+"recentemente)\n"
 "<b>'CVS' prune, isreg</b> (ficheiro regular non está en CVS)\n"
 "<b>IsReg system(grep -q fred \"%\")</b> (conten a palabra 'fred')\n"
 "\n"
 "<u>Probas sinxelas</u>\n"
-"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</b> (types)\n"
-"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> (permisos)\n"
+"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
+"b> (types)\n"
+"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
+"(permisos)\n"
 "<b>IsEmpty, IsMine</b>\n"
 "Un patrón entre comillas simples é un patrón comodin estilo terminal.\n"
 "Si conten unha barra despois do espazo rompe a ruta completa, pola\n"
 "contra rompe o nome da folla.\n"
 "\n"
 "<u>Comparacións</u>\n"
-"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (compara dous valores)\n"
+"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (compara dous "
+"valores)\n"
 "<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (tamaños de ficheiros)\n"
 "<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (veces)\n"
-"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> (valores)\n"
+"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
+"(valores)\n"
 "\n"
 "<u>Especiais</u>\n"
 "<b>system(command)</b> (verdadeiro se «orde» devolve un cero de saida;\n"
 "% na «orde» é substituido por a ruta ao actual ficheiro)\n"
 "<b>prune</b> (falso, e impide a busca de contido nun directorio)."
 
-#: action.c:249
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Referéncia para o cambio de permisos"
 
-#: action.c:260
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
 "\n"
 "The format of a command is: <b>CHANGE, CHANGE, ...</b>\n"
 "Each <b>CHANGE</b> is: <b>WHO HOW PERMISSIONS</b>\n"
-"<b>WHO</b> is some combination of <b>u</b>, <b>g</b> and <b>o</b> which determines whether to\n"
+"<b>WHO</b> is some combination of <b>u</b>, <b>g</b> and <b>o</b> which "
+"determines whether to\n"
 "change the permissions for the User (owner), Group or Others.\n"
-"<b>HOW</b> is <b>+</b>, <b>-</b> or <b>=</b> to add, remove or set exactly the permissions.\n"
+"<b>HOW</b> is <b>+</b>, <b>-</b> or <b>=</b> to add, remove or set exactly "
+"the permissions.\n"
 "<b>PERMISSIONS</b> is some combination of the letters <b>rwxXstugo</b>\n"
 "\n"
 "Bracketed text and spaces are ignored.\n"
@@ -146,7 +159,8 @@ msgid ""
 "<u>Examples</u>\n"
 "<b>u+rw</b>: the file owner gains read and write permission\n"
 "<b>g=u</b>: the group permissions are set to be the same as the user's\n"
-"<b>o=u-w</b>: others get the same permissions as the owner, but without write permission\n"
+"<b>o=u-w</b>: others get the same permissions as the owner, but without "
+"write permission\n"
 "<b>a+x</b>: <b>a</b>ll get execute/access permission - same as <b>ugo+x</b>\n"
 "<b>a+X</b>: directories become accessable by everyone; files which were\n"
 "executable by anyone become executable by everyone\n"
@@ -161,29 +175,34 @@ msgstr ""
 "\n"
 "O formato de unha orde é <b>CAMBIO,CAMBIO,...</b>\n"
 "Cada <b>CAMBIO</b> é: <b>QUEN COMO PERMISOS</b>\n"
-"<b>QUEN</b> é algunha combinación de <b>u</b>, <b>g</b>, <b>o</b> que determina se se van a\n"
+"<b>QUEN</b> é algunha combinación de <b>u</b>, <b>g</b>, <b>o</b> que "
+"determina se se van a\n"
 "cambiar os permisos para O Usuario (propietario), Grupo ou Outros.\n"
-"<b>COMO</b> é <b>+</b>,<b>-</b> o <b>-</b> para engadir, quitar ou manter permisos.\n"
+"<b>COMO</b> é <b>+</b>,<b>-</b> o <b>-</b> para engadir, quitar ou manter "
+"permisos.\n"
 "<b>PERMISOS</b> son combinacións das letras <b>rwxXstugo</b>\n"
 "\n"
 "Os textos entre parénteses e os espazos son ignorados\n"
 "<u>Exemplos</u>\n"
 "<b>u+rw</b>: concede permisos de lectura e escritura ao propietario\n"
 "<b>g=u</b>: os permisos para grupo son os mesmos que os de usuario(s)\n"
-"<b>o=u-w</b>: outros teñen os mesmos permisos que o propietario menos o de escritura\n"
+"<b>o=u-w</b>: outros teñen os mesmos permisos que o propietario menos o de "
+"escritura\n"
 "<b>a+x</b>: <b>a</b>Permisos de acceso/execución - o mesmo que <b>ugo+x</b>\n"
-"<b>a+X</b>: os directorios fanse accesibles para todos; os ficheiros fanse executables para todos\n"
+"<b>a+X</b>: os directorios fanse accesibles para todos; os ficheiros fanse "
+"executables para todos\n"
 "<b>u+rw, go+r</b>: duas ordes á vez!\n"
-"<b>u+s</b>: poñer o bit SetUID - normalmente non ten efeto en ficheiros de escritura\n"
+"<b>u+s</b>: poñer o bit SetUID - normalmente non ten efeto en ficheiros de "
+"escritura\n"
 "<b>755</b>: configura permisos directamente\n"
 "\n"
 "Vexa a páxina de axuda (man) chmod(1) para ver máis detalles."
 
-#: action.c:301
+#: action.c:308
 msgid "Set type reference"
 msgstr "Referéncia para a definición de tipo"
 
-#: action.c:312
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -208,60 +227,59 @@ msgstr ""
 "«user.mime_type» para gardar os tipos de ficheiro.\n"
 "\n"
 "Os tipos de ficheiro só son compatibles con ficheiros regulares, e non\n"
-"para directorios, dispositivos, tuberias (pipes) ou «sockets», polo tanto só\n"
+"para directorios, dispositivos, tuberias (pipes) ou «sockets», polo tanto "
+"só\n"
 "en certos sistemas de ficheiros e cando o S.O. os implementa.\n"
 
-#: action.c:419
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Proceso rematado.\n"
 
-#: action.c:435
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Atopouse un erro.\n"
 
-#: action.c:437
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Atopáronse %d erros.\n"
 
-#: action.c:461
+#: action.c:516
 msgid "ERROR reading"
 msgstr "Atopouse un ERRO ao ler"
 
-#: action.c:504
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Feito\n"
 
-#: action.c:560
-#: support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "ERRO"
 
-#: action.c:714
-#: main.c:698
-#: main.c:705
-#: main.c:712
-#: main.c:726
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Sí"
 
-#: action.c:717
-#: main.c:700
-#: main.c:707
-#: main.c:714
-#: main.c:726
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Non"
 
-#: action.c:735
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -269,7 +287,7 @@ msgstr ""
 "\n"
 "Solicitando proceso fillo para rematar...\n"
 
-#: action.c:742
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -277,41 +295,41 @@ msgstr ""
 "\n"
 "Tentando deter (KILL) procesos desbocados...\n"
 
-#: action.c:895
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Calcular o contido de %s?"
 
-#: action.c:931
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Eliminar %s'%s'?"
 
-#: action.c:932
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "PROTEXIDO CONTRA ESCRITURA"
 
-#: action.c:939
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'Borrando '%s'\n"
 
-#: action.c:952
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'O directorio '%s' foi borrado\n"
 
-#: action.c:985
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?Expulsar '%s'?"
 
-#: action.c:992
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Expulsar '%s'\n"
 
-#: action.c:1011
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -320,98 +338,95 @@ msgstr ""
 "!%s\n"
 "fallou a expulsión\n"
 
-#: action.c:1030
-#: action.c:1049
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Verificar '%s'?"
 
-#: action.c:1046
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!A condición de busca non é válida - debe cambiala e probar de novo\n"
 
-#: action.c:1056
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(ao verificar '%s')\n"
 
-#: action.c:1130
-#: action.c:1155
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Cambiar permisos de '%s'?"
 
-#: action.c:1136
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Cambiando permisos de '%s'\n"
 
-#: action.c:1153
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Orde de modo non válida - debe cambiala e probar de novo\n"
 
-#: action.c:1211
+#: action.c:1332
 #, c-format
 msgid "?Change contents of '%s'?"
 msgstr "?Cambiar o contido de '%s'?"
 
-#: action.c:1214
-#: action.c:1234
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Cambiar o tipo de '%s'?"
 
-#: action.c:1231
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Tipo non válido - debe cambialo e probar de novo\n"
 
-#: action.c:1253
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Cambiando o tipo de '%s' a '%s'\n"
 
-#: action.c:1276
+#: action.c:1397
 #, c-format
 msgid "'Not changing type of directory '%s'\n"
 msgstr "'O tipo de directorio '%s non se cambia'\n"
 
-#: action.c:1282
+#: action.c:1403
 #, c-format
 msgid "'Non-regular file '%s' not changed\n"
 msgstr "'Ficheiro non regular '%s' non se cambia\n"
 
-#: action.c:1342
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' xa existe - %s?"
 
-#: action.c:1344
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "misturar contidos"
 
-#: action.c:1345
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "sobreescribir"
 
-#: action.c:1361
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Tentando copiar ainda asi...\n"
 
-#: action.c:1370
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Copiar %s en %s?"
 
-#: action.c:1374
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Copiando %s en %s\n"
 
-#: action.c:1389
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!ERRO: O destino xa existe pero non é un directorio\n"
 
-#: action.c:1461
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -420,26 +435,7 @@ msgstr ""
 "!%s\n"
 "Fallou ao copiar '%s'\n"
 
-#: action.c:1505
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' xa existe - sobreescribir?"
-
-#: action.c:1520
-msgid "'Trying move anyway...\n"
-msgstr "'Tentando mover ainda asi...\n"
-
-#: action.c:1528
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Mover %s para %s?"
-
-#: action.c:1532
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Movendo %s para %s\n"
-
-#: action.c:1540
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -448,45 +444,59 @@ msgstr ""
 "!%s\n"
 "fallou ao mover %s para %s\n"
 
-#: action.c:1561
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Tentando mover ainda asi...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Mover %s para %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Movendo %s para %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!ERRO: Non se pode copiar un obxecto cara a el mesmo\n"
 
-#: action.c:1576
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!ERRO: Non se pode mover/renomear un obxecto cara a el mesmo\n"
 
-#: action.c:1588
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Ligando %s con %s\n"
 
-#: action.c:1593
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Crear ligazón para %s con %s?"
 
-#: action.c:1636
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Montando %s\n"
 
-#: action.c:1637
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Desmontando %s\n"
 
-#: action.c:1640
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?Montar %s?"
 
-#: action.c:1641
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?Desmontar %s?"
 
-#: action.c:1662
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -495,7 +505,7 @@ msgstr ""
 "!%s\n"
 "Fallou a montaxe\n"
 
-#: action.c:1663
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -504,11 +514,11 @@ msgstr ""
 "!%s\n"
 "Fallou a desmontaxe\n"
 
-#: action.c:1671
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(de cal queira xeito agora parece estar montado)\n"
 
-#: action.c:1717
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -517,319 +527,319 @@ msgstr ""
 "'\n"
 "Total: %s ("
 
-#: action.c:1723
+#: action.c:2108
 msgid "file"
 msgstr "ficheiro"
 
-#: action.c:1723
+#: action.c:2108
 msgid "files"
 msgstr "ficheiros"
 
-#: action.c:1727
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "ningún directorio)\n"
 
-#: action.c:1731
+#: action.c:2116
 msgid "directory"
 msgstr "directorio"
 
-#: action.c:1732
+#: action.c:2117
 msgid "directories"
 msgstr "directorios"
 
-#: action.c:1773
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Punto de montaxe sen selecionar!\n"
 
-#: action.c:1858
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Outra busca?"
 
-#: action.c:1888
-#: action.c:1919
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' é unha ligazón simbólica\n"
 
-#: action.c:1959
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "É preciso seleccionar algúns elementos para buscar en eles"
 
-#: action.c:1969
-#: menu.c:228
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Buscar"
 
-#: action.c:2002
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "É necesario seleccionar algúns elementos para calcular"
 
-#: action.c:2006
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Uso de disco"
 
-#: action.c:2042
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Montar / Desmontar"
 
-#: action.c:2059
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
-msgstr "«ROX-Filer» ainda non é compatible con puntos de montaxe no seu sistema. Desculpe."
+msgstr ""
+"«ROX-Filer» ainda non é compatible con puntos de montaxe no seu sistema. "
+"Desculpe."
 
-#: action.c:2073
-#: menu.c:216
-#: tips:173
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Borrar"
 
-#: action.c:2085
-#: tips:178
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Forzar"
 
-#: action.c:2085
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Non confirme ao borrar en elementos sen permisos de escritura"
 
-#: action.c:2088
-#: action.c:2147
-#: action.c:2210
-#: action.c:2283
-#: action.c:2323
-#: tips:180
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Rexistro"
 
-#: action.c:2088
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Só crea rexistro dos directorios ao ser borrados"
 
-#: action.c:2107
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "É necesario escoller os elementos cuxos permisos quere modificar"
 
-#: action.c:2115
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Facer executable/buscable)"
 
-#: action.c:2117
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (Facer non executale/non buscable)"
 
-#: action.c:2119
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Dar ao propietario permisos de lectura escritura)"
 
-#: action.c:2121
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Privado - aceso permitido só ao propietario)"
 
-#: action.c:2123
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Aceso público, sen escritura)"
 
-#: action.c:2134
-#: menu.c:189
-#: menu.c:226
-#: tips:53
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Permisos"
 
-#: action.c:2147
-#: action.c:2210
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Non listar os ficheiros procesados"
 
-#: action.c:2150
-#: action.c:2213
-#: tips:182
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Recursivo"
 
-#: action.c:2150
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Cambiar tamén o contido dos subdirectorios"
 
-#: action.c:2154
+#: action.c:2547
 msgid "Command:"
 msgstr "Orde:"
 
-#: action.c:2184
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Ten que seleccionar o elemento cuxo tipo quere modificar"
 
-#: action.c:2197
+#: action.c:2590
 msgid "Set type"
 msgstr "Definir tipo"
 
-#: action.c:2213
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Cambiar o contido dos subdirectorios"
 
-#: action.c:2220
-#: infobox.c:638
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Tipo:"
 
-#: action.c:2267
-#: dnd.c:122
-#: menu.c:2024
-#: tips:167
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Copiar"
 
-#: action.c:2279
-#: action.c:2319
-#: tips:184
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Non confirme cada operación"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Sobreescribir só se a fonte é máis recente que o destino"
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Recente"
 
-#: action.c:2280
-#: action.c:2320
-#: tips:185
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Sobreescribir só se a fonte é máis recente que o destino"
 
-#: action.c:2283
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "directorios"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Crear rexistro de directorios só o ser copiados"
 
-#: action.c:2307
-#: dnd.c:123
-#: tips:169
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Mover"
 
-#: action.c:2323
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Non crear rexistro de cada ficheiro ao ser movido"
 
-#: action.c:2346
-#: tips:171
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Ligazón"
 
-#: action.c:2369
-#: appmenu.c:111
-#: filer.c:646
-#: infobox.c:1051
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Expulsar"
 
-#: action.c:2437
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Borrar elementos tales como"
 
-#: action.c:2441
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Borrando o elemento"
 
-#: action.c:2443
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Borrando os elementos"
 
-#: action.c:2462
+#: action.c:2900
 msgid " and "
 msgstr " e "
 
-#: action.c:2471
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
-msgstr " vai a afectar a algúns elementos no taboleiro ou no panel - quere borralo igualmente?"
+msgstr ""
+" vai a afectar a algúns elementos no taboleiro ou no panel - quere borralo "
+"igualmente?"
 
-#: action.c:2478
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
-msgstr " vai a afectar a algúns elementos no taboleiro ou no panel - quere borralos igualmente?"
+msgstr ""
+" vai a afectar a algúns elementos no taboleiro ou no panel - quere borralos "
+"igualmente?"
 
-#: appmenu.c:197
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<falta a etiqueta>"
 
-#: appmenu.c:319
+#: appmenu.c:317
 #, c-format
-msgid "Symlink any programs you want into this directory. They will appear in the menu for all items of this type (%s/%s)."
-msgstr "Cree as ligazóns simbólicas para os programas que precise neste directorio. Apareceran no menú para todos os elementos deste tipo (%s/%s)."
+msgid ""
+"Symlink any programs you want into this directory. They will appear in the "
+"menu for all items of this type (%s/%s)."
+msgstr ""
+"Cree as ligazóns simbólicas para os programas que precise neste directorio. "
+"Apareceran no menú para todos os elementos deste tipo (%s/%s)."
 
-#: appmenu.c:363
-#: menu.c:239
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Personalizar o menú..."
 
-#: appmenu.c:420
-#: menu.c:257
-#: toolbar.c:158
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Axuda"
 
-#: bookmarks.c:148
-#: log.c:160
-msgid "Path"
-msgstr "Ruta"
-
-#: bookmarks.c:156
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Título"
 
-#: bookmarks.c:305
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Ruta"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Non é posible gardar nos favoritos un recurso non local '%s'\n"
 
-#: bookmarks.c:313
-#: bookmarks.c:631
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' non é un directorio"
 
-#: bookmarks.c:519
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Debe seleccionar algunhas liñas para borrar"
 
-#: bookmarks.c:543
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Sitúe o punteiro nunha entrada da lista para mover"
 
-#: bookmarks.c:563
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Este elemento xa está no fin"
 
-#: bookmarks.c:637
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Non é posible gardar nos favoritos directorios non locais como '%s'"
 
-#: bookmarks.c:779
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Engadir a marca páxinas"
 
-#: bookmarks.c:786
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Editar marca páxinas"
 
-#: bookmarks.c:791
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Visitado recentemente"
 
-#: bulk_rename.c:66
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Renomear ficheiros en grupo"
 
-#: bulk_rename.c:69
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Restaurar"
 
-#: bulk_rename.c:74
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "Facer na columna «Novo» unha copia da columna «Antigo»"
 
-#: bulk_rename.c:79
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "_Renomear"
 
-#: bulk_rename.c:92
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Substituir:"
 
-#: bulk_rename.c:99
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -843,58 +853,72 @@ msgstr ""
 "\\. coincidencia a un punto \n"
 "\\.htm$ coincidencia ao '.htm' en 'index.htm', etc"
 
-#: bulk_rename.c:107
+#: bulk_rename.c:109
 msgid "With:"
 msgstr "Por:"
 
-#: bulk_rename.c:114
-msgid "The first match in each filename will be replaced by this string. The only special characters are back-references from \\0 to \\9. To use them literally, they have to be escaped with a backslash."
-msgstr "A primeira coincidencia en cada nome de ficheiro será substituida por esta expresión. Os únicos caracteres especiais son copias das referencias de \\0 a \\9. Para usalos, literalmente, teñen que ser escapados con unha barra invertida «\\»."
+#: bulk_rename.c:116
+msgid ""
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
+msgstr ""
+"A primeira coincidencia en cada nome de ficheiro será substituida por esta "
+"expresión. Os únicos caracteres especiais son copias das referencias de \\0 "
+"a \\9. Para usalos, literalmente, teñen que ser escapados con unha barra "
+"invertida «\\»."
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Aplicar"
 
-#: bulk_rename.c:123
-msgid "Do a search-and-replace in the New column. The files are not actually renamed until you click on the Rename button below."
-msgstr "buscar e substituir nos ficheiros da coluna Novo. Os ficheiros non son realmente renomeados até premer no boton Renomear, en baixo."
+#: bulk_rename.c:125
+msgid ""
+"Do a search-and-replace in the New column. The files are not actually "
+"renamed until you click on the Rename button below."
+msgstr ""
+"buscar e substituir nos ficheiros da coluna Novo. Os ficheiros non son "
+"realmente renomeados até premer no boton Renomear, en baixo."
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Nome antigo"
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Nome novo"
 
-#: bulk_rename.c:293
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr "Ningunha expresión (na coluna Novo) coincide con a  expresión dada"
 
-#: bulk_rename.c:298
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Un nome coincide, pero o resultado foi o mesmo"
 
-#: bulk_rename.c:301
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d nomes coinciden, pero os resultados foron os mesmos"
 
-#: bulk_rename.c:327
-msgid "Specify a regular expression to match, and a string to replace matches with."
-msgstr "Especifique unha expresión regular para coincidencias, e unha expresión para substituílas."
+#: bulk_rename.c:330
+msgid ""
+"Specify a regular expression to match, and a string to replace matches with."
+msgstr ""
+"Especifique unha expresión regular para coincidencias, e unha expresión para "
+"substituílas."
 
-#: bulk_rename.c:344
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (para '%s')"
 
-#: bulk_rename.c:377
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr "Xa existe un ficheiro chamado '%s'. Abandonando o renomeado en grupo."
 
-#: bulk_rename.c:382
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -905,17 +929,21 @@ msgstr ""
 "%s\n"
 "Abandonando o renomeado en grupo."
 
-#: bulk_rename.c:444
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "O ficheiro chamado '%s' xa existe"
 
-#: bulk_rename.c:455
+#: bulk_rename.c:458
 #, c-format
-msgid "Some of the New names contain / characters (eg '%s'). This will cause the files to end up in different directories. Continue?"
-msgstr "Algúns dos novos nomes conteñen o carácter / (ex. '%s'). Isto fará que os ficheiros rematen en directorios diferentes. Continuar?"
+msgid ""
+"Some of the New names contain / characters (eg '%s'). This will cause the "
+"files to end up in different directories. Continue?"
+msgstr ""
+"Algúns dos novos nomes conteñen o carácter / (ex. '%s'). Isto fará que os "
+"ficheiros rematen en directorios diferentes. Continuar?"
 
-#: bulk_rename.c:470
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Ningún  dos nomes foi cambiado. Non se fai nada!"
 
@@ -939,113 +967,177 @@ msgstr ""
 "%s\n"
 "%s"
 
-#: dir.c:1041
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Non é posible ver estatísticas do directorio: %s"
 
-#: dir.c:1050
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Non é posible abrir o directorio: %s"
 
-#: display.c:659
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Tamaño"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "Fallo en lstat(2): %s"
 
-#: dnd.c:124
-msgid "Link (relative)"
-msgstr "Crear ligazón (relativa)"
-
-#: dnd.c:125
-msgid "Link (absolute)"
-msgstr "Crear ligazón (absoluta)"
-
-#: dnd.c:424
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Atopouse un erro interno - «info»  non válido"
 
-#: dnd.c:563
+#: dnd.c:565
 msgid "Drag a directory here to bookmark it."
 msgstr "Arrastre un directorio aquí para engadilo a marca páxinas"
 
-#: dnd.c:578
+#: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
-msgstr "Atopouse un erro no protocolo XDS: o nome de unha folla non pode conter '/'\n"
+msgstr ""
+"Atopouse un erro no protocolo XDS: o nome de unha folla non pode conter '/'\n"
 
-#: dnd.c:603
-msgid "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/plain) did not contain a leafname\n"
-msgstr "Destino XdndDirectSave0 dispoñible, pero o elemento XdndDirectSave0 (tipo texto/simple) non contén un nome de folla\n"
+#: dnd.c:605
+msgid ""
+"XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
+"plain) did not contain a leafname\n"
+msgstr ""
+"Destino XdndDirectSave0 dispoñible, pero o elemento XdndDirectSave0 (tipo "
+"texto/simple) non contén un nome de folla\n"
 
-#: dnd.c:616
+#: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
-msgstr "Desculpe - é necesario un destino do tipo text/uri-list ou XdndDirectSave0."
+msgstr ""
+"Desculpe - é necesario un destino do tipo text/uri-list ou XdndDirectSave0."
 
-#: dnd.c:619
-msgid "Sorry - I require a target type of text/uri-list or application/octet-stream."
-msgstr "Desculpe - É necesario o destino do tipo text/uri-list ou application/octet-stream."
+#: dnd.c:621
+msgid ""
+"Sorry - I require a target type of text/uri-list or application/octet-stream."
+msgstr ""
+"Desculpe - É necesario o destino do tipo text/uri-list ou application/octet-"
+"stream."
 
-#: dnd.c:689
+#: dnd.c:691
 #, c-format
 msgid ""
-"Failed to add some items to the pinboard, because they are on a remote machine. For example:\n"
+"Failed to add some items to the pinboard, because they are on a remote "
+"machine. For example:\n"
 "\n"
 "%s"
 msgstr ""
-"Fallou ao engadir algúns elementos ao taboleiro, xa que están nunha máquina remota. Por exemplo:\n"
+"Fallou ao engadir algúns elementos ao taboleiro, xa que están nunha máquina "
+"remota. Por exemplo:\n"
 "\"\n"
 "%s"
 
-#: dnd.c:764
+#: dnd.c:766
 msgid "Unknown target"
 msgstr "Destino descoñecido"
 
-#: dnd.c:797
+#: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
-msgstr "Desculpe - O aplicativo remoto non consigue ou non quere enviar os datos"
+msgstr ""
+"Desculpe - O aplicativo remoto non consigue ou non quere enviar os datos"
 
-#: dnd.c:810
+#: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
-msgstr "Houbo un erro no protocolo XDS: o código de retorno deberia ser 'S', 'F' ou 'E'\n"
+msgstr ""
+"Houbo un erro no protocolo XDS: o código de retorno deberia ser 'S', 'F' ou "
+"'E'\n"
 
-#: dnd.c:843
+#: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
-msgstr "Desculpe, non  é posible amosar un menú de accións para un ficheiro remoto / datos en bruto"
+msgstr ""
+"Desculpe, non  é posible amosar un menú de accións para un ficheiro remoto / "
+"datos en bruto"
 
-#: dnd.c:859
+#: dnd.c:861
 msgid "UntitledData"
 msgstr "DatosSenNome"
 
-#: dnd.c:886
+#: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
 msgstr "Atopouse un erro ao gardar o ficheiro: %s"
 
-#: dnd.c:959
+#: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
 msgstr "Non hai URI's no text/uri-list (non facer nada!)"
 
-#: dnd.c:991
-msgid "Can't get data from remote machine (application/octet-stream not provided)"
-msgstr "Non é posible obter datos da máquina remota (application/octet-stream non dispoñible)"
+#: dnd.c:993
+msgid ""
+"Can't get data from remote machine (application/octet-stream not provided)"
+msgstr ""
+"Non é posible obter datos da máquina remota (application/octet-stream non "
+"dispoñible)"
 
-#: dnd.c:1014
-msgid "Some of these files are on a different machine - they will be ignored - sorry"
-msgstr "Desculpe - Algúns destes ficheiros están nunha máquina diferente - van ser ignorados"
+#: dnd.c:1015 menu.c:2406
+msgid ""
+"Some of these files are on a different machine - they will be ignored - sorry"
+msgstr ""
+"Desculpe - Algúns destes ficheiros están nunha máquina diferente - van ser "
+"ignorados"
 
-#: dnd.c:1021
-msgid "None of these files are on the local machine - I can't operate on multiple remote files - sorry."
-msgstr "Ningún destes ficheiros está na máquina local - non se pode operar en múltiples ficheiros remotos."
+#: dnd.c:1024 menu.c:2414
+msgid ""
+"None of these files are on the local machine - I can't operate on multiple "
+"remote files - sorry."
+msgstr ""
+"Ningún destes ficheiros está na máquina local - non se pode operar en "
+"múltiples ficheiros remotos."
 
-#: dnd.c:1034
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "A acción solicitada é descoñecida"
 
-#: dnd.c:1042
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Atopouse un erro ao obter a lista de ficheiros: %s"
+
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Crear ligazón (relativa)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Crear ligazón (absoluta)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Crear ligazón (relativa)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Crear ligazón (absoluta)"
 
 #: dropbox.c:112
 msgid "Show"
@@ -1060,8 +1152,12 @@ msgid "<nothing>"
 msgstr "<nada>"
 
 #: dropbox.c:237
-msgid "I can't show you the currently set item, because nothing is currently set. Drag something onto me!"
-msgstr "Non se pode amosar o elemento definido actualmente, xá que non hai nada definido actualmente. Arrastre algo cara aquí!"
+msgid ""
+"I can't show you the currently set item, because nothing is currently set. "
+"Drag something onto me!"
+msgstr ""
+"Non se pode amosar o elemento definido actualmente, xá que non hai nada "
+"definido actualmente. Arrastre algo cara aquí!"
 
 #: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
@@ -1072,8 +1168,7 @@ msgstr "Desculpe, debe soltar un ficheiro exactamente na área de destino."
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr "Desculpe, non se pode usar '%s' porque non é un ficheiro local."
 
-#: dropbox.c:278
-#: pinboard.c:932
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1082,7 +1177,7 @@ msgstr ""
 "Non se pode aceder a '%s':\n"
 "%s"
 
-#: filer.c:461
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1091,16 +1186,7 @@ msgstr ""
 "Atopouse un erro ao explorar '%s':\n"
 "%s\n"
 
-#: filer.c:465
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Atopouse un erro ao explorar '%s':\n"
-"%s"
-
-#: filer.c:621
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1110,141 +1196,167 @@ msgstr ""
 "\n"
 "Desmontar un dispositivo fai que sexa seguro extraelo."
 
-#: filer.c:626
+#: filer.c:889
 msgid "Perform the same action in future for this mount point"
 msgstr "Realizar a mesma acción no futuro para este punto de montaxe"
 
-#: filer.c:633
+#: filer.c:896
 msgid "No change"
 msgstr "Sen cambios"
 
-#: filer.c:639
-#: infobox.c:1049
-#: menu.c:872
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Desmontar"
 
-#: filer.c:743
-msgid "Directory missing/deleted"
-msgstr "Directorio ausente/borrado"
-
-#: filer.c:1107
+#: filer.c:1490
 #, c-format
 msgid ""
-"Group %s is not set. Select some files and press Ctrl+%s to set the group. Press %s on its own to reselect the files later.\n"
+"Group %s is not set. Select some files and press Ctrl+%s to set the group. "
+"Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"O grupo %s non está definido. Seleccione algúns ficheiros e prema en Ctrl+%s para definir o grupo. Prema só %s para seleccionar os ficheiros mais tarde.\n"
+"O grupo %s non está definido. Seleccione algúns ficheiros e prema en Ctrl+%s "
+"para definir o grupo. Prema só %s para seleccionar os ficheiros mais tarde.\n"
 "Asegúrese de que «BloqNum» está activado ao usar o teclado numérico."
 
-#: filer.c:1343
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Non se pode aceder ao directorio '%s'"
-
-#: filer.c:1495
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Non se atopa o directorio '%s'."
-
-#: filer.c:1795
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: filer.c:2076
+#: filer.c:2655
 msgid "A"
 msgstr "T"
 
-#: filer.c:2078
-#: find.c:923
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr "G"
 
-#: filer.c:2083
+#: filer.c:2664
 msgid "S"
 msgstr "E"
 
-#: filer.c:2085
+#: filer.c:2669
 msgid "T"
 msgstr "M"
 
-#: filer.c:2095
-msgid "All, "
-msgstr "Todos, "
+#: filer.c:2670
+msgid "D"
+msgstr ""
 
-#: filer.c:2098
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
 msgstr "Glob (%s),"
 
-#: filer.c:2106
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Explorando,"
 
-#: filer.c:2108
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Miniaturas,"
 
-#: filer.c:2384
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Miniaturas,"
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Ligazón simbólica a "
 
-#: filer.c:2426
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "O nome do ficheiro non é un UTF-8 válido. Debe renomealo.\n"
 
-#: filer.c:2743
-#: menu.c:2014
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "O elemento xa non existe!"
 
-#: filer.c:3549
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Seleccione as propiedades de visualización para gardar"
 
-#: filer.c:3553
+#: filer.c:4712
+#, fuzzy
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr "<b>Gardar axustes de visualización para o directorio/b>"
+
+#: filer.c:4713
 msgid "<b>Save display settings for directory</b>"
 msgstr "<b>Gardar axustes de visualización para o directorio/b>"
 
-#: filer.c:3560
+#: filer.c:4720
 msgid "Select settings to save"
 msgstr "Seleccione os axustes para gardar"
 
-#: filer.c:3567
+#: filer.c:4727
 msgid "Position"
 msgstr "Posición"
 
-#: filer.c:3572
-#: toolbar.c:133
-#: toolbar.c:137
-#: tips:39
-msgid "Size"
-msgstr "Tamaño"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Fiestra"
 
-#: filer.c:3577
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Amosar agochados"
 
-#: filer.c:3583
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Estilo de visualización"
 
-#: filer.c:3589
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Ordenar por tipo e propietario"
 
-#: filer.c:3594
-#: toolbar.c:141
+#: filer.c:4754
 msgid "Details"
 msgstr "Detalles"
 
-#: filer.c:3599
-#: tips:92
-#: tips:93
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Miniaturas"
 
-#: filer.c:3605
+#: filer.c:4765
 msgid "Filter"
 msgstr "Filtro"
 
@@ -1468,15 +1580,19 @@ msgstr "bloque"
 msgid "Save As:"
 msgstr "Gardar como"
 
-#: gtksavebox.c:395
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Sen nome"
 
-#: gtksavebox.c:471
-msgid "Remote application wants to use Direct Save, but I can't read the XdndDirectSave0 (type text/plain) property.\n"
-msgstr "O aplicativo remoto quere usar «Direct Save», pero non se pode ler a propriedade XdndDirectSave0 (type text/plain).\n"
+#: gtksavebox.c:477
+msgid ""
+"Remote application wants to use Direct Save, but I can't read the "
+"XdndDirectSave0 (type text/plain) property.\n"
+msgstr ""
+"O aplicativo remoto quere usar «Direct Save», pero non se pode ler a "
+"propriedade XdndDirectSave0 (type text/plain).\n"
 
-#: gtksavebox.c:596
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1484,7 +1600,7 @@ msgstr ""
 "Arraste a ícona cara a un directorio\n"
 "(ou introduza a ruta completa)"
 
-#: gui_support.c:330
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1492,195 +1608,193 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:399
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
-msgstr "Tentando ler un ficheiro XML como un ficheiro de texto. O ficheiro '%s' pode estar danado."
+msgstr ""
+"Tentando ler un ficheiro XML como un ficheiro de texto. O ficheiro '%s' pode "
+"estar danado."
 
-#: gui_support.c:416
+#: gui_support.c:542
 #, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
-"This may be due to upgrading from a previous version of ROX-Filer. Open the Options window and try changing something and then changing it back (causing the file to be resaved).\n"
+"This may be due to upgrading from a previous version of ROX-Filer. Open the "
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
 "Atopouse un erro no ficheiro '%s' na liña %d: \n"
 "\"%s\"\n"
-"Isto pode ser debido a ter actualizado desde unha versión antiga do «ROX-Filer». Abra a fiestra «Opcións» probe a cambiar cal queira cousa para darlle o valor desexado (para que o ficheiro volva a ser gardado).\n"
+"Isto pode ser debido a ter actualizado desde unha versión antiga do «ROX-"
+"Filer». Abra a fiestra «Opcións» probe a cambiar cal queira cousa para "
+"darlle o valor desexado (para que o ficheiro volva a ser gardado).\n"
 "Os próximos erros serán ignorados."
 
-#: gui_support.c:1008
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Creba de liña incorrecta ou faltan os datos «text/uri-list»"
 
-#: gui_support.c:1341
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "Non se pode abrir o ficheiro '%s': %s"
 
-#: gui_support.c:1385
-#, c-format
-msgid "Failed to load image '%s': reason not known, probably a corrupt image file"
-msgstr "Fallou ao cargar a imaxe '%s': razón descoñecida, é probable que o ficheiro de imaxe este danado"
-
-#: gui_support.c:1450
+#: gui_support.c:1517
 #, c-format
 msgid ""
-"This program (%s) cannot be run, as the 0launch command is not available. It can be downloaded from here:\n"
+"Failed to load image '%s': reason not known, probably a corrupt image file"
+msgstr ""
+"Fallou ao cargar a imaxe '%s': razón descoñecida, é probable que o ficheiro "
+"de imaxe este danado"
+
+#: gui_support.c:1583
+#, c-format
+msgid ""
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
-"Este aplicativo (%s) non pode executarse, xa que a orde «0launch» non está dispoñible. Pode descargalo desta ligazón:\n"
+"Este aplicativo (%s) non pode executarse, xa que a orde «0launch» non está "
+"dispoñible. Pode descargalo desta ligazón:\n"
 "\n"
 "http://0install.net/injector.html"
 
 #: i18n.c:39
-msgid "Note that you must save your choices and restart the filer for the new language setting to take full effect."
-msgstr "Fíxese en que ten que gardar a súa selección e reiniciar o xestor para que as novas definicións de idioma teñan efecto."
+msgid ""
+"Note that you must save your choices and restart the filer for the new "
+"language setting to take full effect."
+msgstr ""
+"Fíxese en que ten que gardar a súa selección e reiniciar o xestor para que "
+"as novas definicións de idioma teñan efecto."
 
-#: icon.c:76
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(prema para definir)"
 
-#: icon.c:131
-msgid "ROX-Filer"
-msgstr "«ROX-Filer»"
-
-#: icon.c:132
-#: menu.c:258
-msgid "About ROX-Filer..."
-msgstr "Acerca de «ROX-Filer»..."
-
-#: icon.c:133
-#: menu.c:259
-msgid "Show Help Files"
-msgstr "Amosar ficheiros de axuda"
-
-#: icon.c:134
-#: menu.c:260
-msgid "Manual"
-msgstr "Manual"
-
-#: icon.c:136
-#: menu.c:235
-msgid "Options..."
-msgstr "Opcións..."
-
-#: icon.c:137
-#: menu.c:244
-msgid "Home Directory"
-msgstr "Directorio persoal"
-
-#: icon.c:138
-#: icon.c:1410
-#: menu.c:212
-#: type.c:223
-msgid "File"
-msgstr "Ficheiro"
-
-#: icon.c:139
-#: menu.c:218
-#: menu.c:885
-msgid "Shift Open"
-msgstr "Abrir Con «Mayús»"
-
-#: icon.c:140
-#: menu.c:223
-msgid "Properties"
-msgstr "Propiedades"
-
-#: icon.c:141
-#: menu.c:221
-msgid "Set Run Action..."
-msgstr "Definir a acción a executar..."
-
-#: icon.c:142
-#: menu.c:222
-msgid "Set Icon..."
-msgstr "Definir a icona..."
-
-#: icon.c:143
-#: icon.c:867
-msgid "Edit Item"
-msgstr "Editar o elemento"
-
-#: icon.c:144
-msgid "Show Location"
-msgstr "Amosar a localización"
-
-#: icon.c:145
-msgid "Remove Item(s)"
-msgstr "Eliminar elemento(s)"
-
-#: icon.c:318
-#: log.c:110
-#: menu.c:774
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:331
+#: icon.c:311
 msgid "Nothing"
 msgstr "Nada"
 
-#: icon.c:592
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "A localización debe conter polo menos un carácter!"
 
-#: icon.c:657
+#: icon.c:641
 #, c-format
 msgid "You must unlock '%s' before removing it"
 msgstr "Debe desbloquear '%s' antes de quitalo"
 
-#: icon.c:667
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Antes de quitalo debe seleccionar algún elemento"
 
-#: icon.c:673
+#: icon.c:657
 msgid "An item must be unlocked before it can be removed."
 msgstr "O elemento debe ser desbloqueado antes de quitalo."
 
-#: icon.c:687
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Hai que abrir o menú sobre o elemento"
 
-#: icon.c:712
-#: menu.c:1285
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "Só se pode definir a acción de executar para un ficheiro regular"
 
-#: icon.c:798
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Prema o atallo desexado (ex. Control+F1)"
 
-#: icon.c:820
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Falla o aceso ao teclado!"
 
-#: icon.c:870
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Editar o elemento"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Premer na icona abre:"
 
-#: icon.c:880
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Argumentos necesarios (para executables):"
 
-#: icon.c:894
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "O texto amosado baixo a icona é:"
 
-#: icon.c:907
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "O atallo de teclado é:"
 
-#: icon.c:927
+#: icon.c:910
 msgid "Locked"
 msgstr "Bloqueado"
 
-#: icon.c:932
+#: icon.c:915
 msgid "Locking an item prevents it from being accidentally removed"
 msgstr "O bloqueo dun elemento impide que sexa eliminado accidentalmente"
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "«ROX-Filer»"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Acerca de «ROX-Filer»..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Amosar ficheiros de axuda"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Manual"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Opcións..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Directorio persoal"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Ficheiro"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Abrir Con «Mayús»"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Propiedades"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Definir a acción a executar..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Definir a icona..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Amosar a localización"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Eliminar elemento(s)"
 
 #: infobox.c:113
 #, c-format
@@ -1691,43 +1805,40 @@ msgstr "Quere confirmar a apertura de %d fiestras?"
 msgid "Show Info"
 msgstr "Información"
 
-#: infobox.c:136
-#: menu.c:779
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(utf-8 incorrecto)"
 
-#: infobox.c:261
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Amosar fic_heiros de axuda"
 
-#: infobox.c:274
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Permisos</b>"
 
-#: infobox.c:292
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>O contido indica...</b>"
 
-#: infobox.c:302
+#: infobox.c:319
 msgid "<b>When all directories are closed</b>"
 msgstr "<b>Cando se pechan todos os directorios</b>"
 
-#: infobox.c:438
-#: infobox.c:579
-#: support.c:349
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "bytes"
 
-#: infobox.c:461
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Fallou ao ler o tamaño"
 
-#: infobox.c:522
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' xa non é unha ligazón simbólica"
 
-#: infobox.c:529
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1736,7 +1847,7 @@ msgstr ""
 "Fallou ao desligar '%s':\n"
 "%s"
 
-#: infobox.c:534
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1747,184 +1858,185 @@ msgstr ""
 "%s\n"
 "(nota: a ligazón antiga foi eliminada)"
 
-#: infobox.c:558
-#: tips:242
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Erro:"
 
-#: infobox.c:565
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Directorio real:"
 
-#: infobox.c:568
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Propietario, Grupo:"
 
-#: infobox.c:575
-#: infobox.c:590
-#: infobox.c:599
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Tamaño:"
 
-#: infobox.c:600
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Explorando"
 
-#: infobox.c:625
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Fallou a exploración"
 
-#: infobox.c:632
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Cambiar data:"
 
-#: infobox.c:634
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Modificar data:"
 
-#: infobox.c:636
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Hora de aceso:"
 
-#: infobox.c:644
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Atributos estendidos:"
 
-#: infobox.c:646
+#: infobox.c:667
 msgid "Present"
 msgstr "Presente"
 
-#: infobox.c:647
+#: infobox.c:668
 msgid "None"
 msgstr "Ningún"
 
-#: infobox.c:648
+#: infobox.c:669
 msgid "Not supported"
 msgstr "Non compatible"
 
-#: infobox.c:660
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Destino da ligazón:"
 
-#: infobox.c:672
-#: infobox.c:675
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Acción:"
 
-#: infobox.c:672
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Executar ficheiro"
 
-#: infobox.c:784
+#: infobox.c:805
 msgid "Comment"
 msgstr "Comentario"
 
-#: infobox.c:786
+#: infobox.c:807
 msgid "Execute"
 msgstr "Executar"
 
-#: infobox.c:800
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<ainda nada>"
 
-#: infobox.c:871
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "o ficheiro(1) dice... %s"
 
-#: infobox.c:928
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Non foi posible cambiar os permisos: %s"
 
-#: infobox.c:946
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Propietario"
 
-#: infobox.c:948
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Grupo"
 
-#: infobox.c:950
+#: infobox.c:974
 msgid "World"
 msgstr "Mundo"
 
-#: infobox.c:953
+#: infobox.c:977
 msgid "Read"
 msgstr "Ler"
 
-#: infobox.c:956
+#: infobox.c:980
 msgid "Write"
 msgstr "Escribir"
 
-#: infobox.c:959
+#: infobox.c:983
 msgid "Exec"
 msgstr "Executar"
 
-#: infobox.c:977
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:984
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:991
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Pegañento"
 
-#: infobox.c:1047
+#: infobox.c:1071
 msgid "Do nothing"
 msgstr "Non facer nada"
 
-#: infobox.c:1053
+#: infobox.c:1077
 msgid "Ask"
 msgstr "Preguntar"
 
-#: infobox.c:1065
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Ligazón simbólica"
 
-#: infobox.c:1068
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "Aplicativo ROX"
 
-#: infobox.c:1076
+#: infobox.c:1100
 msgid "mounted"
 msgstr "montado"
 
-#: infobox.c:1076
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "desmontado"
 
-#: infobox.c:1080
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Punto de montaxe para %s (%s)"
 
-#: infobox.c:1083
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Punto de montaxe (%s)"
 
-#: log.c:55
+#: log.c:54
 msgid "ROX-Filer started"
 msgstr "«ROX-Filer» activado"
 
-#: log.c:112
+#: log.c:115
 #, c-format
 msgid "%s on %d items"
 msgstr "%s en %d elementos"
 
-#: log.c:125
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Copiar..."
+
+#: log.c:139
 msgid "Item"
 msgstr "Elemento"
 
-#: log.c:149
+#: log.c:165
 msgid "Time"
 msgstr "Hora"
 
-#: log.c:154
+#: log.c:170
 msgid "Action"
 msgstr "Acción"
 
@@ -2012,7 +2124,8 @@ msgstr ""
 "                               \tdereito da pantalla\n"
 "  -R, --RPC\t\tinvocar method call read from stdin\n"
 "  -s, --show=FILE\tabrir o directorio amosando FILE\n"
-"  -S, --rox-session\tusar as opcións predeterminadas de panel e escritorio, e -n\n"
+"  -S, --rox-session\tusar as opcións predeterminadas de panel e escritorio, "
+"e -n\n"
 "  -t, --top=PANEL\tabrir PANEL como un panel no bordol\n"
 "                            \tsuperior da pantalla\n"
 "  -u, --user\t\tamosar o nome de usuario en cada fiestra \n"
@@ -2024,71 +2137,69 @@ msgstr ""
 
 #: main.c:237
 msgid ""
-"We got a BadWindow error from the X server. This might be due to this GTK bug (during drag-and-drop?):\n"
+"We got a BadWindow error from the X server. This might be due to this GTK "
+"bug (during drag-and-drop?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Trying to continue..."
 msgstr ""
-"Obtivemos o erro BadWindow do servidor X. Isto pode ser debido a este bug do GTK (ao facer arrastar-e-soltar?):\n"
+"Obtivemos o erro BadWindow do servidor X. Isto pode ser debido a este bug do "
+"GTK (ao facer arrastar-e-soltar?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Tentando continuar..."
 
-#: main.c:400
-msgid "The -o argument is no longer used. You can turn on override redirect from the Options box instead."
-msgstr "O argumento -o xa non se usa. Pode no seu lugar activar «override» a partir da caixa de Opcións."
+#: main.c:399
+msgid ""
+"The -o argument is no longer used. You can turn on override redirect from "
+"the Options box instead."
+msgstr ""
+"O argumento -o xa non se usa. Pode no seu lugar activar «override» a partir "
+"da caixa de Opcións."
 
-#: main.c:529
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Executando como usuario '%s'"
 
-#: main.c:690
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Compilado con GTK versión %s\n"
 
-#: main.c:691
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Executando con GTK versión %d.%d.%d\n"
 
-#: main.c:695
+#: main.c:693
 msgid "features set at compile time"
 msgstr "características definidas ao compilar"
 
-#: main.c:696
+#: main.c:694
 msgid "Large File Support"
 msgstr "Compatibilidade para ficheiros longos (LFS)"
 
-#: main.c:703
-msgid "Inotify support"
-msgstr "Compatibilidade para «Inotify»"
-
-#: main.c:710
-msgid "Dnotify support"
-msgstr "Compatibilidade para «dnotify»"
-
-#: main.c:717
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Compatibilidade binária"
 
-#: main.c:719
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Si (pode executarse con versións antigas do glibc)"
 
-#: main.c:721
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Non (non se atopa apsymbols.h)"
 
-#: main.c:725
+#: main.c:709
 msgid "Extended attribute support"
 msgstr "Compatibilidade para atributos estendidos"
 
-#: main.c:876
+#: main.c:856
 #, c-format
 msgid "Unable to read '%s': %s"
 msgstr "Incapaz de ler '%s': %s"
 
-#: main.c:918
+#: main.c:895
 #, c-format
 msgid ""
 "Left-click to run %s.\n"
@@ -2097,455 +2208,624 @@ msgstr ""
 "Prema no botón esquerdo para executar %s.\n"
 "Prema no botón dereito para listar as versións."
 
-#: menu.c:185
-#: tips:28
-msgid "Display"
-msgstr "Amosar"
-
-#: menu.c:186
-#: tips:33
-msgid "Icons View"
-msgstr "Vista de iconas"
-
-#: menu.c:187
-msgid "Icons, With..."
-msgstr "Iconas, con..."
-
-#: menu.c:188
-#: tips:52
-msgid "Sizes"
-msgstr "Tamaños"
-
-#: menu.c:190
-#: tips:226
-msgid "Types"
-msgstr "Tipos"
-
-#: menu.c:191
-#: tips:55
-msgid "Times"
-msgstr "Datas"
-
-#: menu.c:192
-#: tips:34
-#: tips:70
-msgid "List View"
-msgstr "Lista"
-
-#: menu.c:194
-msgid "Bigger Icons"
-msgstr "Iconas grandes"
-
-#: menu.c:195
-msgid "Smaller Icons"
-msgstr "Iconas pequenas"
-
-#: menu.c:196
-#: tips:49
-msgid "Automatic"
-msgstr "Automático"
-
-#: menu.c:198
-msgid "Sort by Name"
-msgstr "Ordenar por nome"
-
-#: menu.c:199
-msgid "Sort by Type"
-msgstr "Ordenar por tipo"
-
-#: menu.c:200
-msgid "Sort by Date"
-msgstr "Ordenar por data"
-
-#: menu.c:201
-msgid "Sort by Size"
-msgstr "Ordenar por tamaño"
-
-#: menu.c:202
-msgid "Sort by Owner"
-msgstr "Ordenar por propietario"
-
-#: menu.c:203
-msgid "Sort by Group"
-msgstr "Ordenar por grupo"
-
-#: menu.c:204
-msgid "Reversed"
-msgstr "Orde inversa"
-
-#: menu.c:206
-msgid "Show Hidden"
-msgstr "Amosar agochados"
-
-#: menu.c:207
-msgid "Filter Files..."
-msgstr "Filtrar ficheiros..."
-
-#: menu.c:208
-msgid "Filter Directories With Files"
-msgstr "Filtrar directorios con ficheiros"
-
-#: menu.c:209
-msgid "Show Thumbnails"
-msgstr "Amosar miniaturas"
-
-#: menu.c:210
-msgid "Refresh"
-msgstr "Actualizar"
-
-#: menu.c:211
-msgid "Save Current Display Settings..."
-msgstr "Gardar axustes de visualización..."
-
-#: menu.c:213
-msgid "Copy..."
-msgstr "Copiar..."
-
-#: menu.c:214
-msgid "Rename..."
-msgstr "Renomear..."
-
-#: menu.c:215
-msgid "Link..."
-msgstr "Ligazón..."
-
-#: menu.c:219
-msgid "Send To..."
-msgstr "Enviar a..."
-
-#: menu.c:224
-msgid "Count"
-msgstr "Tamaño"
-
-#: menu.c:225
-msgid "Set Type..."
-msgstr "Definir tipo..."
-
-#: menu.c:229
-#: toolbar.c:154
-msgid "Select"
-msgstr "Seleccionar"
-
-#: menu.c:230
-msgid "Select All"
-msgstr "Seleccionar todos"
-
-#: menu.c:231
-msgid "Clear Selection"
-msgstr "Limpar selección"
-
-#: menu.c:232
-msgid "Invert Selection"
-msgstr "Inverter selección"
-
-#: menu.c:233
-msgid "Select by Name..."
-msgstr "Seleccionar por nome..."
-
-#: menu.c:234
-msgid "Select If..."
-msgstr "Seleccionar si..."
-
-#: menu.c:236
-msgid "New"
-msgstr "Novo"
-
-#: menu.c:238
-msgid "Blank file"
-msgstr "Ficheiro en branco"
-
-#: menu.c:240
-#: tasklist.c:309
-msgid "Window"
-msgstr "Fiestra"
-
-#: menu.c:241
-msgid "Parent, New Window"
-msgstr "Directorio anterior, nova fiestra"
-
-#: menu.c:242
-msgid "Parent, Same Window"
-msgstr "Directorio anterior, mesma fiestra"
-
-#: menu.c:243
-msgid "New Window"
-msgstr "Nova fiestra"
-
-#: menu.c:245
-msgid "Show Bookmarks"
-msgstr "Amosar marca páxinas"
-
-#: menu.c:246
-msgid "Show Log"
-msgstr "Amosar rexistro"
-
-#: menu.c:247
-msgid "Follow Symbolic Links"
-msgstr "Seguir ligazóns simbólicas"
-
-#: menu.c:248
-msgid "Resize Window"
-msgstr "Redimensionar fiestra"
-
-#: menu.c:251
-msgid "Close Window"
-msgstr "Pechar fiestra"
-
-#: menu.c:253
-msgid "Enter Path..."
-msgstr "Introducir a ruta..."
-
-#: menu.c:254
-msgid "Shell Command..."
-msgstr "Orde de terminal..."
-
-#: menu.c:255
-msgid "Terminal Here"
-msgstr "Abrir aquí unha terminal"
-
-#: menu.c:256
-msgid "Switch to Terminal"
-msgstr "Cambiar a unha terminal"
-
-#: menu.c:725
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "Prema a tecla «Mayús» e faga clic sobre un ficheiro para envialo a algún sitio"
-
-#: menu.c:764
-msgid "Next Click"
-msgstr "Seguinte clic"
-
-#: menu.c:786
-#, c-format
-msgid "%d items"
-msgstr "%d elementos"
-
-#: menu.c:874
-msgid "Open unmounted"
-msgstr "Abrir desmontado"
-
-#: menu.c:877
-msgid "Show Target"
-msgstr "Amosar destino"
-
-#: menu.c:879
-msgid "Look Inside"
-msgstr "Amosar contido"
-
-#: menu.c:881
-msgid "Open As Text"
-msgstr "Abrir Como Texto"
-
-#: menu.c:1052
-msgid ""
-"Extended attributes, used to store types, are not supported for this file or files.\n"
-"This may be due to lack of support from the filesystem or the C library, or it may simply be that the filesystem needs to be mounted with the right mount option ('user_xattr' on Linux)."
-msgstr ""
-"Os atributos estendidos, usados para gardar os tipos de ficheiro, non son compatibles con este(s) ficheiro(s).\n"
-"Isto pode ser debido a falta de compatibilidade por parte do sistema de ficheiros ou da biblioteca de C, ou pode simplemente ser necesario montar o sistema de ficheiros con as opcións de montaxe correctas ('user_xattr' en Linux)."
-
-#: menu.c:1058
-msgid "Setting type not supported for some of these files"
-msgstr "Definir o tipo non é compatible con algúns destes ficheiros"
-
-#: menu.c:1095
-msgid "_Relative link"
-msgstr "Ligazón _relativa"
-
-#: menu.c:1101
-msgid ""
-"If on, the symlink will store the path from the symlink to the target file. Use this if the symlink and the target will be moved together.\n"
-"If off, the path from the root directory is stored - use this if the symlink may move but the target will stay put."
-msgstr ""
-"Si esta activado, a ligazón simbólica gardará o camiño desde esta ao ficheiro de destino. Usalo deste modo se a ligazón e o destino moveranse xuntos.\n"
-"Si esta desactivado, a ligazón gardará o camiño a partir do directorio de raíz - usalo deste modo se a ligazón poderá moverse pero o destino deberá permanecer no mesmo sítio."
-
-#: menu.c:1171
-msgid "New pathname is not absolute"
-msgstr "A nova ruta non é absoluta"
-
-#: menu.c:1239
-#, c-format
-msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
-msgstr "A ligazón a partir de '%s' xa existe. Substituir por unha ligazón a '%s'?"
-
-#: menu.c:1245
-msgid "_Replace"
-msgstr "_Substituir"
-
-#: menu.c:1365
-#: menu.c:1406
-#: menu.c:1468
-msgid "Create"
-msgstr "Crear"
-
-#: menu.c:1366
-msgid "NewDir"
-msgstr "NovoDirectorio"
-
-#: menu.c:1380
-#: menu.c:1386
+#: main.c:942 menu.c:1723 menu.c:1729
 #, c-format
 msgid "Error creating '%s': %s"
 msgstr "Atopouse un erro ao crear '%s': %s"
 
-#: menu.c:1407
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Gardar como"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
+msgid "Display"
+msgstr "Amosar"
+
+#: menu.c:641 tips:49
+msgid "Icons View"
+msgstr "Vista de iconas"
+
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
+msgstr "Iconas, con..."
+
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Tema de iconas"
+
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Permisos"
+
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Iconas, con..."
+
+#: menu.c:647 tips:50 tips:98 tips:99
+msgid "List View"
+msgstr "Lista"
+
+#: menu.c:651
+msgid "Bigger Icons"
+msgstr "Iconas grandes"
+
+#: menu.c:653
+msgid "Smaller Icons"
+msgstr "Iconas pequenas"
+
+#: menu.c:655 tips:71
+msgid "Automatic"
+msgstr "Automático"
+
+#: menu.c:661
+msgid "Sort by Name"
+msgstr "Ordenar por nome"
+
+#: menu.c:662
+msgid "Sort by Type"
+msgstr "Ordenar por tipo"
+
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
+msgstr "Ordenar por data"
+
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Ordenar por data"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Ordenar por data"
+
+#: menu.c:666
+msgid "Sort by Size"
+msgstr "Ordenar por tamaño"
+
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Permisos"
+
+#: menu.c:668
+msgid "Sort by Owner"
+msgstr "Ordenar por propietario"
+
+#: menu.c:669
+msgid "Sort by Group"
+msgstr "Ordenar por grupo"
+
+#: menu.c:671
+msgid "Reversed"
+msgstr "Orde inversa"
+
+#: menu.c:675
+msgid "Show Hidden"
+msgstr "Amosar agochados"
+
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Amosar ficheiros de axuda"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "ningún directorio)\n"
+
+#: menu.c:679
+msgid "Filter Files..."
+msgstr "Filtrar ficheiros..."
+
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Filtrar ficheiros..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr "Filtrar directorios con ficheiros"
+
+#: menu.c:682
+msgid "Show Thumbnails"
+msgstr "Amosar miniaturas"
+
+#: menu.c:683
+msgid "Refresh"
+msgstr "Actualizar"
+
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Actualizar"
+
+#: menu.c:686
+#, fuzzy
+msgid "Save Display Settings..."
+msgstr "Gardar axustes de visualización..."
+
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Gardar axustes de visualización..."
+
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Tamaño"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
+msgid "Rename..."
+msgstr "Renomear..."
+
+#: menu.c:700
+msgid "Link..."
+msgstr "Ligazón..."
+
+#: menu.c:708
+msgid "Send To..."
+msgstr "Enviar a..."
+
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Atributos estendidos"
+
+#: menu.c:721
+msgid "Count"
+msgstr "Tamaño"
+
+#: menu.c:723
+msgid "Set Type..."
+msgstr "Definir tipo..."
+
+#: menu.c:731 toolbar.c:179
+msgid "Select"
+msgstr "Seleccionar"
+
+#: menu.c:733
+msgid "Select All"
+msgstr "Seleccionar todos"
+
+#: menu.c:735
+msgid "Clear Selection"
+msgstr "Limpar selección"
+
+#: menu.c:736
+msgid "Invert Selection"
+msgstr "Inverter selección"
+
+#: menu.c:737
+msgid "Select by Name..."
+msgstr "Seleccionar por nome..."
+
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Seleccionar si..."
+
+#: menu.c:741
+msgid "Select If..."
+msgstr "Seleccionar si..."
+
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
+msgid "New"
+msgstr "Novo"
+
+#: menu.c:752
+msgid "Blank file"
+msgstr "Ficheiro en branco"
+
+#: menu.c:756 tasklist.c:305
+msgid "Window"
+msgstr "Fiestra"
+
+#: menu.c:758
+msgid "Parent, New Window"
+msgstr "Directorio anterior, nova fiestra"
+
+#: menu.c:759
+msgid "Parent, Same Window"
+msgstr "Directorio anterior, mesma fiestra"
+
+#: menu.c:761 tips:44
+msgid "New Window"
+msgstr "Nova fiestra"
+
+#: menu.c:764
+msgid "Show Bookmarks"
+msgstr "Amosar marca páxinas"
+
+#: menu.c:766
+msgid "Show Log"
+msgstr "Amosar rexistro"
+
+#: menu.c:768
+msgid "Follow Symbolic Links"
+msgstr "Seguir ligazóns simbólicas"
+
+#: menu.c:769
+msgid "Resize Window"
+msgstr "Redimensionar fiestra"
+
+#: menu.c:771
+msgid "Close Window"
+msgstr "Pechar fiestra"
+
+#: menu.c:776
+msgid "Enter Path..."
+msgstr "Introducir a ruta..."
+
+#: menu.c:778
+msgid "Shell Command..."
+msgstr "Orde de terminal..."
+
+#: menu.c:780
+msgid "Terminal Here"
+msgstr "Abrir aquí unha terminal"
+
+#: menu.c:782
+msgid "Switch to Terminal"
+msgstr "Cambiar a unha terminal"
+
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Personalizar o menú..."
+
+#: menu.c:976
+msgid "Next Click"
+msgstr "Seguinte clic"
+
+#: menu.c:998
+#, c-format
+msgid "%d items"
+msgstr "%d elementos"
+
+#: menu.c:1094
+msgid "Open unmounted"
+msgstr "Abrir desmontado"
+
+#: menu.c:1097
+msgid "Show Target"
+msgstr "Amosar destino"
+
+#: menu.c:1099
+msgid "Look Inside"
+msgstr "Amosar contido"
+
+#: menu.c:1101
+msgid "Open As Text"
+msgstr "Abrir Como Texto"
+
+#: menu.c:1320
+msgid ""
+"Extended attributes, used to store types, are not supported for this file or "
+"files.\n"
+"This may be due to lack of support from the filesystem or the C library, or "
+"it may simply be that the filesystem needs to be mounted with the right "
+"mount option ('user_xattr' on Linux)."
+msgstr ""
+"Os atributos estendidos, usados para gardar os tipos de ficheiro, non son "
+"compatibles con este(s) ficheiro(s).\n"
+"Isto pode ser debido a falta de compatibilidade por parte do sistema de "
+"ficheiros ou da biblioteca de C, ou pode simplemente ser necesario montar o "
+"sistema de ficheiros con as opcións de montaxe correctas ('user_xattr' en "
+"Linux)."
+
+#: menu.c:1326
+msgid "Setting type not supported for some of these files"
+msgstr "Definir o tipo non é compatible con algúns destes ficheiros"
+
+#: menu.c:1364
+msgid "_Relative link"
+msgstr "Ligazón _relativa"
+
+#: menu.c:1370
+msgid ""
+"If on, the symlink will store the path from the symlink to the target file. "
+"Use this if the symlink and the target will be moved together.\n"
+"If off, the path from the root directory is stored - use this if the symlink "
+"may move but the target will stay put."
+msgstr ""
+"Si esta activado, a ligazón simbólica gardará o camiño desde esta ao "
+"ficheiro de destino. Usalo deste modo se a ligazón e o destino moveranse "
+"xuntos.\n"
+"Si esta desactivado, a ligazón gardará o camiño a partir do directorio de "
+"raíz - usalo deste modo se a ligazón poderá moverse pero o destino deberá "
+"permanecer no mesmo sítio."
+
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
+msgid "New pathname is not absolute"
+msgstr "A nova ruta non é absoluta"
+
+#: menu.c:1540
+#, c-format
+msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
+msgstr ""
+"A ligazón a partir de '%s' xa existe. Substituir por unha ligazón a '%s'?"
+
+#: menu.c:1546
+msgid "_Replace"
+msgstr "_Substituir"
+
+#: menu.c:1704
+msgid "NewDir"
+msgstr "NovoDirectorio"
+
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Crear"
+
+#: menu.c:1755
 msgid "NewFile"
 msgstr "NovoFicheiro"
 
-#: menu.c:1425
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
-msgstr "Atopouse un erro ao crear o ficheiro: non foi posible atopar o modelo para %s"
+msgstr ""
+"Atopouse un erro ao crear o ficheiro: non foi posible atopar o modelo para %s"
 
-#: menu.c:1498
-#, c-format
+#: menu.c:1847
+#, fuzzy
 msgid ""
-"The `Send To' menu provides a quick way to send some files to an application. The applications listed are those in the following directories:\n"
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Cree as ligazóns simbólicas para os programas que precise neste directorio. "
+"Apareceran no menú para todos os elementos deste tipo (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
+msgid ""
+"The `Send To' menu provides a quick way to send some files to an "
+"application. The applications listed are those in the following "
+"directories:\n"
 "\n"
 "%s\n"
 "%s\n"
 "The `Send To' menu may be opened by Shift+Menu clicking over a file.\n"
 "\n"
 "Advanced use:\n"
-"You can also create subdirectories called `.text_html', `.text', etc which will only be shown for files of that type. `.group' is shown only when multiple files are selected."
+"You can also create subdirectories called `.text_html', `.text', etc which "
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
-"O menu «Enviar a...» permite enviar facilmente ficheiros para un aplicativo. Os aplicativos listados son os dos seguintes directorios:\n"
+"O menu «Enviar a...» permite enviar facilmente ficheiros para un aplicativo. "
+"Os aplicativos listados son os dos seguintes directorios:\n"
 "\n"
 "%s\n"
 "%s\n"
-"O menu «Enviar a...» pode ser aberto con Shift+Clic de Menu sobre un ficheiro.\n"
+"O menu «Enviar a...» pode ser aberto con Shift+Clic de Menu sobre un "
+"ficheiro.\n"
 "\n"
 "Uso avanzado:\n"
-"Pode tamén crear subdirectorios chamados «.text_html», «.text», etc que serán presentados só para ficheiros dese tipo. «.group» é amosado só cando sexan seleccionados varios ficheiros."
+"Pode tamén crear subdirectorios chamados «.text_html», «.text», etc que "
+"serán presentados só para ficheiros dese tipo. «.group» é amosado só cando "
+"sexan seleccionados varios ficheiros."
 
-#: menu.c:1509
-msgid "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift drag) any applications you want into it."
-msgstr "Agora amosarase o directorio «Enviar a»; nel deberá crear ligazóns simbólicas (Ctrl+Mayús arrastar) para os aplicativos que queira."
+#: menu.c:1895
+msgid ""
+"I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
+"drag) any applications you want into it."
+msgstr ""
+"Agora amosarase o directorio «Enviar a»; nel deberá crear ligazóns "
+"simbólicas (Ctrl+Mayús arrastar) para os aplicativos que queira."
 
-#: menu.c:1512
-#: menu.c:1552
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
-msgstr "Desculpe - A súa variable CHOICESPATH -elección da ruta- non permite a personalización."
+msgstr ""
+"Desculpe - A súa variable CHOICESPATH -elección da ruta- non permite a "
+"personalización."
 
-#: menu.c:1545
+#: menu.c:1931
 #, c-format
 msgid ""
-"Any files placed in your Templates directories will appear on the `New' menu. Choosing one of them will make a copy of it as the new file.\n"
+"Any files placed in your Templates directories will appear on the `New' "
+"menu. Choosing one of them will make a copy of it as the new file.\n"
 "\n"
 "The following directories contain templates:\n"
 "\n"
 "%s\n"
 "%s\n"
 msgstr ""
-"Cal queira ficheiro colocado no seu directorio de plantillas aparecerá no menú «Novo». Escollendo un deles creará unha cópia deste como un novo ficheiro.\n"
+"Cal queira ficheiro colocado no seu directorio de plantillas aparecerá no "
+"menú «Novo». Escollendo un deles creará unha cópia deste como un novo "
+"ficheiro.\n"
 "\"\n"
 "Os seguintes directorios conteñen plantillas:\n"
 "\n"
 "%s\n"
 "%s\n"
 
-#: menu.c:1550
-msgid "I'll show you your Templates directory now; you should place any template files you want inside it."
-msgstr "Agora amosarase o directorio de plantillas; nel deberá colocar os ficheiros-plantilla que queira."
+#: menu.c:1936
+msgid ""
+"I'll show you your Templates directory now; you should place any template "
+"files you want inside it."
+msgstr ""
+"Agora amosarase o directorio de plantillas; nel deberá colocar os ficheiros-"
+"plantilla que queira."
 
-#: menu.c:1667
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Personalizar"
 
-#: menu.c:1740
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Personalizar o menú..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Este xá é o nome canónigo para este directorio."
 
-#: menu.c:1771
-msgid "You can't open a second view onto this directory because the `Unique Windows' option is turned on in the Options window."
-msgstr "Non é posible abrir unha segunda vista para este directorio porque a opción «fiestras únicas» está activada na caixa Opcións."
+#: menu.c:2200
+msgid ""
+"You can't open a second view onto this directory because the `Unique "
+"Windows' option is turned on in the Options window."
+msgstr ""
+"Non é posible abrir unha segunda vista para este directorio porque a opción "
+"«fiestras únicas» está activada na caixa Opcións."
 
-#: menu.c:1897
-msgid "Copy ... ?"
-msgstr "Copiar ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1900
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Copiar %s en %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Copiar %s en %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Renomear ... ?"
 
-#: menu.c:1903
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Crear ligazón ... ?"
 
-#: menu.c:1906
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Abrir con «Mayús» ... ?"
 
-#: menu.c:1909
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Propiedades de ... ?"
 
-#: menu.c:1912
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Atributos estendidos"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Definir tipo de ... ?"
 
-#: menu.c:1915
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Definir acción executar para ... ?"
 
-#: menu.c:1918
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Definir ícona de ... ?"
 
-#: menu.c:1921
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Enviar ... a ... ?"
 
-#: menu.c:1924
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "BORRAR ... ?"
 
-#: menu.c:1927
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Calcular o tamaño de ... ?"
 
-#: menu.c:1930
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Definir permisos de ... ?"
 
-#: menu.c:1933
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Buscar dentro de ... ?"
 
-#: menu.c:1997
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Copiar ... ?"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr ""
 "Isto só é posible facelo con un elemento de cada vez.\n"
-"Rox ten unha política moi visual, arrastre directamente os elementos cara a fiestra de destino."
+"Rox ten unha política moi visual, arrastre directamente os elementos cara a "
+"fiestra de destino."
 
-#: menu.c:2029
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Renomear"
 
-#: menu.c:2034
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Crear ligazón"
 
-#: menu.c:2063
+#: menu.c:2654
 msgid ""
-"User-definable shortcuts are disabled by default in Gtk2, and you have not enabled them. You can turn this feature on by:\n"
+"User-definable shortcuts are disabled by default in Gtk2, and you have not "
+"enabled them. You can turn this feature on by:\n"
 "\n"
-"1) using an XSettings manager, such as ROX-Session or gnome-settings-daemon, or\n"
+"1) using an XSettings manager, such as ROX-Session or gnome-settings-daemon, "
+"or\n"
 "\n"
 "2) adding this line to ~/.gtkrc-2.0:\n"
 "\tgtk-can-change-accels = 1\n"
 "\t(this only works if NOT using XSETTINGS)"
 msgstr ""
-"Os atallos definíbles polo usuario están  desactivados por omisión no Gtk2, e vostede non os activou. Pode activar esta característica ao:\n"
+"Os atallos definíbles polo usuario están  desactivados por omisión no Gtk2, "
+"e vostede non os activou. Pode activar esta característica ao:\n"
 "\n"
-"1) usar un xestor de XSettings, tal como o ROX-Session ou o gnome-settings-daemon, ou\n"
+"1) usar un xestor de XSettings, tal como o ROX-Session ou o gnome-settings-"
+"daemon, ou\n"
 "\n"
 "2) engadindo esta liña ao ~/.gtkrc-2.0:\n"
 "\tgtk-can-change-accels = 1\n"
 "\t(isto funciona se NON se utiliza XSETTINGS)"
 
-#: menu.c:2074
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2553,7 +2833,8 @@ msgid ""
 "- Move the pointer over the item you want to use,\n"
 "- Press the key you want attached to it.\n"
 "\n"
-"The key will appear next to the menu item and you can just press that key without opening the menu in future."
+"The key will appear next to the menu item and you can just press that key "
+"without opening the menu in future."
 msgstr ""
 "Para definir un atallo de teclado para un elemento do menu:\n"
 "\n"
@@ -2561,41 +2842,78 @@ msgstr ""
 "- Mova o punteiro sobre o elemento que quere usar,\n"
 "- Presione a tecla que quere asociar ao menú.\n"
 "\n"
-"A tecla aparecerá ao lado do elemento do menú, e no futuro poderá simplemente premer nesa tecla sen ter que abrir o menú."
+"A tecla aparecerá ao lado do elemento do menú, e no futuro poderá "
+"simplemente premer nesa tecla sen ter que abrir o menú."
 
-#: menu.c:2089
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Definir atallos de teclado"
 
-#: minibuffer.c:129
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Ir a:"
 
-#: minibuffer.c:130
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Orde:"
 
-#: minibuffer.c:131
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Seleccionar se:"
 
-#: minibuffer.c:132
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Seleccionar nome:"
 
-#: minibuffer.c:133
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Seleccionar se:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Patrón:"
 
-#: minibuffer.c:265
-msgid "Enter the name of a file and I'll display it for you. Press Tab to fill in the longest match. Escape to close the minibuffer."
-msgstr "Introduza o nome de un ficheiro para ser amosado polo xestor, Prema TAB para completar con a selección máis próxima, Esc para pechar."
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
 
-#: minibuffer.c:271
-msgid "Enter a shell command to execute. Click on a file to add it to the buffer."
-msgstr "Introduza unha orde de terminal para executar. Faga clic nun ficheiro para asignalo."
+#: minibuffer.c:320
+msgid ""
+"Enter the name of a file and I'll display it for you. Press Tab to fill in "
+"the longest match. Escape to close the minibuffer."
+msgstr ""
+"Introduza o nome de un ficheiro para ser amosado polo xestor, Prema TAB para "
+"completar con a selección máis próxima, Esc para pechar."
 
-#: minibuffer.c:276
+#: minibuffer.c:326
+msgid ""
+"Enter a shell command to execute. Click on a file to add it to the buffer."
+msgstr ""
+"Introduza unha orde de terminal para executar. Faga clic nun ficheiro para "
+"asignalo."
+
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Introduza un patrón de nome de ficheiro para seleccionar os coincidentes:\n"
+"\n"
+"? equivale a cal queira carácter\n"
+"* equivale a cero ou a máis carácteres\n"
+"[aA] equivale a «a» ou «A»\n"
+"[a-z] equivale a cal queira caráter desde a «a» a «z» (minúscula)\n"
+"*.png equivale a cal queira nome que remate en «.png»"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2613,51 +2931,66 @@ msgstr ""
 "[a-z] equivale a cal queira caráter desde a «a» a «z» (minúscula)\n"
 "*.png equivale a cal queira nome que remate en «.png»"
 
-#: minibuffer.c:288
-msgid "Enter a pattern to match for files to be shown.  An empty filter turns the filter off."
-msgstr "Introduza un patrón para os ficheiros que se amosan. Un filtro baleiro é un filtro desactivado."
+#: minibuffer.c:352
+msgid ""
+"Enter a pattern to match for files to be shown.  An empty filter turns the "
+"filter off."
+msgstr ""
+"Introduza un patrón para os ficheiros que se amosan. Un filtro baleiro é un "
+"filtro desactivado."
 
-#: minibuffer.c:908
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Introduza un patrón para os ficheiros que se amosan. Un filtro baleiro é un "
+"filtro desactivado."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Condición de busca non válida"
 
 #: mount.c:103
 #, c-format
 msgid "File system table \"%s\" not found, cannot monitor system mounts"
-msgstr "Non se atopa a táboa de sistema de ficheiros \"%s\", non se supervisan as montaxes"
+msgstr ""
+"Non se atopa a táboa de sistema de ficheiros \"%s\", non se supervisan as "
+"montaxes"
 
 #: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s total, %s usado, %s libre (%.1f %%)"
 
-#: options.c:275
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "ROX-Filer converteu o seu ficheiro de opcións a o novo formato XML"
 
-#: options.c:535
-#: options.c:1256
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(predefinido)"
 
-#: options.c:805
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "atopouse un erro interno: %s non é lexible"
 
-#: options.c:914
+#: options.c:929
 msgid "Options"
 msgstr "Opcións"
 
-#: options.c:959
+#: options.c:974
 msgid "_Revert"
 msgstr "_Reverter"
 
-#: options.c:965
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
-msgstr "Restaurar todas as opcións a como estaban cando abriu o cadro de opcións."
+msgstr ""
+"Restaurar todas as opcións a como estaban cando abriu o cadro de opcións."
 
-#: options.c:980
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2666,52 +2999,55 @@ msgstr ""
 "As opcións gardaranse como:\n"
 "%s"
 
-#: options.c:988
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(Non está dispoñible gardar por CHOICESPATH -elección da ruta-)"
 
-#: options.c:1161
-#: usericons.c:452
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Produciuse un erro gardando %s: %s"
 
-#: options.c:1793
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Falta '='"
 
-#: panel.c:322
+#: panel.c:326
 #, c-format
 msgid "Unable to replace '%s'"
 msgstr "Non se pode substituir '%s'"
 
-#: panel.c:326
+#: panel.c:330
 #, c-format
 msgid "Unable to save '%s'"
 msgstr "Non se pode gardar '%s'"
 
-#: panel.c:529
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "O antiguo ficheiro de panel foi convertido ao novo formato XML."
 
-#: panel.c:637
-msgid "You have tried to close a panel via the window manager - I usually find that this is accidental... really close?"
-msgstr "Tratou de pechar o panel dende o xestor de fiestras - Normalmete eso é accidental... realmente quere pechalo?"
+#: panel.c:670
+msgid ""
+"You have tried to close a panel via the window manager - I usually find that "
+"this is accidental... really close?"
+msgstr ""
+"Tratou de pechar o panel dende o xestor de fiestras - Normalmete eso é "
+"accidental... realmente quere pechalo?"
 
-#: panel.c:738
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Falta < or > no ficheiro de configuración do panel"
 
-#: panel.c:1610
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Produciuse un erro gardando o panel %s: %s"
 
-#: panel.c:1925
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "O miniaplicativo pechouse sen crear un «widget»!"
 
-#: panel.c:2021
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2720,45 +3056,44 @@ msgstr ""
 "Produciuse un erro executando o miniaplicativo:\n"
 "%sa "
 
-#: panel.c:2646
+#: panel.c:2751
 msgid "Are you sure you want to remove this panel from the desktop?"
 msgstr "Esta seguro de que quere eliminar este panel do escritorio?"
 
-#: panel.c:2649
-#: panel.c:2676
+#: panel.c:2754 panel.c:2781
 msgid "Remove Panel"
 msgstr "Eliminar panel"
 
-#: panel.c:2672
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Opcions do panel..."
 
-#: panel.c:2757
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Monitor Xinerama %d non dispoñible"
 
-#: panel.c:2787
+#: panel.c:2897
 msgid "Top"
 msgstr "Arriba"
 
-#: panel.c:2789
+#: panel.c:2899
 msgid "Bottom"
 msgstr "Abaixo"
 
-#: panel.c:2791
+#: panel.c:2901
 msgid "Left"
 msgstr "Esquerda"
 
-#: panel.c:2793
+#: panel.c:2903
 msgid "Right"
 msgstr "Dereita"
 
-#: panel.c:2795
+#: panel.c:2905
 msgid "Default"
 msgstr "Predeterminado"
 
-#: panel.c:2799
+#: panel.c:2909
 msgid "Unknown side"
 msgstr "Descoñecido"
 
@@ -2767,18 +3102,28 @@ msgid "Your old pinboard file has been converted to the new XML format."
 msgstr "O seu antigo taboleiro foi convertido ao novo formato XML"
 
 #: pinboard.c:711
-msgid "The backdrop handler must be an application directory. Drag an application directory into the Set Backdrop dialog box, or (for programmers) pass it to the SOAP SetBackdropApp method."
-msgstr "O xestor do fondo debe ser un directorio de aplicativo. Arrastre un aplicativo do directorio á caixa de diálogo, ou (para programadores) asignalo a SetBackdropApp método SOAP."
+msgid ""
+"The backdrop handler must be an application directory. Drag an application "
+"directory into the Set Backdrop dialog box, or (for programmers) pass it to "
+"the SOAP SetBackdropApp method."
+msgstr ""
+"O xestor do fondo debe ser un directorio de aplicativo. Arrastre un "
+"aplicativo do directorio á caixa de diálogo, ou (para programadores) "
+"asignalo a SetBackdropApp método SOAP."
 
 #: pinboard.c:730
 msgid ""
-"You can only set the backdrop to an image or to a program which knows how to manage ROX-Filer's backdrop.\n"
+"You can only set the backdrop to an image or to a program which knows how to "
+"manage ROX-Filer's backdrop.\n"
 "\n"
-"Programmers: the application's AppInfo.xml must contain the CanSetBackdrop element, as described in ROX-Filer's manual."
+"Programmers: the application's AppInfo.xml must contain the CanSetBackdrop "
+"element, as described in ROX-Filer's manual."
 msgstr ""
-"Só poderá crear un fondo con unha imaxen o un programa para que «ROX-Filer» saiba como manexala.\n"
+"Só poderá crear un fondo con unha imaxen o un programa para que «ROX-Filer» "
+"saiba como manexala.\n"
 "\n"
-"Programadores: o aplicativo AppInfo.xml debe conter o elemento CanSetBackdrop, tal como se describe no manual de «ROX-Filer»."
+"Programadores: o aplicativo AppInfo.xml debe conter o elemento "
+"CanSetBackdrop, tal como se describe no manual de «ROX-Filer»."
 
 #: pinboard.c:750
 msgid "Set backdrop"
@@ -2805,8 +3150,12 @@ msgid "Scale"
 msgstr "Escalado"
 
 #: pinboard.c:779
-msgid "Scale the image to fit the backdrop area, regardless of image dimensions - overscale"
-msgstr "Escala a imaxe para adaptala ao tamaño do fondo, independente das dimensións -"
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr ""
+"Escala a imaxe para adaptala ao tamaño do fondo, independente das dimensións "
+"-"
 
 #: pinboard.c:781
 msgid "Fit"
@@ -2833,35 +3182,43 @@ msgid "Drop an image here"
 msgstr "Solte unha imaxe aquí"
 
 #: pinboard.c:851
-msgid "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox -p=Default' to turn it on in future."
-msgstr "Non hai un taboleiro en uso... o taboleiro «Default» está seleccionado. Utilice «rox -p=Default» cando queira activalo"
+msgid ""
+"No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
+"-p=Default' to turn it on in future."
+msgstr ""
+"Non hai un taboleiro en uso... o taboleiro «Default» está seleccionado. "
+"Utilice «rox -p=Default» cando queira activalo"
 
 #: pinboard.c:945
-msgid "Only files (and certain applications) can be used to set the background image."
-msgstr "Só se poden utilizar ficheiros (e algúns aplicativos) para fixar unha imaxe de fondo."
+msgid ""
+"Only files (and certain applications) can be used to set the background "
+"image."
+msgstr ""
+"Só se poden utilizar ficheiros (e algúns aplicativos) para fixar unha imaxe "
+"de fondo."
 
-#: pinboard.c:1602
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Falta '>' na etiqueta da icona"
 
-#: pinboard.c:1611
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Falta ',' despos da etiqueta da icona"
 
-#: pinboard.c:1699
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Produciuse un erro gardando o taboleiro %s: %s"
 
-#: pinboard.c:2244
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Fondo de pantalla..."
 
-#: pinboard.c:2247
+#: pinboard.c:2250
 msgid "Add Panel"
 msgstr "Engadir panel"
 
-#: pinboard.c:2341
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2872,7 +3229,7 @@ msgstr ""
 "%s\n"
 "Fondo eliminado."
 
-#: pixmaps.c:969
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2881,212 +3238,270 @@ msgstr ""
 "Non se poden eliminar miniaturas en %s:\n"
 "%s"
 
-#: pixmaps.c:990
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Non hai miniaturas para borrar"
 
-#: pixmaps.c:1003
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Eliminar miniaturas da «caché»"
 
-#: remote.c:722
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Estilo '%s' descoñecido"
 
-#: remote.c:744
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Detalles do tipo '%s' decoñecidos"
 
-#: remote.c:772
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Tipo de ordenamento '%s' descoñecido"
 
-#: remote.c:1247
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Intento de invocar o método '%s' SOAP descoñecido"
 
-#: run.c:99
-#: run.c:152
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "O programa %s non se atopa - borrado?"
 
-#: run.c:302
+#: run.c:359
+#, c-format
+msgid ""
+"No run action specified for files of this type (%s/%s) - you can set a run "
+"action by choosing `Set Run Action' from the File menu, or you can just drag "
+"the file to an application.%s"
+msgstr ""
+"Non se especificou ningunha acción para ficheiros de este tipo (%s/%s) - "
+"Defina a acción Executar no menú «Seguinte clic» ou arrastre este ficheiro á "
+"un aplicativo.%s"
+
+#: run.c:365
+msgid ""
+"\n"
+"\n"
+"Note: If this is a computer program which you want to run, you need to set "
+"the execute bit by choosing Permissions from the File menu."
+msgstr ""
+"\n"
+"\n"
+"Nota: Se se trata de executar un aplicativo, necesita axustar o bit de "
+"execución no menú «Permisos»."
+
+#: run.c:373
 #, c-format
 msgid "File doesn't exist, or I can't access it: %s"
 msgstr "O ficheiro: %s non existe ou non se pode aceder a el"
 
-#: run.c:307
+#: run.c:378
 #, c-format
 msgid "I don't know how to open '%s'"
 msgstr "Non se sabe como abrir '%s'"
 
-#: run.c:338
+#: run.c:409
 #, c-format
 msgid "'%s' is not a valid URI"
 msgstr "'%s' non é unha URI válida"
 
-#: run.c:349
+#: run.c:420
 #, c-format
 msgid "%s not accessable"
 msgstr "%s non é accesible"
 
-#: run.c:357
+#: run.c:428
 #, c-format
 msgid "Non-local URL %s"
 msgstr "%s non é una URL local"
 
-#: run.c:374
+#: run.c:445
 #, c-format
 msgid "%s: no handler for %s"
 msgstr "%s: non é manexado por %s"
 
-#: run.c:394
+#: run.c:465
 msgid ""
 "Application:\n"
-"This is an application directory - you can run it as a program, or open it (hold down Shift while you open it). Most applications provide their own help here, but this one doesn't."
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
 msgstr ""
 "Aplicativo:\n"
-"Tratase de un directorio de aplicativo - pode executalo como un programa, ou abrilo (prema «Maiús» mentres o abre). A maioría dos aplicativos fornecen a súa propia axuda aquí, pero este non o fai."
+"Tratase de un directorio de aplicativo - pode executalo como un programa, ou "
+"abrilo (prema «Maiús» mentres o abre). A maioría dos aplicativos fornecen a "
+"súa propia axuda aquí, pero este non o fai."
 
-#: run.c:478
+#: run.c:549
 #, c-format
 msgid "Could not send data to program: %s"
 msgstr "Non se puideron enviar os datos ao programa: %s"
 
-#: run.c:508
+#: run.c:578
 #, c-format
 msgid "Could not read link: %s"
 msgstr "Non se pode ler a ligazón: %s"
 
-#: run.c:536
+#: run.c:606
 #, c-format
 msgid "Broken symlink (or you don't have permission to follow it): %s"
 msgstr "Ligazón simbólica rota (ou vostede non ten permiso para usala): %s"
 
-#: run.c:573
-#, c-format
-msgid "No run action specified for files of this type (%s/%s) - you can set a run action by choosing `Set Run Action' from the File menu, or you can just drag the file to an application.%s"
-msgstr "Non se especificou ningunha acción para ficheiros de este tipo (%s/%s) - Defina a acción Executar no menú «Seguinte clic» ou arrastre este ficheiro á un aplicativo.%s"
-
-#: run.c:579
-msgid ""
-"\n"
-"\n"
-"Note: If this is a computer program which you want to run, you need to set the execute bit by choosing Permissions from the File menu."
-msgstr ""
-"\n"
-"\n"
-"Nota: Se se trata de executar un aplicativo, necesita axustar o bit de execución no menú «Permisos»."
-
-#: run.c:753
+#: run.c:785
 #, c-format
 msgid ""
-"Executable '%s' is world-writeable! Refusing to run. Please change the permissions now (this problem may have been caused by a bug in earlier versions of the filer).\n"
+"Executable '%s' is world-writeable! Refusing to run. Please change the "
+"permissions now (this problem may have been caused by a bug in earlier "
+"versions of the filer).\n"
 "\n"
-"Having (non-symlink) run actions world-writeable means that other people who use your computer can replace your run actions with malicious versions.\n"
+"Having (non-symlink) run actions world-writeable means that other people who "
+"use your computer can replace your run actions with malicious versions.\n"
 "\n"
-"If you trust everyone who could write to these files then you needn't worry. Otherwise, you should check, or even just delete, all the existing run actions."
+"If you trust everyone who could write to these files then you needn't worry. "
+"Otherwise, you should check, or even just delete, all the existing run "
+"actions."
 msgstr ""
-"O executable '%s' é escribible por todos! Refusase a súa execución. Por favor cambie os permisos agora (este problema puido ser causado por un fallo nas versións  anteriores do xestor).\n"
+"O executable '%s' é escribible por todos! Refusase a súa execución. Por "
+"favor cambie os permisos agora (este problema puido ser causado por un fallo "
+"nas versións  anteriores do xestor).\n"
 "\n"
-"Hai executables (non ligazóns simbólicas) escribibles por todos, eso significa que cal queira persoa que manexe a súa computadora pode substituír oa seus aplicativos por outros con código malicioso.\n"
+"Hai executables (non ligazóns simbólicas) escribibles por todos, eso "
+"significa que cal queira persoa que manexe a súa computadora pode substituír "
+"oa seus aplicativos por outros con código malicioso.\n"
 "\n"
-"Si vostede confía en quen poida escribir nestos ficheiros non debe preocuparse. Senón, debería comprobar, ou suprimir, todos os permisos que afecten ficheiros executables."
+"Si vostede confía en quen poida escribir nestos ficheiros non debe "
+"preocuparse. Senón, debería comprobar, ou suprimir, todos os permisos que "
+"afecten ficheiros executables."
 
-#: run.c:766
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Evita problemas de seguridade)"
 
-#: support.c:272
-msgid "B"
-msgstr "B"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:351
+#: support.c:381
 msgid "byte"
 msgstr "byte"
 
-#: support.c:1596
-#: support.c:1650
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
 msgstr "Fallou abrindo e analisando o ficheiro '%s': %s"
 
-#: support.c:1607
-#: support.c:1661
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
 msgstr "Fallou mapeando o ficheiro '%s': %s"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close"
 msgstr "Pechar"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close filer window"
 msgstr "Pechar fiestra do xestor"
 
-#: toolbar.c:117
+#: toolbar.c:120
 msgid "Up"
 msgstr "Subir"
 
-#: toolbar.c:117
-msgid "Change to parent directory"
-msgstr "Cambiar a directorio superior"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:121
+#: toolbar.c:126
 msgid "Home"
 msgstr "Inicio"
 
-#: toolbar.c:121
-msgid "Change to home directory"
-msgstr "Cambiar a directorio de inicio"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks"
-msgstr "Marca páxinas"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks menu"
-msgstr "Menu de marca páxinas"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:129
+#: toolbar.c:138
 msgid "Scan"
 msgstr "Analisar"
 
-#: toolbar.c:129
-msgid "Rescan directory contents"
-msgstr "Actualizar o contido do directorio"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:133
-msgid "Change icon size"
-msgstr "Cambiar tamaño da icona"
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Tamaño"
 
-#: toolbar.c:137
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automático"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
 msgstr "Tamaño automático"
 
-#: toolbar.c:141
-msgid "Show extra details"
-msgstr "Amosar detalles extra"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Lista"
 
-#: toolbar.c:145
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
 msgstr "Ordenar"
 
-#: toolbar.c:145
+#: toolbar.c:165
 msgid "Change sort criteria"
 msgstr "Cambiar critério de ordenamento"
 
-#: toolbar.c:149
-msgid "Hidden"
-msgstr "Agochado"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:149
+#: toolbar.c:169
 msgid ""
 "Left: Show/hide hidden files\n"
 "Right: Show/hide thumbnails"
@@ -3094,111 +3509,154 @@ msgstr ""
 "Esquerda: Amosa/agocha ficheiros agochados\n"
 "Dereita: Amosa/agocha miniaturas"
 
-#: toolbar.c:154
-msgid "Select all/invert selection"
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+#, fuzzy
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+"Esquerda: Amosa/agocha ficheiros agochados\n"
+"Dereita: Amosa/agocha miniaturas"
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
 msgstr "Seleccionar todo/inverter a selección"
 
-#: toolbar.c:158
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
 msgstr "Amosar axuda de «ROX-Filer»"
 
-#: toolbar.c:221
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
 msgstr " (%u agochado)"
 
-#: toolbar.c:229
-#: tips:58
+#: toolbar.c:276 tips:79
 msgid "items"
 msgstr "elementos"
 
-#: toolbar.c:229
+#: toolbar.c:276
 msgid "item"
 msgstr "elemento"
 
-#: toolbar.c:232
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
 msgstr "Sin elementos%s"
 
-#: toolbar.c:251
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
 msgstr "%u seleccionado (%s)"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by name"
 msgstr "Ordenar por nome"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by type"
 msgstr "Ordenar por tipo"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by date"
 msgstr "Ordenar por data"
 
-#: toolbar.c:446
+#: toolbar.c:535
 msgid "Sort by size"
 msgstr "Ordenar por tamaño"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by owner"
 msgstr "Ordenar por propietario"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by group"
 msgstr "Ordenar por grupo"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "ascending"
 msgstr "ascendente"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "descending"
 msgstr "descendente"
 
-#: type.c:214
+#: toolbar.c:891
+#, fuzzy
+msgid "_N_Items_"
+msgstr "Elemento"
+
+#: type.c:221
 msgid "Sym link"
 msgstr "Ligazón simbólica"
 
-#: type.c:216
+#: type.c:223
 msgid "Mount point"
 msgstr "Punto de montaxe"
 
-#: type.c:218
+#: type.c:225
 msgid "App dir"
 msgstr "Directorio de aplicativos"
 
-#: type.c:225
+#: type.c:232
 msgid "Dir"
 msgstr "Directorio"
 
-#: type.c:227
+#: type.c:234
 msgid "Char dev"
 msgstr "Dispositivo de carácter"
 
-#: type.c:229
+#: type.c:236
 msgid "Block dev"
 msgstr "Dispositivo de bloque"
 
-#: type.c:231
+#: type.c:238
 msgid "Pipe"
 msgstr "Canalización"
 
-#: type.c:233
+#: type.c:240
 msgid "Socket"
 msgstr "Socket"
 
-#: type.c:235
+#: type.c:242
 msgid "Door"
 msgstr "Porta"
 
-#: type.c:238
+#: type.c:245
 msgid "Unknown"
 msgstr "Descoñecido"
 
-#: type.c:554
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3208,81 +3666,89 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:735
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Non é un aplicativo ou ficheiro executable!"
 
-#: type.c:795
+#: type.c:839
 msgid "No run action defined"
 msgstr "Non está definida ningunha acción para executar"
 
-#: type.c:799
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Produciuse un erro en: %s manexando %s"
 
-#: type.c:814
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "O aplicativo %s non é válido (AppRun defectuoso)"
 
-#: type.c:825
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "Non executable %s"
 
-#: type.c:858
+#: type.c:902
 msgid "Set run action"
 msgstr "Definir acción para executar"
 
-#: type.c:864
-msgid "If a handler for the specific type isn't set up, use this as the default."
-msgstr "Se o programa usado para este tipo de ficheiro non está definido, usar este como predeterminado."
+#: type.c:908
+msgid ""
+"If a handler for the specific type isn't set up, use this as the default."
+msgstr ""
+"Se o programa usado para este tipo de ficheiro non está definido, usar este "
+"como predeterminado."
 
-#: type.c:866
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Predeterminar para todos `%s/<cal queira>'"
 
-#: type.c:870
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Utilizar este aplicativo para todos os ficheiros do mesmo tipo MIME"
 
-#: type.c:872
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Só para os do tipo `%s' (%s/%s)"
 
-#: type.c:878
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Arrastre o aplicativo axeitado aquí"
 
-#: type.c:893
+#: type.c:963
 msgid "OR"
 msgstr "OU"
 
-#: type.c:900
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Introduza unha orde de terminal:"
 
-#: type.c:929
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Usar a orde"
 
-#: type.c:959
-msgid "A run action already exists and is quite a big program - are you sure you want to delete it?"
-msgstr "Xa está especificada unha acción e é un programa - está seguro de que quere eliminalo?"
+#: type.c:1030
+msgid ""
+"A run action already exists and is quite a big program - are you sure you "
+"want to delete it?"
+msgstr ""
+"Xa está especificada unha acción e é un programa - está seguro de que quere "
+"eliminalo?"
 
-#: type.c:970
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Non se pode eliminar %s: %s"
 
-#: type.c:1007
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
-msgstr "A opción gardar foi desactivada pola variable CHOICESPATH (elección da ruta)"
+msgstr ""
+"A opción gardar foi desactivada pola variable CHOICESPATH (elección da ruta)"
 
-#: type.c:1309
+#: type.c:1395
 #, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
@@ -3291,25 +3757,26 @@ msgstr ""
 "Fallou creando a ligazón simbólica '%s':\n"
 "%s"
 
-#: usericons.c:179
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "A ruta indicada non existe. A icona non foi cambiada."
 
-#: usericons.c:189
-#: usericons.c:618
+#: usericons.c:198 usericons.c:644
 msgid ""
-"Unable to load image file -- maybe it's not in a format I understand, or maybe the permissions are wrong?\n"
+"Unable to load image file -- maybe it's not in a format I understand, or "
+"maybe the permissions are wrong?\n"
 "The icon has not been changed."
 msgstr ""
-"Non é posible cargar a imaxe -- ou está nun formato descoñecido ou non ten os permisos axeitados\n"
+"Non é posible cargar a imaxe -- ou está nun formato descoñecido ou non ten "
+"os permisos axeitados\n"
 "A icona non foi cambiada."
 
-#: usericons.c:235
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Quere borrar a icona '%s'?"
 
-#: usericons.c:239
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3318,54 +3785,68 @@ msgstr ""
 "Non se pode borrar '%s':\n"
 "%s"
 
-#: usericons.c:272
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Definir icona"
 
-#: usericons.c:281
-msgid "Use a copy of the image as the default for all files of these MIME types."
-msgstr "Use unha copia da imaxe como predeterminado para todos os ficheiros de este tipo MIME."
+#: usericons.c:290
+msgid ""
+"Use a copy of the image as the default for all files of these MIME types."
+msgstr ""
+"Use unha copia da imaxe como predeterminado para todos os ficheiros de este "
+"tipo MIME."
 
-#: usericons.c:283
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Predeterminar para todos `%s/<cal queira>'"
 
-#: usericons.c:288
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "Use unha copia da imaxe para todos os ficheiros de este tipo MIME"
 
-#: usericons.c:290
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Para todos os do tipo `%s' (%s/%s)"
 
-#: usericons.c:296
-msgid "Add the file and image filenames to your personal list. The setting will be lost if the image or the file is moved."
-msgstr "Engadir o ficheiro e nomes de ficheiro de imaxe a tua lista persoal. Isto perderase se a imaxe ou o ficheiro se moven."
+#: usericons.c:305
+msgid ""
+"Add the file and image filenames to your personal list. The setting will be "
+"lost if the image or the file is moved."
+msgstr ""
+"Engadir o ficheiro e nomes de ficheiro de imaxe a tua lista persoal. Isto "
+"perderase se a imaxe ou o ficheiro se moven."
 
-#: usericons.c:299
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Só para o ficheiro `%s'"
 
-#: usericons.c:307
-msgid "Copy the image inside the directory, as a hidden file called '.DirIcon'. All users will then see the icon, and you can move the directory around safely. This is usually the best option if you can write to the directory."
-msgstr "Copiar a imaxe dentro do directorio, como un ficheiro agochado chamado |. DirIcon ». Todos os usuarios verán a icona, e poden mover o directorio con seguridade. Esta adoita ser a mellor opción se vostede  pode escribir no directorio."
+#: usericons.c:316
+msgid ""
+"Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
+"users will then see the icon, and you can move the directory around safely. "
+"This is usually the best option if you can write to the directory."
+msgstr ""
+"Copiar a imaxe dentro do directorio, como un ficheiro agochado chamado |. "
+"DirIcon ». Todos os usuarios verán a icona, e poden mover o directorio con "
+"seguridade. Esta adoita ser a mellor opción se vostede  pode escribir no "
+"directorio."
 
-#: usericons.c:313
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Copie a imaxe a este directorio"
 
-#: usericons.c:319
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Arrastre un ficheiro de icona aquí"
 
-#: usericons.c:589
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "-elección da ruta-"
 
-#: usericons.c:633
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3374,41 +3855,57 @@ msgstr ""
 "Produciuse un erro creando a imaxe '%s':\n"
 "%s"
 
-#: view_details.c:957
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
 msgid "Mono font"
 msgstr "Fonte «Mono»"
 
-#: view_details.c:958
+#: view_details.c:1019
 msgid "Font for displaying mono-spaced text"
 msgstr "Fonte para amosar texto mono espazado"
 
-#: view_details.c:1059
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Nome"
 
-#: view_details.c:1062
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Tipo"
 
-#: view_details.c:1065
-msgid "_Permissions"
-msgstr "_Permisos"
-
-#: view_details.c:1070
-msgid "_Owner"
-msgstr "P_ropietario"
-
-#: view_details.c:1072
-msgid "_Group"
-msgstr "_Grupo"
-
-#: view_details.c:1074
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Tamaño"
 
-#: view_details.c:1080
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Permisos"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "P_ropietario"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Grupo"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "Última _modificación"
+
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Atributos estendidos"
 
 #: tips:1
 msgid "Filer windows"
@@ -3423,1045 +3920,1856 @@ msgid "Never automatically resize"
 msgstr "Non axustar nunca automáticamente"
 
 #: tips:4
-msgid "You'll have to resize windows manually, using the window manager, the `Resize Window' menu entry or by double-clicking on the window background."
-msgstr "Terá que cambiar o tamaño das fiestras manualmente, utilizando o xestor de fiestras, na entrada do menú «Redimensionar fiestra» ou facendo dobre clic no fondo da fiestra."
+msgid ""
+"You'll have to resize windows manually, using the window manager, the "
+"`Resize Window' menu entry or by double-clicking on the window background."
+msgstr ""
+"Terá que cambiar o tamaño das fiestras manualmente, utilizando o xestor de "
+"fiestras, na entrada do menú «Redimensionar fiestra» ou facendo dobre clic "
+"no fondo da fiestra."
 
 #: tips:5
 msgid "Resize when changing the display style"
 msgstr "Redimensionar cando cambie o estilo de fiestra"
 
 #: tips:6
-msgid "Changing the size of the icons or which details are displayed will resize the window for you."
-msgstr "Cambia o tamaño das iconas ou detalles que se amosan  cando redimensiona o tamaño da fiestra."
+msgid ""
+"Changing the size of the icons or which details are displayed will resize "
+"the window for you."
+msgstr ""
+"Cambia o tamaño das iconas ou detalles que se amosan  cando redimensiona o "
+"tamaño da fiestra."
 
 #: tips:7
 msgid "Always resize"
 msgstr "Redimensionar sempre"
 
 #: tips:8
-msgid "The filer will resize windows whenever it seems useful (that is, when changing directory or display style)."
-msgstr "O xestor redimensionará fiestras sempre que pareza útil (é dicir cambiando o directorio ou o estilo de amosar)."
+msgid ""
+"The filer will resize windows whenever it seems useful (that is, when "
+"changing directory or display style)."
+msgstr ""
+"O xestor redimensionará fiestras sempre que pareza útil (é dicir cambiando o "
+"directorio ou o estilo de amosar)."
 
 #: tips:9
 msgid "Largest window size:"
 msgstr "Tamaño da fiestra máis grande"
 
-#: tips:10
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
 #: tips:11
-msgid "The largest size, as a percentage of the screen size, that the auto-resizer will resize a window to."
-msgstr "Maior tamaño, como un porcentaxe do tamaño de pantalla, ao que se redimensionará automáticamente unha fiestra."
+msgid ""
+"The largest size, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Maior tamaño, como un porcentaxe do tamaño de pantalla, ao que se "
+"redimensionará automáticamente unha fiestra."
 
 #: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Tamaño da fiestra máis grande"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Maior tamaño, como un porcentaxe do tamaño de pantalla, ao que se "
+"redimensionará automáticamente unha fiestra."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Comportamento da fiestra"
 
-#: tips:13
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Marcas de barra de título cortas"
 
-#: tips:14
-msgid "Use single letters instead of words for Scanning, All and Thumbs indicators in the titlebar."
-msgstr "Emprego de marcas no lugar de palabras para exploración, indicadores de «Todo» e «Miniaturas» na barra de título."
+#: tips:17
+msgid ""
+"Use single letters instead of words for Scanning, All and Thumbs indicators "
+"in the titlebar."
+msgstr ""
+"Emprego de marcas no lugar de palabras para exploración, indicadores de "
+"«Todo» e «Miniaturas» na barra de título."
 
-#: tips:15
+#: tips:18
 msgid "Unique windows"
 msgstr "Fiestras únicas"
 
-#: tips:16
-msgid "If you open a directory and that directory is already displayed in another window, then this option causes the other window to be closed."
-msgstr "Se abre un directorio que xa está aberto noutra fiestra, isto fará que a outra fiestra sexa pechada."
+#: tips:19
+msgid ""
+"If you open a directory and that directory is already displayed in another "
+"window, then this option causes the other window to be closed."
+msgstr ""
+"Se abre un directorio que xa está aberto noutra fiestra, isto fará que a "
+"outra fiestra sexa pechada."
 
-#: tips:17
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Fiestra"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Fiestra nova en botón 1"
 
-#: tips:18
-msgid "Clicking with mouse button 1 (usually the left button) opens a directory in a new window with this turned on. Clicking with the button-2 (middle) will reuse the current window."
-msgstr "Activando esta opción ao facer clic no botón 1 (normalmente o esquerdo) abre o directorio nunha fiestra nova. Facer clic co botón 2 (o do medio) fará que se abra na fiestra actual."
+#: tips:25
+msgid ""
+"Clicking with mouse button 1 (usually the left button) opens a directory in "
+"a new window with this turned on. Clicking with the button-2 (middle) will "
+"reuse the current window."
+msgstr ""
+"Activando esta opción ao facer clic no botón 1 (normalmente o esquerdo) abre "
+"o directorio nunha fiestra nova. Facer clic co botón 2 (o do medio) fará que "
+"se abra na fiestra actual."
 
-#: tips:19
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Navegación cun só clic"
 
-#: tips:20
-#: tips:116
-msgid "Clicking on an item opens it with this on. Hold down Control to select the item instead. If off, clicking once selects an item; double click to open things."
-msgstr "Facer clic unha vez abre o elemento sobre o que se atope. Para seleccionalo empregue a tecla «Ctrl». Se esta opción esta desactivada cun só clic selecciona e con dous o abre."
+#: tips:27 tips:191
+msgid ""
+"Clicking on an item opens it with this on. Hold down Control to select the "
+"item instead. If off, clicking once selects an item; double click to open "
+"things."
+msgstr ""
+"Facer clic unha vez abre o elemento sobre o que se atope. Para seleccionalo "
+"empregue a tecla «Ctrl». Se esta opción esta desactivada cun só clic "
+"selecciona e con dous o abre."
 
-#: tips:21
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Dobre clic sobre o fondo redimensiona"
 
-#: tips:22
-msgid "If on then double clicking on the window background resizes the window, just like clicking on the Automatic size mode button in the toolbar."
-msgstr "Si fai dobre clic sobre o fondo de fiestra redimensiona a fiestra, como se fixera clic na icona de tamaño automático na barra de tarefas."
+#: tips:29
+msgid ""
+"If on then double clicking on the window background resizes the window, just "
+"like clicking on the Automatic size mode button in the toolbar."
+msgstr ""
+"Si fai dobre clic sobre o fondo de fiestra redimensiona a fiestra, como se "
+"fixera clic na icona de tamaño automático na barra de tarefas."
 
-#: tips:23
+#: tips:30
 msgid "Sorting"
 msgstr "Ordenando"
 
-#: tips:24
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Os directorios van antes (para ordenamento por nomes)"
 
-#: tips:25
-msgid "If this is on then directories will always appear before anything else when sorting by name."
-msgstr "Activada esta opción os directorios aparecerán antes que os ficheiros cando se ordena por nome."
+#: tips:32
+msgid ""
+"If this is on then directories will always appear before anything else when "
+"sorting by name."
+msgstr ""
+"Activada esta opción os directorios aparecerán antes que os ficheiros cando "
+"se ordena por nome."
 
-#: tips:26
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Nomes en maiúscula van antes  (para ordenamento por nomes)"
 
-#: tips:27
-msgid "If on, all filenames starting with a capital letter come before filenames starting with lowercase ones."
-msgstr "Activada esta opción os ficheiros cuxos nomes comezan con unha maiúscula van antes que os ficheiros cuxos nomes comezan con minúsculas."
-
-#: tips:29
-msgid "Default settings for new windows"
-msgstr "Axustes predeterminados para fiestras novas"
-
-#: tips:30
-msgid "Inherit options from source window"
-msgstr "Herdar opcións da fiestra orixe"
-
-#: tips:31
-msgid "If this is on then display options for a new window are inherited from the source window if possible, otherwise they are set to the defaults below."
-msgstr "Activando esta opción as fiestras novas herdan os axuste da fiestra orixe, se é posible, do contrario toman de xeito predeterminado o aquí definido ."
-
-#: tips:32
-msgid "View type:"
-msgstr "Ver tipo:"
+#: tips:34
+msgid ""
+"If on, all filenames starting with a capital letter come before filenames "
+"starting with lowercase ones."
+msgstr ""
+"Activada esta opción os ficheiros cuxos nomes comezan con unha maiúscula van "
+"antes que os ficheiros cuxos nomes comezan con minúsculas."
 
 #: tips:35
-msgid "Sort by:"
-msgstr "Ordenar por:"
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Os directorios van antes (para ordenamento por nomes)"
 
-#: tips:37
-#: tips:54
-msgid "Type"
-msgstr "Tipo"
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Segundo"
 
 #: tips:38
-msgid "Date"
-msgstr "Data"
-
-#: tips:40
-msgid "Show hidden files"
-msgstr "Amosar ficheiros agochados"
-
-#: tips:41
-msgid "If this is on then files whose names start with a dot are shown too, otherwise they are hidden."
-msgstr "Si está activada os ficheiros cuxos nomes comezan con un punto amosaranse, por a contra permaneceran agochados."
-
-#: tips:42
 msgid "Show extended attribute indicator"
 msgstr "Amosar indicador de atributo estendido"
 
-#: tips:43
-msgid "If this is on then files which have one or more extended attributes set will have an emblem added to indicate this."
-msgstr "Si está activada a opción, os ficheiros que teñen un ou máis atributos estendidos terán un emblema engadido para indicalo."
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+"Si está activada a opción, os ficheiros que teñen un ou máis atributos "
+"estendidos terán un emblema engadido para indicalo."
 
-#: tips:44
-msgid "Icon View"
-msgstr "Ver como iconas"
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
 
 #: tips:45
-msgid "Default size:"
-msgstr "Tamaño predeterminado:"
+msgid "Default settings for new windows"
+msgstr "Axustes predeterminados para fiestras novas"
 
 #: tips:46
-msgid "Huge Icons"
-msgstr "Iconas moi grandes"
+msgid "Inherit options from source window"
+msgstr "Herdar opcións da fiestra orixe"
 
 #: tips:47
-#: tips:217
-msgid "Large Icons"
-msgstr "Iconas grandes"
+msgid ""
+"If this is on then display options for a new window are inherited from the "
+"source window if possible, otherwise they are set to the defaults below."
+msgstr ""
+"Activando esta opción as fiestras novas herdan os axuste da fiestra orixe, "
+"se é posible, do contrario toman de xeito predeterminado o aquí definido ."
 
 #: tips:48
-#: tips:216
-msgid "Small Icons"
-msgstr "Iconas pequenas"
-
-#: tips:50
-msgid "Default details:"
-msgstr "Detalles predeterminados"
+msgid "View type:"
+msgstr "Ver tipo:"
 
 #: tips:51
-msgid "No details"
-msgstr "Sen detalles"
+msgid "Sort by:"
+msgstr "Ordenar por:"
+
+#: tips:53 tips:76 tips:114
+msgid "Type"
+msgstr "Tipo"
+
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
+msgstr "Data"
+
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Data"
 
 #: tips:56
-msgid "Automatic small icons:"
-msgstr "Iconas pequenas automáticamente"
+#, fuzzy
+msgid "Date (a)"
+msgstr "Data"
 
-#: tips:57
-msgid "Change at:"
-msgstr "Cambiar a:"
+#: tips:58
+msgid "Show hidden files"
+msgstr "Amosar ficheiros agochados"
 
 #: tips:59
-msgid "When automatic icon sizing is selected: If the directory contains this many items then it will be shown using Small Icons, otherwise Large Icons will be used."
-msgstr "Cando se selecciona o tamaño automático: Se o directorio conten moitos elementos amosará iconas pequenas, senón amosará iconas grandes."
+msgid ""
+"If this is on then files whose names start with a dot are shown too, "
+"otherwise they are hidden."
+msgstr ""
+"Si está activada os ficheiros cuxos nomes comezan con un punto amosaranse, "
+"por a contra permaneceran agochados."
 
 #: tips:60
-msgid "Max width (Large icons):"
-msgstr "Largura máxima (iconas grandes)"
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Amosar ficheiros agochados"
 
 #: tips:61
-#: tips:64
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Si está activada os ficheiros cuxos nomes comezan con un punto amosaranse, "
+"por a contra permaneceran agochados."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Iconas moi grandes"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
 msgid "pixels"
 msgstr "píxeles"
 
-#: tips:62
-msgid "Text wider than this is broken onto two lines in Large Icons mode. In Huge Icons mode, text is wrapped when 50% wider than this."
-msgstr "Se o texto é moi amplo, con iconas grandes, cortase en duas liñas. con iconas  moi grandes cortase cando supera o 50% do tamaño"
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
 
-#: tips:63
-msgid "(Small Icons):"
+#: tips:65 tips:66
+msgid "Icon View"
+msgstr "Ver como iconas"
+
+#: tips:67
+msgid "Default size:"
+msgstr "Tamaño predeterminado:"
+
+#: tips:68
+msgid "Huge Icons"
+msgstr "Iconas moi grandes"
+
+#: tips:69 tips:296
+msgid "Large Icons"
+msgstr "Iconas grandes"
+
+#: tips:70 tips:295
+msgid "Small Icons"
+msgstr "Iconas pequenas"
+
+#: tips:72
+msgid "Default details:"
+msgstr "Detalles predeterminados"
+
+#: tips:73
+msgid "No details"
+msgstr "Sen detalles"
+
+#: tips:74
+msgid "Sizes"
+msgstr "Tamaños"
+
+#: tips:77
+msgid "Times"
+msgstr "Datas"
+
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
+msgstr "Iconas pequenas automáticamente"
+
+#: tips:80
+msgid ""
+"When automatic icon sizing is selected: If the directory contains this many "
+"items then it will be shown using Small Icons, otherwise Large Icons will be "
+"used."
+msgstr ""
+"Cando se selecciona o tamaño automático: Se o directorio conten moitos "
+"elementos amosará iconas pequenas, senón amosará iconas grandes."
+
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Iconas grandes"
+
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
+msgstr ""
+"Se o texto é moi amplo, con iconas grandes, cortase en duas liñas. con "
+"iconas  moi grandes cortase cando supera o 50% do tamaño"
+
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
+
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
+#: tips:88
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr ""
+"Si se activa esta opción, as iconas grandes amosaranse en columnas, senón en "
+"filas."
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
 msgstr "(Iconas pequenas)"
 
-#: tips:65
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "Largura máxima para o texto baixo as iconas pequenas"
 
-#: tips:66
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "Ordenar as iconas pequenas en vertical"
 
-#: tips:67
-msgid "If this option is on, then small icons are arranged in columns, not rows."
-msgstr "Si se activa esta opción, as iconas pequenas amosaranse en columnas, senón en filas."
+#: tips:93
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
+msgstr ""
+"Si se activa esta opción, as iconas pequenas amosaranse en columnas, senón "
+"en filas."
 
-#: tips:68
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "Ordenar as iconas grandes en vertical"
 
-#: tips:69
-msgid "If this option is on, then large icons are arranged in columns, not rows."
-msgstr "Si se activa esta opción, as iconas grandes amosaranse en columnas, senón en filas."
+#: tips:95
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
+msgstr ""
+"Si se activa esta opción, as iconas grandes amosaranse en columnas, senón en "
+"filas."
 
-#: tips:71
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Amosar encabezamentos das columnas"
 
-#: tips:72
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
-msgstr "Activando esta opción os encabezamentos das columnas amosaranse na vista de lista."
+msgstr ""
+"Activando esta opción os encabezamentos das columnas amosaranse na vista de "
+"lista."
 
-#: tips:73
+#: tips:102
 msgid "Show full type"
 msgstr "Amosar todos os tipos"
 
-#: tips:74
-msgid "If this is on then the full description of each object's type will be show rather than a short summary of its basic type."
-msgstr "Activando esta opción, a descrición completa de cada tipo de obxecto non se amosa máis que como un resume do seu tipo básico."
+#: tips:103
+msgid ""
+"If this is on then the full description of each object's type will be show "
+"rather than a short summary of its basic type."
+msgstr ""
+"Activando esta opción, a descrición completa de cada tipo de obxecto non se "
+"amosa máis que como un resume do seu tipo básico."
 
-#: tips:75
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Largura máxima para o texto baixo as iconas pequenas"
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Amosar encabezamentos das columnas"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Activando esta opción os encabezamentos das columnas amosaranse na vista de "
+"lista."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Activando esta opción os encabezamentos das columnas amosaranse na vista de "
+"lista."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Activando esta opción os encabezamentos das columnas amosaranse na vista de "
+"lista."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Activando esta opción os encabezamentos das columnas amosaranse na vista de "
+"lista."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Activando esta opción os encabezamentos das columnas amosaranse na vista de "
+"lista."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Activando esta opción os encabezamentos das columnas amosaranse na vista de "
+"lista."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "Última _modificación"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Activando esta opción os encabezamentos das columnas amosaranse na vista de "
+"lista."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Activando esta opción os encabezamentos das columnas amosaranse na vista de "
+"lista."
+
+#: tips:128
+#, fuzzy
+msgid "Last Accessed"
+msgstr "%s non é accesible"
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Activando esta opción os encabezamentos das columnas amosaranse na vista de "
+"lista."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Ferramentas/Mini bufer"
 
-#: tips:76
+#: tips:131
 msgid "Toolbar"
 msgstr "Barra ferramentas"
 
-#: tips:77
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Tipo de barra de ferramentas"
 
-#: tips:78
+#: tips:133
 msgid "No toolbar"
 msgstr "Sen barra de ferramentas"
 
-#: tips:79
+#: tips:134
 msgid "Icons only"
 msgstr "Só iconas"
 
-#: tips:80
+#: tips:135
 msgid "Text under icons"
 msgstr "Texto baixo as iconas"
 
-#: tips:81
+#: tips:136
 msgid "Text beside icons"
 msgstr "Texto a veira das iconas"
 
-#: tips:82
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Só o panel"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Amosa a totalidade dos elementos"
 
-#: tips:83
-msgid "Show the number of items displayed in a filer window, as well as the number of hidden items (if any). When there's a selection, show the number of selected items and their combined size."
-msgstr "Amosa o número de elementos que aparece nunha fiestra do xestor, así como o número de elementos agochados (no seu caso). Cando hai una selección, amosa o número de elementos seleccionados e o  seu tamaño combinado."
+#: tips:139
+msgid ""
+"Show the number of items displayed in a filer window, as well as the number "
+"of hidden items (if any). When there's a selection, show the number of "
+"selected items and their combined size."
+msgstr ""
+"Amosa o número de elementos que aparece nunha fiestra do xestor, así como o "
+"número de elementos agochados (no seu caso). Cando hai una selección, amosa "
+"o número de elementos seleccionados e o  seu tamaño combinado."
 
-#: tips:84
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Seleccione os botóns que desexe ter na barra"
 
-#: tips:85
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "A Largura da barra de ferramentas establece o ancho minimo da fiestra"
 
-#: tips:86
-msgid "Each filer window is constrained to be wide enough to show the whole of the toolbar"
-msgstr "As fiestras son obligadas a ser o suficientemente amplas como para amosar a totalidade da barra de ferramentas"
+#: tips:142
+msgid ""
+"Each filer window is constrained to be wide enough to show the whole of the "
+"toolbar"
+msgstr ""
+"As fiestras son obligadas a ser o suficientemente amplas como para amosar a "
+"totalidade da barra de ferramentas"
 
-#: tips:87
+#: tips:143
 msgid "Minibuffer"
 msgstr "Mini bufer"
 
-#: tips:88
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Pitido se falla completar con «Tab»"
 
-#: tips:89
-msgid "When using the `Enter Path...' minibuffer and Tab is pressed, beep if nothing happens (eg, because there are several possibilities and the next letter varies)."
-msgstr "Cando se emprega «Introducir a ruta...» e se preme «Tab», se se escoita un ton de aviso non ocorre nada (Ex.: porque hai varias posibilidades e a seguinte letra varía)."
+#: tips:145
+msgid ""
+"When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
+"nothing happens (eg, because there are several possibilities and the next "
+"letter varies)."
+msgstr ""
+"Cando se emprega «Introducir a ruta...» e se preme «Tab», se se escoita un "
+"ton de aviso non ocorre nada (Ex.: porque hai varias posibilidades e a "
+"seguinte letra varía)."
 
-#: tips:90
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Yon de aviso se hai varias coincidencias"
 
-#: tips:91
-msgid "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there is more than one matching file, even though some more letters were added."
-msgstr "Cando se emprega «Introducir a ruta...» e se preme «Tab», se se escoita un ton de aviso e non ocorre nada é porque hai máis dun ficheiro, engada máis letras."
+#: tips:147
+msgid ""
+"When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
+"is more than one matching file, even though some more letters were added."
+msgstr ""
+"Cando se emprega «Introducir a ruta...» e se preme «Tab», se se escoita un "
+"ton de aviso e non ocorre nada é porque hai máis dun ficheiro, engada máis "
+"letras."
 
-#: tips:94
-msgid "When thumbnails are turned on, each image file in a directory is loaded and a small thumbnail of it is shown."
-msgstr "Cando se activan as miniaturas, cada ficheiro de imaxe dun directorio carga unha pequena miniatura para amosar."
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Xestor de descargas"
 
-#: tips:95
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Produciuse un erro en: %s manexando %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
+msgid ""
+"When thumbnails are turned on, each image file in a directory is loaded and "
+"a small thumbnail of it is shown."
+msgstr ""
+"Cando se activan as miniaturas, cada ficheiro de imaxe dun directorio carga "
+"unha pequena miniatura para amosar."
+
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Amosar miniaturas"
 
-#: tips:96
-msgid "This is the default setting for new windows. Use the Display menu to turn thumbnails on and off for individual windows."
-msgstr "Esta é a configuración predeterminada para as fiestras novas. Use o menú despregable para activar/desactivar as miniaturas nas fiestras."
+#: tips:156
+msgid ""
+"This is the default setting for new windows. Use the Display menu to turn "
+"thumbnails on and off for individual windows."
+msgstr ""
+"Esta é a configuración predeterminada para as fiestras novas. Use o menú "
+"despregable para activar/desactivar as miniaturas nas fiestras."
 
-#: tips:97
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Amosar miniaturas"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "Miniaturas de video"
 
-#: tips:98
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Caché de miniaturas"
 
-#: tips:99
-msgid "To speed things up, the generated thumbnails are stored in the hidden ~/.thumbnails directory. Click here to remove all the cached thumbnails. They will be created again as needed."
-msgstr "Para acelerar o traballo, as miniaturas xeradas son almacenadas no directorio agochado ~/.thumbnails. Faga clic aquí para eliminar a caché das miniaturas. Se é necesario volveran a crearse."
+#: tips:161
+#, fuzzy
+msgid ""
+"To speed things up, the generated thumbnails are stored in the hidden ~/."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
+msgstr ""
+"Para acelerar o traballo, as miniaturas xeradas son almacenadas no "
+"directorio agochado ~/.thumbnails. Faga clic aquí para eliminar a caché das "
+"miniaturas. Se é necesario volveran a crearse."
 
-#: tips:100
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
 msgid "Manage thumbnails"
 msgstr "Xestión de miniaturas"
 
-#: tips:101
-#: tips:158
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Miniaturas de video"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Segundo"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Escritorio"
 
-#: tips:102
-msgid "When using a pinboard, you can drag files and applications onto the desktop background to create shortcuts to them."
-msgstr "Usando un taboleiro, vostede pode arrastrar ficheiros e aplicativos no fondo de escritorio para crear acesos rápidos."
+#: tips:177
+msgid ""
+"When using a pinboard, you can drag files and applications onto the desktop "
+"background to create shortcuts to them."
+msgstr ""
+"Usando un taboleiro, vostede pode arrastrar ficheiros e aplicativos no fondo "
+"de escritorio para crear acesos rápidos."
 
-#: tips:103
-#: tips:213
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Aparencia"
 
-#: tips:104
+#: tips:179
 msgid "Foreground:"
 msgstr "Primeiro plano"
 
-#: tips:105
+#: tips:180
 msgid "Text shadow:"
 msgstr "Texto sombreado"
 
-#: tips:106
+#: tips:181
 msgid "Background:"
 msgstr "Segundo plano"
 
-#: tips:107
+#: tips:182
 msgid "No shadow"
 msgstr "Sen sombra"
 
-#: tips:108
+#: tips:183
 msgid "Thin"
 msgstr "Delgado"
 
-#: tips:109
+#: tips:184
 msgid "Thick"
 msgstr "Groso"
 
-#: tips:110
+#: tips:185
 msgid "Use custom font:"
 msgstr "Usar fontes personalizadas:"
 
-#: tips:111
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Fonte utilizada para o texto baixo as iconas"
 
-#: tips:112
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Escalado rápido de imaxes"
 
-#: tips:113
-msgid "Choose between the fast or slow method of scaling backdrop images.  The slow method can give better results."
-msgstr "Escolla entre o método rápido ou lento de escalado de imaxes de fondo. O método lento pode dar mellores resultados."
+#: tips:188
+msgid ""
+"Choose between the fast or slow method of scaling backdrop images.  The slow "
+"method can give better results."
+msgstr ""
+"Escolla entre o método rápido ou lento de escalado de imaxes de fondo. O "
+"método lento pode dar mellores resultados."
 
-#: tips:114
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Comportamento do taboleiro"
 
-#: tips:115
+#: tips:190
 msgid "Single-click to open"
 msgstr "Un só clic para abrir"
 
-#: tips:117
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Manter as iconas dentro dos limites da pantalla"
 
-#: tips:118
-msgid "If this is set, pinboard icons are always kept completely within screen limits, including the label."
-msgstr "Activada esta opción, as iconas manteranse sempre dentro dos límites da pantalla, incluindo a etiqueta."
+#: tips:193
+msgid ""
+"If this is set, pinboard icons are always kept completely within screen "
+"limits, including the label."
+msgstr ""
+"Activada esta opción, as iconas manteranse sempre dentro dos límites da "
+"pantalla, incluindo a etiqueta."
 
-#: tips:119
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Rella de separación de iconas"
 
-#: tips:120
+#: tips:195
 msgid "Fine"
 msgstr "Fina"
 
-#: tips:121
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "Usar rella de 2 píxeles para posicionar as iconas no escritorio"
 
-#: tips:122
+#: tips:197
 msgid "Medium"
 msgstr "Media"
 
-#: tips:123
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "Usar rella de 16 píxeles para posicionar as iconas no escritorio"
 
-#: tips:124
+#: tips:199
 msgid "Coarse"
 msgstr "Grosa"
 
-#: tips:125
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "Usar rella de 32 píxeles para posicionar as iconas no escritorio"
 
-#: tips:126
-#: tips:128
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Fiestras como iconas"
 
-#: tips:127
-msgid "Most window managers provide a way to iconify (or 'minimise') windows, and various programs, including ROX-Filer, can be used to display the iconified windows."
-msgstr "A maioría de xestores de fiestras proporcionan unha forma de «iconificar» (ou «minimizar»), as fiestras, e diversos programas, entre eles «ROX-Filer», poden utilizar para amosar as fiestras coma iconas."
+#: tips:202
+msgid ""
+"Most window managers provide a way to iconify (or 'minimise') windows, and "
+"various programs, including ROX-Filer, can be used to display the iconified "
+"windows."
+msgstr ""
+"A maioría de xestores de fiestras proporcionan unha forma de "
+"«iconificar» (ou «minimizar»), as fiestras, e diversos programas, entre eles "
+"«ROX-Filer», poden utilizar para amosar as fiestras coma iconas."
 
-#: tips:129
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Amosar fiestras como iconas"
 
-#: tips:130
-msgid "If this option is on, the filer will show each iconified window as a small button on the pinboard. Requires a compatible window manager, and the pinboard must be in use."
-msgstr "Activada esta opción, o xestor amosa cada fiestra como un pequeno botón no taboleiro. Require un xestor de fiestras compatible, e o taboleiro debe estar en uso."
+#: tips:205
+msgid ""
+"If this option is on, the filer will show each iconified window as a small "
+"button on the pinboard. Requires a compatible window manager, and the "
+"pinboard must be in use."
+msgstr ""
+"Activada esta opción, o xestor amosa cada fiestra como un pequeno botón no "
+"taboleiro. Require un xestor de fiestras compatible, e o taboleiro debe "
+"estar en uso."
 
-#: tips:131
+#: tips:206
 msgid "Show per workspace"
 msgstr "Amosar por espazo de traballo"
 
-#: tips:132
-msgid "If this option is on, the filer will only show iconified windows associated with the current workspace."
-msgstr "Activada esta opción, o xestor só amosará como iconas as fiestras asociadas co actual espazo de traballo."
+#: tips:207
+msgid ""
+"If this option is on, the filer will only show iconified windows associated "
+"with the current workspace."
+msgstr ""
+"Activada esta opción, o xestor só amosará como iconas as fiestras asociadas "
+"co actual espazo de traballo."
 
-#: tips:133
+#: tips:208
 msgid "Iconify to the"
 msgstr "Poñer as iconas"
 
-#: tips:134
+#: tips:209
 msgid "top-left"
 msgstr "arriba a esquerda"
 
-#: tips:135
+#: tips:210
 msgid "top-right"
 msgstr "arriba a dereita"
 
-#: tips:136
+#: tips:211
 msgid "bottom-left"
 msgstr "abaixo a esquerda"
 
-#: tips:137
+#: tips:212
 msgid "bottom-right"
 msgstr "abaixo a dereita"
 
-#: tips:138
+#: tips:213
 msgid ", going"
 msgstr ", en"
 
-#: tips:139
+#: tips:214
 msgid "horizontally"
 msgstr "horizontal"
 
-#: tips:140
+#: tips:215
 msgid "vertically"
 msgstr "vertical"
 
-#: tips:141
-msgid "Sometimes the filer doesn't know about your desktop furniture and puts iconified windows under (for example) the Gnome panel. You can define a top or bottom margin to avoid placing the icons there. The filer already knows about its own panel."
-msgstr "As veces o xestor non sabe dos seus obxectos no escritorio e pon fiestras en miniatura baixo (por exemplo) o panel de Gnome. Vostede pode definir unha marxe inferior para evitar colocar as iconas alí. O xestor xa sabe así do seu propio panel."
+#: tips:216
+msgid ""
+"Sometimes the filer doesn't know about your desktop furniture and puts "
+"iconified windows under (for example) the Gnome panel. You can define a top "
+"or bottom margin to avoid placing the icons there. The filer already knows "
+"about its own panel."
+msgstr ""
+"As veces o xestor non sabe dos seus obxectos no escritorio e pon fiestras en "
+"miniatura baixo (por exemplo) o panel de Gnome. Vostede pode definir unha "
+"marxe inferior para evitar colocar as iconas alí. O xestor xa sabe así do "
+"seu propio panel."
 
-#: tips:142
+#: tips:217
 msgid "Top margin"
 msgstr "Marxe superior"
 
-#: tips:143
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Altura de zona prohibida no bordo superior da pantalla."
 
-#: tips:144
+#: tips:219
 msgid "Bottom margin"
 msgstr "Marxe inferior"
 
-#: tips:145
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "Altura de zona prohibida no bordo inferior da pantalla."
 
-#: tips:146
+#: tips:221
 msgid "Left margin"
 msgstr "Marxe esquerdo"
 
-#: tips:147
+#: tips:222
 msgid "Width of no-go area at left of screen."
 msgstr "Largura de zona prohibida no bordo esquerdo da pantalla."
 
-#: tips:148
+#: tips:223
 msgid "Right margin"
 msgstr "Marxe dereito"
 
-#: tips:149
+#: tips:224
 msgid "Width of no-go area at right of screen."
 msgstr "largura de zona prohibida no bordo dereito da pantalla."
 
-#: tips:150
+#: tips:225
 msgid "Desktop"
 msgstr "Escritorio"
 
-#: tips:151
-msgid "When run by a session manager program (such as ROX-Session) the filer can open up a panel and/or the pinboard.  Here you configure which."
-msgstr "Cando se executa un administrador de sesións (como ROX-Session) o xestor pode abrir un panel e/ou un taboleiro. Configureo aquí."
+#: tips:226
+msgid ""
+"When run by a session manager program (such as ROX-Session) the filer can "
+"open up a panel and/or the pinboard.  Here you configure which."
+msgstr ""
+"Cando se executa un administrador de sesións (como ROX-Session) o xestor "
+"pode abrir un panel e/ou un taboleiro. Configureo aquí."
 
-#: tips:152
+#: tips:227
 msgid "Panel only"
 msgstr "Só o panel"
 
-#: tips:153
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Só se amosa o panel"
 
-#: tips:154
+#: tips:229
 msgid "Pinboard only"
 msgstr "Só o taboleiro"
 
-#: tips:155
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "Só se amosa o taboleiro (escritorio)"
 
-#: tips:156
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "Panel e taboleiro"
 
-#: tips:157
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "Amosase tanto o panel como o taboleiro"
 
-#: tips:159
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "Poña o nome do taboleiro que vai a ser amosado"
 
-#: tips:160
-msgid "Panel (obsolete)"
-msgstr "Panel (obsoleto)"
-
-#: tips:161
-msgid "Enter the name of the panel to show here. This option is now only used when upgrading from an old version."
-msgstr "Poña o nome do panel que vai ser amosado. Esta opción agora só se usa se actualizou dunha versión anterior."
-
-#: tips:162
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr "Os cambios só terán efecto despois de que inicie de novo «ROX-Filer»"
 
-#: tips:163
-msgid "The session manager activates these options by using the -S or --rox-session argument to rox."
-msgstr "O administrador de sesións activa estas opcións empregando «-S» ou «--rox-session» como argumentos de «rox»."
+#: tips:236
+#, fuzzy
+msgid ""
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
+msgstr ""
+"O administrador de sesións activa estas opcións empregando «-S» ou «--rox-"
+"session» como argumentos de «rox»."
 
-#: tips:164
+#: tips:237
 msgid "Action windows"
 msgstr "Accións nas fiestras"
 
-#: tips:165
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
-msgstr "A caixa de accións aparece cando se inicia unha operación en segundo plano como copiar ou borrar ficheiros."
+msgstr ""
+"A caixa de accións aparece cando se inicia unha operación en segundo plano "
+"como copiar ou borrar ficheiros."
 
-#: tips:166
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Iniciar (silenciosamente) estas accións"
 
-#: tips:168
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Copiar ficheiros sen pedir confirmación"
 
-#: tips:170
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Mover ficheiros sen pedir confirmación"
 
-#: tips:172
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Crear ligazóns á os ficheiros sen pedir confirmación"
 
-#: tips:174
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Borrar ficheiros sen pedir confirmación"
 
-#: tips:175
+#: tips:248
 msgid "Mount"
 msgstr "Montar"
 
-#: tips:176
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Montar e desmontar sistemas de ficheiros sen pedir confirmación"
 
-#: tips:177
+#: tips:250
 msgid "Default settings"
 msgstr "Configuración predeterminada"
 
-#: tips:179
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Forzar"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "Non confirmar a eliminación de elementos non escribibles"
 
-#: tips:181
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Non amosar moita información na área de mensaxes"
 
-#: tips:183
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Tamén cambia o contido dos directorios"
 
-#: tips:186
+#: tips:263
 msgid "Mount commands"
 msgstr "Ordenes de montaxe"
 
-#: tips:187
+#: tips:264
 msgid "Mount command"
 msgstr "Orde de montaxe"
 
-#: tips:188
+#: tips:265
 msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
-msgstr "Orde para montar o sistema de ficheiros, se non está seguro use «mount»"
+msgstr ""
+"Orde para montar o sistema de ficheiros, se non está seguro use «mount»"
 
-#: tips:189
+#: tips:266
 msgid "Unmount command"
 msgstr "Orde de desmontaxe"
 
-#: tips:190
-msgid "The command used to unmount a filesystem. If unsure, use \"umount\" (yes, without the first \"n\")."
-msgstr "Orde para desmontar o sistema de ficheiros, se non está seguro use «umount»(si, sen o primeiro «n»)."
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+"Orde para desmontar o sistema de ficheiros, se non está seguro use "
+"«umount»(si, sen o primeiro «n»)."
 
-#: tips:191
+#: tips:268
 msgid "Eject command"
 msgstr "Orde de expulsión"
 
-#: tips:192
+#: tips:269
 msgid "The command used to eject removable media. If unsure, use \"eject\"."
-msgstr "Orde usada para expulsar dispositivos extraibles, se non esta seguro use «eject»"
+msgstr ""
+"Orde usada para expulsar dispositivos extraibles, se non esta seguro use "
+"«eject»"
 
-#: tips:193
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Arrastrar e pegar"
 
-#: tips:194
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Arrastrar á icona"
 
-#: tips:195
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Permite arrastar iconas a fiestra do xestor"
 
-#: tips:196
-msgid "When this is on you can drag a file over a sub-directory or program in a filer window. The item will highlight when you do this and dropping the file will put it into that directory, or load it into the program."
-msgstr "Con esta opción activada vostede pode arrastrar un ficheiro á fiestra dun subdorectorio ou á un programa. O elemento porase en foco cando vostede fai iso e soltando nel o elemento deixalo ahí ou cargar/executar o programa."
+#: tips:275
+msgid ""
+"When this is on you can drag a file over a sub-directory or program in a "
+"filer window. The item will highlight when you do this and dropping the file "
+"will put it into that directory, or load it into the program."
+msgstr ""
+"Con esta opción activada vostede pode arrastrar un ficheiro á fiestra dun "
+"subdorectorio ou á un programa. O elemento porase en foco cando vostede fai "
+"iso e soltando nel o elemento deixalo ahí ou cargar/executar o programa."
 
-#: tips:197
+#: tips:276
 msgid "Directories spring open"
 msgstr "Abrir directorios de xeito automático"
 
-#: tips:198
-msgid "This option, which requires the above option to be turned on too, causes the highlighted directory to 'spring open' after the file is held over it for a short while."
-msgstr "Esta opción, que require que a opción de acima sexa actvada tamén , fai que o directorio pase a foco con «apertura inmediata» durante un breve tempo despois de que o ficheiro sexa desprazado sobre el."
+#: tips:277
+msgid ""
+"This option, which requires the above option to be turned on too, causes the "
+"highlighted directory to 'spring open' after the file is held over it for a "
+"short while."
+msgstr ""
+"Esta opción, que require que a opción de acima sexa actvada tamén , fai que "
+"o directorio pase a foco con «apertura inmediata» durante un breve tempo "
+"despois de que o ficheiro sexa desprazado sobre el."
 
-#: tips:199
+#: tips:278
 msgid "Spring delay:"
 msgstr "Retardo de «apertura automática»"
 
-#: tips:200
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:201
-msgid "This option sets how long, in ms, you must hold a file over a directory before it will spring open. The above option must be turned on for this to have any effect."
-msgstr "Nesta opción indicase canto tempo, en ms, debe manterse un ficheiro sobor dun directorio antes de que adopte «apertura automática». Esa opción debe ter sido activada para que isto teña efecto."
+#: tips:280
+msgid ""
+"This option sets how long, in ms, you must hold a file over a directory "
+"before it will spring open. The above option must be turned on for this to "
+"have any effect."
+msgstr ""
+"Nesta opción indicase canto tempo, en ms, debe manterse un ficheiro sobor "
+"dun directorio antes de que adopte «apertura automática». Esa opción debe "
+"ter sido activada para que isto teña efecto."
 
-#: tips:202
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Cando arrastra os ficheiros co botón esquerdo de rato"
 
-#: tips:203
-#: tips:207
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Amosar un menú de accións posibles"
 
-#: tips:204
+#: tips:283
 msgid "Copy the files"
 msgstr "Copiar os ficheiros"
 
-#: tips:205
-msgid "Note that you can still get the menu to appear, by dragging with Alt held down."
-msgstr "Observe que pode obter o menú despregable, arrastrando ao tempo que mantén premida a tecla «Alt»."
+#: tips:284
+msgid ""
+"Note that you can still get the menu to appear, by dragging with Alt held "
+"down."
+msgstr ""
+"Observe que pode obter o menú despregable, arrastrando ao tempo que mantén "
+"premida a tecla «Alt»."
 
-#: tips:206
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Cando arrastra os ficheiros co botón do medio do rato"
 
-#: tips:208
+#: tips:287
 msgid "Move the files"
 msgstr "Move os ficheiros"
 
-#: tips:209
-msgid "Note that you can still get the menu to appear, by dragging with the left button and holding down the Alt key."
-msgstr "Observe que pode obter o menú despregable, arrastrando co botón esquerdo ao tempo que mantén premida a tecla «Alt»."
+#: tips:288
+msgid ""
+"Note that you can still get the menu to appear, by dragging with the left "
+"button and holding down the Alt key."
+msgstr ""
+"Observe que pode obter o menú despregable, arrastrando co botón esquerdo ao "
+"tempo que mantén premida a tecla «Alt»."
 
-#: tips:210
+#: tips:289
 msgid "Download handler"
 msgstr "Xestor de descargas"
 
-#: tips:211
+#: tips:290
 msgid ""
-"When you drag a file from a web browser or other remote source, this program will be run to download it. $1 is the URI dragged to the filer, and the current directory is the destination. Eg:\n"
+"When you drag a file from a web browser or other remote source, this program "
+"will be run to download it. $1 is the URI dragged to the filer, and the "
+"current directory is the destination. Eg:\n"
 "xterm -e wget $1"
 msgstr ""
-"Cando vostede arrastra un ficheiro dun navegador de web ou outra fonte remota, este programa será o encargado de descargalo. $1 é a URI arrastrada ao xestor, e o directorio actual será o de destino. Ex:\n"
+"Cando vostede arrastra un ficheiro dun navegador de web ou outra fonte "
+"remota, este programa será o encargado de descargalo. $1 é a URI arrastrada "
+"ao xestor, e o directorio actual será o de destino. Ex:\n"
 "xterm-e wget $1"
 
-#: tips:212
+#: tips:291
 msgid "Menus"
 msgstr "Menús"
 
-#: tips:214
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Tamaño das iconas no menú:"
 
-#: tips:215
+#: tips:294
 msgid "No Icons"
 msgstr "Sen iconas"
 
-#: tips:218
+#: tips:297
 msgid "Same as current window"
 msgstr "Fiestra actual"
 
-#: tips:219
+#: tips:298
 msgid "Same as default"
 msgstr "Predeterminado"
 
-#: tips:220
+#: tips:299
 msgid "Behaviour"
 msgstr "Comportamento"
 
-#: tips:221
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Menú de ficheiro con clic no botón dereito"
 
-#: tips:222
-msgid "Show the File menu instead of the main menu when right-clicking with files selected (the main menu can be accessed by holding down Control)."
-msgstr "Amosa o menú de ficheiro no lugar do principal premendo o botón dereito do rato con ficheiros seleccionados (Para aceder ao menú principal manteña premida a tecla «Ctrl»."
+#: tips:301
+msgid ""
+"Show the File menu instead of the main menu when right-clicking with files "
+"selected (the main menu can be accessed by holding down Control)."
+msgstr ""
+"Amosa o menú de ficheiro no lugar do principal premendo o botón dereito do "
+"rato con ficheiros seleccionados (Para aceder ao menú principal manteña "
+"premida a tecla «Ctrl»."
 
-#: tips:223
+#: tips:302
 msgid "Terminal emulator program"
 msgstr "Programa emulador de terminal"
 
-#: tips:224
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
-msgstr "Este programa iniciaráse cando elixa no menú «Abrir aquí unha terminal»"
+msgstr ""
+"Este programa iniciaráse cando elixa no menú «Abrir aquí unha terminal»"
 
-#: tips:225
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Atallos de teclado"
 
-#: tips:227
+#: tips:305
+msgid "Types"
+msgstr "Tipos"
+
+#: tips:306
 msgid "MIME types"
 msgstr "Tipos MIME"
 
-#: tips:228
-msgid "The filer uses a set of rules to work out the correct MIME type for each regular file, and then chooses a suitable icon for that type."
-msgstr "O xestor de ficheiros usa un xogo de regras para buscar o tipo MIME correcto para cada ficheiro regular e logo escolle a icona axeitada para ese tipo."
+#: tips:307
+msgid ""
+"The filer uses a set of rules to work out the correct MIME type for each "
+"regular file, and then chooses a suitable icon for that type."
+msgstr ""
+"O xestor de ficheiros usa un xogo de regras para buscar o tipo MIME correcto "
+"para cada ficheiro regular e logo escolle a icona axeitada para ese tipo."
 
-#: tips:229
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "Editar as regras MIME"
 
-#: tips:230
+#: tips:309
 msgid "Themes"
 msgstr "Temas"
 
-#: tips:231
+#: tips:310
 msgid "Icon theme"
 msgstr "Tema de iconas"
 
-#: tips:232
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "Os temas de iconas deben estar no directorio «~/.icons»"
 
-#: tips:233
-msgid "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note that icons set this way override those from the selected theme."
-msgstr "Utilice a caixa «Definir iconas...» para configurar a icona para cada tipo MIME. Teña en conta que as iconas definidas deste xeito anulan as do tema seleccionado."
+#: tips:312
+msgid ""
+"Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
+"that icons set this way override those from the selected theme."
+msgstr ""
+"Utilice a caixa «Definir iconas...» para configurar a icona para cada tipo "
+"MIME. Teña en conta que as iconas definidas deste xeito anulan as do tema "
+"seleccionado."
 
-#: tips:234
+#: tips:313
 msgid "Colours"
 msgstr "Cores"
 
-#: tips:235
+#: tips:314
 msgid "File type colours"
 msgstr "Cores de tipos de ficheiro"
 
-#: tips:236
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Colorar os ficheiros según estos tipos"
 
-#: tips:237
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
-msgstr "Os nomes de ficheiro (e os detalles) hanse colorar de acordo co tipo do ficheiro"
+msgstr ""
+"Os nomes de ficheiro (e os detalles) hanse colorar de acordo co tipo do "
+"ficheiro"
 
-#: tips:238
+#: tips:317
 msgid "Directory:"
 msgstr "Directorio:"
 
-#: tips:239
+#: tips:318
 msgid "Regular file:"
 msgstr "Ficheiro regular:"
 
-#: tips:240
+#: tips:319
 msgid "Pipe:"
 msgstr "Canalización:"
 
-#: tips:241
+#: tips:320
 msgid "Socket:"
 msgstr "Socket:"
 
-#: tips:243
-msgid "Error, such as a symlink which points to a non-existant file, or a file which the filer does not have permission to examine."
-msgstr "Produciuse un erro, a ligazón simbólica apunta a un ficheiro que non existe ou a un ficheiro que o xestor nos ten permisos para aceder."
+#: tips:322
+msgid ""
+"Error, such as a symlink which points to a non-existant file, or a file "
+"which the filer does not have permission to examine."
+msgstr ""
+"Produciuse un erro, a ligazón simbólica apunta a un ficheiro que non existe "
+"ou a un ficheiro que o xestor nos ten permisos para aceder."
 
-#: tips:244
+#: tips:323
 msgid "Character device:"
 msgstr "Dispositivo de carácter:"
 
-#: tips:245
+#: tips:324
 msgid "Block device:"
 msgstr "Dispositivo de bloque:"
 
-#: tips:246
+#: tips:325
 msgid "Door:"
 msgstr "Porta:"
 
-#: tips:247
-msgid "Door files are a bit like sockets or pipes, and have only been seen on Solaris."
-msgstr "Ficheiros de porta son como «sockets» ou «canalizacións» e só se usan en Solaris."
+#: tips:326
+msgid ""
+"Door files are a bit like sockets or pipes, and have only been seen on "
+"Solaris."
+msgstr ""
+"Ficheiros de porta son como «sockets» ou «canalizacións» e só se usan en "
+"Solaris."
 
-#: tips:248
+#: tips:327
 msgid "Executable file:"
 msgstr "Ficheiro executable:"
 
-#: tips:249
+#: tips:328
 msgid "Application directory:"
 msgstr "Directorio de aplicativo:"
 
-#: tips:250
+#: tips:329
 msgid "Unknown type:"
 msgstr "Tipo descoñecido:"
 
-#: tips:251
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Segundo plano"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Usar fontes personalizadas:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
-#: tips:252
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Problemas no xestor de fiestras"
 
-#: tips:253
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "Sobrescribir o xestor de fiestras co control do taboleiro e do panel"
 
-#: tips:254
-msgid "Some window managers don't support the new Extended Window Manager Hints system, and so treat the pinboard and panels like normal windows. Turn this on to fix problems such as the pinboard coming to the front when you click on it, titlebars and other decorations appearing around windows, or having them appear in window-select lists."
-msgstr "Algúns xestores de fiestras non son compatibles co novo sistema «Extended Window Manager Hints» e tratan os taboleiros e paneis como fiestras normais. Active esta opción para solucionar problemas como que o taboleiro se veña a primeiro plano cando preme nel, barras de título e outras decoracións de fiestras, ou que teñan que aparecer na lista de fiestras."
+#: tips:340
+msgid ""
+"Some window managers don't support the new Extended Window Manager Hints "
+"system, and so treat the pinboard and panels like normal windows. Turn this "
+"on to fix problems such as the pinboard coming to the front when you click "
+"on it, titlebars and other decorations appearing around windows, or having "
+"them appear in window-select lists."
+msgstr ""
+"Algúns xestores de fiestras non son compatibles co novo sistema «Extended "
+"Window Manager Hints» e tratan os taboleiros e paneis como fiestras normais. "
+"Active esta opción para solucionar problemas como que o taboleiro se veña a "
+"primeiro plano cando preme nel, barras de título e outras decoracións de "
+"fiestras, ou que teñan que aparecer na lista de fiestras."
 
-#: tips:255
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "Enviar os clics do rato no escritorio á o xestor de fiestras"
 
-#: tips:256
-msgid "Normally, right clicking on the desktop background will open the pinboard menu and left clicking will clear the selection. Turn this on to forward the events to your window manager instead. Clicks on icons will not be forwarded."
-msgstr "Normalmente, facer click dereito no fondo de escritorio abre o menú e no esquerdo limpa a selección. Active esta opción se desexa enviar estos eventos ao xestor de fiestras. Os clics nas iconas non van ser enviados."
+#: tips:342
+msgid ""
+"Normally, right clicking on the desktop background will open the pinboard "
+"menu and left clicking will clear the selection. Turn this on to forward the "
+"events to your window manager instead. Clicks on icons will not be forwarded."
+msgstr ""
+"Normalmente, facer click dereito no fondo de escritorio abre o menú e no "
+"esquerdo limpa a selección. Active esta opción se desexa enviar estos "
+"eventos ao xestor de fiestras. Os clics nas iconas non van ser enviados."
 
-#: tips:257
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Menus de «Blackbox» cortados"
 
-#: tips:258
-msgid "Blackbox, Fluxbox and similar window managers do not yet work well with the ROX-Filer pinboard. This option enables some workarounds. These window managers are expected to change their behaviour in new versions so that this isn't necessary."
-msgstr "Blackbox, Fluxbox e xestores de fiestras similares ainda non traballan ben co taboleiro de ROX-Filer. Esta opción soluciona algúns problemas. Agardamos que estos xestores de fiestras muden o seu comportamento en novas versions de xeito que isto non sexa necesario."
+#: tips:344
+msgid ""
+"Blackbox, Fluxbox and similar window managers do not yet work well with the "
+"ROX-Filer pinboard. This option enables some workarounds. These window "
+"managers are expected to change their behaviour in new versions so that this "
+"isn't necessary."
+msgstr ""
+"Blackbox, Fluxbox e xestores de fiestras similares ainda non traballan ben "
+"co taboleiro de ROX-Filer. Esta opción soluciona algúns problemas. Agardamos "
+"que estos xestores de fiestras muden o seu comportamento en novas versions "
+"de xeito que isto non sexa necesario."
 
-#: tips:259
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "O panel é «ancorado»"
 
-#: tips:260
-msgid "Makes sure panels stay against screen edges. Disable this option if the panel stays above other windows against your wishes. Requires a restart to take effect."
-msgstr "Asegura que os paneles se manteñen nos bordos da pantalla. Desactive esta opción se o panel se manten por eriba de outras fiestras en contra dos seus desexos. Require un reinicio para ter efecto."
+#: tips:346
+msgid ""
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
+msgstr ""
+"Asegura que os paneles se manteñen nos bordos da pantalla. Desactive esta "
+"opción se o panel se manten por eriba de outras fiestras en contra dos seus "
+"desexos. Require un reinicio para ter efecto."
 
-#: tips:261
+#: tips:347
 msgid "Panel stays on top"
 msgstr "O panel permanece en primeiro plano"
 
-#: tips:262
-msgid "Keeps the panel above other windows. Enable this option to make sure the dock option works correctly in some versions of compiz. May require a restart to take effect."
-msgstr "Manten o panel por enriba de outras fiestras. Active esta opción para asegurarse de que a opción acoplar funciona correctamente en algunhas versións de compiz. Pode requerir un reinicio para ter efecto."
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+"Manten o panel por enriba de outras fiestras. Active esta opción para "
+"asegurarse de que a opción acoplar funciona correctamente en algunhas "
+"versións de compiz. Pode requerir un reinicio para ter efecto."
 
-#: tips:263
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Arrastrar e pegar"
 
-#: tips:264
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Non usar nomes de host"
 
-#: tips:265
-msgid "Some older applications don't support XDND fully and may need to have this option turned on. Use this if dragging files to an application shows a + sign on the pointer but the drop doesn't work."
-msgstr "Algúns aplicativos antigos non son compatibles con «XDND» e poden precisar que esta opción esté activada. Use esta opción se ao arrastrar un ficheiro ao aplicativo amosa un «+» no punteiro pero non traballa."
+#: tips:353
+msgid ""
+"Some older applications don't support XDND fully and may need to have this "
+"option turned on. Use this if dragging files to an application shows a + "
+"sign on the pointer but the drop doesn't work."
+msgstr ""
+"Algúns aplicativos antigos non son compatibles con «XDND» e poden precisar "
+"que esta opción esté activada. Use esta opción se ao arrastrar un ficheiro "
+"ao aplicativo amosa un «+» no punteiro pero non traballa."
 
-#: tips:266
-msgid "Extended attributes"
-msgstr "Atributos estendidos"
-
-#: tips:267
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Non usar os atributos estendidos"
 
-#: tips:268
-msgid "This disables the use of extended attributes available in newer operating systems and file systems.  With this option set the 'Set Type' menu entry is disabled, the MIME type of the file is only derived from the file name and the properties window does not report extended attributes."
-msgstr "Esto desactiva o uso de atributos estendidos dispoñible nos novos sistemas operativos e sistemas de ficheiros. Con esta opción o «Definir tipo» no menú de entrada está desactivado, e o tipo MIME dos ficheiros é o derivado do nome e a caixa das propiedades non informa delas."
+#: tips:356
+msgid ""
+"This disables the use of extended attributes available in newer operating "
+"systems and file systems.  With this option set the 'Set Type' menu entry is "
+"disabled, the MIME type of the file is only derived from the file name and "
+"the properties window does not report extended attributes."
+msgstr ""
+"Esto desactiva o uso de atributos estendidos dispoñible nos novos sistemas "
+"operativos e sistemas de ficheiros. Con esta opción o «Definir tipo» no menú "
+"de entrada está desactivado, e o tipo MIME dos ficheiros é o derivado do "
+"nome e a caixa das propiedades non informa delas."
 
-#: ../Templates.glade:7
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Bordo inferior"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "Bordo dereito"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
 msgid "ROX-Filer log viewer"
 msgstr "Visor do rexistro de «ROX-Filer»"
 
-#: ../Templates.glade:22
+#: ../Templates.ui.h:2
 msgid "Recently performed actions..."
 msgstr "Accións realizadas recentemente---"
 
-#: ../Templates.glade:77
+#: ../Templates.ui.h:3
 msgid "Open Directory"
 msgstr "Abrir directorio"
 
-#: ../Templates.glade:129
+#: ../Templates.ui.h:4
 msgid "Panel Options"
 msgstr "Opcións do panel"
 
-#: ../Templates.glade:169
-msgid "Every icon on this panel is shown with an image and some text."
-msgstr "Cada icona no panel é amosada como imaxe e algún texto"
-
-#: ../Templates.glade:170
+#: ../Templates.ui.h:5
 msgid "Image and Text"
 msgstr "Imaxe e texto"
 
-#: ../Templates.glade:186
-msgid "Applications in this panel have just an image, everything else has both an image and text."
-msgstr "Só os aplicativos teñen imaxe, todo o demáis ten tanto imaxe como texto."
+#: ../Templates.ui.h:6
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Cada icona no panel é amosada como imaxe e algún texto"
 
-#: ../Templates.glade:187
+#: ../Templates.ui.h:7
 msgid "Image only for applications"
 msgstr "Imaxe só para aplicativos"
 
-#: ../Templates.glade:205
-msgid "Only the image is shown for icons in this panel."
-msgstr "Só se amosa a imaxe para iconas no panel"
+#: ../Templates.ui.h:8
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"Só os aplicativos teñen imaxe, todo o demáis ten tanto imaxe como texto."
 
-#: ../Templates.glade:206
+#: ../Templates.ui.h:9
 msgid "Image only"
 msgstr "Só imaxe"
 
-#: ../Templates.glade:235
+#: ../Templates.ui.h:10
+msgid "Only the image is shown for icons in this panel."
+msgstr "Só se amosa a imaxe para iconas no panel"
+
+#: ../Templates.ui.h:11
 msgid "Panel width"
 msgstr "Largura do panel"
 
-#: ../Templates.glade:247
+#: ../Templates.ui.h:12
 msgid "The size of this panel."
 msgstr "Tamaño de este panel"
 
-#: ../Templates.glade:259
+#: ../Templates.ui.h:13
 msgid "px"
 msgstr "px"
 
-#: ../Templates.glade:278
-msgid "Ask the window manager not to cover this panel when maximising windows, otherwise leave just 2 pixels at the edge of the screen to allow auto-raising. Some window managers may not honour this setting."
-msgstr "Indicarlle o xestor de fiestras que non cubra este panel cando se máximizan ás fiestras, do contrario, deixe a só 2 píxeles o bordo da pantalla para permitir o redimensionado. Algún xestor de fiestras no poderá fornecer esta configuración."
+#: ../Templates.ui.h:14
+msgid "Transparency"
+msgstr ""
 
-#: ../Templates.glade:279
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
 msgid "Do not cover panel"
 msgstr "Non tapar o panel"
 
-#: ../Templates.glade:297
+#: ../Templates.ui.h:19
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Indicarlle o xestor de fiestras que non cubra este panel cando se máximizan "
+"ás fiestras, do contrario, deixe a só 2 píxeles o bordo da pantalla para "
+"permitir o redimensionado. Algún xestor de fiestras no poderá fornecer esta "
+"configuración."
+
+#: ../Templates.ui.h:20
 msgid "<b>Panel style</b>"
 msgstr "<b>Estilo de panel</b>"
 
-#: ../Templates.glade:331
-msgid "If you use multiple monitors with Xinerama, use this option to confine the panel to one monitor."
-msgstr "Se utiliza múltiples monitores con «Xinerama», utilice esta opción para asignar o panel a un monitor ."
-
-#: ../Templates.glade:332
+#: ../Templates.ui.h:21
 msgid "Confine to Xinerama monitor"
 msgstr "Asignar un monitor Xinerama"
 
-#: ../Templates.glade:347
-msgid "The monitor this panel is confined to when using Xinerama. The numbering starts from zero."
+#: ../Templates.ui.h:22
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Se utiliza múltiples monitores con «Xinerama», utilice esta opción para "
+"asignar o panel a un monitor ."
+
+#: ../Templates.ui.h:23
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
 msgstr "Monitor do panel asignado con Xinerama. A numeración comeza de cero."
 
-#: ../Templates.glade:372
+#: ../Templates.ui.h:24
 msgid "<b>Xinerama</b>"
 msgstr "<b>Xinerama</b>"
 
-#: ../Templates.glade:407
+#: ../Templates.ui.h:25
 msgid "Right edge"
 msgstr "Bordo dereito"
 
-#: ../Templates.glade:426
+#: ../Templates.ui.h:26
 msgid "Left edge"
 msgstr "Bordo esquerdo"
 
-#: ../Templates.glade:443
+#: ../Templates.ui.h:27
 msgid "Bottom edge"
 msgstr "Bordo inferior"
 
-#: ../Templates.glade:462
+#: ../Templates.ui.h:28
 msgid "Top edge"
 msgstr "Bordo superior"
 
-#: ../Templates.glade:496
+#: ../Templates.ui.h:29
 msgid "<b>Position</b>"
 msgstr "<b>Posición</b>"
 
+#~ msgid "<dir>"
+#~ msgstr "<dir>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' xa existe - sobreescribir?"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Atopouse un erro ao explorar '%s':\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Directorio ausente/borrado"
+
+#~ msgid "Directory '%s' is not accessible"
+#~ msgstr "Non se pode aceder ao directorio '%s'"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Non se atopa o directorio '%s'."
+
+#~ msgid "Cancel"
+#~ msgstr "Cancelar"
+
+#~ msgid "All, "
+#~ msgstr "Todos, "
+
+#~ msgid "Inotify support"
+#~ msgstr "Compatibilidade para «Inotify»"
+
+#~ msgid "Dnotify support"
+#~ msgstr "Compatibilidade para «dnotify»"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Prema a tecla «Mayús» e faga clic sobre un ficheiro para envialo a algún "
+#~ "sitio"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Cambiar a directorio superior"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Cambiar a directorio de inicio"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Marca páxinas"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Menu de marca páxinas"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Actualizar o contido do directorio"
+
+#~ msgid "Change icon size"
+#~ msgstr "Cambiar tamaño da icona"
+
+#~ msgid "Show extra details"
+#~ msgstr "Amosar detalles extra"
+
+#~ msgid "Hidden"
+#~ msgstr "Agochado"
+
+#~ msgid "Change at:"
+#~ msgstr "Cambiar a:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Largura máxima (iconas grandes)"
+
+#~ msgid "Panel (obsolete)"
+#~ msgstr "Panel (obsoleto)"
+
+#~ msgid ""
+#~ "Enter the name of the panel to show here. This option is now only used "
+#~ "when upgrading from an old version."
+#~ msgstr ""
+#~ "Poña o nome do panel que vai ser amosado. Esta opción agora só se usa se "
+#~ "actualizou dunha versión anterior."

--- a/ROX-Filer/src/po/hu.po
+++ b/ROX-Filer/src/po/hu.po
@@ -6,42 +6,44 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ROX-Filer 2.4.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2007-09-17 09:37+0200\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2007-09-17 11:26+0100\n"
 "Last-Translator: András Mohari <mayday@vizslamail.hu>\n"
 "Language-Team: Hungarian\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: abox.c:125
-msgid "<dir>"
-msgstr "<könyvtár>"
+#: abox.c:127
+msgid "<src>"
+msgstr ""
 
-#: abox.c:218
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Csendben"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Quiet"
 msgstr "Csendben"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Nem kell jóváhagyni minden műveletet"
 
-#: abox.c:454
-#: infobox.c:771
-#: tips:63
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Név"
 
-#: abox.c:460
-#: menu.c:233
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Könyvtár"
 
-#: abox.c:549
+#: abox.c:546
 msgid "Expression:"
 msgstr "Kifejezés:"
 
@@ -57,11 +59,11 @@ msgstr "Lásd az fsattr(5) kézikönyv oldalt részletes leírásért."
 msgid "You do not appear to have OS support."
 msgstr "Úgy tűnik, az op. rendszer nem támogatja."
 
-#: action.c:191
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Segítség a keresési kifejezésekhez"
 
-#: action.c:202
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -77,10 +79,13 @@ msgid ""
 "<b>IsReg system(grep -q fred \"%\")</b> (contains the word 'fred')\n"
 "\n"
 "<u>Simple Tests</u>\n"
-"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</b> (types)\n"
-"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> (permissions)\n"
+"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
+"b> (types)\n"
+"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
+"(permissions)\n"
 "<b>IsEmpty, IsMine</b>\n"
-"A pattern in single quotes is a shell-style wildcard pattern to match. If it\n"
+"A pattern in single quotes is a shell-style wildcard pattern to match. If "
+"it\n"
 "contains a slash then the match is against the full path; otherwise it is\n"
 "against the leafname only.\n"
 "\n"
@@ -88,7 +93,8 @@ msgid ""
 "<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (compare two values)\n"
 "<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (file sizes)\n"
 "<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (times)\n"
-"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> (values)\n"
+"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
+"(values)\n"
 "\n"
 "<u>Specials</u>\n"
 "<b>system(command)</b> (true if 'command' returns with a zero exit status;\n"
@@ -109,37 +115,45 @@ msgstr ""
 "<b>IsReg system(grep -q fred \"%\")</b> (\"fred\" szót tartalmazó fájlok)\n"
 "\n"
 "<u>Egyszerű vizsgálatok</u>\n"
-"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</b> (fájltípusok)\n"
-"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> (jogosultságok)\n"
+"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
+"b> (fájltípusok)\n"
+"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
+"(jogosultságok)\n"
 "<b>IsEmpty, IsMine</b>\n"
-"Szimpla idézőjelek között a shellből ismert névminta lehet. Ha a minta perjelet\n"
-"tartalmaz, akkor a teljes útvonalra illeszkedik; máskülönben csak a fájlnévre.\n"
+"Szimpla idézőjelek között a shellből ismert névminta lehet. Ha a minta "
+"perjelet\n"
+"tartalmaz, akkor a teljes útvonalra illeszkedik; máskülönben csak a "
+"fájlnévre.\n"
 "\n"
 "<u>Összehasonlítások</u>\n"
-"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (két érték összehasonlítása)\n"
+"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (két érték "
+"összehasonlítása)\n"
 "<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (fájlméretek)\n"
 "<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (idők)\n"
-"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> (értékek)\n"
+"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
+"(értékek)\n"
 "\n"
 "<u>Különleges vizsgálatok</u>\n"
 "<b>system(parans)</b> (igaz, ha \"parancs\" visszatérési értéke nulla;\n"
 "a parancsban a % jel az éppen vizsgált fájlt jelenti)\n"
 "<b>prune</b> (hamis; továbbá megakadályozza a könyvtár átvizsgálását)."
 
-#: action.c:249
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Segítség a jogosultságok megváltoztatásához"
 
-#: action.c:260
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
 "\n"
 "The format of a command is: <b>CHANGE, CHANGE, ...</b>\n"
 "Each <b>CHANGE</b> is: <b>WHO HOW PERMISSIONS</b>\n"
-"<b>WHO</b> is some combination of <b>u</b>, <b>g</b> and <b>o</b> which determines whether to\n"
+"<b>WHO</b> is some combination of <b>u</b>, <b>g</b> and <b>o</b> which "
+"determines whether to\n"
 "change the permissions for the User (owner), Group or Others.\n"
-"<b>HOW</b> is <b>+</b>, <b>-</b> or <b>=</b> to add, remove or set exactly the permissions.\n"
+"<b>HOW</b> is <b>+</b>, <b>-</b> or <b>=</b> to add, remove or set exactly "
+"the permissions.\n"
 "<b>PERMISSIONS</b> is some combination of the letters <b>rwxXstugo</b>\n"
 "\n"
 "Bracketed text and spaces are ignored.\n"
@@ -147,7 +161,8 @@ msgid ""
 "<u>Examples</u>\n"
 "<b>u+rw</b>: the file owner gains read and write permission\n"
 "<b>g=u</b>: the group permissions are set to be the same as the user's\n"
-"<b>o=u-w</b>: others get the same permissions as the owner, but without write permission\n"
+"<b>o=u-w</b>: others get the same permissions as the owner, but without "
+"write permission\n"
 "<b>a+x</b>: <b>a</b>ll get execute/access permission - same as <b>ugo+x</b>\n"
 "<b>a+X</b>: directories become accessable by everyone; files which were\n"
 "executable by anyone become executable by everyone\n"
@@ -158,13 +173,17 @@ msgid ""
 "See the chmod(1) man page for full details."
 msgstr ""
 "Általában elegendő kiválasztani a módosító parancsot a menüből \n"
-"(a parancssor melletti nyilra kattintva). Néha azonban többre van szükség...\n"
+"(a parancssor melletti nyilra kattintva). Néha azonban többre van "
+"szükség...\n"
 "\n"
 "A módosító parancs formája: <b>MÓDOSÍTÁS, MÓDOSÍTÁS, ...</b>\n"
 "A <b>MÓDOSÍTÁS</b> formája: <b>KI HOGYAN ENGEDÉLYEK</b>\n"
-"A <b>KI</b> az <b>u</b>, <b>g</b> és <b>o</b> betűk kombinációja, amely meghatározza, hogy a\n"
-"felhasználó (tulajdonos), csoport vagy a többiek elérési jogai módosítandók-e.\n"
-"<b>HOGYAN</b>: <b>+</b>, <b>-</b> vagy <b>=</b> a jogok adásához, megvonásához vagy pontos beállításához.\n"
+"A <b>KI</b> az <b>u</b>, <b>g</b> és <b>o</b> betűk kombinációja, amely "
+"meghatározza, hogy a\n"
+"felhasználó (tulajdonos), csoport vagy a többiek elérési jogai módosítandók-"
+"e.\n"
+"<b>HOGYAN</b>: <b>+</b>, <b>-</b> vagy <b>=</b> a jogok adásához, "
+"megvonásához vagy pontos beállításához.\n"
 "<b>ENGEDÉLYEK</b>: az <b>rwxXstugo</b> betűk kombinációjából áll.\n"
 "\n"
 "Zárójeles kifejezések illetve a szóközök nem számítanak.\n"
@@ -173,20 +192,22 @@ msgstr ""
 "<b>u+rw</b>: olvasási és írási jogot ad a tulajdonosnak\n"
 "<b>g=u</b>: a csoport jogai megegyeznek a tulajdonoséval\n"
 "<b>o=u-w</b>: a többiek az írási jog kivételével a tulajdonos jogait kapják\n"
-"<b>a+x</b>: végrehajtási/elérési jog mindenkinek - ugyanaz, mint az <b>ugo+x</b>\n"
+"<b>a+x</b>: végrehajtási/elérési jog mindenkinek - ugyanaz, mint az <b>ugo"
+"+x</b>\n"
 "<b>a+X</b>: mindenki elérheti a könyvtárakat; mindenki futtathatja\n"
 "a korábban bárki által futtatható fájlokat\n"
 "<b>u+rw, go+r</b>: két parancs egyszerre!\n"
-"<b>u+s</b>: beállítja a SetUID bitet - parancsfájloknál általában hatástalan\n"
+"<b>u+s</b>: beállítja a SetUID bitet - parancsfájloknál általában "
+"hatástalan\n"
 "<b>755</b>: jogok közvetlen beállítása\n"
 "\n"
 "Lásd a chmod(1) parancs kézikönyvét részletes leírásért."
 
-#: action.c:301
+#: action.c:308
 msgid "Set type reference"
 msgstr "Segítség a fájltípus beállításához"
 
-#: action.c:312
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -214,55 +235,55 @@ msgstr ""
 "nincs típusuk, csak a közönséges fájloknak, de ezeknek is\n"
 "csak akkor, ha a fájlrendszer és az operációs rendszer támogatja.\n"
 
-#: action.c:419
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "A processz leállt.\n"
 
-#: action.c:435
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Egyetlen hiba volt.\n"
 
-#: action.c:437
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "%d hiba volt.\n"
 
-#: action.c:461
+#: action.c:516
 msgid "ERROR reading"
 msgstr "Olvasási HIBA:"
 
-#: action.c:504
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Kész\n"
 
-#: action.c:560
-#: support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "HIBA"
 
-#: action.c:714
-#: main.c:693
-#: main.c:700
-#: main.c:714
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Igen"
 
-#: action.c:717
-#: main.c:695
-#: main.c:702
-#: main.c:714
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Nem"
 
-#: action.c:735
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -270,7 +291,7 @@ msgstr ""
 "\n"
 "Gyerekprocessz leállítása...\n"
 
-#: action.c:742
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -278,41 +299,41 @@ msgstr ""
 "\n"
 "Kísérlet az elszabadult processz KILÖVÉSÉRE...\n"
 
-#: action.c:895
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Megméred %s tartalmát?"
 
-#: action.c:931
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Törlöd? %s\"%s\""
 
-#: action.c:932
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "(ÍRÁSVÉDETT) "
 
-#: action.c:939
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'\"%s\" törlése\n"
 
-#: action.c:952
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'Könyvtár törölve: \"%s\"\n"
 
-#: action.c:985
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?Kiadod? \"%s\""
 
-#: action.c:992
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'\"%s\" kiadása\n"
 
-#: action.c:1011
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -321,99 +342,96 @@ msgstr ""
 "!%s\n"
 "nem sikerült kiadni a lemezt\n"
 
-#: action.c:1030
-#: action.c:1049
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Mehet \"%s\"?"
 
-#: action.c:1046
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Érvénytelen keresési kifejezés - javítsd ki és próbáld újra\n"
 
-#: action.c:1056
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(\"%s\" feldolgozásakor)\n"
 
-#: action.c:1130
-#: action.c:1155
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Módosítod \"%s\" jogosultságait?"
 
-#: action.c:1136
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'\"%s\" jogosultságainak módosítása\n"
 
-#: action.c:1153
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Érvénytelen módosítási parancs - javítsd ki és próbáld újra\n"
 
-#: action.c:1211
+#: action.c:1332
 #, c-format
 msgid "?Change contents of '%s'?"
 msgstr "?Módosítod \"%s\" tartalmát?"
 
-#: action.c:1214
-#: action.c:1234
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Módosítod \"%s\" típusát?"
 
-#: action.c:1231
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Érvénytelen típus - javítsd ki és próbáld újra\n"
 
-#: action.c:1253
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'\"%s\" típusának módosítása \"%s\" típusra\n"
 
-#: action.c:1276
+#: action.c:1397
 #, c-format
 msgid "'Not changing type of directory '%s'\n"
 msgstr "'Nem módosítom e könyvtár típusát: \"%s\"\n"
 
 # XXX [mayday]: Egyelőre csak a típus módosításakor írja.
-#: action.c:1282
+#: action.c:1403
 #, c-format
 msgid "'Non-regular file '%s' not changed\n"
 msgstr "'Ez a nem közönséges fájl ki lett kihagyva: \"%s\"\n"
 
-#: action.c:1342
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?\"%s\" már létezik - %s?"
 
-#: action.c:1344
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "összefésülöd a tartalmukat"
 
-#: action.c:1345
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "felülírod"
 
-#: action.c:1361
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Megpróbálom másolni...\n"
 
-#: action.c:1370
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Másolod? Forrás: %s Cél: %s"
 
-#: action.c:1374
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'%s másolása %s néven\n"
 
-#: action.c:1389
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!HIBA: A cél már létezik, de nem könyvtár\n"
 
-#: action.c:1461
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -422,26 +440,7 @@ msgstr ""
 "!%s\n"
 "Nem sikerült \"%s\" másolása\n"
 
-#: action.c:1505
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?\"%s\" már létezik - felülírod?"
-
-#: action.c:1520
-msgid "'Trying move anyway...\n"
-msgstr "'Megpróbálom áthelyezni...\n"
-
-#: action.c:1528
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Áthelyezed? Forrás: %s Cél: %s"
-
-#: action.c:1532
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'%s áthelyezése %s néven\n"
-
-#: action.c:1540
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -450,47 +449,61 @@ msgstr ""
 "!%s\n"
 "Nem sikerült \"%s\" áthelyezése \"%s\" néven\n"
 
-#: action.c:1561
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Megpróbálom áthelyezni...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Áthelyezed? Forrás: %s Cél: %s"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'%s áthelyezése %s néven\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!HIBA: Nem másolható önmagába\n"
 
-#: action.c:1576
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!HIBA: Nem helyezhető/nevezhető át önmagába\n"
 
 # XXX
-#: action.c:1588
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'%s linkelése %s néven\n"
 
 # XXX
-#: action.c:1593
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Linkeled? Forrás: %s Cél: %s"
 
-#: action.c:1636
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'%s csatolása\n"
 
-#: action.c:1637
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'%s lecsatolása\n"
 
-#: action.c:1640
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?Csatolod ezt: \"%s\"?"
 
-#: action.c:1641
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?Lecsatolod ezt: \"%s\"?"
 
-#: action.c:1662
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -499,7 +512,7 @@ msgstr ""
 "!%s\n"
 "Nem sikerült csatolni\n"
 
-#: action.c:1663
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -508,11 +521,11 @@ msgstr ""
 "!%s\n"
 "Nem sikerült lecsatolni\n"
 
-#: action.c:1671
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(úgy tűnik, már csatolva van)\n"
 
-#: action.c:1717
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -521,320 +534,321 @@ msgstr ""
 "'\n"
 "Összesen: %s ("
 
-#: action.c:1723
+#: action.c:2108
 msgid "file"
 msgstr "fájl"
 
 # XXX: többes szám miatt baj lehet, de ez jelenleg így jó.
-#: action.c:1723
+#: action.c:2108
 msgid "files"
 msgstr "fájl"
 
-#: action.c:1727
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "nincsenek könyvtárak)\n"
 
-#: action.c:1731
+#: action.c:2116
 msgid "directory"
 msgstr "könyvtár"
 
 # XXX: többes szám miatt baj lehet, de ez jelenleg így jó.
-#: action.c:1732
+#: action.c:2117
 msgid "directories"
 msgstr "könyvtár"
 
-#: action.c:1773
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Nincs kijelölve csatolási pont!\n"
 
-#: action.c:1858
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Újabb keresés?"
 
-#: action.c:1888
-#: action.c:1919
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!\"%s\" egy szimbolikus link\n"
 
-#: action.c:1959
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "Ki kell jelölnöd néhány elemet a kereséshez"
 
-#: action.c:1969
-#: menu.c:224
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Keresés"
 
-#: action.c:2002
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Ki kell jelölnöd az elemeket a méretük megállapításához"
 
-#: action.c:2006
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Felhasznált lemezterület"
 
-#: action.c:2042
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Csatolás / Lecsatolás"
 
-#: action.c:2059
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
-msgstr "A ROX-Filer sajnos még nem támogatja a csatolási pontokat ezen a rendszeren."
+msgstr ""
+"A ROX-Filer sajnos még nem támogatja a csatolási pontokat ezen a rendszeren."
 
-#: action.c:2073
-#: menu.c:212
-#: tips:200
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Törlés"
 
-#: action.c:2085
-#: tips:205
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Kényszerítés"
 
-#: action.c:2085
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Ne kérjen megerősítést a nem írható elemek törléséhez"
 
-#: action.c:2088
-#: action.c:2147
-#: action.c:2210
-#: action.c:2283
-#: action.c:2323
-#: tips:207
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Tömör"
 
-#: action.c:2088
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Csak a könyvtárak törlését listázza"
 
-#: action.c:2107
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
-msgstr "Ki kell jelölnöd az elemeket, amelyeknek a jogosultságait módosítani akarod"
+msgstr ""
+"Ki kell jelölnöd az elemeket, amelyeknek a jogosultságait módosítani akarod"
 
-#: action.c:2115
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Engedélyezi a végrehajást/elérést)"
 
-#: action.c:2117
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (Tiltja a végrehajtást/elérést)"
 
-#: action.c:2119
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Olvasási+írási jog a tulajdonosnak)"
 
-#: action.c:2121
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Privát - tulajdonos fér csak hozzá)"
 
-#: action.c:2123
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Nyilvános elérés, írás tiltva)"
 
-#: action.c:2134
-#: menu.c:185
-#: menu.c:222
-#: tips:80
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Jogosultságok"
 
-#: action.c:2147
-#: action.c:2210
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Ne listázza a feldolgozott fájlokat"
 
-#: action.c:2150
-#: action.c:2213
-#: tips:209
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Rekurzív"
 
-#: action.c:2150
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Az alkönyvtárak tartalmát is feldolgozza"
 
-#: action.c:2154
+#: action.c:2547
 msgid "Command:"
 msgstr "Parancs:"
 
-#: action.c:2184
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Ki kell jelölnöd a fájlokat, amelyeknek a típusát módosítani akarod"
 
-#: action.c:2197
+#: action.c:2590
 msgid "Set type"
 msgstr "Típus beállítása"
 
-#: action.c:2213
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Az alkönyvtárak tartalmát is feldolgozza"
 
-#: action.c:2220
-#: infobox.c:627
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Típus:"
 
-#: action.c:2267
-#: dnd.c:122
-#: menu.c:2014
-#: tips:194
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Másolás"
 
-#: action.c:2279
-#: action.c:2319
-#: tips:211
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Nem kell jóváhagyni minden műveletet"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Csak akkor írja felül a célt, ha a forrás újabb nála."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Újabb"
 
-#: action.c:2280
-#: action.c:2320
-#: tips:212
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Csak akkor írja felül a célt, ha a forrás újabb nála."
 
-#: action.c:2283
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+# XXX: többes szám miatt baj lehet, de ez jelenleg így jó.
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "könyvtár"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Csak a könyvtárak másolását listázza"
 
-#: action.c:2307
-#: dnd.c:123
-#: tips:196
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Áthelyezés"
 
-#: action.c:2323
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Ne listázza az áthelyezett fájlokat"
 
-#: action.c:2346
-#: tips:198
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Linkelés"
 
-#: action.c:2369
-#: appmenu.c:111
-#: filer.c:593
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Kiadás"
 
-#: action.c:2437
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Az ehhez hasonló elemeknek ("
 
-#: action.c:2441
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Ennek az elemnek ("
 
-#: action.c:2443
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Ezeknek az elemeknek ("
 
-#: action.c:2462
+#: action.c:2900
 msgid " and "
 msgstr " és "
 
-#: action.c:2471
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
-msgstr ") a törlése hatással van az asztal vagy panel elemeire. Tényleg törlöd?"
+msgstr ""
+") a törlése hatással van az asztal vagy panel elemeire. Tényleg törlöd?"
 
-#: action.c:2478
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
-msgstr ") a törlése hatással van az asztal vagy panel elemeire. Tényleg törlöd őket?"
+msgstr ""
+") a törlése hatással van az asztal vagy panel elemeire. Tényleg törlöd őket?"
 
-#: appmenu.c:197
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<hiányzó címke>"
 
-#: appmenu.c:319
+#: appmenu.c:317
 #, c-format
-msgid "Symlink any programs you want into this directory. They will appear in the menu for all items of this type (%s/%s)."
-msgstr "Készíts linkeket ebben a könyvtárban a kívánt programokra. Ezek fognak megjelenni a menüben az ilyen típusú fájloknál (%s/%s)."
+msgid ""
+"Symlink any programs you want into this directory. They will appear in the "
+"menu for all items of this type (%s/%s)."
+msgstr ""
+"Készíts linkeket ebben a könyvtárban a kívánt programokra. Ezek fognak "
+"megjelenni a menüben az ilyen típusú fájloknál (%s/%s)."
 
-#: appmenu.c:363
-#: menu.c:235
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Menü testreszabása..."
 
-#: appmenu.c:420
-#: menu.c:253
-#: toolbar.c:158
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Segítség"
 
-#: bookmarks.c:148
-msgid "Path"
-msgstr "Útvonal"
-
-#: bookmarks.c:156
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Cím"
 
-#: bookmarks.c:305
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Útvonal"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Távoli erőforrás nem adható a könyvjelzőkhöz: \"%s\"\n"
 
-#: bookmarks.c:313
-#: bookmarks.c:631
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "\"%s\" nem könyvtár"
 
-#: bookmarks.c:519
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Előbb jelöld ki a törlendő sorokat"
 
-#: bookmarks.c:543
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Jelöld ki a lista áthelyezendő bejegyzését"
 
 # XXX: Ezt írja az első elem előbbre mozgatásakor is!
-#: bookmarks.c:563
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Ez a bejegyzés már szélső helyzetben van"
 
-#: bookmarks.c:637
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Nem adhatók távoli könyvtárak a könyvjelzőkhöz: \"%s\""
 
-#: bookmarks.c:779
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Új könyvjelző hozzáadása"
 
-#: bookmarks.c:786
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Könyvjelzők szerkesztése"
 
-#: bookmarks.c:791
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Legutóbbi könyvtárak"
 
-#: bulk_rename.c:66
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Fájlok tömeges átnevezése"
 
-#: bulk_rename.c:69
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Visszaállítás"
 
-#: bulk_rename.c:74
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "Az \"Új\" oszlopba másolja a \"Régi\" tartalmát"
 
-#: bulk_rename.c:79
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "Átnevezés"
 
-#: bulk_rename.c:92
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Csere:"
 
-#: bulk_rename.c:99
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -848,59 +862,72 @@ msgstr ""
 "\\. a pont karakterre illeszkedik\n"
 "\\.htm$ a \".htm\" részre illeszkedik az \"index.htm\" stb. névben"
 
-#: bulk_rename.c:107
+#: bulk_rename.c:109
 msgid "With:"
 msgstr "Erre:"
 
-#: bulk_rename.c:114
-msgid "The first match in each filename will be replaced by this string. There are no special characters."
-msgstr "Erre a karaktersorozatra cseréli le a fájlnevekben az első egyező részt. Itt nincsenek különleges karakterek."
+#: bulk_rename.c:116
+#, fuzzy
+msgid ""
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
+msgstr ""
+"Erre a karaktersorozatra cseréli le a fájlnevekben az első egyező részt. Itt "
+"nincsenek különleges karakterek."
 
-#: bulk_rename.c:118
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Alkalmazás"
 
-#: bulk_rename.c:121
-msgid "Do a search-and-replace in the New column. The files are not actually renamed until you click on the Rename button below."
-msgstr "Keresést és cserét hajt végre az \"Új\" oszlopban. A fájlokat csak akkor nevezi át ténylegesen, ha rákattintasz az \"Átnevezés\" gombra."
+#: bulk_rename.c:125
+msgid ""
+"Do a search-and-replace in the New column. The files are not actually "
+"renamed until you click on the Rename button below."
+msgstr ""
+"Keresést és cserét hajt végre az \"Új\" oszlopban. A fájlokat csak akkor "
+"nevezi át ténylegesen, ha rákattintasz az \"Átnevezés\" gombra."
 
-#: bulk_rename.c:140
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Régi név"
 
-#: bulk_rename.c:149
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Új név"
 
-#: bulk_rename.c:257
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr "Nincs a megadott mintára illeszkedő szöveg (az \"Új\" oszlopban)"
 
-#: bulk_rename.c:262
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Egy név egyezett, de az eredmény ugyanaz volt"
 
-#: bulk_rename.c:265
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d név egyezett, de az eredmények ugyanazok voltak"
 
-#: bulk_rename.c:291
-msgid "Specify a regular expression to match, and a string to replace matches with."
-msgstr "Add meg a keresendő reguláris kifejezést, és a találatokat helyettesítő karaktersorozatot."
+#: bulk_rename.c:330
+msgid ""
+"Specify a regular expression to match, and a string to replace matches with."
+msgstr ""
+"Add meg a keresendő reguláris kifejezést, és a találatokat helyettesítő "
+"karaktersorozatot."
 
 # XXX: Ez egy hibaüzenet hibás reguláris kifejezésekhez... Argh!
-#: bulk_rename.c:308
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (kifejezés: \"%s\")"
 
-#: bulk_rename.c:341
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr "Már létezik \"%s\" nevű fájl. Tömeges átnevezés megszakítva."
 
-#: bulk_rename.c:346
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -911,17 +938,21 @@ msgstr ""
 "%s\n"
 "Tömeges átnevezés megszakítva."
 
-#: bulk_rename.c:408
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "Már létezik \"%s\" nevű fájl"
 
-#: bulk_rename.c:419
+#: bulk_rename.c:458
 #, c-format
-msgid "Some of the New names contain / characters (eg '%s'). This will cause the files to end up in different directories. Continue?"
-msgstr "Az új nevek némelyike \"/\" karaktert tartalmaz (például \"%s\"). Ezek a fájlok más könyvtárakba kerülnek. Folytatod?"
+msgid ""
+"Some of the New names contain / characters (eg '%s'). This will cause the "
+"files to end up in different directories. Continue?"
+msgstr ""
+"Az új nevek némelyike \"/\" karaktert tartalmaz (például \"%s\"). Ezek a "
+"fájlok más könyvtárakba kerülnek. Folytatod?"
 
-#: bulk_rename.c:434
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Egyik név sem változott meg. Nincs semmi dolgom!"
 
@@ -946,118 +977,177 @@ msgstr ""
 "%s"
 
 # XXX (mondjuk az angol szöveg is lehetne jobb...)
-#: dir.c:980
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Nem kérdezhető le a könyvtár állapota: %s"
 
-#: dir.c:989
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Nem nyitható meg a könyvtár: %s"
 
-#: display.c:629
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Méret"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) hiba: %s"
 
-# A "Link" itt bizony ige...
-#: dnd.c:124
-msgid "Link (relative)"
-msgstr "Linkelés (relatív)"
-
-# A "Link" itt bizony ige...
-#: dnd.c:125
-msgid "Link (absolute)"
-msgstr "Linkelés (abszolút)"
-
-#: dnd.c:424
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Belső hiba - rossz infó típus"
 
-#: dnd.c:563
+#: dnd.c:565
 msgid "Drag a directory here to bookmark it."
 msgstr "Dobd ide a könyvjelzőkhöz adandó könyvtárat."
 
 # leafname = ???
-#: dnd.c:578
+#: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
 msgstr "XDS protokoll hiba: a fájlnévben nem lehet \"/\"\n"
 
 # leafname = ???
-#: dnd.c:603
-msgid "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/plain) did not contain a leafname\n"
-msgstr "Az XdndDirectSave0 cél meg van adva, de a text/plain típusú XdndDirectSave0 atom nem tartalmazott fájlnevet\n"
+#: dnd.c:605
+msgid ""
+"XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
+"plain) did not contain a leafname\n"
+msgstr ""
+"Az XdndDirectSave0 cél meg van adva, de a text/plain típusú XdndDirectSave0 "
+"atom nem tartalmazott fájlnevet\n"
 
-#: dnd.c:616
+#: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
 msgstr "Sajnálom, csak text/uri-list vagy XdndDirectSave0 típusú célt fogadok."
 
-#: dnd.c:619
-msgid "Sorry - I require a target type of text/uri-list or application/octet-stream."
-msgstr "Sajnálom, csak text/uri-list vagy application/octet-stream típusú célt fogadok."
+#: dnd.c:621
+msgid ""
+"Sorry - I require a target type of text/uri-list or application/octet-stream."
+msgstr ""
+"Sajnálom, csak text/uri-list vagy application/octet-stream típusú célt "
+"fogadok."
 
-#: dnd.c:689
+#: dnd.c:691
 #, c-format
 msgid ""
-"Failed to add some items to the pinboard, because they are on a remote machine. For example:\n"
+"Failed to add some items to the pinboard, because they are on a remote "
+"machine. For example:\n"
 "\n"
 "%s"
 msgstr ""
-"Néhány elemet nem sikerült a pinboardra helyezni, mert egy másik gépen vannak. Például:\n"
+"Néhány elemet nem sikerült a pinboardra helyezni, mert egy másik gépen "
+"vannak. Például:\n"
 "\n"
 "%s"
 
-#: dnd.c:764
+#: dnd.c:766
 msgid "Unknown target"
 msgstr "Ismeretlen cél"
 
-#: dnd.c:797
+#: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
 msgstr "A távoli alkalmazás nem küldött adatot"
 
-#: dnd.c:810
+#: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
-msgstr "XDS protokoll hiba: a visszatérési érték csak \"S\", \"F\" vagy \"E\" lehet\n"
+msgstr ""
+"XDS protokoll hiba: a visszatérési érték csak \"S\", \"F\" vagy \"E\" lehet\n"
 
 # XXX: raw data = ???
-#: dnd.c:843
+#: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
-msgstr "Távoli fájloknál / nyers adatoknál nem jeleníthető meg a műveleti menü."
+msgstr ""
+"Távoli fájloknál / nyers adatoknál nem jeleníthető meg a műveleti menü."
 
-#: dnd.c:859
+#: dnd.c:861
 msgid "UntitledData"
 msgstr "NévtelenAdat"
 
-#: dnd.c:886
+#: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
 msgstr "Hiba a fájl mentésekor: %s"
 
-#: dnd.c:959
+#: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
 msgstr "Nem tartalmaz URI-t a text/uri-list (nincs semmi dolgom!)"
 
-#: dnd.c:991
-msgid "Can't get data from remote machine (application/octet-stream not provided)"
-msgstr "Nem lehet adatokat fogadni a távoli gépről (az application/octet-stream nincs megadva)"
+#: dnd.c:993
+msgid ""
+"Can't get data from remote machine (application/octet-stream not provided)"
+msgstr ""
+"Nem lehet adatokat fogadni a távoli gépről (az application/octet-stream "
+"nincs megadva)"
 
-#: dnd.c:1014
-msgid "Some of these files are on a different machine - they will be ignored - sorry"
+#: dnd.c:1015 menu.c:2406
+msgid ""
+"Some of these files are on a different machine - they will be ignored - sorry"
 msgstr "A fájlok némelyike egy másik gépen van - ezek sajnos kimaradnak"
 
-#: dnd.c:1021
-msgid "None of these files are on the local machine - I can't operate on multiple remote files - sorry."
-msgstr "Egyik fájl sincs a helyi gépen. Sajnos nem tudok egyszerre több távoli fájllal dolgozni."
+#: dnd.c:1024 menu.c:2414
+msgid ""
+"None of these files are on the local machine - I can't operate on multiple "
+"remote files - sorry."
+msgstr ""
+"Egyik fájl sincs a helyi gépen. Sajnos nem tudok egyszerre több távoli "
+"fájllal dolgozni."
 
-#: dnd.c:1034
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Ismeretlen műveletkérés"
 
-#: dnd.c:1042
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Hiba a fájllista lekérdezésekor: %s"
+
+# A "Link" itt bizony ige...
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Linkelés (relatív)"
+
+# A "Link" itt bizony ige...
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Linkelés (abszolút)"
+
+# A "Link" itt bizony ige...
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Linkelés (relatív)"
+
+# A "Link" itt bizony ige...
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Linkelés (abszolút)"
 
 #: dropbox.c:112
 msgid "Show"
@@ -1073,8 +1163,12 @@ msgstr "<semmi>"
 
 # XXX
 #: dropbox.c:237
-msgid "I can't show you the currently set item, because nothing is currently set. Drag something onto me!"
-msgstr "Nem tudom megmutatni a jelenlegi beállítást, mert nincs beállítva semmi. Dobj ide valamit!"
+msgid ""
+"I can't show you the currently set item, because nothing is currently set. "
+"Drag something onto me!"
+msgstr ""
+"Nem tudom megmutatni a jelenlegi beállítást, mert nincs beállítva semmi. "
+"Dobj ide valamit!"
 
 # XXX: drop area
 #: dropbox.c:261
@@ -1086,8 +1180,7 @@ msgstr "Csak egyetlen fájlt dobhatsz a célterületre."
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr "Sajnos \"%s\" nem használható, mert nem helyi fájl."
 
-#: dropbox.c:278
-#: pinboard.c:932
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1096,7 +1189,7 @@ msgstr ""
 "\"%s\" nem elérhető:\n"
 "%s"
 
-#: filer.c:456
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1105,16 +1198,7 @@ msgstr ""
 "Hiba \"%s\" olvasásakor:\n"
 "%s\n"
 
-#: filer.c:460
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Hiba \"%s\" olvasásakor:\n"
-"%s"
-
-#: filer.c:576
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1124,133 +1208,174 @@ msgstr ""
 "\n"
 "Lecsatolás után biztonságosan kivehető a lemez."
 
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
 # XXX: Lecsatoláskor használt gomb felirata. Miért nem Cancel???
-#: filer.c:580
+#: filer.c:896
 msgid "No change"
 msgstr "Mégsem"
 
-#: filer.c:586
-#: menu.c:868
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Lecsatolás"
 
-#: filer.c:690
-msgid "Directory missing/deleted"
-msgstr "Hiányzó/törölt könyvtár"
-
-#: filer.c:1054
+#: filer.c:1490
 #, c-format
 msgid ""
-"Group %s is not set. Select some files and press Ctrl+%s to set the group. Press %s on its own to reselect the files later.\n"
+"Group %s is not set. Select some files and press Ctrl+%s to set the group. "
+"Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"Nincs ilyen csoport: %s. Jelölj ki néhány fájlt, majd a Ctrl+%s leütésével hozd létre a csoportot. A szám (%s) leütésével a fájlok kijelölése később visszaállítható.\n"
-"Ügyelj rá, hogy a NumLock be legyen kapcsolva a numerikus billentyűzet használatakor."
-
-#: filer.c:1290
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Nem érhető el a könyvtár: \"%s\""
-
-#: filer.c:1442
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Nem található a könyvtár: \"%s\""
-
-#: filer.c:1742
-msgid "Cancel"
-msgstr "Mégsem"
+"Nincs ilyen csoport: %s. Jelölj ki néhány fájlt, majd a Ctrl+%s leütésével "
+"hozd létre a csoportot. A szám (%s) leütésével a fájlok kijelölése később "
+"visszaállítható.\n"
+"Ügyelj rá, hogy a NumLock be legyen kapcsolva a numerikus billentyűzet "
+"használatakor."
 
 # Az "All" rövidítése
-#: filer.c:2023
+#: filer.c:2655
 msgid "A"
 msgstr "M"
 
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
 # A "Glob" rövidítése
-#: filer.c:2025
-#: find.c:923
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr "Sz"
 
 # A "Scanning" rövidítése
-#: filer.c:2030
+#: filer.c:2664
 msgid "S"
 msgstr "F"
 
 # A "Thumbs" rövidítése
-#: filer.c:2032
+#: filer.c:2669
 msgid "T"
 msgstr "B"
 
-#: filer.c:2042
-msgid "All, "
-msgstr "Mind, "
+#: filer.c:2670
+msgid "D"
+msgstr ""
 
-#: filer.c:2045
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
 msgstr "Szűrő (%s), "
 
-#: filer.c:2053
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Frissítés, "
 
-#: filer.c:2055
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Bélyeg, "
 
-#: filer.c:2331
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Bélyeg, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Szimbolikus link ehhez: "
 
-#: filer.c:2373
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "Ez a fájlnév nem UTF-8 kódolású. Nevezd át, ha lehet.\n"
 
-#: filer.c:2684
-#: menu.c:2004
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "Az elem már nem létezik!"
 
-#: filer.c:3411
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Válaszd ki a nézet mentendő jellemzőit"
 
-#: filer.c:3418
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Válaszd ki a nézet mentendő jellemzőit"
+
+#: filer.c:4727
 msgid "Position"
 msgstr "Pozíció"
 
-#: filer.c:3423
-#: toolbar.c:133
-#: toolbar.c:137
-#: tips:66
-msgid "Size"
-msgstr "Méret"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Ablak"
 
-#: filer.c:3428
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Rejtett fájlok mutatása"
 
-#: filer.c:3434
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Nézet stílusa"
 
-#: filer.c:3440
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Rendezési szempont és irány"
 
-#: filer.c:3445
-#: toolbar.c:141
+#: filer.c:4754
 msgid "Details"
 msgstr "Részletek"
 
-#: filer.c:3450
-#: tips:119
-#: tips:120
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Bélyegképek"
 
-#: filer.c:3456
+#: filer.c:4765
 msgid "Filter"
 msgstr "Szűrő"
 
@@ -1475,16 +1600,20 @@ msgid "Save As:"
 msgstr "Mentés másként:"
 
 # XXX: Ez fájlnév lesz...
-#: gtksavebox.c:395
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Névtelen"
 
 # XXX: A "property" mi legyen? Gondolom, ez egy X-atom.
-#: gtksavebox.c:471
-msgid "Remote application wants to use Direct Save, but I can't read the XdndDirectSave0 (type text/plain) property.\n"
-msgstr "A távoli alkalmazás Direct Save protokollt használ, de nem sikerült kiolvasni a text/plain típusú XdndDirectSave0 atomot.\n"
+#: gtksavebox.c:477
+msgid ""
+"Remote application wants to use Direct Save, but I can't read the "
+"XdndDirectSave0 (type text/plain) property.\n"
+msgstr ""
+"A távoli alkalmazás Direct Save protokollt használ, de nem sikerült "
+"kiolvasni a text/plain típusú XdndDirectSave0 atomot.\n"
 
-#: gtksavebox.c:596
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1494,7 +1623,7 @@ msgstr ""
 
 # XXX: Több hibaüzenet elválasztására szolgál a delayed_error()
 #      által készített hibaablakban. De miért van megjelölve fordításra???
-#: gui_support.c:329
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1502,243 +1631,241 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:398
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
-msgstr "A beolvasandó szöveges fájl egy XML dokumentum. A fájl (%s) sérült lehet."
+msgstr ""
+"A beolvasandó szöveges fájl egy XML dokumentum. A fájl (%s) sérült lehet."
 
-#: gui_support.c:415
+#: gui_support.c:542
 #, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
-"This may be due to upgrading from a previous version of ROX-Filer. Open the Options window and try changing something and then changing it back (causing the file to be resaved).\n"
+"This may be due to upgrading from a previous version of ROX-Filer. Open the "
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
 "Hiba a fájl (%s) %d. sorában: \n"
 "\"%s\"\n"
-"Előfordulhat, hogy a fájl a ROX-Filer egy korábbi verziójából származik. Nyisd meg a Beállítások ablakot, változtass meg valamit, majd állítsd vissza (hogy a fájl újra el legyen mentve).\n"
+"Előfordulhat, hogy a fájl a ROX-Filer egy korábbi verziójából származik. "
+"Nyisd meg a Beállítások ablakot, változtass meg valamit, majd állítsd vissza "
+"(hogy a fájl újra el legyen mentve).\n"
 "A további hibákat figyelmen kívül hagyom."
 
-#: gui_support.c:1007
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Helytelen vagy hiányzik a sortörés a text/uri-list adatokban"
 
-#: gui_support.c:1339
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "Nem sikerült megnyitni a fájlt (%s): %s"
 
-#: gui_support.c:1383
-#, c-format
-msgid "Failed to load image '%s': reason not known, probably a corrupt image file"
-msgstr "Nem sikerült betölteni a képet (%s): az ok ismeretlen, talán sérült a fájl"
-
-#: gui_support.c:1434
+#: gui_support.c:1517
 #, c-format
 msgid ""
-"This program (%s) cannot be run, as the 0launch command is not available. It can be downloaded from here:\n"
+"Failed to load image '%s': reason not known, probably a corrupt image file"
+msgstr ""
+"Nem sikerült betölteni a képet (%s): az ok ismeretlen, talán sérült a fájl"
+
+#: gui_support.c:1583
+#, c-format
+msgid ""
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
-"Nem futtatható ez a program (%s), mert nem található a 0launch parancs. Innen lehet letölteni:\n"
+"Nem futtatható ez a program (%s), mert nem található a 0launch parancs. "
+"Innen lehet letölteni:\n"
 "\n"
 "http://0install.net/injector.html"
 
-#: i18n.c:36
-msgid "Note that you must save your choices and restart the filer for the new language setting to take full effect."
-msgstr "Az újonnan kijelölt nyelv használatához menteni kell a beállításokat, majd újra kell indítani a fájlkezelőt."
+#: i18n.c:39
+msgid ""
+"Note that you must save your choices and restart the filer for the new "
+"language setting to take full effect."
+msgstr ""
+"Az újonnan kijelölt nyelv használatához menteni kell a beállításokat, majd "
+"újra kell indítani a fájlkezelőt."
 
-#: icon.c:76
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(kattints a beállításhoz)"
 
-#: icon.c:131
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:132
-#: menu.c:254
-msgid "About ROX-Filer..."
-msgstr "A ROX-Filer névjegye..."
-
-# XXX: Az alkalmazási könyvtárak Help könyvtárának megnyitására szolgáló menüparancs szövege.
-#: icon.c:133
-#: menu.c:255
-msgid "Show Help Files"
-msgstr "Help könyvtár megnyitása"
-
-#: icon.c:134
-#: menu.c:256
-msgid "Manual"
-msgstr "Kézikönyv"
-
-#: icon.c:136
-#: menu.c:231
-msgid "Options..."
-msgstr "Beállítások..."
-
-#: icon.c:137
-#: menu.c:240
-msgid "Home Directory"
-msgstr "Saját könyvtár"
-
-#: icon.c:138
-#: icon.c:1389
-#: menu.c:208
-#: type.c:223
-msgid "File"
-msgstr "Fájl"
-
-#: icon.c:139
-#: menu.c:214
-#: menu.c:881
-msgid "Shift Open"
-msgstr "Megnyitás másként"
-
-#: icon.c:140
-#: menu.c:219
-msgid "Properties"
-msgstr "Tulajdonságok"
-
-#: icon.c:141
-#: menu.c:217
-msgid "Set Run Action..."
-msgstr "Program hozzárendelése..."
-
-#: icon.c:142
-#: menu.c:218
-msgid "Set Icon..."
-msgstr "Ikon hozzárendelése..."
-
-#: icon.c:143
-#: icon.c:846
-msgid "Edit Item"
-msgstr "Elem szerkesztése"
-
-#: icon.c:144
-msgid "Show Location"
-msgstr "Hely megmutatása"
-
-# Szerintem nem kell zárójelezni a többesszámot.
-#: icon.c:145
-msgid "Remove Item(s)"
-msgstr "Elemek törlése"
-
-#: icon.c:297
-#: log.c:107
-#: menu.c:770
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s: \"%s\""
 
-#: icon.c:310
+#: icon.c:311
 msgid "Nothing"
 msgstr "Semmi"
 
-#: icon.c:571
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "Az elérési út nem maradhat üresen!"
 
-#: icon.c:636
+#: icon.c:641
 #, c-format
 msgid "You must unlock '%s' before removing it"
 msgstr "\"%s\" eltávolításához előbb meg kell szüntetni a zárolását"
 
-#: icon.c:646
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Előbb jelöld ki a törlendő elemeket"
 
 # XXX: Akkor írja ki, amikor egy nem zárolt ikont akarunk eltávolítani, de vannak kijelölve zároltak is... A kérdés csak az: Ezt egy általános instrukcióként kell értelmezni, vagy inkább arra utal, hogy van egy (vagy több) kijelölt zárolt elem, amelyek miatt az eltávolítás nem működik?
-#: icon.c:652
+#: icon.c:657
 msgid "An item must be unlocked before it can be removed."
 msgstr "Csak akkor törölhetők ez elemek, ha nincsenek zárolva."
 
-#: icon.c:666
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "A menüt elem felett kell megnyitni"
 
-#: icon.c:691
-#: menu.c:1277
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "Program csak közönséges fájlhoz rendelhető"
 
-#: icon.c:777
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Üsd le a kívánt billentyűt (pl. Control+F1)"
 
 # XXX:
-#: icon.c:799
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Nem sikerült kisajátítani a billentyűzetet!"
 
-#: icon.c:849
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Elem szerkesztése"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Az ikonhoz rendelt útvonal:"
 
-#: icon.c:859
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Argumentumok (végrehajtható fájlokhoz):"
 
-#: icon.c:873
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "Az ikon alatt megjelenő szöveg:"
 
-#: icon.c:886
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "A hozzárendelt billentyű:"
 
-#: icon.c:906
+#: icon.c:910
 msgid "Locked"
 msgstr "Zárolt"
 
-#: icon.c:911
+#: icon.c:915
 msgid "Locking an item prevents it from being accidentally removed"
 msgstr "A zárolt elemeket nem lehet véletlenül törölni"
 
-#: infobox.c:111
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "A ROX-Filer névjegye..."
+
+# XXX: Az alkalmazási könyvtárak Help könyvtárának megnyitására szolgáló menüparancs szövege.
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Help könyvtár megnyitása"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Kézikönyv"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Beállítások..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Saját könyvtár"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Fájl"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Megnyitás másként"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Tulajdonságok"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Program hozzárendelése..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Ikon hozzárendelése..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Hely megmutatása"
+
+# Szerintem nem kell zárójelezni a többesszámot.
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Elemek törlése"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
 msgstr "Tényleg megnyitsz %d ablakot?"
 
-#: infobox.c:112
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Információ mutatása"
 
-#: infobox.c:134
-#: menu.c:775
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(hibás utf-8)"
 
 # XXX: Lásd: "Show Help files"
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "_Help könyvtár megnyitása"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Jogosultságok</b>"
 
-#: infobox.c:290
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>Tartalma szerint...</b>"
 
-#: infobox.c:427
-#: infobox.c:568
-#: support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Csak a könyvtárak másolását listázza"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "byte"
 
-#: infobox.c:450
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Nem sikerült lekérdezni a méretet"
 
-#: infobox.c:511
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "\"%s\" már nem szimlink"
 
-#: infobox.c:518
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1748,7 +1875,7 @@ msgstr ""
 "%s"
 
 # XXX
-#: infobox.c:523
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1759,178 +1886,198 @@ msgstr ""
 "%s\n"
 "(a régi linket töröltem)"
 
-#: infobox.c:547
-#: tips:269
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Hiba:"
 
-#: infobox.c:554
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Valódi könyvtár:"
 
-#: infobox.c:557
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Tulajdonos, csoport:"
 
-#: infobox.c:564
-#: infobox.c:579
-#: infobox.c:588
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Méret:"
 
-#: infobox.c:589
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Olvasás"
 
-#: infobox.c:614
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Nem sikerült beolvasni"
 
 # XXX: Khm, egyáltalán van erre JÓ magyar fordítás?
 #      A "létrehozási idő" NEM jó!
-#: infobox.c:621
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Változtatási idő:"
 
-#: infobox.c:623
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Módosítási idő:"
 
-#: infobox.c:625
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Hozzáférési idő:"
 
-#: infobox.c:633
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Kiterjesztett attribútumok:"
 
-#: infobox.c:635
+#: infobox.c:667
 msgid "Present"
 msgstr "Jelen"
 
-#: infobox.c:636
+#: infobox.c:668
 msgid "None"
 msgstr "Nincs"
 
-#: infobox.c:637
+#: infobox.c:669
 msgid "Not supported"
 msgstr "Nem támogatott"
 
-#: infobox.c:649
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Link célja:"
 
 # XXX: A "Hozzárendelt program:" túl hosszú. :)
-#: infobox.c:661
-#: infobox.c:664
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Megnyitás:"
 
 # XXX: Ez még bajt okozhat. Egyelőre egy helyen használják: ezt írja ki a tulajdonságok ablakban a futtatható fájlok "run action"-jeként.
-#: infobox.c:661
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Futtasd a fájlt"
 
-#: infobox.c:773
+#: infobox.c:805
 msgid "Comment"
 msgstr "Megjegyzés"
 
-#: infobox.c:775
+#: infobox.c:807
 msgid "Execute"
 msgstr "Futtatás"
 
-#: infobox.c:789
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<még nincs kész>"
 
-#: infobox.c:860
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "A file(1) szerint... %s"
 
-#: infobox.c:917
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Nem sikerült megváltoztatni a jogokat: %s"
 
-#: infobox.c:935
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Tulajdonos"
 
-#: infobox.c:937
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Csoport"
 
-#: infobox.c:939
+#: infobox.c:974
 msgid "World"
 msgstr "Többiek"
 
-#: infobox.c:942
+#: infobox.c:977
 msgid "Read"
 msgstr "Olvasás"
 
-#: infobox.c:944
+#: infobox.c:980
 msgid "Write"
 msgstr "Írás"
 
-#: infobox.c:946
+#: infobox.c:983
 msgid "Exec"
 msgstr "Végrehajtás"
 
-#: infobox.c:963
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:970
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:977
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky"
 
-#: infobox.c:999
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<semmi>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Szimbolikus link"
 
-#: infobox.c:1002
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX-alkalmazás"
 
-#: infobox.c:1010
+#: infobox.c:1100
 msgid "mounted"
 msgstr "csatolva"
 
-#: infobox.c:1010
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "lecsatolva"
 
-#: infobox.c:1014
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "%s csatolási pontja (%s)"
 
-#: infobox.c:1017
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Csatolási pont (%s)"
 
-#: log.c:52
+#: log.c:54
 msgid "ROX-Filer started"
 msgstr "A ROX-Filer elindult"
 
-#: log.c:109
+#: log.c:115
 #, fuzzy, c-format
 msgid "%s on %d items"
 msgstr "%d elem"
 
-#: log.c:122
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Másolás..."
+
+#: log.c:139
 #, fuzzy
 msgid "Item"
 msgstr "elem"
 
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Dátumok"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Beállítások"
+
 # XXX: Jó ez így, jogászok?
-#: main.c:94
+#: main.c:95
 msgid ""
 "Copyright (C) 2005 Thomas Leonard.\n"
 "ROX-Filer comes with ABSOLUTELY NO WARRANTY,\n"
@@ -1946,15 +2093,15 @@ msgstr ""
 "hatálya alatt terjeszthető.\n"
 "Bővebb felvilágosításért lásd a COPYING nevű fájlt.\n"
 
-#: main.c:103
+#: main.c:104
 msgid "Try `ROX-Filer/AppRun --help' for more information.\n"
 msgstr "Futtasd a \"ROX-Filer/AppRun --help\" parancsot segítségért.\n"
 
-#: main.c:106
+#: main.c:107
 msgid "Try `ROX-Filer/AppRun -h' for more information.\n"
 msgstr "Futtasd a \"ROX-Filer/AppRun -h\" parancsot segítségért.\n"
 
-#: main.c:108
+#: main.c:109
 msgid ""
 "NOTE: Your system does not support long options - \n"
 "you must use the short versions instead.\n"
@@ -1964,7 +2111,7 @@ msgstr ""
 "a rövid változatukat kell használni.\n"
 "\n"
 
-#: main.c:114
+#: main.c:115
 #, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
@@ -2022,64 +2169,71 @@ msgstr ""
 "A hibákat ezen a címen jelentsd: %s.\n"
 "Honlap (újabb verziókkal): http://rox.sourceforge.net/\n"
 
-#: main.c:236
+#: main.c:237
 msgid ""
-"We got a BadWindow error from the X server. This might be due to this GTK bug (during drag-and-drop?):\n"
+"We got a BadWindow error from the X server. This might be due to this GTK "
+"bug (during drag-and-drop?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Trying to continue..."
 msgstr ""
-"BadWindow hibát jelzett az X-szerver. Ezt a következő GTK-hiba okozhatta (drag-and-drop közben?):\n"
+"BadWindow hibát jelzett az X-szerver. Ezt a következő GTK-hiba okozhatta "
+"(drag-and-drop közben?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Megpróbálom folytatni..."
 
-#: main.c:395
-msgid "The -o argument is no longer used. You can turn on override redirect from the Options box instead."
-msgstr "Az \"-o\" opció már nem használatos. A Beállítások ablakban adható meg, hogy az ablakkezelők ne kezeljék a pinboardot és a panelt."
+#: main.c:399
+msgid ""
+"The -o argument is no longer used. You can turn on override redirect from "
+"the Options box instead."
+msgstr ""
+"Az \"-o\" opció már nem használatos. A Beállítások ablakban adható meg, hogy "
+"az ablakkezelők ne kezeljék a pinboardot és a panelt."
 
-#: main.c:524
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Felhasználó: \"%s\""
 
-#: main.c:685
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "A fordításhoz használt GTK verziója: %s\n"
 
-#: main.c:686
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "A jelenlegi GTK verziója: %d.%d.%d\n"
 
-#: main.c:690
+#: main.c:693
 msgid "features set at compile time"
 msgstr "fordításkor beállított támogatások"
 
-#: main.c:691
+#: main.c:694
 msgid "Large File Support"
 msgstr "Nagy fájlok támogatása"
 
-#: main.c:698
-msgid "Dnotify support"
-msgstr "Dnotify támogatása"
-
-#: main.c:705
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Bináris kompatibilitás"
 
-#: main.c:707
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Igen (régebbi glibc-vel is működik)"
 
-#: main.c:709
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Nem (nincsen apsymbols.h)"
 
-#: main.c:713
+#: main.c:709
 msgid "Extended attribute support"
 msgstr "Kiterjesztett attribútumok támogatása"
 
-#: main.c:870
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr "Nem sikerült megnyitni a fájlt (%s): %s"
+
+#: main.c:895
 #, c-format
 msgid ""
 "Left-click to run %s.\n"
@@ -2088,450 +2242,612 @@ msgstr ""
 "Bal kattintás: %s futtatása.\n"
 "Jobb kattintás: verziók listája."
 
-#: menu.c:181
-#: tips:55
-msgid "Display"
-msgstr "Nézet"
-
-#: menu.c:182
-#: tips:60
-msgid "Icons View"
-msgstr "Ikonnézet"
-
-#: menu.c:183
-msgid "Icons, With..."
-msgstr "Ikonok és..."
-
-#: menu.c:184
-#: tips:79
-msgid "Sizes"
-msgstr "Méretek"
-
-#: menu.c:186
-#: tips:253
-msgid "Types"
-msgstr "Típusok"
-
-#: menu.c:187
-#: tips:82
-msgid "Times"
-msgstr "Dátumok"
-
-#: menu.c:188
-#: tips:61
-#: tips:97
-msgid "List View"
-msgstr "Listanézet"
-
-#: menu.c:190
-msgid "Bigger Icons"
-msgstr "Nagyobb ikonok"
-
-#: menu.c:191
-msgid "Smaller Icons"
-msgstr "Kisebb ikonok"
-
-#: menu.c:192
-#: tips:76
-msgid "Automatic"
-msgstr "Automatikus"
-
-#: menu.c:194
-msgid "Sort by Name"
-msgstr "Rendezés név szerint"
-
-#: menu.c:195
-msgid "Sort by Type"
-msgstr "Rendezés típus szerint"
-
-#: menu.c:196
-msgid "Sort by Date"
-msgstr "Rendezés dátum szerint"
-
-#: menu.c:197
-msgid "Sort by Size"
-msgstr "Rendezés méret szerint"
-
-#: menu.c:198
-msgid "Sort by Owner"
-msgstr "Rendezés tulajdonos szerint"
-
-#: menu.c:199
-msgid "Sort by Group"
-msgstr "Rendezés csoport szerint"
-
-#: menu.c:200
-msgid "Reversed"
-msgstr "Fordítva"
-
-#: menu.c:202
-msgid "Show Hidden"
-msgstr "Rejtett fájlok mutatása"
-
-#: menu.c:203
-msgid "Filter Files..."
-msgstr "Fájlok szűrése..."
-
-# XXX: A "Könyvtárak szűrése a fájlokkal együtt" jobb lenne, de túl hosszú a menübe.
-#: menu.c:204
-msgid "Filter Directories With Files"
-msgstr "Szűrő a könyvtárakra is"
-
-#: menu.c:205
-msgid "Show Thumbnails"
-msgstr "Bélyegképek mutatása"
-
-#: menu.c:206
-msgid "Refresh"
-msgstr "Frissítés"
-
-# XXX: A "Nézet aktuális beállításainak mentése" túl hosszú (ez egy menüpont)! Remélhetőleg így is értelmes.
-#: menu.c:207
-msgid "Save Current Display Settings..."
-msgstr "Aktuális nézet mentése..."
-
-#: menu.c:209
-msgid "Copy..."
-msgstr "Másolás..."
-
-#: menu.c:210
-msgid "Rename..."
-msgstr "Átnevezés..."
-
-#: menu.c:211
-msgid "Link..."
-msgstr "Linkelés..."
-
-#: menu.c:215
-msgid "Send To..."
-msgstr "Küldés..."
-
-#: menu.c:220
-msgid "Count"
-msgstr "Méret"
-
-#: menu.c:221
-msgid "Set Type..."
-msgstr "Típus beállítása..."
-
-#: menu.c:225
-#: toolbar.c:154
-msgid "Select"
-msgstr "Kijelölés"
-
-#: menu.c:226
-msgid "Select All"
-msgstr "Az összes kijelölése"
-
-#: menu.c:227
-msgid "Clear Selection"
-msgstr "Kijelölés megszüntetése"
-
-#: menu.c:228
-msgid "Invert Selection"
-msgstr "Kijelölés megfordítása"
-
-#: menu.c:229
-msgid "Select by Name..."
-msgstr "Kijelölés név alapján..."
-
-#: menu.c:230
-msgid "Select If..."
-msgstr "Feltételes kijelölés..."
-
-#: menu.c:232
-msgid "New"
-msgstr "Új"
-
-#: menu.c:234
-msgid "Blank file"
-msgstr "Üres fájl"
-
-#: menu.c:236
-#: tasklist.c:306
-msgid "Window"
-msgstr "Ablak"
-
-#: menu.c:237
-msgid "Parent, New Window"
-msgstr "Szülő (új ablak)"
-
-#: menu.c:238
-msgid "Parent, Same Window"
-msgstr "Szülő (ez az ablak)"
-
-#: menu.c:239
-msgid "New Window"
-msgstr "Új ablak"
-
-#: menu.c:241
-msgid "Show Bookmarks"
-msgstr "Könyvjelzők mutatása"
-
-#: menu.c:242
-msgid "Show Log"
-msgstr "Napló megtekintése"
-
-#: menu.c:243
-msgid "Follow Symbolic Links"
-msgstr "Szimbolikus linkek követése"
-
-#: menu.c:244
-msgid "Resize Window"
-msgstr "Ablak átméretezése"
-
-#: menu.c:247
-msgid "Close Window"
-msgstr "Ablak bezárása"
-
-#: menu.c:249
-msgid "Enter Path..."
-msgstr "Útvonal megadása..."
-
-#: menu.c:250
-msgid "Shell Command..."
-msgstr "Shell parancs..."
-
-#: menu.c:251
-msgid "Terminal Here"
-msgstr "Terminál"
-
-#: menu.c:252
-msgid "Switch to Terminal"
-msgstr "Váltás terminálra"
-
-#: menu.c:721
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "Ha fájlt akarsz küldeni egy alkalmazásnak, akkor tartsd nyomva a Shift billentyűt a menü megnyitásakor."
-
-#: menu.c:760
-msgid "Next Click"
-msgstr "Következő kattintás"
-
-#: menu.c:782
-#, c-format
-msgid "%d items"
-msgstr "%d elem"
-
-#: menu.c:870
-msgid "Open unmounted"
-msgstr "Megnyitás csatolás nélkül"
-
-#: menu.c:873
-msgid "Show Target"
-msgstr "Cél mutatása"
-
-# Menüpont alkalmazási könyvtárak megnyitásához (az alkalmazás futtatása helyett)
-#: menu.c:875
-msgid "Look Inside"
-msgstr "Könyvtár megnyitása"
-
-#: menu.c:877
-msgid "Open As Text"
-msgstr "Megnyitás szövegként"
-
-#: menu.c:1048
-msgid ""
-"Extended attributes, used to store types, are not supported for this file or files.\n"
-"This may be due to lack of support from the filesystem or the C library, or it may simply be that the filesystem needs to be mounted with the right mount option ('user_xattr' on Linux)."
-msgstr ""
-"A fájlok típusának tárolásához használt kiterjesztett attribútumok nem használhatók ennél a fájlnál, vagy ezeknél a fájloknál.\n"
-"Talán a fájlrendszer vagy a C könyvtár ezt nem támogatja, de az is lehet, hogy csak a megfelelő opcióval kell csatolni a fájlrendszert (Linuxon ez a \"user_xattr\")."
-
-#: menu.c:1054
-msgid "Setting type not supported for some of these files"
-msgstr "Néhány fájlnak nem lehet beállítani a típusát"
-
-#: menu.c:1089
-msgid "_Relative link"
-msgstr "_Relatív link"
-
-#: menu.c:1095
-msgid ""
-"If on, the symlink will store the path from the symlink to the target file. Use this if the symlink and the target will be moved together.\n"
-"If off, the path from the root directory is stored - use this if the symlink may move but the target will stay put."
-msgstr ""
-"Bekapcsolt állapotban a szimlinkhez viszonyított útvonalat tárolja. Akkor hasznos, ha a szimlink és a cél egymáshoz viszonyított helyzete nem változik.\n"
-"Kikapcsolt állapotban a cél teljes útvonalát tárolja. Akkor hasznos, ha a szimlink bárhol lehet, de a cél a helyén marad."
-
-#: menu.c:1165
-msgid "New pathname is not absolute"
-msgstr "Az új elérési útvonal nem teljes"
-
-# XXX
-#: menu.c:1231
-#, c-format
-msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
-msgstr "A szimlink (%s) már létezik. Az új célra mutasson (%s)?"
-
-#: menu.c:1237
-msgid "_Replace"
-msgstr "C_sere"
-
-#: menu.c:1357
-#: menu.c:1398
-#: menu.c:1458
-msgid "Create"
-msgstr "Létrehozás"
-
-#: menu.c:1358
-msgid "NewDir"
-msgstr "ÚjKönyvtár"
-
-#: menu.c:1372
-#: menu.c:1378
+#: main.c:942 menu.c:1723 menu.c:1729
 #, c-format
 msgid "Error creating '%s': %s"
 msgstr "Hiba \"%s\" létrehozásakor: %s"
 
-#: menu.c:1399
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Mentés másként:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
+msgid "Display"
+msgstr "Nézet"
+
+#: menu.c:641 tips:49
+msgid "Icons View"
+msgstr "Ikonnézet"
+
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
+msgstr "Ikonok és..."
+
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Ikontéma"
+
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Jogosultságok"
+
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Ikonok és..."
+
+#: menu.c:647 tips:50 tips:98 tips:99
+msgid "List View"
+msgstr "Listanézet"
+
+#: menu.c:651
+msgid "Bigger Icons"
+msgstr "Nagyobb ikonok"
+
+#: menu.c:653
+msgid "Smaller Icons"
+msgstr "Kisebb ikonok"
+
+#: menu.c:655 tips:71
+msgid "Automatic"
+msgstr "Automatikus"
+
+#: menu.c:661
+msgid "Sort by Name"
+msgstr "Rendezés név szerint"
+
+#: menu.c:662
+msgid "Sort by Type"
+msgstr "Rendezés típus szerint"
+
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
+msgstr "Rendezés dátum szerint"
+
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Rendezés dátum szerint"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Rendezés dátum szerint"
+
+#: menu.c:666
+msgid "Sort by Size"
+msgstr "Rendezés méret szerint"
+
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Jogosultságok"
+
+#: menu.c:668
+msgid "Sort by Owner"
+msgstr "Rendezés tulajdonos szerint"
+
+#: menu.c:669
+msgid "Sort by Group"
+msgstr "Rendezés csoport szerint"
+
+#: menu.c:671
+msgid "Reversed"
+msgstr "Fordítva"
+
+#: menu.c:675
+msgid "Show Hidden"
+msgstr "Rejtett fájlok mutatása"
+
+# XXX: Az alkalmazási könyvtárak Help könyvtárának megnyitására szolgáló menüparancs szövege.
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Help könyvtár megnyitása"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "nincsenek könyvtárak)\n"
+
+#: menu.c:679
+msgid "Filter Files..."
+msgstr "Fájlok szűrése..."
+
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Fájlok szűrése..."
+
+# XXX: A "Könyvtárak szűrése a fájlokkal együtt" jobb lenne, de túl hosszú a menübe.
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr "Szűrő a könyvtárakra is"
+
+#: menu.c:682
+msgid "Show Thumbnails"
+msgstr "Bélyegképek mutatása"
+
+#: menu.c:683
+msgid "Refresh"
+msgstr "Frissítés"
+
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Frissítés"
+
+# XXX: A "Nézet aktuális beállításainak mentése" túl hosszú (ez egy menüpont)! Remélhetőleg így is értelmes.
+#: menu.c:686
+#, fuzzy
+msgid "Save Display Settings..."
+msgstr "Aktuális nézet mentése..."
+
+# XXX: A "Nézet aktuális beállításainak mentése" túl hosszú (ez egy menüpont)! Remélhetőleg így is értelmes.
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Aktuális nézet mentése..."
+
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Méret"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
+msgid "Rename..."
+msgstr "Átnevezés..."
+
+#: menu.c:700
+msgid "Link..."
+msgstr "Linkelés..."
+
+#: menu.c:708
+msgid "Send To..."
+msgstr "Küldés..."
+
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Kiterjesztett attribútumok"
+
+#: menu.c:721
+msgid "Count"
+msgstr "Méret"
+
+#: menu.c:723
+msgid "Set Type..."
+msgstr "Típus beállítása..."
+
+#: menu.c:731 toolbar.c:179
+msgid "Select"
+msgstr "Kijelölés"
+
+#: menu.c:733
+msgid "Select All"
+msgstr "Az összes kijelölése"
+
+#: menu.c:735
+msgid "Clear Selection"
+msgstr "Kijelölés megszüntetése"
+
+#: menu.c:736
+msgid "Invert Selection"
+msgstr "Kijelölés megfordítása"
+
+#: menu.c:737
+msgid "Select by Name..."
+msgstr "Kijelölés név alapján..."
+
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Feltételes kijelölés..."
+
+#: menu.c:741
+msgid "Select If..."
+msgstr "Feltételes kijelölés..."
+
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
+msgid "New"
+msgstr "Új"
+
+#: menu.c:752
+msgid "Blank file"
+msgstr "Üres fájl"
+
+#: menu.c:756 tasklist.c:305
+msgid "Window"
+msgstr "Ablak"
+
+#: menu.c:758
+msgid "Parent, New Window"
+msgstr "Szülő (új ablak)"
+
+#: menu.c:759
+msgid "Parent, Same Window"
+msgstr "Szülő (ez az ablak)"
+
+#: menu.c:761 tips:44
+msgid "New Window"
+msgstr "Új ablak"
+
+#: menu.c:764
+msgid "Show Bookmarks"
+msgstr "Könyvjelzők mutatása"
+
+#: menu.c:766
+msgid "Show Log"
+msgstr "Napló megtekintése"
+
+#: menu.c:768
+msgid "Follow Symbolic Links"
+msgstr "Szimbolikus linkek követése"
+
+#: menu.c:769
+msgid "Resize Window"
+msgstr "Ablak átméretezése"
+
+#: menu.c:771
+msgid "Close Window"
+msgstr "Ablak bezárása"
+
+#: menu.c:776
+msgid "Enter Path..."
+msgstr "Útvonal megadása..."
+
+#: menu.c:778
+msgid "Shell Command..."
+msgstr "Shell parancs..."
+
+#: menu.c:780
+msgid "Terminal Here"
+msgstr "Terminál"
+
+#: menu.c:782
+msgid "Switch to Terminal"
+msgstr "Váltás terminálra"
+
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Menü testreszabása..."
+
+#: menu.c:976
+msgid "Next Click"
+msgstr "Következő kattintás"
+
+#: menu.c:998
+#, c-format
+msgid "%d items"
+msgstr "%d elem"
+
+#: menu.c:1094
+msgid "Open unmounted"
+msgstr "Megnyitás csatolás nélkül"
+
+#: menu.c:1097
+msgid "Show Target"
+msgstr "Cél mutatása"
+
+# Menüpont alkalmazási könyvtárak megnyitásához (az alkalmazás futtatása helyett)
+#: menu.c:1099
+msgid "Look Inside"
+msgstr "Könyvtár megnyitása"
+
+#: menu.c:1101
+msgid "Open As Text"
+msgstr "Megnyitás szövegként"
+
+#: menu.c:1320
+msgid ""
+"Extended attributes, used to store types, are not supported for this file or "
+"files.\n"
+"This may be due to lack of support from the filesystem or the C library, or "
+"it may simply be that the filesystem needs to be mounted with the right "
+"mount option ('user_xattr' on Linux)."
+msgstr ""
+"A fájlok típusának tárolásához használt kiterjesztett attribútumok nem "
+"használhatók ennél a fájlnál, vagy ezeknél a fájloknál.\n"
+"Talán a fájlrendszer vagy a C könyvtár ezt nem támogatja, de az is lehet, "
+"hogy csak a megfelelő opcióval kell csatolni a fájlrendszert (Linuxon ez a "
+"\"user_xattr\")."
+
+#: menu.c:1326
+msgid "Setting type not supported for some of these files"
+msgstr "Néhány fájlnak nem lehet beállítani a típusát"
+
+#: menu.c:1364
+msgid "_Relative link"
+msgstr "_Relatív link"
+
+#: menu.c:1370
+msgid ""
+"If on, the symlink will store the path from the symlink to the target file. "
+"Use this if the symlink and the target will be moved together.\n"
+"If off, the path from the root directory is stored - use this if the symlink "
+"may move but the target will stay put."
+msgstr ""
+"Bekapcsolt állapotban a szimlinkhez viszonyított útvonalat tárolja. Akkor "
+"hasznos, ha a szimlink és a cél egymáshoz viszonyított helyzete nem "
+"változik.\n"
+"Kikapcsolt állapotban a cél teljes útvonalát tárolja. Akkor hasznos, ha a "
+"szimlink bárhol lehet, de a cél a helyén marad."
+
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
+msgid "New pathname is not absolute"
+msgstr "Az új elérési útvonal nem teljes"
+
+# XXX
+#: menu.c:1540
+#, c-format
+msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
+msgstr "A szimlink (%s) már létezik. Az új célra mutasson (%s)?"
+
+#: menu.c:1546
+msgid "_Replace"
+msgstr "C_sere"
+
+#: menu.c:1704
+msgid "NewDir"
+msgstr "ÚjKönyvtár"
+
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Létrehozás"
+
+#: menu.c:1755
 msgid "NewFile"
 msgstr "ÚjFájl"
 
-#: menu.c:1417
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "Hiba a fájl létrehozásakor: nincs meg hozzá a sablon (%s)"
 
-#: menu.c:1488
-#, c-format
+#: menu.c:1847
+#, fuzzy
 msgid ""
-"The `Send To' menu provides a quick way to send some files to an application. The applications listed are those in the following directories:\n"
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Készíts linkeket ebben a könyvtárban a kívánt programokra. Ezek fognak "
+"megjelenni a menüben az ilyen típusú fájloknál (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
+msgid ""
+"The `Send To' menu provides a quick way to send some files to an "
+"application. The applications listed are those in the following "
+"directories:\n"
 "\n"
 "%s\n"
 "%s\n"
 "The `Send To' menu may be opened by Shift+Menu clicking over a file.\n"
 "\n"
 "Advanced use:\n"
-"You can also create subdirectories called `.text_html', `.text', etc which will only be shown for files of that type. `.group' is shown only when multiple files are selected."
+"You can also create subdirectories called `.text_html', `.text', etc which "
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
-"A \"Küldés\" menü segítségével a kijelölt fájlok egyszerűen átadhatók egy alkalmazásnak. A menüben felsorolt alkalmazások a következő könyvtárakból kerülnek ki:\n"
+"A \"Küldés\" menü segítségével a kijelölt fájlok egyszerűen átadhatók egy "
+"alkalmazásnak. A menüben felsorolt alkalmazások a következő könyvtárakból "
+"kerülnek ki:\n"
 "\n"
 "%s\n"
 "%s\n"
-"A \"Küldés\" menü megnyitásához tartsd nyomva a Shift billentyűt miközben egy fájlra kattintasz.\n"
+"A \"Küldés\" menü megnyitásához tartsd nyomva a Shift billentyűt miközben "
+"egy fájlra kattintasz.\n"
 "\n"
 "Haladóknak:\n"
-"\".text_html\", \".text\" stb. nevű alkönyvtárak is készíthetők; ezek csak a megfelelő fájltípusnál jelennek meg. A \".group\" csak több kijelölt fájl esetén jelenik meg."
+"\".text_html\", \".text\" stb. nevű alkönyvtárak is készíthetők; ezek csak a "
+"megfelelő fájltípusnál jelennek meg. A \".group\" csak több kijelölt fájl "
+"esetén jelenik meg."
 
-#: menu.c:1499
-msgid "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift drag) any applications you want into it."
-msgstr "Most megnyitom a saját \"Küldés\" (SendTo) könyvtárad, amelyben létrehozhatsz szimlinkeket a kívánt alkalmazásokra (Ctrl+Shift-tel húzással)."
+#: menu.c:1895
+msgid ""
+"I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
+"drag) any applications you want into it."
+msgstr ""
+"Most megnyitom a saját \"Küldés\" (SendTo) könyvtárad, amelyben "
+"létrehozhatsz szimlinkeket a kívánt alkalmazásokra (Ctrl+Shift-tel húzással)."
 
-#: menu.c:1502
-#: menu.c:1542
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr "A CHOICESPATH változó sajnos tiltja a beállítások mentését."
 
-#: menu.c:1535
+#: menu.c:1931
 #, c-format
 msgid ""
-"Any files placed in your Templates directories will appear on the `New' menu. Choosing one of them will make a copy of it as the new file.\n"
+"Any files placed in your Templates directories will appear on the `New' "
+"menu. Choosing one of them will make a copy of it as the new file.\n"
 "\n"
 "The following directories contain templates:\n"
 "\n"
 "%s\n"
 "%s\n"
 msgstr ""
-"A sablonkönyvtáradban (Templates) levő fájlok fognak megjelenni az \"Új\" menüben. A menüből kiválasztott fájl másolata lesz az új fájl.\n"
+"A sablonkönyvtáradban (Templates) levő fájlok fognak megjelenni az \"Új\" "
+"menüben. A menüből kiválasztott fájl másolata lesz az új fájl.\n"
 "\n"
 "A következő könyvtárakban vannak sablonok:\n"
 "\n"
 "%s\n"
 "%s\n"
 
-#: menu.c:1540
-msgid "I'll show you your Templates directory now; you should place any template files you want inside it."
-msgstr "Most megnyitom a sablonjaid könyvtárát; ide helyezd el a sablonfájlokat."
+#: menu.c:1936
+msgid ""
+"I'll show you your Templates directory now; you should place any template "
+"files you want inside it."
+msgstr ""
+"Most megnyitom a sablonjaid könyvtárát; ide helyezd el a sablonfájlokat."
 
-#: menu.c:1657
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Testreszabás"
 
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Menü testreszabása..."
+
 # XXX: canonical = a realpath() által visszaadott név
-#: menu.c:1730
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Ez már a könyvtár egyszerűsített neve."
 
-#: menu.c:1761
-msgid "You can't open a second view onto this directory because the `Unique Windows' option is turned on in the Options window."
-msgstr "Nem lehet másik ablakban is megnyitni ezt a könyvtárat, mert az \"Egyedi ablakok\" beállítás engedélyezve van."
+#: menu.c:2200
+msgid ""
+"You can't open a second view onto this directory because the `Unique "
+"Windows' option is turned on in the Options window."
+msgstr ""
+"Nem lehet másik ablakban is megnyitni ezt a könyvtárat, mert az \"Egyedi "
+"ablakok\" beállítás engedélyezve van."
 
-#: menu.c:1887
-msgid "Copy ... ?"
-msgstr "Mit másolsz?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1890
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Másolod? Forrás: %s Cél: %s"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Másolod? Forrás: %s Cél: %s"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Mit nevezel át?"
 
-#: menu.c:1893
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Mit linkelsz?"
 
-#: menu.c:1896
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Mit nyitsz meg másként?"
 
-#: menu.c:1899
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Minek a tulajdonságaira vagy kiváncsi?"
 
-#: menu.c:1902
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Kiterjesztett attribútumok"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Minek a típusát állítod be?"
 
-#: menu.c:1905
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Mihez rendelsz programot?"
 
-#: menu.c:1908
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Mihez rendelsz ikont?"
 
-#: menu.c:1911
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Mit küldesz?"
 
-#: menu.c:1914
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "Mit TÖRÖLSZ?"
 
-#: menu.c:1917
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Minek a méretét akarod tudni?"
 
-#: menu.c:1920
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Minek a jogosultságait módosítod?"
 
-#: menu.c:1923
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Hol akarsz keresni?"
 
-#: menu.c:1987
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Mit másolsz?"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Ezt egyszerre csak egy elemmel lehet megtenni"
 
-#: menu.c:2019
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Átnevezés"
 
-#: menu.c:2024
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Szimlink"
 
-#: menu.c:2053
+#: menu.c:2654
 msgid ""
-"User-definable shortcuts are disabled by default in Gtk2, and you have not enabled them. You can turn this feature on by:\n"
+"User-definable shortcuts are disabled by default in Gtk2, and you have not "
+"enabled them. You can turn this feature on by:\n"
 "\n"
-"1) using an XSettings manager, such as ROX-Session or gnome-settings-daemon, or\n"
+"1) using an XSettings manager, such as ROX-Session or gnome-settings-daemon, "
+"or\n"
 "\n"
 "2) adding this line to ~/.gtkrc-2.0:\n"
 "\tgtk-can-change-accels = 1\n"
 "\t(this only works if NOT using XSETTINGS)"
 msgstr ""
-"A GTK2 alapesetben tiltja a gyorsbillentyűk menet közbeni módosítását, és ez nálad is tiltva van. Ha engedélyezni akarod:\n"
+"A GTK2 alapesetben tiltja a gyorsbillentyűk menet közbeni módosítását, és ez "
+"nálad is tiltva van. Ha engedélyezni akarod:\n"
 "\n"
 "1) használj egy XSettings kezelőt, mint például a ROX-Session\n"
 "vagy a gnome-settings-daemon; vagy\n"
@@ -2540,7 +2856,7 @@ msgstr ""
 "\tgtk-can-change-accels = 1\n"
 "\t(ez csak akkor működik, ha NEM használsz XSETTINGS kezelőt)"
 
-#: menu.c:2064
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2548,7 +2864,8 @@ msgid ""
 "- Move the pointer over the item you want to use,\n"
 "- Press the key you want attached to it.\n"
 "\n"
-"The key will appear next to the menu item and you can just press that key without opening the menu in future."
+"The key will appear next to the menu item and you can just press that key "
+"without opening the menu in future."
 msgstr ""
 "Billentyűk hozzárendelése a menüpontokhoz:\n"
 "\n"
@@ -2556,41 +2873,79 @@ msgstr ""
 "- Vidd az egérmutatót a kívánt menüpontra.\n"
 "- Üsd le a billentyűt, amelyet hozzá akarsz rendelni.\n"
 "\n"
-"A kiválasztott menüpont után megjelenik a billentyű, amelyet attól kezdve elég leütni a menü megnyitása nélkül is."
+"A kiválasztott menüpont után megjelenik a billentyű, amelyet attól kezdve "
+"elég leütni a menü megnyitása nélkül is."
 
-#: menu.c:2079
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Gyorsbillentyűk beállítása"
 
-#: minibuffer.c:129
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Ugrás:"
 
-#: minibuffer.c:130
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Shell:"
 
-#: minibuffer.c:131
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Feltételes kijelölés:"
 
-#: minibuffer.c:132
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Kijelölés név alapján:"
 
-#: minibuffer.c:133
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Feltételes kijelölés:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Minta:"
 
-#: minibuffer.c:265
-msgid "Enter the name of a file and I'll display it for you. Press Tab to fill in the longest match. Escape to close the minibuffer."
-msgstr "Írd be a megjelenítendő fájl nevét (a Tab leütésével egészítheted ki a leghosszabb illeszkedő névre). A beviteli sort az Escape billentyűvel tudod bezárni."
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
 
-#: minibuffer.c:271
-msgid "Enter a shell command to execute. Click on a file to add it to the buffer."
-msgstr "Írd be a végrehajtandó shell parancsot. Kattints egy fájlra, ha a nevét be akarod szúrni a parancssorba."
+#: minibuffer.c:320
+msgid ""
+"Enter the name of a file and I'll display it for you. Press Tab to fill in "
+"the longest match. Escape to close the minibuffer."
+msgstr ""
+"Írd be a megjelenítendő fájl nevét (a Tab leütésével egészítheted ki a "
+"leghosszabb illeszkedő névre). A beviteli sort az Escape billentyűvel tudod "
+"bezárni."
 
-#: minibuffer.c:276
+#: minibuffer.c:326
+msgid ""
+"Enter a shell command to execute. Click on a file to add it to the buffer."
+msgstr ""
+"Írd be a végrehajtandó shell parancsot. Kattints egy fájlra, ha a nevét be "
+"akarod szúrni a parancssorba."
+
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Írj be egy mintát a rá illeszkedő fájlok kijelöléséhez:\n"
+"\n"
+"A ? tetszőleges karaktert jelent.\n"
+"A * egy vagy több karaktert jelent.\n"
+"Az [aA] az \"a\" vagy \"A\" karaktert jelenti.\n"
+"Az [a-z] az összes karaktert jelenti a-tól z-ig (kisbetűk).\n"
+"A *.png a \".png\" végű neveket jelenti."
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2608,46 +2963,63 @@ msgstr ""
 "Az [a-z] az összes karaktert jelenti a-tól z-ig (kisbetűk).\n"
 "A *.png a \".png\" végű neveket jelenti."
 
-#: minibuffer.c:288
-msgid "Enter a pattern to match for files to be shown.  An empty filter turns the filter off."
-msgstr "Adj meg egy mintát a rá illeszkedő fájlok megjelenítéséhez. A szűrést üres kifejezéssel lehet kikapcsolni."
+#: minibuffer.c:352
+msgid ""
+"Enter a pattern to match for files to be shown.  An empty filter turns the "
+"filter off."
+msgstr ""
+"Adj meg egy mintát a rá illeszkedő fájlok megjelenítéséhez. A szűrést üres "
+"kifejezéssel lehet kikapcsolni."
 
-#: minibuffer.c:908
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Adj meg egy mintát a rá illeszkedő fájlok megjelenítéséhez. A szűrést üres "
+"kifejezéssel lehet kikapcsolni."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Érvénytelen keresési feltétel"
 
-#: mount.c:372
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s összesen, %s foglalt, %s szabad (%.1f %%)"
 
-#: options.c:275
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "Az Options fájl az új XML formátumba lett alakítva"
 
-#: options.c:535
-#: options.c:1256
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(alapérték)"
 
-#: options.c:805
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Belső hiba: %s nem olvasható"
 
-#: options.c:914
+#: options.c:929
 msgid "Options"
 msgstr "Beállítások"
 
-#: options.c:959
+#: options.c:974
 msgid "_Revert"
 msgstr "_Visszavonás"
 
-#: options.c:965
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr "Visszaállítja az ablak megnyitásakor érvényes beállításokat."
 
-#: options.c:980
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2656,42 +3028,55 @@ msgstr ""
 "A beállításokat ide menti:\n"
 "%s"
 
-#: options.c:988
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(a mentést tiltja a CHOICESPATH)"
 
-#: options.c:1161
-#: usericons.c:452
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Hiba %s mentésekor: %s"
 
-#: options.c:1793
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Hiányzó \"=\""
 
-#: panel.c:495
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr "Nem sikerült megnyitni a fájlt (%s): %s"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "A régi panel fájl az új XML formátumba lett alakítva."
 
-#: panel.c:601
-msgid "You have tried to close a panel via the window manager - I usually find that this is accidental... really close?"
-msgstr "Az ablakkezelőn keresztül próbáltad bezárni a panelt. Ez általában nem szándékosan történik... Tényleg bezárod?"
+#: panel.c:670
+msgid ""
+"You have tried to close a panel via the window manager - I usually find that "
+"this is accidental... really close?"
+msgstr ""
+"Az ablakkezelőn keresztül próbáltad bezárni a panelt. Ez általában nem "
+"szándékosan történik... Tényleg bezárod?"
 
-#: panel.c:702
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Hiányzik a < vagy > a panel konfigurációs fájlban"
 
-#: panel.c:1589
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Hiba a panel (%s) mentésekor: %s"
 
-#: panel.c:1905
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "Az applet kilépett mielőtt megjelent volna!"
 
-#: panel.c:2004
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2700,32 +3085,82 @@ msgstr ""
 "Hiba az applet futtatásakor:\n"
 "%s"
 
-#: panel.c:2640
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "Tényleg megnyitsz %d ablakot?"
+
+# Szerintem nem kell zárójelezni a többesszámot.
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Elemek törlése"
+
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Panel beállításai..."
 
-#: panel.c:2721
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Nem érhető el a Xinerama monitor (%d)"
+
+#: panel.c:2897
+msgid "Top"
+msgstr ""
+
+#: panel.c:2899
+#, fuzzy
+msgid "Bottom"
+msgstr "Alul"
+
+#: panel.c:2901
+#, fuzzy
+msgid "Left"
+msgstr "Bal oldalon"
+
+#: panel.c:2903
+#, fuzzy
+msgid "Right"
+msgstr "Jobb oldalon"
+
+#: panel.c:2905
+#, fuzzy
+msgid "Default"
+msgstr "Alapértelmezett méret:"
+
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "Ismeretlen"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
 msgstr "A régi pinboard fájl az új XML formátumba lett alakítva."
 
 #: pinboard.c:711
-msgid "The backdrop handler must be an application directory. Drag an application directory into the Set Backdrop dialog box, or (for programmers) pass it to the SOAP SetBackdropApp method."
-msgstr "A háttérkezelőnek alkalmazási könyvtárnak kell lennie. Dobj egy alkalmazási könyvtárat a \"Háttér beállítása\" párbeszédablakba. (Programozóknak: Add át a SetBackdropApp SOAP-metódusnak paraméterként.)"
+msgid ""
+"The backdrop handler must be an application directory. Drag an application "
+"directory into the Set Backdrop dialog box, or (for programmers) pass it to "
+"the SOAP SetBackdropApp method."
+msgstr ""
+"A háttérkezelőnek alkalmazási könyvtárnak kell lennie. Dobj egy alkalmazási "
+"könyvtárat a \"Háttér beállítása\" párbeszédablakba. (Programozóknak: Add át "
+"a SetBackdropApp SOAP-metódusnak paraméterként.)"
 
 #: pinboard.c:730
 msgid ""
-"You can only set the backdrop to an image or to a program which knows how to manage ROX-Filer's backdrop.\n"
+"You can only set the backdrop to an image or to a program which knows how to "
+"manage ROX-Filer's backdrop.\n"
 "\n"
-"Programmers: the application's AppInfo.xml must contain the CanSetBackdrop element, as described in ROX-Filer's manual."
+"Programmers: the application's AppInfo.xml must contain the CanSetBackdrop "
+"element, as described in ROX-Filer's manual."
 msgstr ""
-"Háttérnek csak kép, vagy pedig a ROX-Filer hátterét kezelni képes program adható meg.\n"
+"Háttérnek csak kép, vagy pedig a ROX-Filer hátterét kezelni képes program "
+"adható meg.\n"
 "\n"
-"Programozóknak: Az alkalmazás AppInfo.xml fájljában szerepelnie kell a CanSetBackdrop elemnek, ahogy az a ROX-Filer kézikönyvében le van írva."
+"Programozóknak: Az alkalmazás AppInfo.xml fájljában szerepelnie kell a "
+"CanSetBackdrop elemnek, ahogy az a ROX-Filer kézikönyvében le van írva."
 
 #: pinboard.c:750
 msgid "Set backdrop"
@@ -2753,7 +3188,9 @@ msgstr "Átméretezve"
 
 #: pinboard.c:779
 #, fuzzy
-msgid "Scale the image to fit the backdrop area, regardless of image dimensions - overscale"
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
 msgstr "Úgy méretezi a képet, hogy teljesen betöltse az asztalt"
 
 #: pinboard.c:781
@@ -2782,31 +3219,43 @@ msgid "Drop an image here"
 msgstr "Dobj ide egy képet"
 
 #: pinboard.c:851
-msgid "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox -p=Default' to turn it on in future."
-msgstr "Nem volt használatban pinboard... kijelöltem a \"Default\" nevű pinboardot. Ezt a későbbiekben a \"rox -p=Default\" paranccsal használhatod."
+msgid ""
+"No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
+"-p=Default' to turn it on in future."
+msgstr ""
+"Nem volt használatban pinboard... kijelöltem a \"Default\" nevű pinboardot. "
+"Ezt a későbbiekben a \"rox -p=Default\" paranccsal használhatod."
 
 #: pinboard.c:945
-msgid "Only files (and certain applications) can be used to set the background image."
-msgstr "Csak fájlok (és bizonyos alkalmazások) adhatók meg háttérkép beállításához."
+msgid ""
+"Only files (and certain applications) can be used to set the background "
+"image."
+msgstr ""
+"Csak fájlok (és bizonyos alkalmazások) adhatók meg háttérkép beállításához."
 
-#: pinboard.c:1570
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Hiányzik a \">\" az ikon címkéjében"
 
-#: pinboard.c:1579
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Hiányzik a \",\" az ikon címkéje után"
 
-#: pinboard.c:1667
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Hiba a pinboard (%s) mentésekor: %s"
 
-#: pinboard.c:2211
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Háttér..."
 
-#: pinboard.c:2304
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Panel"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2817,7 +3266,7 @@ msgstr ""
 "%s\n"
 "Háttér eltávolítva."
 
-#: pixmaps.c:976
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2826,228 +3275,276 @@ msgstr ""
 "Nem tudom törölni a bélyegképeket a könyvtárból (%s):\n"
 "%s"
 
-#: pixmaps.c:997
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Nincsenek törlendő bélyegképek"
 
-#: pixmaps.c:1010
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Bélyegképek gyorstárának kiürítése"
 
-#: remote.c:722
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Ismeretlen stílus: \"%s\""
 
 # XXX
-#: remote.c:744
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Ismeretlen részletezési mód: \"%s\""
 
-#: remote.c:772
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Ismeretlen rendezési mód: \"%s\""
 
-#: remote.c:1247
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Kísérlet ismeretlen SOAP-metódus hívására: \"%s\""
 
-#: rox_gettext.c:93
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Érvénytelen .gmo nyelvi fájl (túl rövid): %s"
-
-#: rox_gettext.c:106
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Érvénytelen .gmo nyelvi fájl (nincs meg a GNU azonosító): %s"
-
-#: run.c:99
-#: run.c:152
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "A program (%s) nem található. Törölték?"
 
-#: run.c:302
+#: run.c:359
+#, c-format
+msgid ""
+"No run action specified for files of this type (%s/%s) - you can set a run "
+"action by choosing `Set Run Action' from the File menu, or you can just drag "
+"the file to an application.%s"
+msgstr ""
+"Nincs hozzárendelve program ehhez a fájltípushoz (%s/%s). Rendelj hozzá egy "
+"programot a \"Fájl\" menü \"Program hozzárendelése\" parancsával, vagy pedig "
+"egyszerűen dobd rá a fájlt egy programra.%s"
+
+#: run.c:365
+msgid ""
+"\n"
+"\n"
+"Note: If this is a computer program which you want to run, you need to set "
+"the execute bit by choosing Permissions from the File menu."
+msgstr ""
+"\n"
+"\n"
+"Megjegyzés: Ha ez egy futtatható program, akkor a futtatásához be kell "
+"állítani a végrehajtható bitet a \"Fájl\" menü \"Jogosultságok\" parancsával."
+
+#: run.c:373
 #, c-format
 msgid "File doesn't exist, or I can't access it: %s"
 msgstr "A fájl nem létezik vagy nem érhető el: %s"
 
-#: run.c:307
+#: run.c:378
 #, c-format
 msgid "I don't know how to open '%s'"
 msgstr "Nem tudom, hogyan nyissam meg ezt: \"%s\""
 
-#: run.c:338
+#: run.c:409
 #, c-format
 msgid "'%s' is not a valid URI"
 msgstr "Érvénytelen URI: \"%s\""
 
-#: run.c:349
+#: run.c:420
 #, c-format
 msgid "%s not accessable"
 msgstr "%s nem elérhető"
 
-#: run.c:357
+#: run.c:428
 #, c-format
 msgid "Non-local URL %s"
 msgstr "Nem helyi URL: %s"
 
-#: run.c:374
+#: run.c:445
 #, c-format
 msgid "%s: no handler for %s"
 msgstr "%s: nincs kezelő ehhez: %s"
 
-#: run.c:394
+#: run.c:465
 msgid ""
 "Application:\n"
-"This is an application directory - you can run it as a program, or open it (hold down Shift while you open it). Most applications provide their own help here, but this one doesn't."
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
 msgstr ""
 "Alkalmazás:\n"
-"Ez egy alkalmazási könyvtár, amely futtatható programként, vagy megnyitható (a megnyitáshoz tartsd nyomva a Shiftet). Az alkalmazások többnyire itt tárolják a dokumentációjukat is, de ezé az alkalmazásé nincs itt."
+"Ez egy alkalmazási könyvtár, amely futtatható programként, vagy megnyitható "
+"(a megnyitáshoz tartsd nyomva a Shiftet). Az alkalmazások többnyire itt "
+"tárolják a dokumentációjukat is, de ezé az alkalmazásé nincs itt."
 
-#: run.c:478
+#: run.c:549
 #, c-format
 msgid "Could not send data to program: %s"
 msgstr "Nem sikerült adatot küldeni a programnak: %s"
 
-#: run.c:508
+#: run.c:578
 #, c-format
 msgid "Could not read link: %s"
 msgstr "Nem sikerült a link olvasása: %s"
 
-#: run.c:536
+#: run.c:606
 #, c-format
 msgid "Broken symlink (or you don't have permission to follow it): %s"
 msgstr "Rossz szimlink (vagy nincs jogosultságod a követésére): %s"
 
-#: run.c:573
-#, c-format
-msgid "No run action specified for files of this type (%s/%s) - you can set a run action by choosing `Set Run Action' from the File menu, or you can just drag the file to an application.%s"
-msgstr "Nincs hozzárendelve program ehhez a fájltípushoz (%s/%s). Rendelj hozzá egy programot a \"Fájl\" menü \"Program hozzárendelése\" parancsával, vagy pedig egyszerűen dobd rá a fájlt egy programra.%s"
-
-#: run.c:579
-msgid ""
-"\n"
-"\n"
-"Note: If this is a computer program which you want to run, you need to set the execute bit by choosing Permissions from the File menu."
-msgstr ""
-"\n"
-"\n"
-"Megjegyzés: Ha ez egy futtatható program, akkor a futtatásához be kell állítani a végrehajtható bitet a \"Fájl\" menü \"Jogosultságok\" parancsával."
-
 # XXX: Már megint ezek a run actionök.
 #      A run action valójában egy fájltípushoz rendelt programot futtató
 #      (többnyire shell) fájl. Azaz röviden fogalmazva: ...?
-#: run.c:746
+#: run.c:785
 #, c-format
 msgid ""
-"Executable '%s' is world-writeable! Refusing to run. Please change the permissions now (this problem may have been caused by a bug in earlier versions of the filer).\n"
+"Executable '%s' is world-writeable! Refusing to run. Please change the "
+"permissions now (this problem may have been caused by a bug in earlier "
+"versions of the filer).\n"
 "\n"
-"Having (non-symlink) run actions world-writeable means that other people who use your computer can replace your run actions with malicious versions.\n"
+"Having (non-symlink) run actions world-writeable means that other people who "
+"use your computer can replace your run actions with malicious versions.\n"
 "\n"
-"If you trust everyone who could write to these files then you needn't worry. Otherwise, you should check, or even just delete, all the existing run actions."
+"If you trust everyone who could write to these files then you needn't worry. "
+"Otherwise, you should check, or even just delete, all the existing run "
+"actions."
 msgstr ""
-"Ezt a végrehajtható fájlt (%s) mindenki írhatja! Nem futtatom. Változtasd meg a jogosultságait (ezt a problémát a program egy korábbi változatában levő hiba is okozhatta).\n"
+"Ezt a végrehajtható fájlt (%s) mindenki írhatja! Nem futtatom. Változtasd "
+"meg a jogosultságait (ezt a problémát a program egy korábbi változatában "
+"levő hiba is okozhatta).\n"
 "\n"
-"Ha a hozzárendelt programok futtatásához használt végrehajtható (nem szimlink) fájlokat mindenki írhatja, akkor bárki, akinek hozzáférése van a gépedhez, könnyedén kártékony változtatokra cserélheti őket.\n"
+"Ha a hozzárendelt programok futtatásához használt végrehajtható (nem "
+"szimlink) fájlokat mindenki írhatja, akkor bárki, akinek hozzáférése van a "
+"gépedhez, könnyedén kártékony változtatokra cserélheti őket.\n"
 "\n"
-"Ha megbízol mindazokban, akik ezeket a fájlokat írhatják, akkor nincs baj. Máskülönben ellenőrizd (vagy egyszerűen csak töröld) a hozzárendelt programok futtatásához használt összes végrehajtható fájlt."
+"Ha megbízol mindazokban, akik ezeket a fájlokat írhatják, akkor nincs baj. "
+"Máskülönben ellenőrizd (vagy egyszerűen csak töröld) a hozzárendelt "
+"programok futtatásához használt összes végrehajtható fájlt."
 
-#: run.c:759
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Biztonsági hiba javítása)"
 
-#: support.c:272
-msgid "B"
-msgstr "B"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:351
+#: support.c:381
 msgid "byte"
 msgstr "byte"
 
 # XXX stat()-olni...
-#: support.c:1589
-#: support.c:1643
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
 msgstr "Nem sikerült megnyitni és stat()-olni a fájlt (%s): %s"
 
 # XXX mmap-olni...
-#: support.c:1600
-#: support.c:1654
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
 msgstr "Nem sikerült mmap-olni a fájlt (%s): %s"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close"
 msgstr "Bezárás"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close filer window"
 msgstr "Könyvtárablak bezárása"
 
-#: toolbar.c:117
+#: toolbar.c:120
 msgid "Up"
 msgstr "Fel"
 
-#: toolbar.c:117
-msgid "Change to parent directory"
-msgstr "Ugrás a szülő könyvtárba"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:121
+#: toolbar.c:126
 msgid "Home"
 msgstr "Saját könyvtár"
 
-#: toolbar.c:121
-msgid "Change to home directory"
-msgstr "Ugrás a saját könyvtárba"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks"
-msgstr "Könyvjelzők"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks menu"
-msgstr "Könyvjelzők menü"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:129
+#: toolbar.c:138
 msgid "Scan"
 msgstr "Frissítés"
 
-#: toolbar.c:129
-msgid "Rescan directory contents"
-msgstr "Könyvtár tartalmának újraolvasása"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:133
-msgid "Change icon size"
-msgstr "Ikonméret megváltoztatása"
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Méret"
 
-#: toolbar.c:137
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automatikus"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
 msgstr "Automatikus méretezés"
 
-#: toolbar.c:141
-msgid "Show extra details"
-msgstr "Részletes nézet"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Listanézet"
 
-#: toolbar.c:145
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
 msgstr "Rendezés"
 
-#: toolbar.c:145
+#: toolbar.c:165
 msgid "Change sort criteria"
 msgstr "Rendezési mód megváltoztatása"
 
-#: toolbar.c:149
-msgid "Hidden"
-msgstr "Rejtett"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:149
+#: toolbar.c:169
 msgid ""
 "Left: Show/hide hidden files\n"
 "Right: Show/hide thumbnails"
@@ -3055,178 +3552,223 @@ msgstr ""
 "Bal: Rejtett fájlok be/ki\n"
 "Jobb: Bélyegképek be/ki"
 
-#: toolbar.c:154
-msgid "Select all/invert selection"
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+#, fuzzy
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+"Bal: Rejtett fájlok be/ki\n"
+"Jobb: Bélyegképek be/ki"
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
 msgstr "Az összes kijelölése / Kijelölés megfordítása"
 
-#: toolbar.c:158
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
 msgstr "ROX-Filer dokumentáció"
 
-#: toolbar.c:221
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
 msgstr " (%u rejtett)"
 
-#: toolbar.c:229
-#: tips:85
+#: toolbar.c:276 tips:79
 msgid "items"
 msgstr "elem"
 
-#: toolbar.c:229
+#: toolbar.c:276
 msgid "item"
 msgstr "elem"
 
-#: toolbar.c:232
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
 msgstr "0 elem%s"
 
-#: toolbar.c:251
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
 msgstr "%u kijelölve (%s)"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by name"
 msgstr "Rendezés név szerint"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by type"
 msgstr "Rendezés típus szerint"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by date"
 msgstr "Rendezés dátum szerint"
 
-#: toolbar.c:446
+#: toolbar.c:535
 msgid "Sort by size"
 msgstr "Rendezés méret szerint"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by owner"
 msgstr "Rendezés tulajdonos szerint"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by group"
 msgstr "Rendezés csoport szerint"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "ascending"
 msgstr "növekvő"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "descending"
 msgstr "csökkenő"
 
-#: type.c:214
+#: toolbar.c:891
+#, fuzzy
+msgid "_N_Items_"
+msgstr "elem"
+
+#: type.c:221
 msgid "Sym link"
 msgstr "Szimlink"
 
-#: type.c:216
+#: type.c:223
 msgid "Mount point"
 msgstr "Csatolási pont"
 
-#: type.c:218
+#: type.c:225
 msgid "App dir"
 msgstr "Alk. könyvtár"
 
-#: type.c:225
+#: type.c:232
 msgid "Dir"
 msgstr "Könyvtár"
 
-#: type.c:227
+#: type.c:234
 msgid "Char dev"
 msgstr "Karakteres eszköz"
 
-#: type.c:229
+#: type.c:236
 msgid "Block dev"
 msgstr "Blokkos eszköz"
 
-#: type.c:231
+#: type.c:238
 msgid "Pipe"
 msgstr "Pipe"
 
-#: type.c:233
+#: type.c:240
 msgid "Socket"
 msgstr "Socket"
 
-#: type.c:235
+#: type.c:242
 msgid "Door"
 msgstr "Door"
 
-#: type.c:238
+#: type.c:245
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#: type.c:556
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
 "gimp \"$@\""
 msgstr ""
-"Írd be a shell parancsot a \"$@\" megfelelő programba való betöltéséhez. Például:\n"
+"Írd be a shell parancsot a \"$@\" megfelelő programba való betöltéséhez. "
+"Például:\n"
 "\n"
 "gimp \"$@\""
 
-#: type.c:737
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Ez nem program. Adj meg egy futtatható programot!"
 
-#: type.c:797
+#: type.c:839
 msgid "No run action defined"
 msgstr "Nincs hozzárendelve program"
 
-#: type.c:801
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Hiba a kezelőben (%s): %s"
 
-#: type.c:816
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Érvénytelen alkalmazás: %s (hibás az AppRun)"
 
-#: type.c:827
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "Nem végrehajtható: %s"
 
-#: type.c:860
+#: type.c:902
 msgid "Set run action"
 msgstr "Program hozzárendelése"
 
-#: type.c:866
-msgid "If a handler for the specific type isn't set up, use this as the default."
+#: type.c:908
+msgid ""
+"If a handler for the specific type isn't set up, use this as the default."
 msgstr "Ha a teljes típushoz nincs hozzárendelve semmi, akkor ezt használja."
 
-#: type.c:868
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Minden ilyen típushoz: %s/<akármi>"
 
-#: type.c:872
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "A megadott programot használja ehhez a MIME-típushoz."
 
-#: type.c:874
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Csak ehhez a típushoz: \"%s\" (%s/%s)"
 
-#: type.c:880
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Dobj ide egy megfelelő programot"
 
-#: type.c:895
+#: type.c:963
 msgid "OR"
 msgstr "VAGY"
 
-#: type.c:902
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Adj meg egy shell parancsot:"
 
-#: type.c:931
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Parancs használata"
 
@@ -3235,51 +3777,51 @@ msgstr "_Parancs használata"
 # egy script, egy program, vagy egy szimbolikus link programra/scriptre.
 # Így aztán a "run action...is...big" fordítása elég körülményes (legalábbis
 # nekem).
-#: type.c:961
-msgid "A run action already exists and is quite a big program - are you sure you want to delete it?"
-msgstr "Már van hozzárendelve program, és elég nagy méretű. Tényleg törölni akarod?"
+#: type.c:1030
+msgid ""
+"A run action already exists and is quite a big program - are you sure you "
+"want to delete it?"
+msgstr ""
+"Már van hozzárendelve program, és elég nagy méretű. Tényleg törölni akarod?"
 
-#: type.c:972
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "%s nem törölhető: %s"
 
-#: type.c:1009
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "A beállítások mentését tiltja a CHOICESPATH változó"
 
-#: type.c:1309
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that %s already exists as a link to an invalid directory; try deleting it)"
+"%s"
 msgstr ""
-"Nem sikerült létrehozni a szimlinket (%s):\n"
-"%s\n"
-"\n"
-"(talán egy érvénytelen könyvtárra mutat az esetleg már létező \"%s\" link; próbáld törölni)"
+"\"%s\" törlése nem sikerült:\n"
+"%s"
 
-#: usericons.c:179
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "A megadott elérési út nem létezik. Az ikon változatlan marad."
 
-#: usericons.c:189
-#: usericons.c:618
+#: usericons.c:198 usericons.c:644
 msgid ""
-"Unable to load image file -- maybe it's not in a format I understand, or maybe the permissions are wrong?\n"
+"Unable to load image file -- maybe it's not in a format I understand, or "
+"maybe the permissions are wrong?\n"
 "The icon has not been changed."
 msgstr ""
-"Nem sikerült betölteni a képfájlt -- talán ismeretlen a formátuma, vagy rosszul vannak beállítva a jogosultságai.\n"
+"Nem sikerült betölteni a képfájlt -- talán ismeretlen a formátuma, vagy "
+"rosszul vannak beállítva a jogosultságai.\n"
 "Az ikon változatlan marad."
 
-#: usericons.c:235
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Tényleg törlöd az ikont (%s)?"
 
-#: usericons.c:239
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3288,55 +3830,67 @@ msgstr ""
 "\"%s\" nem törölhető:\n"
 "%s"
 
-#: usericons.c:272
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Ikon hozzárendelése"
 
-#: usericons.c:281
-msgid "Use a copy of the image as the default for all files of these MIME types."
+#: usericons.c:290
+msgid ""
+"Use a copy of the image as the default for all files of these MIME types."
 msgstr "A kép másolatát használja az összes fájlhoz, melynek ez a MIME-típusa."
 
-#: usericons.c:283
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Minden ilyen típushoz: %s/<akármi>"
 
-#: usericons.c:288
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "A kép másolatát használja az összes ilyen MIME-típusú fájlnál."
 
-#: usericons.c:290
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Csak ehhez a típushoz: \"%s\" (%s/%s)"
 
 # XXX
-#: usericons.c:296
-msgid "Add the file and image filenames to your personal list. The setting will be lost if the image or the file is moved."
-msgstr "A saját listádhoz adja a fájl és a képfájl nevét. A beállítás hatástalanná válik, ha a képet vagy a fájlt áthelyezed."
+#: usericons.c:305
+msgid ""
+"Add the file and image filenames to your personal list. The setting will be "
+"lost if the image or the file is moved."
+msgstr ""
+"A saját listádhoz adja a fájl és a képfájl nevét. A beállítás hatástalanná "
+"válik, ha a képet vagy a fájlt áthelyezed."
 
-#: usericons.c:299
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Csak ehhez a fájlhoz: %s"
 
-#: usericons.c:307
-msgid "Copy the image inside the directory, as a hidden file called '.DirIcon'. All users will then see the icon, and you can move the directory around safely. This is usually the best option if you can write to the directory."
-msgstr "A könyvtárba másolja a képet \".DirIcon\" nevű rejtett fájlként. Minden felhasználónál ugyanez a kép jelenik meg, a könyvtár pedig bárhová áthelyezhető. Általában ez legjobb választás, ha van írási jogod a könyvtárra."
+#: usericons.c:316
+msgid ""
+"Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
+"users will then see the icon, and you can move the directory around safely. "
+"This is usually the best option if you can write to the directory."
+msgstr ""
+"A könyvtárba másolja a képet \".DirIcon\" nevű rejtett fájlként. Minden "
+"felhasználónál ugyanez a kép jelenik meg, a könyvtár pedig bárhová "
+"áthelyezhető. Általában ez legjobb választás, ha van írási jogod a "
+"könyvtárra."
 
-#: usericons.c:313
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Kép könyvtárba másolása"
 
-#: usericons.c:319
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Dobj ide egy ikonfájlt"
 
-#: usericons.c:589
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "Az ikon beállítását tiltja a CHOICESPATH változó"
 
-#: usericons.c:633
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3345,743 +3899,1112 @@ msgstr ""
 "Hiba a kép (%s) létrehozásakor:\n"
 "%s"
 
-#: view_details.c:942
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
 msgid "Mono font"
 msgstr "Rögzített szélességű betűtípus"
 
-#: view_details.c:943
+#: view_details.c:1019
 msgid "Font for displaying mono-spaced text"
 msgstr "A rögzített szélességű szöveg betűkészlete"
 
-#: view_details.c:1044
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Név"
 
-#: view_details.c:1047
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Típus"
 
-#: view_details.c:1050
-msgid "_Permissions"
-msgstr "_Jogok"
-
-#: view_details.c:1055
-msgid "_Owner"
-msgstr "Tu_lajdonos"
-
-#: view_details.c:1057
-msgid "_Group"
-msgstr "_Csoport"
-
-#: view_details.c:1059
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Méret"
 
-#: view_details.c:1065
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Jogok"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "Tu_lajdonos"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Csoport"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "_Utolsó módosítás"
 
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Kiterjesztett attribútumok"
+
 #: tips:1
-msgid "Translation"
-msgstr "Fordítás"
-
-#: tips:2
-msgid "Language"
-msgstr "Nyelv"
-
-#: tips:3
-msgid "Use the LANG environment variable"
-msgstr "A LANG környezeti változó alapján"
-
-#: tips:4
-msgid "Basque"
-msgstr "Baszk"
-
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Kínai (hagyományos)"
-
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Kínai (egyszerűsített)"
-
-#: tips:7
-msgid "Czech"
-msgstr "Cseh"
-
-#: tips:8
-msgid "Danish"
-msgstr "Dán"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Holland"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Angol (nincs fordítás)"
-
-#: tips:11
-msgid "Estonian"
-msgstr "Észt"
-
-#: tips:12
-msgid "Finnish"
-msgstr "Finn"
-
-#: tips:13
-msgid "French"
-msgstr "Francia"
-
-#: tips:14
-msgid "German"
-msgstr "Német"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Magyar"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Japán"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "Norvég"
-
-#: tips:18
-msgid "Italian"
-msgstr "Olasz"
-
-#: tips:19
-msgid "Polish"
-msgstr "Lengyel"
-
-#: tips:20
-msgid "Portuguese (Portugal)"
-msgstr "Portugál (Portugália)"
-
-#: tips:21
-msgid "Portuguese (Brasil)"
-msgstr "Portugál (Brazília)"
-
-#: tips:22
-msgid "Romanian"
-msgstr "Román"
-
-#: tips:23
-msgid "Russian"
-msgstr "Orosz"
-
-#: tips:24
-msgid "Spanish"
-msgstr "Spanyol"
-
-#: tips:25
-msgid "Swedish"
-msgstr "Svéd"
-
-#: tips:26
-msgid "Ukrainian"
-msgstr "Ukrán"
-
-#: tips:27
-msgid "Vietnamese"
-msgstr "Vietnámi"
-
-#: tips:28
 msgid "Filer windows"
 msgstr "Könyvtárablakok"
 
-#: tips:29
+#: tips:2
 msgid "Auto-resize filer windows"
 msgstr "Könyvtárablakok automatikus átméretezése"
 
-#: tips:30
+#: tips:3
 msgid "Never automatically resize"
 msgstr "Nincs automatikus átméretezés"
 
-#: tips:31
-msgid "You'll have to resize windows manually, using the window manager, the `Resize Window' menu entry or by double-clicking on the window background."
-msgstr "Az ablakot kézzel kell átméretezni: vagy az ablakkezelő segítségével, vagy az \"Ablak átméretezése\" menüpont használatával, vagy pedig dupla kattintással az ablak hátterére."
+#: tips:4
+msgid ""
+"You'll have to resize windows manually, using the window manager, the "
+"`Resize Window' menu entry or by double-clicking on the window background."
+msgstr ""
+"Az ablakot kézzel kell átméretezni: vagy az ablakkezelő segítségével, vagy "
+"az \"Ablak átméretezése\" menüpont használatával, vagy pedig dupla "
+"kattintással az ablak hátterére."
 
-#: tips:32
+#: tips:5
 msgid "Resize when changing the display style"
 msgstr "Átméretezés a nézet megváltoztatásakor"
 
-#: tips:33
-msgid "Changing the size of the icons or which details are displayed will resize the window for you."
-msgstr "Az ikonméret megváltoztatása vagy a részletes nézet kapcsolgatása átméretezi az ablakot."
+#: tips:6
+msgid ""
+"Changing the size of the icons or which details are displayed will resize "
+"the window for you."
+msgstr ""
+"Az ikonméret megváltoztatása vagy a részletes nézet kapcsolgatása átméretezi "
+"az ablakot."
 
-#: tips:34
+#: tips:7
 msgid "Always resize"
 msgstr "Mindig méretezze át"
 
-#: tips:35
-msgid "The filer will resize windows whenever it seems useful (that is, when changing directory or display style)."
-msgstr "Az ablak minden szükséges esetben át lesz méretezve (könyvtárváltáskor, illetve a nézet megváltoztatásakor)."
+#: tips:8
+msgid ""
+"The filer will resize windows whenever it seems useful (that is, when "
+"changing directory or display style)."
+msgstr ""
+"Az ablak minden szükséges esetben át lesz méretezve (könyvtárváltáskor, "
+"illetve a nézet megváltoztatásakor)."
 
-#: tips:36
+#: tips:9
 msgid "Largest window size:"
 msgstr "Legnagyobb ablakméret:"
 
-#: tips:37
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:38
-msgid "The largest size, as a percentage of the screen size, that the auto-resizer will resize a window to."
-msgstr "A legnagyobb méret, amelyet egy ablak az automatikus átméretezés során felvehet. (A képernyő méretének százalékában értendő.)"
+#: tips:11
+msgid ""
+"The largest size, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"A legnagyobb méret, amelyet egy ablak az automatikus átméretezés során "
+"felvehet. (A képernyő méretének százalékában értendő.)"
 
-#: tips:39
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Legnagyobb ablakméret:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"A legnagyobb méret, amelyet egy ablak az automatikus átméretezés során "
+"felvehet. (A képernyő méretének százalékában értendő.)"
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Ablakok viselkedése"
 
-#: tips:40
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Rövid jelzők a címsorban"
 
-#: tips:41
-msgid "Use single letters instead of words for Scanning, All and Thumbs indicators in the titlebar."
-msgstr "A címsorban betűket használ a \"Frissítés\", \"Mind\" és \"Bélyeg\" szavak helyett."
+#: tips:17
+msgid ""
+"Use single letters instead of words for Scanning, All and Thumbs indicators "
+"in the titlebar."
+msgstr ""
+"A címsorban betűket használ a \"Frissítés\", \"Mind\" és \"Bélyeg\" szavak "
+"helyett."
 
-#: tips:42
+#: tips:18
 msgid "Unique windows"
 msgstr "Egyedi ablakok"
 
-#: tips:43
-msgid "If you open a directory and that directory is already displayed in another window, then this option causes the other window to be closed."
-msgstr "Ha megnyitsz egy könyvtárat, amelyik egy másik ablakban már meg van nyitva, akkor ennek a beállításnak a hatására a másik ablak bezáródik."
+#: tips:19
+msgid ""
+"If you open a directory and that directory is already displayed in another "
+"window, then this option causes the other window to be closed."
+msgstr ""
+"Ha megnyitsz egy könyvtárat, amelyik egy másik ablakban már meg van nyitva, "
+"akkor ennek a beállításnak a hatására a másik ablak bezáródik."
 
-#: tips:44
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Ablak"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Új ablak az 1-es gombra"
 
-#: tips:45
-msgid "Clicking with mouse button 1 (usually the left button) opens a directory in a new window with this turned on. Clicking with the button-2 (middle) will reuse the current window."
-msgstr "Az 1-es (általában a bal) gombbal kattintva a könyvtár tartalma egy új ablakban jelenik meg. A 2-es (középső) gombbal kattintva a könyvtár tartalma az aktuális ablakban jelenik meg."
+#: tips:25
+msgid ""
+"Clicking with mouse button 1 (usually the left button) opens a directory in "
+"a new window with this turned on. Clicking with the button-2 (middle) will "
+"reuse the current window."
+msgstr ""
+"Az 1-es (általában a bal) gombbal kattintva a könyvtár tartalma egy új "
+"ablakban jelenik meg. A 2-es (középső) gombbal kattintva a könyvtár tartalma "
+"az aktuális ablakban jelenik meg."
 
-#: tips:46
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Megnyitás egy kattintásra"
 
-#: tips:47
-#: tips:143
-msgid "Clicking on an item opens it with this on. Hold down Control to select the item instead. If off, clicking once selects an item; double click to open things."
-msgstr "Egyetlen kattintás egy elemre megnyitja azt. Ilyenkor a kijelöléshez nyomva kell tartani a Control billentyűt. Ha ez a beállítás nincs engedélyezve, akkor a megnyitáshoz duplán kell kattintani."
+#: tips:27 tips:191
+msgid ""
+"Clicking on an item opens it with this on. Hold down Control to select the "
+"item instead. If off, clicking once selects an item; double click to open "
+"things."
+msgstr ""
+"Egyetlen kattintás egy elemre megnyitja azt. Ilyenkor a kijelöléshez nyomva "
+"kell tartani a Control billentyűt. Ha ez a beállítás nincs engedélyezve, "
+"akkor a megnyitáshoz duplán kell kattintani."
 
-#: tips:48
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Átméretezés dupla kattintással a háttérre"
 
-#: tips:49
-msgid "If on then double clicking on the window background resizes the window, just like clicking on the Automatic size mode button in the toolbar."
-msgstr "Az ablakokat át lehet méretezni duplán kattintva a hátterükre. Ez ugyanazt eredményezi, mint az eszköztár \"Automatikus méretezés\" gombjára kattintás."
+#: tips:29
+msgid ""
+"If on then double clicking on the window background resizes the window, just "
+"like clicking on the Automatic size mode button in the toolbar."
+msgstr ""
+"Az ablakokat át lehet méretezni duplán kattintva a hátterükre. Ez ugyanazt "
+"eredményezi, mint az eszköztár \"Automatikus méretezés\" gombjára kattintás."
 
-#: tips:50
+#: tips:30
 msgid "Sorting"
 msgstr "Rendezés"
 
-#: tips:51
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "A könyvtárak elöl legyenek (név szerinti rendezéskor)"
 
-#: tips:52
-msgid "If this is on then directories will always appear before anything else when sorting by name."
-msgstr "Engedélyezésével a könyvtárak mindig a többi fájl elé kerülnek név szerinti rendezéskor."
+#: tips:32
+msgid ""
+"If this is on then directories will always appear before anything else when "
+"sorting by name."
+msgstr ""
+"Engedélyezésével a könyvtárak mindig a többi fájl elé kerülnek név szerinti "
+"rendezéskor."
 
-#: tips:53
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "A nagy kezdőbetűsek elöl legyenek (név szerinti rendezéskor)"
 
-#: tips:54
-msgid "If on, all filenames starting with a capital letter come before filenames starting with lowercase ones."
-msgstr "Engedélyezésével a nagy kezdőbetűs fájlnevek a kis kezdőbetűsek elé kerülnek."
+#: tips:34
+msgid ""
+"If on, all filenames starting with a capital letter come before filenames "
+"starting with lowercase ones."
+msgstr ""
+"Engedélyezésével a nagy kezdőbetűs fájlnevek a kis kezdőbetűsek elé kerülnek."
 
-#: tips:56
-msgid "Default settings for new windows"
-msgstr "Új ablakok alapbeállításai"
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "A könyvtárak elöl legyenek (név szerinti rendezéskor)"
 
-#: tips:57
-msgid "Inherit options from source window"
-msgstr "Beállítások öröklése az előző ablaktól"
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
 
-#: tips:58
-msgid "If this is on then display options for a new window are inherited from the source window if possible, otherwise they are set to the defaults below."
-msgstr "Engedélyezésekor az új ablakok lehetőség szerint az előző ablaktól öröklik a nézet beállításait, máskülönben az alábbi alapbeállításokat használják."
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sec"
 
-#: tips:59
-msgid "View type:"
-msgstr "Nézet:"
-
-#: tips:62
-msgid "Sort by:"
-msgstr "Rendezés:"
-
-#: tips:64
-#: tips:81
-msgid "Type"
-msgstr "Típus"
-
-#: tips:65
-msgid "Date"
-msgstr "Dátum"
-
-#: tips:67
-msgid "Show hidden files"
-msgstr "Rejtett fájlok mutatása"
-
-#: tips:68
-msgid "If this is on then files whose names start with a dot are shown too, otherwise they are hidden."
-msgstr "Engedélyezésekor azok a fájlok is látszanak, amelyeknek neve ponttal kezdődik, egyébként rejtve maradnak."
-
-#: tips:69
+#: tips:38
 msgid "Show extended attribute indicator"
 msgstr "Kiterjesztett attribútumok jelzése"
 
-#: tips:70
-msgid "If this is on then files which have one or more extended attributes set will have an emblem added to indicate this."
-msgstr "Ha be van kapcsolva, akkor a fájloknál egy matrica jelzi a kiterjesztett attribútumok meglétét."
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+"Ha be van kapcsolva, akkor a fájloknál egy matrica jelzi a kiterjesztett "
+"attribútumok meglétét."
 
-#: tips:71
-msgid "Icon View"
-msgstr "Ikonnézet"
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
 
-#: tips:72
-msgid "Default size:"
-msgstr "Alapértelmezett méret:"
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
 
-#: tips:73
-msgid "Huge Icons"
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
+msgid "Default settings for new windows"
+msgstr "Új ablakok alapbeállításai"
+
+#: tips:46
+msgid "Inherit options from source window"
+msgstr "Beállítások öröklése az előző ablaktól"
+
+#: tips:47
+msgid ""
+"If this is on then display options for a new window are inherited from the "
+"source window if possible, otherwise they are set to the defaults below."
+msgstr ""
+"Engedélyezésekor az új ablakok lehetőség szerint az előző ablaktól öröklik a "
+"nézet beállításait, máskülönben az alábbi alapbeállításokat használják."
+
+#: tips:48
+msgid "View type:"
+msgstr "Nézet:"
+
+#: tips:51
+msgid "Sort by:"
+msgstr "Rendezés:"
+
+#: tips:53 tips:76 tips:114
+msgid "Type"
+msgstr "Típus"
+
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
+msgstr "Dátum"
+
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Dátum"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Dátum"
+
+#: tips:58
+msgid "Show hidden files"
+msgstr "Rejtett fájlok mutatása"
+
+#: tips:59
+msgid ""
+"If this is on then files whose names start with a dot are shown too, "
+"otherwise they are hidden."
+msgstr ""
+"Engedélyezésekor azok a fájlok is látszanak, amelyeknek neve ponttal "
+"kezdődik, egyébként rejtve maradnak."
+
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Rejtett fájlok mutatása"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Engedélyezésekor azok a fájlok is látszanak, amelyeknek neve ponttal "
+"kezdődik, egyébként rejtve maradnak."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
 msgstr "Óriás ikonok"
 
-#: tips:74
-#: tips:244
-msgid "Large Icons"
-msgstr "Nagy ikonok"
-
-#: tips:75
-#: tips:243
-msgid "Small Icons"
-msgstr "Kis ikonok"
-
-#: tips:77
-msgid "Default details:"
-msgstr "Alapértelmezett részletek:"
-
-#: tips:78
-msgid "No details"
-msgstr "Nincsenek részletek"
-
-#: tips:83
-msgid "Automatic small icons:"
-msgstr "Kis ikonokra váltás:"
-
-#: tips:84
-msgid "Change at:"
-msgstr "Váltás határa:"
-
-#: tips:86
-msgid "When automatic icon sizing is selected: If the directory contains this many items then it will be shown using Small Icons, otherwise Large Icons will be used."
-msgstr "Amikor engedélyezve van az ikonok automatikus méretezése: Ha ennél több elem van a könyvtárban, akkor kis ikonokat használ, máskülönben nagyokat."
-
-#: tips:87
-msgid "Max width (Large icons):"
-msgstr "Max. szélesség (nagy ikonok):"
-
-#: tips:88
-#: tips:91
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
 msgid "pixels"
 msgstr "pixel"
 
-#: tips:89
-msgid "Text wider than this is broken onto two lines in Large Icons mode. In Huge Icons mode, text is wrapped when 50% wider than this."
-msgstr "Az ennél hosszabb szöveg két sorban jelenik meg a nagy ikonok alatt. Óriás ikonok esetén az ennél 50%-kal szélesebb szöveg lesz két sorba törve."
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
 
-#: tips:90
-msgid "(Small Icons):"
+#: tips:65 tips:66
+msgid "Icon View"
+msgstr "Ikonnézet"
+
+#: tips:67
+msgid "Default size:"
+msgstr "Alapértelmezett méret:"
+
+#: tips:68
+msgid "Huge Icons"
+msgstr "Óriás ikonok"
+
+#: tips:69 tips:296
+msgid "Large Icons"
+msgstr "Nagy ikonok"
+
+#: tips:70 tips:295
+msgid "Small Icons"
+msgstr "Kis ikonok"
+
+#: tips:72
+msgid "Default details:"
+msgstr "Alapértelmezett részletek:"
+
+#: tips:73
+msgid "No details"
+msgstr "Nincsenek részletek"
+
+#: tips:74
+msgid "Sizes"
+msgstr "Méretek"
+
+#: tips:77
+msgid "Times"
+msgstr "Dátumok"
+
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
+msgstr "Kis ikonokra váltás:"
+
+#: tips:80
+msgid ""
+"When automatic icon sizing is selected: If the directory contains this many "
+"items then it will be shown using Small Icons, otherwise Large Icons will be "
+"used."
+msgstr ""
+"Amikor engedélyezve van az ikonok automatikus méretezése: Ha ennél több elem "
+"van a könyvtárban, akkor kis ikonokat használ, máskülönben nagyokat."
+
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Nagy ikonok"
+
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
+msgstr ""
+"Az ennél hosszabb szöveg két sorban jelenik meg a nagy ikonok alatt. Óriás "
+"ikonok esetén az ennél 50%-kal szélesebb szöveg lesz két sorba törve."
+
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
+
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
+#: tips:88
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr "Engedélyezésekor a nagy ikonokat oszlopokba rendezi, nem sorokba."
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
 msgstr "(Kis ikonok):"
 
-#: tips:92
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "A kis ikonok utáni szöveg maximális szélessége."
 
-#: tips:93
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "A kis ikonokat függőlegesen rendezze el"
 
-#: tips:94
-msgid "If this option is on, then small icons are arranged in columns, not rows."
+#: tips:93
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
 msgstr "Engedélyezésekor a kis ikonokat oszlopokba rendezi, nem sorokba."
 
-#: tips:95
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "A nagy ikonokat függőlegesen rendezze el"
 
-#: tips:96
-msgid "If this option is on, then large icons are arranged in columns, not rows."
+#: tips:95
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
 msgstr "Engedélyezésekor a nagy ikonokat oszlopokba rendezi, nem sorokba."
 
-#: tips:98
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Oszlopfejlécek mutatása"
 
-#: tips:99
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr "Engedélyezésekor látszanak az oszlopfejlécek listanézetben."
 
-#: tips:100
+#: tips:102
 msgid "Show full type"
 msgstr "Teljes típus mutatása"
 
-#: tips:101
-msgid "If this is on then the full description of each object's type will be show rather than a short summary of its basic type."
-msgstr "Engedélyezésekor listanézetben a fájltípusok teljes leírása látható, nem pedig az alaptípus rövid neve."
+#: tips:103
+msgid ""
+"If this is on then the full description of each object's type will be show "
+"rather than a short summary of its basic type."
+msgstr ""
+"Engedélyezésekor listanézetben a fájltípusok teljes leírása látható, nem "
+"pedig az alaptípus rövid neve."
 
-#: tips:102
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "A kis ikonok utáni szöveg maximális szélessége."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Oszlopfejlécek mutatása"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr "Engedélyezésekor látszanak az oszlopfejlécek listanézetben."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr "Engedélyezésekor látszanak az oszlopfejlécek listanézetben."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr "Engedélyezésekor látszanak az oszlopfejlécek listanézetben."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr "Engedélyezésekor látszanak az oszlopfejlécek listanézetben."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr "Engedélyezésekor látszanak az oszlopfejlécek listanézetben."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr "Engedélyezésekor látszanak az oszlopfejlécek listanézetben."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "_Utolsó módosítás"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr "Engedélyezésekor látszanak az oszlopfejlécek listanézetben."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr "Engedélyezésekor látszanak az oszlopfejlécek listanézetben."
+
+#: tips:128
+#, fuzzy
+msgid "Last Accessed"
+msgstr "%s nem elérhető"
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr "Engedélyezésekor látszanak az oszlopfejlécek listanézetben."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Eszközök/Minipuffer"
 
-#: tips:103
+#: tips:131
 msgid "Toolbar"
 msgstr "Eszköztár"
 
-#: tips:104
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Eszköztár fajtája:"
 
-#: tips:105
+#: tips:133
 msgid "No toolbar"
 msgstr "Nincs eszköztár"
 
-#: tips:106
+#: tips:134
 msgid "Icons only"
 msgstr "Csak ikonok"
 
-#: tips:107
+#: tips:135
 msgid "Text under icons"
 msgstr "Szöveg az ikonok alatt"
 
-#: tips:108
+#: tips:136
 msgid "Text beside icons"
 msgstr "Szöveg az ikonok mellett"
 
-#: tips:109
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Csak a panel"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Elemek számának megjelenítése"
 
-#: tips:110
-msgid "Show the number of items displayed in a filer window, as well as the number of hidden items (if any). When there's a selection, show the number of selected items and their combined size."
-msgstr "Kijelzi a könyvtárablakban megjelenített (valamint ez esetleges rejtett) elemek számát. Kijelölés esetén a kijelölt elemek számát és összegzett méretét mutatja."
+#: tips:139
+msgid ""
+"Show the number of items displayed in a filer window, as well as the number "
+"of hidden items (if any). When there's a selection, show the number of "
+"selected items and their combined size."
+msgstr ""
+"Kijelzi a könyvtárablakban megjelenített (valamint ez esetleges rejtett) "
+"elemek számát. Kijelölés esetén a kijelölt elemek számát és összegzett "
+"méretét mutatja."
 
-#: tips:111
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Válaszd ki az eszköztáron megjelenítendő gombokat:"
 
-#: tips:112
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "Az eszköztár szélessége megszabja az ablak legkisebb szélességét"
 
-#: tips:113
-msgid "Each filer window is constrained to be wide enough to show the whole of the toolbar"
-msgstr "Minden könyvtárablak elég széles lesz ahhoz, hogy az egész eszköztár látszódjék."
+#: tips:142
+msgid ""
+"Each filer window is constrained to be wide enough to show the whole of the "
+"toolbar"
+msgstr ""
+"Minden könyvtárablak elég széles lesz ahhoz, hogy az egész eszköztár "
+"látszódjék."
 
-#: tips:114
+#: tips:143
 msgid "Minibuffer"
 msgstr "Minipuffer"
 
-#: tips:115
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Hangjelzés a fájlnevek sikertelen kiegészítéskor"
 
-#: tips:116
-msgid "When using the `Enter Path...' minibuffer and Tab is pressed, beep if nothing happens (eg, because there are several possibilities and the next letter varies)."
-msgstr "Hangjelzést ad, ha az \"Útvonal megadása...\" parancs használatakor a Tab leütésére semmi sem történik (például mert több lehetséges kiegészítés is van, és a következő betűjük eltérő)."
+#: tips:145
+msgid ""
+"When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
+"nothing happens (eg, because there are several possibilities and the next "
+"letter varies)."
+msgstr ""
+"Hangjelzést ad, ha az \"Útvonal megadása...\" parancs használatakor a Tab "
+"leütésére semmi sem történik (például mert több lehetséges kiegészítés is "
+"van, és a következő betűjük eltérő)."
 
-#: tips:117
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Hangjelzés több fájlnév esetén"
 
-#: tips:118
-msgid "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there is more than one matching file, even though some more letters were added."
-msgstr "Hangjelzést ad, ha az \"Útvonal megadása...\" parancs használatakor a Tab leütésére még akkor is több fájlnév jöhet szóba kiegészítésként, ha megadtál pár betűt."
+#: tips:147
+msgid ""
+"When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
+"is more than one matching file, even though some more letters were added."
+msgstr ""
+"Hangjelzést ad, ha az \"Útvonal megadása...\" parancs használatakor a Tab "
+"leütésére még akkor is több fájlnév jöhet szóba kiegészítésként, ha megadtál "
+"pár betűt."
 
-#: tips:121
-msgid "When thumbnails are turned on, each image file in a directory is loaded and a small thumbnail of it is shown."
-msgstr "Amikor a bélyegképek engedélyezve vannak, akkor a könyvtárban levő képekfájlok ikonjai a képeket mutatják."
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Letöltéskezelő"
 
-#: tips:122
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Hiba a kezelőben (%s): %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
+msgid ""
+"When thumbnails are turned on, each image file in a directory is loaded and "
+"a small thumbnail of it is shown."
+msgstr ""
+"Amikor a bélyegképek engedélyezve vannak, akkor a könyvtárban levő "
+"képekfájlok ikonjai a képeket mutatják."
+
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Bélyegképek mutatása"
 
-#: tips:123
-msgid "This is the default setting for new windows. Use the Display menu to turn thumbnails on and off for individual windows."
-msgstr "Alapesetben ezt a beállítást használják az új ablakok. Az egyes ablakoknál külön-külön kapcsolgathatók a bélyegképek a \"Nézet\" menüben."
+#: tips:156
+msgid ""
+"This is the default setting for new windows. Use the Display menu to turn "
+"thumbnails on and off for individual windows."
+msgstr ""
+"Alapesetben ezt a beállítást használják az új ablakok. Az egyes ablakoknál "
+"külön-külön kapcsolgathatók a bélyegképek a \"Nézet\" menüben."
 
-#: tips:124
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Bélyegképek mutatása"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "Video bélyegképek"
 
-#: tips:125
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Bélyegképek gyorstára"
 
-#: tips:126
-msgid "To speed things up, the generated thumbnails are stored in the hidden ~/.thumbnails directory. Click here to remove all the cached thumbnails. They will be created again as needed."
-msgstr "A gyorsabb működés érdekében az elkészült bélyegképek a rejtett ~/.thumbnails könyvtárban tárolódnak. Kattints ide a bélyegképek törléséhez. Szükség esetén újra létre lesznek hozva."
+#: tips:161
+#, fuzzy
+msgid ""
+"To speed things up, the generated thumbnails are stored in the hidden ~/."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
+msgstr ""
+"A gyorsabb működés érdekében az elkészült bélyegképek a rejtett ~/."
+"thumbnails könyvtárban tárolódnak. Kattints ide a bélyegképek törléséhez. "
+"Szükség esetén újra létre lesznek hozva."
 
-#: tips:127
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
 msgid "Manage thumbnails"
 msgstr "Bélyegképek kezelése"
 
-#: tips:128
-#: tips:187
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Video bélyegképek"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sec"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Pinboard"
 
-#: tips:129
-msgid "When using a pinboard, you can drag files and applications onto the desktop background to create shortcuts to them."
-msgstr "A pinboard használatakor fájlokra és alkalmazásokra mutató ikonok helyezhetők az asztalra."
+#: tips:177
+msgid ""
+"When using a pinboard, you can drag files and applications onto the desktop "
+"background to create shortcuts to them."
+msgstr ""
+"A pinboard használatakor fájlokra és alkalmazásokra mutató ikonok "
+"helyezhetők az asztalra."
 
-#: tips:130
-#: tips:240
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Megjelenés"
 
-#: tips:131
+#: tips:179
 msgid "Foreground:"
 msgstr "Előtér:"
 
-#: tips:132
+#: tips:180
 msgid "Text shadow:"
 msgstr "Szöveg árnyéka:"
 
-#: tips:133
+#: tips:181
 msgid "Background:"
 msgstr "Háttér:"
 
-#: tips:134
+#: tips:182
 msgid "No shadow"
 msgstr "Nincs árnyék"
 
-#: tips:135
+#: tips:183
 msgid "Thin"
 msgstr "Vékony"
 
-#: tips:136
+#: tips:184
 msgid "Thick"
 msgstr "Vastag"
 
-#: tips:137
+#: tips:185
 msgid "Use custom font:"
 msgstr "Egyéni betűtípus használata:"
 
-#: tips:138
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Az ikonok alatti szöveg betűtípusa"
 
-#: tips:139
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Képek gyors átméretezése"
 
-#: tips:140
-msgid "Choose between the fast or slow method of scaling backdrop images.  The slow method can give better results."
-msgstr "Választani lehet a háttérképek gyors vagy lassú átméretezése között. A lassú módszer szebb képet eredményezhet."
+#: tips:188
+msgid ""
+"Choose between the fast or slow method of scaling backdrop images.  The slow "
+"method can give better results."
+msgstr ""
+"Választani lehet a háttérképek gyors vagy lassú átméretezése között. A lassú "
+"módszer szebb képet eredményezhet."
 
-#: tips:141
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Pinboard viselkedése"
 
-#: tips:142
+#: tips:190
 msgid "Single-click to open"
 msgstr "Megnyitás egy kattintásra"
 
-#: tips:144
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Ikonok képernyőn tartása"
 
-#: tips:145
-msgid "If this is set, pinboard icons are always kept completely within screen limits, including the label."
-msgstr "Engedélyezésekor a pinboard ikonjai (és azok címkéi) nem lógnak ki a képernyőről."
+#: tips:193
+msgid ""
+"If this is set, pinboard icons are always kept completely within screen "
+"limits, including the label."
+msgstr ""
+"Engedélyezésekor a pinboard ikonjai (és azok címkéi) nem lógnak ki a "
+"képernyőről."
 
-#: tips:146
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Ikonrács felosztása:"
 
-#: tips:147
+#: tips:195
 msgid "Fine"
 msgstr "Finom"
 
-#: tips:148
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "Az ikonok 2 képpont méretű rácshoz igazodnak."
 
-#: tips:149
+#: tips:197
 msgid "Medium"
 msgstr "Közepes"
 
-#: tips:150
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "Az ikonok 16 képpont méretű rácshoz igazodnak."
 
-#: tips:151
+#: tips:199
 msgid "Coarse"
 msgstr "Durva"
 
-#: tips:152
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "Az ikonok 32 képpont méretű rácshoz igazodnak."
 
-#: tips:153
-#: tips:155
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Ikonizált ablakok"
 
-#: tips:154
-msgid "Most window managers provide a way to iconify (or 'minimise') windows, and various programs, including ROX-Filer, can be used to display the iconified windows."
-msgstr "A legtöbb ablakkezelő képes az ablakok ikonizálására (vagy \"minimalizálására\"), és különféle programok (köztük a ROX-Filer) meg tudják jeleníteni ezeket az ablakokat."
+#: tips:202
+msgid ""
+"Most window managers provide a way to iconify (or 'minimise') windows, and "
+"various programs, including ROX-Filer, can be used to display the iconified "
+"windows."
+msgstr ""
+"A legtöbb ablakkezelő képes az ablakok ikonizálására (vagy \"minimalizálására"
+"\"), és különféle programok (köztük a ROX-Filer) meg tudják jeleníteni "
+"ezeket az ablakokat."
 
-#: tips:156
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Ikonizált ablakok mutatása"
 
-#: tips:157
-msgid "If this option is on, the filer will show each iconified window as a small button on the pinboard. Requires a compatible window manager, and the pinboard must be in use."
-msgstr "Engedélyezésekor az asztalon kis gombokként megjelennek az ikonizált ablakok. Ehhez megfelelő ablakkezelő szükséges, és be kell kapcsolni a pinboardot."
+#: tips:205
+msgid ""
+"If this option is on, the filer will show each iconified window as a small "
+"button on the pinboard. Requires a compatible window manager, and the "
+"pinboard must be in use."
+msgstr ""
+"Engedélyezésekor az asztalon kis gombokként megjelennek az ikonizált "
+"ablakok. Ehhez megfelelő ablakkezelő szükséges, és be kell kapcsolni a "
+"pinboardot."
 
-#: tips:158
+#: tips:206
 msgid "Show per workspace"
 msgstr "Csak egy munkaterület ablakait mutassa"
 
-#: tips:159
-msgid "If this option is on, the filer will only show iconified windows associated with the current workspace."
-msgstr "Engedélyezésekor csak az aktuális munkaterülethez tartozó ikonizált ablakok látszanak."
+#: tips:207
+msgid ""
+"If this option is on, the filer will only show iconified windows associated "
+"with the current workspace."
+msgstr ""
+"Engedélyezésekor csak az aktuális munkaterülethez tartozó ikonizált ablakok "
+"látszanak."
 
-#: tips:160
+#: tips:208
 msgid "Iconify to the"
 msgstr "Ikonizálás a"
 
-#: tips:161
+#: tips:209
 msgid "top-left"
 msgstr "bal felső"
 
-#: tips:162
+#: tips:210
 msgid "top-right"
 msgstr "jobb felső"
 
-#: tips:163
+#: tips:211
 msgid "bottom-left"
 msgstr "bal alsó"
 
-#: tips:164
+#: tips:212
 msgid "bottom-right"
 msgstr "jobb alsó"
 
-#: tips:165
+#: tips:213
 msgid ", going"
 msgstr " sarokba, elhelyezés:"
 
-#: tips:166
+#: tips:214
 msgid "horizontally"
 msgstr "vízszintesen"
 
-#: tips:167
+#: tips:215
 msgid "vertically"
 msgstr "függőlegesen"
 
-#: tips:168
-msgid "Sometimes the filer doesn't know about your desktop furniture and puts iconified windows under (for example) the Gnome panel. You can define a top or bottom margin to avoid placing the icons there. The filer already knows about its own panel."
-msgstr "A fájlkezelő néha nem ismeri fel az asztal elrendezését, ezért az ikonizált ablakokat (például) a Gnome panelje alá helyezi. Itt adható meg az a felső és alsó margó, ahová nem kerülnek ikonok. A fájlkezelő a saját paneljeinek helyét már ismeri."
+#: tips:216
+msgid ""
+"Sometimes the filer doesn't know about your desktop furniture and puts "
+"iconified windows under (for example) the Gnome panel. You can define a top "
+"or bottom margin to avoid placing the icons there. The filer already knows "
+"about its own panel."
+msgstr ""
+"A fájlkezelő néha nem ismeri fel az asztal elrendezését, ezért az ikonizált "
+"ablakokat (például) a Gnome panelje alá helyezi. Itt adható meg az a felső "
+"és alsó margó, ahová nem kerülnek ikonok. A fájlkezelő a saját paneljeinek "
+"helyét már ismeri."
 
-#: tips:169
+#: tips:217
 msgid "Top margin"
 msgstr "Felső margó"
 
-#: tips:170
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "A szabadon hagyandó terület a képernyő tetején."
 
-#: tips:171
+#: tips:219
 msgid "Bottom margin"
 msgstr "Alsó margó"
 
-#: tips:172
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "A szabadon hagyandó terület a képernyő alján."
 
-#: tips:173
+#: tips:221
 msgid "Left margin"
 msgstr "Bal margó"
 
-#: tips:174
+#: tips:222
 msgid "Width of no-go area at left of screen."
 msgstr "A szabadon hagyandó terület a képernyő bal oldalán."
 
-#: tips:175
+#: tips:223
 msgid "Right margin"
 msgstr "Jobb margó"
 
-#: tips:176
+#: tips:224
 msgid "Width of no-go area at right of screen."
 msgstr "A szabadon hagyandó terület a képernyő jobb oldalán."
 
-#: tips:177
+#: tips:225
 msgid "Desktop"
 msgstr "Asztal"
 
-#: tips:178
-msgid "When run by a session manager program (such as ROX-Session) the filer can open up a panel and/or the pinboard.  Here you configure which."
-msgstr "Amikor egy munkamenet-kezelő program (például a ROX-Session) indítja el a fájlkezelőt, akkor egy panel és/vagy a pinboard is megjeleníthető. Itt választhatod ki, hogy melyiket mutassa."
+#: tips:226
+msgid ""
+"When run by a session manager program (such as ROX-Session) the filer can "
+"open up a panel and/or the pinboard.  Here you configure which."
+msgstr ""
+"Amikor egy munkamenet-kezelő program (például a ROX-Session) indítja el a "
+"fájlkezelőt, akkor egy panel és/vagy a pinboard is megjeleníthető. Itt "
+"választhatod ki, hogy melyiket mutassa."
 
-#: tips:179
+#: tips:227
 msgid "Panel only"
 msgstr "Csak a panel"
 
-#: tips:180
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Csak a panelt mutatja."
 
-#: tips:181
+#: tips:229
 msgid "Pinboard only"
 msgstr "Csak a pinboard"
 
-#: tips:182
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "Csak a pinboardot mutatja."
 
-#: tips:183
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "Panel és pinboard"
 
-#: tips:184
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "A panelt és a pinboardot is mutatja."
 
-#: tips:185
-msgid "Panel"
-msgstr "Panel"
-
-#: tips:186
-msgid "Enter the name of the panel to show here."
-msgstr "Add meg a megjelenítendő panel nevét."
-
-#: tips:188
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "Add meg a megjelenítendő pinboard nevét."
 
-#: tips:189
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr "Ezek a változtatások a fájlkezelő következő indításakor lépnek életbe."
 
-#: tips:190
-msgid "The session manager activates these options by using the -S or --rox-session argument to rox."
-msgstr "A munkamenet-kezelő az \"-S\" vagy \"--rox-session\" opciókat használva engedélyezi ezeket a beállításokat."
+#: tips:236
+#, fuzzy
+msgid ""
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
+msgstr ""
+"A munkamenet-kezelő az \"-S\" vagy \"--rox-session\" opciókat használva "
+"engedélyezi ezeket a beállításokat."
 
-#: tips:191
+#: tips:237
 msgid "Action windows"
 msgstr "Műveleti ablakok"
 
-#: tips:192
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4089,503 +5012,935 @@ msgstr ""
 "A műveleti ablakok a háttérben futó műveletek indításakor\n"
 "jelennek meg (például fájlok másolásakor vagy törlésekor)."
 
-#: tips:193
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Automatikusan (Csendben) kezdi a következő műveleteket"
 
-#: tips:195
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Megerősítő kérdés nélkül kezdi a fájlok másolását."
 
-#: tips:197
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Megerősítő kérdés nélkül kezdi a fájlok áthelyezését."
 
-#: tips:199
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Megerősítő kérdés nélkül kezdi a linkek készítését."
 
-#: tips:201
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Megerősítő kérdés nélkül kezdi a fájlok törlését."
 
-#: tips:202
+#: tips:248
 msgid "Mount"
 msgstr "Csatolás"
 
-#: tips:203
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Megerősítő kérdés nélkül kezdi a fájlrendszerek (le)csatolását."
 
-#: tips:204
+#: tips:250
 msgid "Default settings"
 msgstr "Alapértelmezett beállítások"
 
-#: tips:206
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Kényszerítés"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "Nem kér megerősítést a nem írható elemek törléséhez."
 
-#: tips:208
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Kevesebb üzenetet ad műveletvégzés közben."
 
-#: tips:210
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Az alkönyvtárak tartalmát is feldolgozza."
 
-#: tips:213
+#: tips:263
 msgid "Mount commands"
 msgstr "Csatolási parancsok"
 
-#: tips:214
+#: tips:264
 msgid "Mount command"
 msgstr "Csatolási parancs"
 
-#: tips:215
+#: tips:265
 msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
-msgstr "A fájlrendszerek csatolását végző parancs. Kétség esetén használd a \"mount\" parancsot."
+msgstr ""
+"A fájlrendszerek csatolását végző parancs. Kétség esetén használd a \"mount"
+"\" parancsot."
 
-#: tips:216
+#: tips:266
 msgid "Unmount command"
 msgstr "Lecsatolási parancs"
 
-#: tips:217
-msgid "The command used to unmount a filesystem. If unsure, use \"umount\" (yes, without the first \"n\")."
-msgstr "A fájlrendszerek lecsatolását végző parancs. Kétség esetén használd az \"umount\" parancsot (igen, hiányzik az első \"n\")."
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+"A fájlrendszerek lecsatolását végző parancs. Kétség esetén használd az "
+"\"umount\" parancsot (igen, hiányzik az első \"n\")."
 
-#: tips:218
+#: tips:268
 msgid "Eject command"
 msgstr "Lemezkiadási parancs"
 
-#: tips:219
+#: tips:269
 msgid "The command used to eject removable media. If unsure, use \"eject\"."
-msgstr "A cserélhető adathordozók kiadását végző parancs. Kétség esetén használd az \"eject\" parancsot."
+msgstr ""
+"A cserélhető adathordozók kiadását végző parancs. Kétség esetén használd az "
+"\"eject\" parancsot."
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
 
 # XXX: "Fogd és vidd", "Húzd és ejtsd", "Húzd és dobd" ... Argh!
-#: tips:220
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Fogd és vidd"
 
-#: tips:221
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Ikonok fölé húzás"
 
-#: tips:222
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Engedélyezi a könyvtárablakok ikonjaira húzást"
 
-#: tips:223
-msgid "When this is on you can drag a file over a sub-directory or program in a filer window. The item will highlight when you do this and dropping the file will put it into that directory, or load it into the program."
-msgstr "Engedélyezésekor a fájlokat rá lehet húzni a könyvtárablakokban az alkönyvtárakra vagy programokra. Ha a fájlt elengeded, akkor az alatta levő könyvtárba kerül. Ha program felett engeded el, akkor betöltődik a programba."
+#: tips:275
+msgid ""
+"When this is on you can drag a file over a sub-directory or program in a "
+"filer window. The item will highlight when you do this and dropping the file "
+"will put it into that directory, or load it into the program."
+msgstr ""
+"Engedélyezésekor a fájlokat rá lehet húzni a könyvtárablakokban az "
+"alkönyvtárakra vagy programokra. Ha a fájlt elengeded, akkor az alatta levő "
+"könyvtárba kerül. Ha program felett engeded el, akkor betöltődik a programba."
 
-#: tips:224
+#: tips:276
 msgid "Directories spring open"
 msgstr "Könyvtárak megnyitása"
 
-#: tips:225
-msgid "This option, which requires the above option to be turned on too, causes the highlighted directory to 'spring open' after the file is held over it for a short while."
-msgstr "Ha a fenti beállítás is engedélyezve van, akkor a könyvtárak bizonyos idő után automatikusan megnyílnak, ha fájlt húzol föléjük."
+#: tips:277
+msgid ""
+"This option, which requires the above option to be turned on too, causes the "
+"highlighted directory to 'spring open' after the file is held over it for a "
+"short while."
+msgstr ""
+"Ha a fenti beállítás is engedélyezve van, akkor a könyvtárak bizonyos idő "
+"után automatikusan megnyílnak, ha fájlt húzol föléjük."
 
-#: tips:226
+#: tips:278
 msgid "Spring delay:"
 msgstr "Megnyitás késleltetése:"
 
-#: tips:227
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:228
-msgid "This option sets how long, in ms, you must hold a file over a directory before it will spring open. The above option must be turned on for this to have any effect."
-msgstr "A könyvtárak megnyitásának késleltetése ezredmásodpercekben. Ennyi ideig kell egy fájlt a könyvtár felett tartani a könyvtár automatikus megnyitásához. A fenti beállítást is engedélyezni kell a használatához."
+#: tips:280
+msgid ""
+"This option sets how long, in ms, you must hold a file over a directory "
+"before it will spring open. The above option must be turned on for this to "
+"have any effect."
+msgstr ""
+"A könyvtárak megnyitásának késleltetése ezredmásodpercekben. Ennyi ideig "
+"kell egy fájlt a könyvtár felett tartani a könyvtár automatikus "
+"megnyitásához. A fenti beállítást is engedélyezni kell a használatához."
 
-#: tips:229
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Fájlok bal egérgombbal húzása"
 
-#: tips:230
-#: tips:234
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Megjeleníti a lehetséges műveletek menüjét"
 
-#: tips:231
+#: tips:283
 msgid "Copy the files"
 msgstr "Másolja a fájlokat"
 
-#: tips:232
-msgid "Note that you can still get the menu to appear, by dragging with Alt held down."
-msgstr "A menüt még így is meg lehet jeleníteni, ha a fájlok húzása közben nyomva tartod az Alt billentyűt."
+#: tips:284
+msgid ""
+"Note that you can still get the menu to appear, by dragging with Alt held "
+"down."
+msgstr ""
+"A menüt még így is meg lehet jeleníteni, ha a fájlok húzása közben nyomva "
+"tartod az Alt billentyűt."
 
-#: tips:233
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Fájlok középső egérgombbal húzása"
 
-#: tips:235
+#: tips:287
 msgid "Move the files"
 msgstr "Áthelyezi a fájlokat"
 
-#: tips:236
-msgid "Note that you can still get the menu to appear, by dragging with the left button and holding down the Alt key."
-msgstr "A menüt még így is meg lehet jeleníteni, ha nyomva tartod az Alt billentyűt miközben a bal gombbal húzod a fájlokat."
+#: tips:288
+msgid ""
+"Note that you can still get the menu to appear, by dragging with the left "
+"button and holding down the Alt key."
+msgstr ""
+"A menüt még így is meg lehet jeleníteni, ha nyomva tartod az Alt billentyűt "
+"miközben a bal gombbal húzod a fájlokat."
 
-#: tips:237
+#: tips:289
 msgid "Download handler"
 msgstr "Letöltéskezelő"
 
-#: tips:238
+#: tips:290
 msgid ""
-"When you drag a file from a web browser or other remote source, this program will be run to download it. $1 is the URI dragged to the filer, and the current directory is the destination. Eg:\n"
+"When you drag a file from a web browser or other remote source, this program "
+"will be run to download it. $1 is the URI dragged to the filer, and the "
+"current directory is the destination. Eg:\n"
 "xterm -e wget $1"
 msgstr ""
-"Amikor egy webböngészőből vagy máshonnan egy másik gépen levő fájlt húzol át egy könyvtárablakba, akkor ez a program fogja azt letölteni. $1 az ablakba húzott URI, a célkönyvtár pedig az aktuális könyvtár. Például:\n"
+"Amikor egy webböngészőből vagy máshonnan egy másik gépen levő fájlt húzol át "
+"egy könyvtárablakba, akkor ez a program fogja azt letölteni. $1 az ablakba "
+"húzott URI, a célkönyvtár pedig az aktuális könyvtár. Például:\n"
 "xterm -e wget $1"
 
-#: tips:239
+#: tips:291
 msgid "Menus"
 msgstr "Menük"
 
-#: tips:241
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Ikonok mérete a menükben:"
 
-#: tips:242
+#: tips:294
 msgid "No Icons"
 msgstr "Nincsenek ikonok"
 
-#: tips:245
+#: tips:297
 msgid "Same as current window"
 msgstr "Mint az aktuális ablakban"
 
-#: tips:246
+#: tips:298
 msgid "Same as default"
 msgstr "Alapértelmezés szerinti"
 
-#: tips:247
+#: tips:299
 msgid "Behaviour"
 msgstr "Viselkedés"
 
-#: tips:248
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Fájl menü a jobb gombbal kattintásra"
 
-#: tips:249
-msgid "Show the File menu instead of the main menu when right-clicking with files selected (the main menu can be accessed by holding down Control)."
-msgstr "Kijelölt fájlok meglétekor a jobb gombbal kattintás a Fájl menüt nyitja meg, és nem a főmenüt (utóbbi ilyenkor a Control nyomva tartásával érhető el)."
+#: tips:301
+msgid ""
+"Show the File menu instead of the main menu when right-clicking with files "
+"selected (the main menu can be accessed by holding down Control)."
+msgstr ""
+"Kijelölt fájlok meglétekor a jobb gombbal kattintás a Fájl menüt nyitja meg, "
+"és nem a főmenüt (utóbbi ilyenkor a Control nyomva tartásával érhető el)."
 
-#: tips:250
+#: tips:302
 msgid "Terminal emulator program"
 msgstr "Terminálemulátor program"
 
-#: tips:251
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr "A menü \"Terminál\" parancsára futtatandó program."
 
-#: tips:252
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Gyorsbillentyűk"
 
-#: tips:254
+#: tips:305
+msgid "Types"
+msgstr "Típusok"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME-típusok"
 
-#: tips:255
-msgid "The filer uses a set of rules to work out the correct MIME type for each regular file, and then chooses a suitable icon for that type."
-msgstr "A fájlkezelő különféle szabályok alapján határozza meg egy fájl MIME-típusát, aztán a típus alapján választja ki a megfelelő ikont."
+#: tips:307
+msgid ""
+"The filer uses a set of rules to work out the correct MIME type for each "
+"regular file, and then chooses a suitable icon for that type."
+msgstr ""
+"A fájlkezelő különféle szabályok alapján határozza meg egy fájl MIME-"
+"típusát, aztán a típus alapján választja ki a megfelelő ikont."
 
-#: tips:256
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "MIME-szabályok szerkesztése"
 
-#: tips:257
+#: tips:309
 msgid "Themes"
 msgstr "Témák"
 
-#: tips:258
+#: tips:310
 msgid "Icon theme"
 msgstr "Ikontéma"
 
-#: tips:259
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "A témákat az ~/.icons könyvtárban kell elhelyezni."
 
-#: tips:260
-msgid "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note that icons set this way override those from the selected theme."
-msgstr "Használd az \"Ikon hozzárendelése...\" párbeszédablakot az egyes MIME-típusokhoz tartozó ikonok beállítására. Az így beállított ikonok fognak megjelenni az ikontéma megfelelő ikonjai helyett."
+#: tips:312
+msgid ""
+"Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
+"that icons set this way override those from the selected theme."
+msgstr ""
+"Használd az \"Ikon hozzárendelése...\" párbeszédablakot az egyes MIME-"
+"típusokhoz tartozó ikonok beállítására. Az így beállított ikonok fognak "
+"megjelenni az ikontéma megfelelő ikonjai helyett."
 
-#: tips:261
+#: tips:313
 msgid "Colours"
 msgstr "Színek"
 
-#: tips:262
+#: tips:314
 msgid "File type colours"
 msgstr "Fájltípusok színei"
 
-#: tips:263
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Fájlok színezése a típusuk alapján"
 
-#: tips:264
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
-msgstr "A fájlnevek (és a részletek) a fájltípusnak megfelelő színnel jelennek meg."
+msgstr ""
+"A fájlnevek (és a részletek) a fájltípusnak megfelelő színnel jelennek meg."
 
-#: tips:265
+#: tips:317
 msgid "Directory:"
 msgstr "Könyvtár:"
 
-#: tips:266
+#: tips:318
 msgid "Regular file:"
 msgstr "Közönséges fájl:"
 
-#: tips:267
+#: tips:319
 msgid "Pipe:"
 msgstr "Pipe:"
 
-#: tips:268
+#: tips:320
 msgid "Socket:"
 msgstr "Socket:"
 
-#: tips:270
-msgid "Error, such as a symlink which points to a non-existant file, or a file which the filer does not have permission to examine."
-msgstr "Hiba: például nem létező fájlra mutató szimlink, vagy olyan fájl, amelynek nem lehet lekérdezni a tulajdonságait elegendő jogosultság hiányában."
+#: tips:322
+msgid ""
+"Error, such as a symlink which points to a non-existant file, or a file "
+"which the filer does not have permission to examine."
+msgstr ""
+"Hiba: például nem létező fájlra mutató szimlink, vagy olyan fájl, amelynek "
+"nem lehet lekérdezni a tulajdonságait elegendő jogosultság hiányában."
 
-#: tips:271
+#: tips:323
 msgid "Character device:"
 msgstr "Karakteres eszköz:"
 
-#: tips:272
+#: tips:324
 msgid "Block device:"
 msgstr "Blokkos eszköz:"
 
-#: tips:273
+#: tips:325
 msgid "Door:"
 msgstr "Door:"
 
-#: tips:274
-msgid "Door files are a bit like sockets or pipes, and have only been seen on Solaris."
-msgstr "A door fájlok hasonlóak a socketekhez vagy pipe-okhoz, és csak Solarison fordulnak elő."
+#: tips:326
+msgid ""
+"Door files are a bit like sockets or pipes, and have only been seen on "
+"Solaris."
+msgstr ""
+"A door fájlok hasonlóak a socketekhez vagy pipe-okhoz, és csak Solarison "
+"fordulnak elő."
 
-#: tips:275
+#: tips:327
 msgid "Executable file:"
 msgstr "Végrehajtható fájl:"
 
-#: tips:276
+#: tips:328
 msgid "Application directory:"
 msgstr "Alkalmazási könyvtár:"
 
-#: tips:277
+#: tips:329
 msgid "Unknown type:"
 msgstr "Ismeretlen típus:"
 
-#: tips:278
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Háttér:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Egyéni betűtípus használata:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Kompatibilitás"
 
-#: tips:279
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Ablakkezelőkkel kapcsolatos problémák"
 
-#: tips:280
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "A pinboardot és a paneleket ne kezelje az ablakkezelő"
 
-#: tips:281
-msgid "Some window managers don't support the new Extended Window Manager Hints system, and so treat the pinboard and panels like normal windows. Turn this on to fix problems such as the pinboard coming to the front when you click on it, titlebars and other decorations appearing around windows, or having them appear in window-select lists."
-msgstr "Egyes ablakkezelők nem támogatják az új \"Extended Window Manager Hints\" rendszert, ezért a pinboardot és a paneleket normál ablakokként kezelik. Ez a beállítás akkor segít, ha a pinboard előtérbe ugrik minden rákattintáskor, ha címsor vagy egyéb dekoráció veszi körül az ablakokat, vagy ha szerepelnek az ablaklistákban."
+#: tips:340
+msgid ""
+"Some window managers don't support the new Extended Window Manager Hints "
+"system, and so treat the pinboard and panels like normal windows. Turn this "
+"on to fix problems such as the pinboard coming to the front when you click "
+"on it, titlebars and other decorations appearing around windows, or having "
+"them appear in window-select lists."
+msgstr ""
+"Egyes ablakkezelők nem támogatják az új \"Extended Window Manager Hints\" "
+"rendszert, ezért a pinboardot és a paneleket normál ablakokként kezelik. Ez "
+"a beállítás akkor segít, ha a pinboard előtérbe ugrik minden rákattintáskor, "
+"ha címsor vagy egyéb dekoráció veszi körül az ablakokat, vagy ha szerepelnek "
+"az ablaklistákban."
 
-#: tips:282
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "Háttérre kattintások átadása az ablakkezelőnek"
 
-#: tips:283
-msgid "Normally, right clicking on the desktop background will open the pinboard menu and left clicking will clear the selection. Turn this on to forward the events to your window manager instead. Clicks on icons will not be forwarded."
-msgstr "Alapesetben az asztalon jobb gombra megnyílik a pinboard menüje, bal gombra pedig törlődik a kijelölés. Ha ez a beállítás engedélyezve van, akkor a kattintásokat az ablakkezelő kapja meg. Az ikonokra kattintás kivétel ez alól."
+#: tips:342
+msgid ""
+"Normally, right clicking on the desktop background will open the pinboard "
+"menu and left clicking will clear the selection. Turn this on to forward the "
+"events to your window manager instead. Clicks on icons will not be forwarded."
+msgstr ""
+"Alapesetben az asztalon jobb gombra megnyílik a pinboard menüje, bal gombra "
+"pedig törlődik a kijelölés. Ha ez a beállítás engedélyezve van, akkor a "
+"kattintásokat az ablakkezelő kapja meg. Az ikonokra kattintás kivétel ez "
+"alól."
 
 # XXX
-#: tips:284
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "A Blackbox menüjének \"javítása\""
 
 # XXX
-#: tips:285
-msgid "Blackbox, Fluxbox and similar window managers do not yet work well with the ROX-Filer pinboard. This option enables some workarounds. These window managers are expected to change their behaviour in new versions so that this isn't necessary."
-msgstr "A Blackbox, Fluxbox és hasonló ablakkezelők még nem működnek jól a ROX-Filer pinboardjával. Ez a beállítás segít ezen. Ezen ablakkezelők újabb változatai várhatóan máshogyan fognak működni, így ez a beállítás szükségtelenné válik."
+#: tips:344
+msgid ""
+"Blackbox, Fluxbox and similar window managers do not yet work well with the "
+"ROX-Filer pinboard. This option enables some workarounds. These window "
+"managers are expected to change their behaviour in new versions so that this "
+"isn't necessary."
+msgstr ""
+"A Blackbox, Fluxbox és hasonló ablakkezelők még nem működnek jól a ROX-Filer "
+"pinboardjával. Ez a beállítás segít ezen. Ezen ablakkezelők újabb változatai "
+"várhatóan máshogyan fognak működni, így ez a beállítás szükségtelenné válik."
 
 # XXX: dock = ???
-#: tips:286
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "A panel egy \"dokk\""
 
-#: tips:287
-msgid "Disable this option if the panel stays above other windows against your wishes. Requires a restart to take effect."
-msgstr "Tiltsd le ezt a beállítást, ha nem akarod, hogy a panel a többi ablak fölött legyen. Újra kell indítani hozzá a programot."
+#: tips:346
+#, fuzzy
+msgid ""
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
+msgstr ""
+"Tiltsd le ezt a beállítást, ha nem akarod, hogy a panel a többi ablak fölött "
+"legyen. Újra kell indítani hozzá a programot."
 
-#: tips:288
+#: tips:347
+msgid "Panel stays on top"
+msgstr ""
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Fogd és vidd"
 
-#: tips:289
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Ne használjon hosztneveket"
 
-#: tips:290
-msgid "Some older applications don't support XDND fully and may need to have this option turned on. Use this if dragging files to an application shows a + sign on the pointer but the drop doesn't work."
-msgstr "Néhány régebbi (az XDND protokollt csak részben támogató) program esetén lehet szükséges ez a beállítás. Kapcsold be, ha egy fájlt egy programra húzva megjelenik a \"+\" jel az egérmutatóban, de a rádobás mégsem működik."
+#: tips:353
+msgid ""
+"Some older applications don't support XDND fully and may need to have this "
+"option turned on. Use this if dragging files to an application shows a + "
+"sign on the pointer but the drop doesn't work."
+msgstr ""
+"Néhány régebbi (az XDND protokollt csak részben támogató) program esetén "
+"lehet szükséges ez a beállítás. Kapcsold be, ha egy fájlt egy programra "
+"húzva megjelenik a \"+\" jel az egérmutatóban, de a rádobás mégsem működik."
 
-#: tips:291
-msgid "Extended attributes"
-msgstr "Kiterjesztett attribútumok"
-
-#: tips:292
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Ne használjon kiterjesztett attribútumokat"
 
-#: tips:293
-msgid "This disables the use of extended attributes available in newer operating systems and file systems.  With this option set the 'Set Type' menu entry is disabled, the MIME type of the file is only derived from the file name and the properties window does not report extended attributes."
-msgstr "Letiltja az újabb operációs rendszerek és fájlrendszerek által támogatott kiterjesztett attribútumok használatát. Engedélyezésekor nem érhető el a \"Típus beállítása\" menüpont, a fájlok MIME-típusát csak a nevük határozza meg, a tulajdonságok ablakban pedig nem láthatók a kiterjesztett attribútumok."
+#: tips:356
+msgid ""
+"This disables the use of extended attributes available in newer operating "
+"systems and file systems.  With this option set the 'Set Type' menu entry is "
+"disabled, the MIME type of the file is only derived from the file name and "
+"the properties window does not report extended attributes."
+msgstr ""
+"Letiltja az újabb operációs rendszerek és fájlrendszerek által támogatott "
+"kiterjesztett attribútumok használatát. Engedélyezésekor nem érhető el a "
+"\"Típus beállítása\" menüpont, a fájlok MIME-típusát csak a nevük határozza "
+"meg, a tulajdonságok ablakban pedig nem láthatók a kiterjesztett "
+"attribútumok."
 
-#: ../Templates.glade:7
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Alul"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "Jobb oldalon"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
 msgid "ROX-Filer log viewer"
 msgstr "ROX-Filer naplónéző"
 
-#: ../Templates.glade:22
+#: ../Templates.ui.h:2
 msgid "Recently performed actions..."
 msgstr "A legutóbb végrehajtott műveletek..."
 
-#: ../Templates.glade:77
+#: ../Templates.ui.h:3
 msgid "Open Directory"
 msgstr "Könyvtár megnyitása"
 
-#: ../Templates.glade:129
+#: ../Templates.ui.h:4
 msgid "Panel Options"
 msgstr "Panel beállításai"
 
-#: ../Templates.glade:169
-msgid "Every icon on this panel is shown with an image and some text."
-msgstr "A panel minden ikonja képpel és szöveggel jelenik meg."
-
-#: ../Templates.glade:170
+#: ../Templates.ui.h:5
 msgid "Image and Text"
 msgstr "Kép és szöveg"
 
-#: ../Templates.glade:186
-msgid "Applications in this panel have just an image, everything else has both an image and text."
-msgstr "Az alkalmazásoknál csak kép jelenik meg, minden másnál kép és szöveg is."
+#: ../Templates.ui.h:6
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "A panel minden ikonja képpel és szöveggel jelenik meg."
 
-#: ../Templates.glade:187
+#: ../Templates.ui.h:7
 msgid "Image only for applications"
 msgstr "Az alkalmazásoknál csak kép"
 
-#: ../Templates.glade:205
-msgid "Only the image is shown for icons in this panel."
-msgstr "Csak az ikonok képe jelenik meg ezen a panelen."
+#: ../Templates.ui.h:8
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"Az alkalmazásoknál csak kép jelenik meg, minden másnál kép és szöveg is."
 
-#: ../Templates.glade:206
+#: ../Templates.ui.h:9
 msgid "Image only"
 msgstr "Csak kép"
 
-#: ../Templates.glade:235
+#: ../Templates.ui.h:10
+msgid "Only the image is shown for icons in this panel."
+msgstr "Csak az ikonok képe jelenik meg ezen a panelen."
+
+#: ../Templates.ui.h:11
 msgid "Panel width"
 msgstr "Panel szélessége"
 
-#: ../Templates.glade:247
+#: ../Templates.ui.h:12
 msgid "The size of this panel."
 msgstr "A panel mérete."
 
-#: ../Templates.glade:259
+#: ../Templates.ui.h:13
 msgid "px"
 msgstr "képpont"
 
-#: ../Templates.glade:278
-msgid "Ask the window manager not to cover this panel when maximising windows, otherwise leave just 2 pixels at the edge of the screen to allow auto-raising. Some window managers may not honour this setting."
-msgstr "Azt kéri az ablakkezelőtől, hogy a maximalizált ablakok ne takarják el ezt a panelt. Ha nincs beállítva, akkor 2 képpontnyi margó marad a képernyő szélén, hogy a panelt az előtérbe lehessen hozni. Néhány ablakkezelő figyelmen kívül hagyhatja ezt a beállítást."
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Fordítás"
 
-#: ../Templates.glade:279
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
 msgid "Do not cover panel"
 msgstr "Ne takarja el a panelt"
 
-#: ../Templates.glade:297
+#: ../Templates.ui.h:19
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Azt kéri az ablakkezelőtől, hogy a maximalizált ablakok ne takarják el ezt a "
+"panelt. Ha nincs beállítva, akkor 2 képpontnyi margó marad a képernyő "
+"szélén, hogy a panelt az előtérbe lehessen hozni. Néhány ablakkezelő "
+"figyelmen kívül hagyhatja ezt a beállítást."
+
+#: ../Templates.ui.h:20
 msgid "<b>Panel style</b>"
 msgstr "<b>Panel stílusa</b>"
 
-#: ../Templates.glade:331
-msgid "If you use multiple montors with Xinerama, use this option to confine the panel to one monitor."
-msgstr "Ha többmonitoros Xineramát használsz, akkor itt egyetlen monitorra korlátozhatod a panel megjelenítését."
-
-#: ../Templates.glade:332
+#: ../Templates.ui.h:21
 msgid "Confine to Xinerama monitor"
 msgstr "Xinerama monitorra korlátozás"
 
-#: ../Templates.glade:347
-msgid "The monitor this panel is confined to when using Xinerama. The numbering starts from zero."
-msgstr "Xinerama használatakor ezen a monitoron legyen a panel. A számozás 0-val indul."
+#: ../Templates.ui.h:22
+#, fuzzy
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Ha többmonitoros Xineramát használsz, akkor itt egyetlen monitorra "
+"korlátozhatod a panel megjelenítését."
 
-#: ../Templates.glade:372
+#: ../Templates.ui.h:23
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+"Xinerama használatakor ezen a monitoron legyen a panel. A számozás 0-val "
+"indul."
+
+#: ../Templates.ui.h:24
 msgid "<b>Xinerama</b>"
 msgstr "<b>Xinerama</b>"
 
-#: ../Templates.glade:407
+#: ../Templates.ui.h:25
 msgid "Right edge"
 msgstr "Jobb oldalon"
 
-#: ../Templates.glade:426
+#: ../Templates.ui.h:26
 msgid "Left edge"
 msgstr "Bal oldalon"
 
-#: ../Templates.glade:443
+#: ../Templates.ui.h:27
 msgid "Bottom edge"
 msgstr "Alul"
 
-#: ../Templates.glade:462
+#: ../Templates.ui.h:28
 msgid "Top edge"
 msgstr "Felül"
 
-#: ../Templates.glade:496
+#: ../Templates.ui.h:29
 msgid "<b>Position</b>"
 msgstr "<b>Elhelyezés</b>"
 
+#~ msgid "<dir>"
+#~ msgstr "<könyvtár>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?\"%s\" már létezik - felülírod?"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Hiba \"%s\" olvasásakor:\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Hiányzó/törölt könyvtár"
+
+#~ msgid "Directory '%s' is not accessible"
+#~ msgstr "Nem érhető el a könyvtár: \"%s\""
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Nem található a könyvtár: \"%s\""
+
+#~ msgid "Cancel"
+#~ msgstr "Mégsem"
+
+#~ msgid "All, "
+#~ msgstr "Mind, "
+
+#~ msgid "Dnotify support"
+#~ msgstr "Dnotify támogatása"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Ha fájlt akarsz küldeni egy alkalmazásnak, akkor tartsd nyomva a Shift "
+#~ "billentyűt a menü megnyitásakor."
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Érvénytelen .gmo nyelvi fájl (túl rövid): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr "Érvénytelen .gmo nyelvi fájl (nincs meg a GNU azonosító): %s"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Ugrás a szülő könyvtárba"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Ugrás a saját könyvtárba"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Könyvjelzők"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Könyvjelzők menü"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Könyvtár tartalmának újraolvasása"
+
+#~ msgid "Change icon size"
+#~ msgstr "Ikonméret megváltoztatása"
+
+#~ msgid "Show extra details"
+#~ msgstr "Részletes nézet"
+
+#~ msgid "Hidden"
+#~ msgstr "Rejtett"
+
+#~ msgid ""
+#~ "Failed to create symlink '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(this may mean that %s already exists as a link to an invalid directory; "
+#~ "try deleting it)"
+#~ msgstr ""
+#~ "Nem sikerült létrehozni a szimlinket (%s):\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(talán egy érvénytelen könyvtárra mutat az esetleg már létező \"%s\" "
+#~ "link; próbáld törölni)"
+
+#~ msgid "Language"
+#~ msgstr "Nyelv"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "A LANG környezeti változó alapján"
+
+#~ msgid "Basque"
+#~ msgstr "Baszk"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Kínai (hagyományos)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Kínai (egyszerűsített)"
+
+#~ msgid "Czech"
+#~ msgstr "Cseh"
+
+#~ msgid "Danish"
+#~ msgstr "Dán"
+
+#~ msgid "Dutch"
+#~ msgstr "Holland"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Angol (nincs fordítás)"
+
+#~ msgid "Estonian"
+#~ msgstr "Észt"
+
+#~ msgid "Finnish"
+#~ msgstr "Finn"
+
+#~ msgid "French"
+#~ msgstr "Francia"
+
+#~ msgid "German"
+#~ msgstr "Német"
+
+#~ msgid "Hungarian"
+#~ msgstr "Magyar"
+
+#~ msgid "Japanese"
+#~ msgstr "Japán"
+
+#~ msgid "Norwegian"
+#~ msgstr "Norvég"
+
+#~ msgid "Italian"
+#~ msgstr "Olasz"
+
+#~ msgid "Polish"
+#~ msgstr "Lengyel"
+
+#~ msgid "Portuguese (Portugal)"
+#~ msgstr "Portugál (Portugália)"
+
+#~ msgid "Portuguese (Brasil)"
+#~ msgstr "Portugál (Brazília)"
+
+#~ msgid "Romanian"
+#~ msgstr "Román"
+
+#~ msgid "Russian"
+#~ msgstr "Orosz"
+
+#~ msgid "Spanish"
+#~ msgstr "Spanyol"
+
+#~ msgid "Swedish"
+#~ msgstr "Svéd"
+
+#~ msgid "Ukrainian"
+#~ msgstr "Ukrán"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnámi"
+
+#~ msgid "Change at:"
+#~ msgstr "Váltás határa:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Max. szélesség (nagy ikonok):"
+
+#~ msgid "Enter the name of the panel to show here."
+#~ msgstr "Add meg a megjelenítendő panel nevét."
+
 #~ msgid "Panel: %s"
 #~ msgstr "Panel: %s"
+
 #~ msgid "Select the panel's position:"
 #~ msgstr "Válaszd ki a panel helyét:"
+
 #~ msgid "Top-edge panel"
 #~ msgstr "Felső panel"
+
 #~ msgid "Bottom edge panel"
 #~ msgstr "Alsó panel"
+
 #~ msgid "Left edge panel"
 #~ msgstr "Bal panel"
+
 #~ msgid "Right-edge panel"
 #~ msgstr "Jobb panel"
+
 #~ msgid ""
 #~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
 #~ "instead."
 #~ msgstr ""
 #~ "Nincsenek MIME-ikonok az ikontémában (%s). A ROX alapértelmezett témáját "
 #~ "használom helyette."
+
 #~ msgid "Panels"
 #~ msgstr "Panelek"
+
 #~ msgid ""
 #~ "Panels are bars of icons that run along the side of the screen. See the "
 #~ "manual for information about using panels."
 #~ msgstr ""
 #~ "A panelek a képernyő oldalai mentén végigfutó, ikonokat tartalmazó sávok. "
 #~ "Használatukkal kapcsolatban lásd a kézikönyvet."
+
 #~ msgid "(thick)"
 #~ msgstr "(vastag)"
+
 #~ msgid "."
 #~ msgstr "."
+
 #~ msgid " (yes, without the first "
 #~ msgstr " (igen, az első nélkül: "
+
 #~ msgid ")."
 #~ msgstr ")."
+
 #~ msgid "Show/hide hidden files"
 #~ msgstr "Engedélyezi/tiltja a rejtett fájlok mutatását"
+
 #~ msgid "Choices migration"
 #~ msgstr "Beállítások átköltöztetése"
+
 #~ msgid ""
 #~ ".\n"
 #~ "Home page (including updated versions): http://rox.sourceforge.net/\n"
 #~ msgstr ""
 #~ ".\n"
 #~ "Honlap (frissített verziókkal): http://rox.sourceforge.net/\n"
+
 #~ msgid "Open AVFS"
 #~ msgstr "AVFS megnyitása"
-

--- a/ROX-Filer/src/po/it.po
+++ b/ROX-Filer/src/po/it.po
@@ -7,39 +7,44 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ROX-Filer 2.10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2010-01-03 12:00+0100\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2010-01-03 12:00+0100\n"
 "Last-Translator: Yuri Bongiorno http://yuri.bongiorno.googlepages.com <>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: abox.c:125
-msgid "<dir>"
-msgstr "<dir>"
+#: abox.c:127
+msgid "<src>"
+msgstr ""
 
-#: abox.c:218
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Tutti"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Quiet"
 msgstr "Tutti"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Non chiede conferma ad ogni operazione"
 
-#: abox.c:454 infobox.c:782 tips:36
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Nome"
 
-#: abox.c:460 menu.c:237
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Directory"
 
-#: abox.c:549
+#: abox.c:546
 msgid "Expression:"
 msgstr "Espressione:"
 
@@ -55,11 +60,11 @@ msgstr "Vedere la pagina di manuale di fsattr(5) per ulteriori dettagli."
 msgid "You do not appear to have OS support."
 msgstr "Non sembra esserci il supporto da parte del sistema operativo."
 
-#: action.c:191
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Guida alle espressioni di ricerca"
 
-#: action.c:202
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -136,11 +141,11 @@ msgstr ""
 "un % in «comando» viene sostituito dal percorso del file corrente)\n"
 "<b>prune</b> (impedisce la ricerca del contenuto di una directory)."
 
-#: action.c:249
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Guida alla modifica dei permessi"
 
-#: action.c:260
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -204,11 +209,11 @@ msgstr ""
 "\n"
 "Vedere la pagina di manuale di chmod(1) per ulteriori dettagli."
 
-#: action.c:301
+#: action.c:308
 msgid "Set type reference"
 msgstr "Guida alle impostazioni del tipo di file"
 
-#: action.c:312
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -236,48 +241,55 @@ msgstr ""
 "le pipe o i socket, e funzionano solo su certi tipi di file system\n"
 "che devono essere implementati nel sistema operativo.\n"
 
-#: action.c:419
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Processo terminato.\n"
 
-#: action.c:435
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "C'è stato un errore.\n"
 
-#: action.c:437
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Ci sono stati %d errori.\n"
 
-#: action.c:461
+#: action.c:516
 msgid "ERROR reading"
 msgstr "ERRORE in lettura"
 
-#: action.c:504
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Fatto\n"
 
-#: action.c:560 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "ERRORE"
 
-#: action.c:714 main.c:698 main.c:705 main.c:712 main.c:726
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Si"
 
-#: action.c:717 main.c:700 main.c:707 main.c:714 main.c:726
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "No"
 
-#: action.c:735
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -285,7 +297,7 @@ msgstr ""
 "\n"
 "Chiedo al processo figlio di terminare...\n"
 
-#: action.c:742
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -293,41 +305,41 @@ msgstr ""
 "\n"
 "Invio il segnale KILL al processo fuori controllo...\n"
 
-#: action.c:895
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Calcolare il contenuto di %s?"
 
-#: action.c:931
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Eliminare %s«%s»?"
 
-#: action.c:932
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "PROTETTO DA SCRITTURA "
 
-#: action.c:939
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'Eliminazione di «%s» in corso.\n"
 
-#: action.c:952
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'Directory «%s» eliminata\n"
 
-#: action.c:985
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?Espellere «%s»?"
 
-#: action.c:992
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Espulsione di «%s» in corso.\n"
 
-#: action.c:1011
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -336,95 +348,95 @@ msgstr ""
 "!%s\n"
 "Espulsione fallita\n"
 
-#: action.c:1030 action.c:1049
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Controllare «%s»?"
 
-#: action.c:1046
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Condizione di ricerca non valida: cambiarla e riprovare\n"
 
-#: action.c:1056
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(durante il controllo di «%s»)\n"
 
-#: action.c:1130 action.c:1155
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Cambiare i permessi di «%s»?"
 
-#: action.c:1136
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Modifica dei permessi di «%s» in corso.\n"
 
-#: action.c:1153
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Comando non valido: cambiarlo e riprovare\n"
 
-#: action.c:1211
+#: action.c:1332
 #, c-format
 msgid "?Change contents of '%s'?"
 msgstr "?Cambiare il contenuto di «%s»?"
 
-#: action.c:1214 action.c:1234
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Cambiare il tipo di file di «%s»?"
 
-#: action.c:1231
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Tipo non valido: cambiarlo e riprovare\n"
 
-#: action.c:1253
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Modifica del tipo di file da «%s» a «%s» in corso.\n"
 
-#: action.c:1276
+#: action.c:1397
 #, c-format
 msgid "'Not changing type of directory '%s'\n"
 msgstr "'Non cambiare il tipo di directory «%s»\n"
 
-#: action.c:1282
+#: action.c:1403
 #, c-format
 msgid "'Non-regular file '%s' not changed\n"
 msgstr "'Il file non regolare·«%s»·non è stato cambiato\n"
 
-#: action.c:1342
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?«%s» esiste già: %s?"
 
-#: action.c:1344
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "unire i contenuti"
 
-#: action.c:1345
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "sovrascrivere"
 
-#: action.c:1361
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Provo comunque a copiare...\n"
 
-#: action.c:1370
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Copiare %s come %s?"
 
-#: action.c:1374
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Copia di %s come %s in corso.\n"
 
-#: action.c:1389
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!ERRORE: la destinazione esiste già, ma non è una directory\n"
 
-#: action.c:1461
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -433,26 +445,7 @@ msgstr ""
 "!%s\n"
 "Copia di «%s» fallita\n"
 
-#: action.c:1505
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?«%s» esiste già: sovrascrivere?"
-
-#: action.c:1520
-msgid "'Trying move anyway...\n"
-msgstr "'Provo comunque a spostare...\n"
-
-#: action.c:1528
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Spostare %s in %s?"
-
-#: action.c:1532
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Spostamento di %s in %s in corso.\n"
-
-#: action.c:1540
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -461,45 +454,59 @@ msgstr ""
 "!%s\n"
 "Spostamento di %s in %s fallito\n"
 
-#: action.c:1561
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Provo comunque a spostare...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Spostare %s in %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Spostamento di %s in %s in corso.\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!ERRORE: impossibile copiare l'oggetto su se stesso\n"
 
-#: action.c:1576
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!ERRORE: impossibile spostare o rinominare l'oggetto su se stesso\n"
 
-#: action.c:1588
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Collegamento di %s in %s in corso.\n"
 
-#: action.c:1593
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Collegare %s come %s?"
 
-#: action.c:1636
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Montaggio di %s in corso.\n"
 
-#: action.c:1637
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Smontaggio di %s in corso.\n"
 
-#: action.c:1640
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?Montare %s?"
 
-#: action.c:1641
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?Smontare %s?"
 
-#: action.c:1662
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -508,7 +515,7 @@ msgstr ""
 "!%s\n"
 "Montaggio fallito\n"
 
-#: action.c:1663
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -517,11 +524,11 @@ msgstr ""
 "!%s\n"
 "Smontaggio fallito\n"
 
-#: action.c:1671
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(ora sembra montato)\n"
 
-#: action.c:1717
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -530,210 +537,234 @@ msgstr ""
 "'\n"
 "Totale: %s ("
 
-#: action.c:1723
+#: action.c:2108
 msgid "file"
 msgstr "file"
 
-#: action.c:1723
+#: action.c:2108
 msgid "files"
 msgstr "file"
 
-#: action.c:1727
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "nessuna directory)\n"
 
-#: action.c:1731
+#: action.c:2116
 msgid "directory"
 msgstr "directory"
 
-#: action.c:1732
+#: action.c:2117
 msgid "directories"
 msgstr "directory"
 
-#: action.c:1773
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Nessun punto di montaggio selezionato!\n"
 
-#: action.c:1858
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Un'altra ricerca?"
 
-#: action.c:1888 action.c:1919
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!«%s» è un collegamento simbolico\n"
 
-#: action.c:1959
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "È necessario selezionare alcuni elementi in cui cercare"
 
-#: action.c:1969 menu.c:228
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Trova"
 
-#: action.c:2002
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "È necessario selezionare alcuni elementi da contare"
 
-#: action.c:2006
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Utilizzo disco"
 
-#: action.c:2042
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Monta / Smonta"
 
-#: action.c:2059
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr "ROX-Filer non supporta ancora i punti di montaggio su questo sistema."
 
-#: action.c:2073 menu.c:216 tips:173
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Elimina"
 
-#: action.c:2085 tips:178
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Forza"
 
-#: action.c:2085
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr ""
 "Non chiede conferma dell'eliminazione degli elementi protetti da scrittura"
 
-#: action.c:2088 action.c:2147 action.c:2210 action.c:2283 action.c:2323
-#: tips:180
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Breve"
 
-#: action.c:2088
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Elenca solo le directory eliminate"
 
-#: action.c:2107
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "È necessario selezionare gli elementi a cui cambiare i permessi"
 
-#: action.c:2115
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Rende eseguibile/ricercabile)"
 
-#: action.c:2117
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (Rende non eseguibile/non ricercabile)"
 
-#: action.c:2119
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Permette al proprietario di leggere e scrivere)"
 
-#: action.c:2121
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Privato - accesso solo al proprietario)"
 
-#: action.c:2123
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Accesso pubblico, ma non in scrittura)"
 
-#: action.c:2134 menu.c:189 menu.c:226 tips:53
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Permessi"
 
-#: action.c:2147 action.c:2210
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Non elenca i file elaborati"
 
-#: action.c:2150 action.c:2213 tips:182
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Ricorsivo"
 
-#: action.c:2150
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Cambia anche il contenuto delle sottodirectory"
 
-#: action.c:2154
+#: action.c:2547
 msgid "Command:"
 msgstr "Comando:"
 
-#: action.c:2184
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "È necessario selezionare gli elementi a cui cambiare il tipo di MIME"
 
-#: action.c:2197
+#: action.c:2590
 msgid "Set type"
 msgstr "Imposta il tipo"
 
-#: action.c:2213
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Cambia anche il contenuto delle sottodirectory"
 
-#: action.c:2220 infobox.c:638
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Tipo:"
 
-#: action.c:2267 dnd.c:122 menu.c:2024 tips:167
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Copia"
 
-#: action.c:2279 action.c:2319 tips:184
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Non chiede conferma ad ogni operazione"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Sovrascrive solo se l'origine è più recente della destinazione."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Più recente"
 
-#: action.c:2280 action.c:2320 tips:185
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Sovrascrive solo se l'origine è più recente della destinazione."
 
-#: action.c:2283
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "directory"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Elenca solo le directory che sono copiate"
 
-#: action.c:2307 dnd.c:123 tips:169
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Sposta"
 
-#: action.c:2323
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Non elencare ogni file che viene spostato"
 
-#: action.c:2346 tips:171
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Collegamento"
 
-#: action.c:2369 appmenu.c:111 filer.c:646 infobox.c:1051
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Espelli"
 
-#: action.c:2437
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Eliminazione degli elementi come "
 
-#: action.c:2441
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Eliminazione di "
 
-#: action.c:2443
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Eliminazione di "
 
-#: action.c:2462
+#: action.c:2900
 msgid " and "
 msgstr " e "
 
-#: action.c:2471
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr ""
 " influenzerà alcuni elementi della bacheca o del pannello. Eliminarlo "
 "veramente?"
 
-#: action.c:2478
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr ""
 " influenzerà alcuni elementi della bacheca o del pannello. Eliminarli "
 "veramente?"
 
-#: appmenu.c:197
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<etichetta mancante>"
 
-#: appmenu.c:319
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
@@ -742,82 +773,82 @@ msgstr ""
 "Mettere in questa directory i collegamenti simbolici ai programmi. "
 "Appariranno nel menù degli elementi di questo tipo (%s/%s)."
 
-#: appmenu.c:363 menu.c:239
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Personalizza il menù..."
 
-#: appmenu.c:420 menu.c:257 toolbar.c:158
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Aiuto"
 
-#: bookmarks.c:148 log.c:160
-msgid "Path"
-msgstr "Percorso"
-
-#: bookmarks.c:156
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Titolo"
 
-#: bookmarks.c:305
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Percorso"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Impossibile aggiungere nei segnalibri la risorsa non locale «%s»\n"
 
-#: bookmarks.c:313 bookmarks.c:631
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "«%s» non è una directory"
 
-#: bookmarks.c:519
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Selezionare prima alcune righe da eliminare"
 
-#: bookmarks.c:543
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Mettere il cursore su una voce della lista per spostarla"
 
-#: bookmarks.c:563
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Questo elemento è l'ultimo"
 
-#: bookmarks.c:637
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Impossibile aggiungere nei segnalibri directory non locali come «%s»"
 
-#: bookmarks.c:779
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Aggiungi un nuovo segnalibro"
 
-#: bookmarks.c:786
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Modifica segnalibri"
 
-#: bookmarks.c:791
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Visitati di recente"
 
-#: bulk_rename.c:66
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Rinominazione multipla dei file"
 
-#: bulk_rename.c:69
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Azzera"
 
-#: bulk_rename.c:74
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "Rende la colonna «Nuovo nome» uguale alla colonna «Vecchio nome»"
 
-#: bulk_rename.c:79
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "_Rinomina"
 
-#: bulk_rename.c:92
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Sostituisci:"
 
-#: bulk_rename.c:99
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -831,11 +862,11 @@ msgstr ""
 "\\. corrisponde a un punto\n"
 "\\.htm$ corrisponde a «.htm» in «index.html», ecc."
 
-#: bulk_rename.c:107
+#: bulk_rename.c:109
 msgid "With:"
 msgstr "con:"
 
-#: bulk_rename.c:114
+#: bulk_rename.c:116
 msgid ""
 "The first match in each filename will be replaced by this string. The only "
 "special characters are back-references from \\0 to \\9. To use them "
@@ -845,11 +876,11 @@ msgstr ""
 "Gli unici caratteri speciali sono i riferimenti da \\0 a \\9. Per usarli, "
 "devono essere preceduti dalla barra inversa \\."
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Applica"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
@@ -857,47 +888,47 @@ msgstr ""
 "Fa un «Cerca e sostituisci» nella colonna «Nuovo nome». I file non vengono "
 "rinominati fino a quando si clicca sul pulsante «Rinomina» che c'è sotto."
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Vecchio nome"
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Nuovo nome"
 
-#: bulk_rename.c:293
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr ""
 "Nessuna corrispondenza (nella colonna «Nuovo nome») per l'espressione data"
 
-#: bulk_rename.c:298
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Una corrispondenza, ma il risultato era lo stesso"
 
-#: bulk_rename.c:301
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d nomi corrispondono, ma i risultati erano gli stessi"
 
-#: bulk_rename.c:327
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr ""
 "Specificare un'espressione regolare da far corrispondere e una stringa con "
 "cui sostituire le corrispondenze."
 
-#: bulk_rename.c:344
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (per «%s»)"
 
-#: bulk_rename.c:377
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr ""
 "Un file di nome «%s» esiste già. La rinominazione multipla viene interrotta."
 
-#: bulk_rename.c:382
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -908,21 +939,21 @@ msgstr ""
 "%s\n"
 "La rinominazione multipla viene interrotta."
 
-#: bulk_rename.c:444
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "Un file di nome «%s» esiste già"
 
-#: bulk_rename.c:455
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
 "files to end up in different directories. Continue?"
 msgstr ""
-"Alcuni nomi in «Nuovo nome» contengono «/» (es. «%s»). Ciò sposterà i file in "
-"altre directory. Continuare?"
+"Alcuni nomi in «Nuovo nome» contengono «/» (es. «%s»). Ciò sposterà i file "
+"in altre directory. Continuare?"
 
-#: bulk_rename.c:470
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Nessun nome viene cambiato."
 
@@ -946,42 +977,62 @@ msgstr ""
 "%s\n"
 "%s"
 
-#: dir.c:1041
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Impossibile effettuare stat sulla directory: %s"
 
-#: dir.c:1050
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Impossibile aprire la directory: %s"
 
-#: display.c:659
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Dimensioni"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) fallito: %s"
 
-#: dnd.c:124
-msgid "Link (relative)"
-msgstr "Collegamento (relativo)"
-
-#: dnd.c:125
-msgid "Link (absolute)"
-msgstr "Collegamento (assoluto)"
-
-#: dnd.c:424
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Errore interno: tipo di informazione errato"
 
-#: dnd.c:563
+#: dnd.c:565
 msgid "Drag a directory here to bookmark it."
 msgstr "Trascinare qui una directory per aggiungerla nei segnalibri."
 
-#: dnd.c:578
+#: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
 msgstr "Errore di protocollo XDS: il nome potrebbe non contenere «/»\n"
 
-#: dnd.c:603
+#: dnd.c:605
 msgid ""
 "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
 "plain) did not contain a leafname\n"
@@ -989,18 +1040,18 @@ msgstr ""
 "Target XdndDirectSave0 fornito, ma l'atom XdndDirectSave0 (tipo text/plain) "
 "non contiene un nome\n"
 
-#: dnd.c:616
+#: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
 msgstr "È necessario una destinazione di tipo text/uri-list o XdndDirectSave0."
 
-#: dnd.c:619
+#: dnd.c:621
 msgid ""
 "Sorry - I require a target type of text/uri-list or application/octet-stream."
 msgstr ""
 "È necessario una destinazione di tipo text/uri-list o application/octet-"
 "stream."
 
-#: dnd.c:689
+#: dnd.c:691
 #, c-format
 msgid ""
 "Failed to add some items to the pinboard, because they are on a remote "
@@ -1013,51 +1064,52 @@ msgstr ""
 "\n"
 "%s"
 
-#: dnd.c:764
+#: dnd.c:766
 msgid "Unknown target"
 msgstr "Destinazione sconosciuta"
 
-#: dnd.c:797
+#: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
 msgstr "L'applicazione remota non può o non vuole inviare i dati"
 
-#: dnd.c:810
+#: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
 msgstr ""
-"Errore di protocollo XDS: il codice restituito dovrebbe essere «S», «F» o «E»\n"
+"Errore di protocollo XDS: il codice restituito dovrebbe essere «S», «F» o "
+"«E»\n"
 
-#: dnd.c:843
+#: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
 msgstr ""
 "Non è possibile visualizzare un menù di azioni per un file remoto o di dati "
 "raw."
 
-#: dnd.c:859
+#: dnd.c:861
 msgid "UntitledData"
 msgstr "DatiSenzaNome"
 
-#: dnd.c:886
+#: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
 msgstr "Errore nel salvare il file: %s"
 
-#: dnd.c:959
+#: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
 msgstr "Nessun URI nel text/uri-list (niente da fare)"
 
-#: dnd.c:991
+#: dnd.c:993
 msgid ""
 "Can't get data from remote machine (application/octet-stream not provided)"
 msgstr ""
 "Impossibile ottenere i dati dalla macchina remota (application/octet-stream "
 "non fornito)"
 
-#: dnd.c:1014
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr "Alcuni di questi file sono su un'altra macchina e vengono ignorati"
 
-#: dnd.c:1021
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
@@ -1065,14 +1117,32 @@ msgstr ""
 "Nessuno di questi file si trova sulla macchina locale. Non è possibile "
 "operare su file remoti multipli."
 
-#: dnd.c:1034
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Azione sconosciuta richiesta"
 
-#: dnd.c:1042
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Errore nell'ottenere la lista dei file: %s"
+
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Collegamento (relativo)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Collegamento (assoluto)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Collegamento (relativo)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Collegamento (assoluto)"
 
 #: dropbox.c:112
 msgid "Show"
@@ -1091,8 +1161,8 @@ msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
 msgstr ""
-"Non è possibile mostrare attualmente l'elemento impostato, perché attualmente "
-"non è impostato nulla. Trascinare qualcosa qui sopra."
+"Non è possibile mostrare attualmente l'elemento impostato, perché "
+"attualmente non è impostato nulla. Trascinare qualcosa qui sopra."
 
 #: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
@@ -1113,7 +1183,7 @@ msgstr ""
 "Impossibile accedere a «%s»:\n"
 "%s"
 
-#: filer.c:461
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1122,16 +1192,7 @@ msgstr ""
 "Errore durante la scansione di «%s»:\n"
 "%s\n"
 
-#: filer.c:465
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Errore durante la scansione di «%s»:\n"
-"%s"
-
-#: filer.c:621
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1141,23 +1202,19 @@ msgstr ""
 "\n"
 "Smontare un device rende sicura la rimozione del disco."
 
-#: filer.c:626
+#: filer.c:889
 msgid "Perform the same action in future for this mount point"
 msgstr "Esegui la stessa azione in futuro per questo punto di mount"
 
-#: filer.c:633
+#: filer.c:896
 msgid "No change"
 msgstr "Nessun cambiamento"
 
-#: filer.c:639 infobox.c:1049 menu.c:872
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Smonta"
 
-#: filer.c:743
-msgid "Directory missing/deleted"
-msgstr "Directory mancante o eliminata"
-
-#: filer.c:1107
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
@@ -1169,108 +1226,146 @@ msgstr ""
 "seguito.\n"
 "Se si usa il tastierino numerico, assucurarsi che NumLock sia acceso."
 
-#: filer.c:1343
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "La directory «%s» non è accessibile"
-
-#: filer.c:1495
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Directory «%s» non trovata."
-
-#: filer.c:1795
-msgid "Cancel"
-msgstr "Annulla"
-
-#: filer.c:2076
+#: filer.c:2655
 msgid "A"
 msgstr "T"
 
-#: filer.c:2078 find.c:923
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr "F"
 
-#: filer.c:2083
+#: filer.c:2664
 msgid "S"
 msgstr "S"
 
-#: filer.c:2085
+#: filer.c:2669
 msgid "T"
 msgstr "M"
 
-#: filer.c:2095
-msgid "All, "
-msgstr "Tutti, "
+#: filer.c:2670
+msgid "D"
+msgstr ""
 
-#: filer.c:2098
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
 msgstr "Filtro (%s), "
 
-#: filer.c:2106
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Scansione, "
 
-#: filer.c:2108
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Miniature, "
 
-#: filer.c:2384
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Miniature, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Collegamento simbolico a "
 
-#: filer.c:2426
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr ""
 "Il nome di questo file non è in formato UTF-8 valido. Bisognerebbe "
 "rinominarlo.\n"
 
-#: filer.c:2743 menu.c:2014
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "L'elemento non esiste più."
 
-#: filer.c:3549
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Selezionare le proprietà di visualizzazione da salvare"
 
-#: filer.c:3553
+#: filer.c:4712
+#, fuzzy
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr "<b>Salva le impostazioni di visualizzazione per la directory</b>"
+
+#: filer.c:4713
 msgid "<b>Save display settings for directory</b>"
 msgstr "<b>Salva le impostazioni di visualizzazione per la directory</b>"
 
-#: filer.c:3560
+#: filer.c:4720
 msgid "Select settings to save"
 msgstr "Seleziona le impostazioni da salvare"
 
-#: filer.c:3567
+#: filer.c:4727
 msgid "Position"
 msgstr "Posizione"
 
-#: filer.c:3572 toolbar.c:133 toolbar.c:137 tips:39
-msgid "Size"
-msgstr "Dimensioni"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Finestra"
 
-#: filer.c:3577
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Mostra nascosti"
 
-#: filer.c:3583
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Stile di visualizzazione"
 
-#: filer.c:3589
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Tipo di ordinamento"
 
-#: filer.c:3594 toolbar.c:141
+#: filer.c:4754
 msgid "Details"
 msgstr "Dettagli"
 
-#: filer.c:3599 tips:92 tips:93
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Miniature"
 
-#: filer.c:3605
+#: filer.c:4765
 msgid "Filter"
 msgstr "Filtro"
 
@@ -1494,11 +1589,11 @@ msgstr "blocks"
 msgid "Save As:"
 msgstr "Salva come:"
 
-#: gtksavebox.c:395
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "SenzaNome"
 
-#: gtksavebox.c:471
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
@@ -1506,7 +1601,7 @@ msgstr ""
 "L'applicazione remota vuole usare Direct Save, ma non è possibile leggere la "
 "proprietà di XdndDirectSave0 (tipo text/plain).\n"
 
-#: gtksavebox.c:596
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1514,7 +1609,7 @@ msgstr ""
 "Trascinare l'icona su un visualizzatore di directory\n"
 "(o inserire il percorso completo)"
 
-#: gui_support.c:330
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1522,14 +1617,14 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:399
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr ""
 "Si prova a leggere un file XML come file di testo. Il file «%s» potrebbe "
 "essere danneggiato."
 
-#: gui_support.c:416
+#: gui_support.c:542
 #, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
@@ -1546,16 +1641,16 @@ msgstr ""
 "tutto come prima (così il file viene risalvato).\n"
 "Ulteriori errori verranno ignorati."
 
-#: gui_support.c:1008
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Non corretto o a capo mancante nei dati di tipo text/uri-list"
 
-#: gui_support.c:1341
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "Apertura del file «%s» fallita: %s"
 
-#: gui_support.c:1385
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
@@ -1563,7 +1658,7 @@ msgstr ""
 "Caricamento dell'immagine «%s» fallito: motivo sconosciuto, probabilmente il "
 "file è corrotto."
 
-#: gui_support.c:1450
+#: gui_support.c:1583
 #, c-format
 msgid ""
 "This program (%s) cannot be run, as the 0launch command is not available. It "
@@ -1584,131 +1679,131 @@ msgstr ""
 "È necessario salvare le preferenze e riavviare il filer affinché le nuove "
 "impostazioni della lingua abbiano effetto."
 
-#: icon.c:76
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(fare clic per impostare)"
 
-#: icon.c:131
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:132 menu.c:258
-msgid "About ROX-Filer..."
-msgstr "Informazioni su ROX-Filer"
-
-#: icon.c:133 menu.c:259
-msgid "Show Help Files"
-msgstr "Mostra i file di aiuto"
-
-#: icon.c:134 menu.c:260
-msgid "Manual"
-msgstr "Manuale"
-
-#: icon.c:136 menu.c:235
-msgid "Options..."
-msgstr "Opzioni"
-
-#: icon.c:137 menu.c:244
-msgid "Home Directory"
-msgstr "Directory home"
-
-#: icon.c:138 icon.c:1410 menu.c:212 type.c:223
-msgid "File"
-msgstr "File"
-
-#: icon.c:139 menu.c:218 menu.c:885
-msgid "Shift Open"
-msgstr "Apri con Shift"
-
-#: icon.c:140 menu.c:223
-msgid "Properties"
-msgstr "Proprietà"
-
-#: icon.c:141 menu.c:221
-msgid "Set Run Action..."
-msgstr "Imposta azione..."
-
-#: icon.c:142 menu.c:222
-msgid "Set Icon..."
-msgstr "Imposta icona..."
-
-#: icon.c:143 icon.c:867
-msgid "Edit Item"
-msgstr "Modifica elemento"
-
-#: icon.c:144
-msgid "Show Location"
-msgstr "Mostra posizione"
-
-#: icon.c:145
-msgid "Remove Item(s)"
-msgstr "Rimuovi elemento"
-
-#: icon.c:318 log.c:110 menu.c:774
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s «%s»"
 
-#: icon.c:331
+#: icon.c:311
 msgid "Nothing"
 msgstr "Nulla"
 
-#: icon.c:592
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "La posizione deve contenere almeno un carattere."
 
-#: icon.c:657
+#: icon.c:641
 #, c-format
 msgid "You must unlock '%s' before removing it"
 msgstr "Sbloccare «%s» prima di rimuoverlo."
 
-#: icon.c:667
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Selezionare prima gli elementi da rimuovere"
 
-#: icon.c:673
+#: icon.c:657
 msgid "An item must be unlocked before it can be removed."
 msgstr "Un elemento deve essere sbloccato prima di essere rimosso."
 
-#: icon.c:687
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Attivare il menù sopra un elemento"
 
-#: icon.c:712 menu.c:1285
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "È possibile impostare l'azione solo per i file regolari"
 
-#: icon.c:798
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Digitare la scorciatoia da tastiera desiderata (es. Control+F1)"
 
-#: icon.c:820
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Fallita la cattura della scorciatoia da tastiera."
 
-#: icon.c:870
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Modifica elemento"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Facendo clic sull'icona viene aperto:"
 
-#: icon.c:880
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Argomenti da passare (per gli eseguibili):"
 
-#: icon.c:894
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "Il testo visualizzato sotto l'icona è:"
 
-#: icon.c:907
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "La scorciatoia da tastiera è:"
 
-#: icon.c:927
+#: icon.c:910
 msgid "Locked"
 msgstr "Bloccato"
 
-#: icon.c:932
+#: icon.c:915
 msgid "Locking an item prevents it from being accidentally removed"
 msgstr "Bloccare un elemento ne previene la rimozione accidentale."
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Informazioni su ROX-Filer"
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Mostra i file di aiuto"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Manuale"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Opzioni"
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Directory home"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "File"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Apri con Shift"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Proprietà"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Imposta azione..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Imposta icona..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Mostra posizione"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Rimuovi elemento"
 
 #: infobox.c:113
 #, c-format
@@ -1719,40 +1814,40 @@ msgstr "Aprire veramente %d finestre?"
 msgid "Show Info"
 msgstr "Mostra le informazioni"
 
-#: infobox.c:136 menu.c:779
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(errato utf-8)"
 
-#: infobox.c:261
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Mostra i file di _aiuto"
 
-#: infobox.c:274
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Permessi</b>"
 
-#: infobox.c:292
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>Il contenuto sembra essere:</b>"
 
-#: infobox.c:302
+#: infobox.c:319
 msgid "<b>When all directories are closed</b>"
 msgstr "<b>Quando tutte le directory sono chiuse</b>"
 
-#: infobox.c:438 infobox.c:579 support.c:349
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "byte"
 
-#: infobox.c:461
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Fallita la lettura della dimensione"
 
-#: infobox.c:522
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "«%s» non è più un collegamento simbolico"
 
-#: infobox.c:529
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1761,7 +1856,7 @@ msgstr ""
 "Scollegamento di «%s» fallito:\n"
 "%s"
 
-#: infobox.c:534
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1772,180 +1867,185 @@ msgstr ""
 "%s\n"
 "(nota: il vecchio collegamento è stato eliminato)"
 
-#: infobox.c:558 tips:242
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Errore:"
 
-#: infobox.c:565
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Directory effettiva:"
 
-#: infobox.c:568
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Proprietario, gruppo:"
 
-#: infobox.c:575 infobox.c:590 infobox.c:599
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Dimensione:"
 
-#: infobox.c:600
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Scansione in corso."
 
-#: infobox.c:625
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Scansione fallita"
 
-#: infobox.c:632
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Ultimo cambiamento:"
 
-#: infobox.c:634
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Ultima modifica:"
 
-#: infobox.c:636
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Ultimo accesso:"
 
-#: infobox.c:644
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Attributi estesi:"
 
-#: infobox.c:646
+#: infobox.c:667
 msgid "Present"
 msgstr "Presente"
 
-#: infobox.c:647
+#: infobox.c:668
 msgid "None"
 msgstr "Nessuno"
 
-#: infobox.c:648
+#: infobox.c:669
 msgid "Not supported"
 msgstr "Non supportato"
 
-#: infobox.c:660
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Il collegamento punta a:"
 
-#: infobox.c:672 infobox.c:675
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Azione:"
 
-#: infobox.c:672
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Esegui file"
 
-#: infobox.c:784
+#: infobox.c:805
 msgid "Comment"
 msgstr "Commento"
 
-#: infobox.c:786
+#: infobox.c:807
 msgid "Execute"
 msgstr "Eseguire"
 
-#: infobox.c:800
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<ancora nulla>"
 
-#: infobox.c:871
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "file(1) dice: %s"
 
-#: infobox.c:928
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Impossibile cambiare i permessi: %s"
 
-#: infobox.c:946
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Proprietario"
 
-#: infobox.c:948
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Gruppo"
 
-#: infobox.c:950
+#: infobox.c:974
 msgid "World"
 msgstr "Altri"
 
-#: infobox.c:953
+#: infobox.c:977
 msgid "Read"
 msgstr "Lettura"
 
-#: infobox.c:956
+#: infobox.c:980
 msgid "Write"
 msgstr "Scrittura"
 
-#: infobox.c:959
+#: infobox.c:983
 msgid "Exec"
 msgstr "Esecuzione"
 
-#: infobox.c:977
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:984
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:991
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky"
 
-#: infobox.c:1047
+#: infobox.c:1071
 msgid "Do nothing"
 msgstr "Non fare nulla"
 
-#: infobox.c:1053
+#: infobox.c:1077
 msgid "Ask"
 msgstr "Chiedi"
 
-#: infobox.c:1065
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Collegamento simbolico"
 
-#: infobox.c:1068
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "Applicazione ROX"
 
-#: infobox.c:1076
+#: infobox.c:1100
 msgid "mounted"
 msgstr "montato"
 
-#: infobox.c:1076
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "smontato"
 
-#: infobox.c:1080
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Punto di montaggio per %s (%s)"
 
-#: infobox.c:1083
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Punto di montaggio (%s)"
 
-#: log.c:55
+#: log.c:54
 msgid "ROX-Filer started"
 msgstr "ROX-Filer avviato"
 
-#: log.c:112
+#: log.c:115
 #, c-format
 msgid "%s on %d items"
 msgstr "%s su %d elementi"
 
-#: log.c:125
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Copia..."
+
+#: log.c:139
 msgid "Item"
 msgstr "Elemento"
 
-#: log.c:149
+#: log.c:165
 msgid "Time"
 msgstr "Tempo"
 
-#: log.c:154
+#: log.c:170
 msgid "Action"
 msgstr "Azione"
 
@@ -2052,67 +2152,59 @@ msgstr ""
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Si sta provando a continuare..."
 
-#: main.c:400
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
 msgstr ""
-"L'argomento -o non è più supportato. Nella finestra «Opzioni» si può decidere "
-"di ignorare la redirezione."
+"L'argomento -o non è più supportato. Nella finestra «Opzioni» si può "
+"decidere di ignorare la redirezione."
 
-#: main.c:529
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "In esecuzione come utente «%s»"
 
-#: main.c:690
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Compilato con GTK versione %s\n"
 
-#: main.c:691
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "In esecuzione con GTK versione %d.%d.%d\n"
 
-#: main.c:695
+#: main.c:693
 msgid "features set at compile time"
 msgstr "caratteristiche impostate in fase di compilazione"
 
-#: main.c:696
+#: main.c:694
 msgid "Large File Support"
 msgstr "Supporto per file grandi"
 
-#: main.c:703
-msgid "Inotify support"
-msgstr "Supporto a Inotify"
-
-#: main.c:710
-msgid "Dnotify support"
-msgstr "Supporto a Dnotify"
-
-#: main.c:717
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Compatibilità binaria"
 
-#: main.c:719
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Si (si può eseguire con le precedenti versioni di glibc)"
 
-#: main.c:721
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "No («apsymbls.h» non trovato)"
 
-#: main.c:725
+#: main.c:709
 msgid "Extended attribute support"
 msgstr "Supporto attributi estesi"
 
-#: main.c:876
+#: main.c:856
 #, c-format
 msgid "Unable to read '%s': %s"
 msgstr "Impossibile leggere «%s»: %s"
 
-#: main.c:918
+#: main.c:895
 #, c-format
 msgid ""
 "Left-click to run %s.\n"
@@ -2121,237 +2213,322 @@ msgstr ""
 "Clic sinistro per eseguire «%s».\n"
 "Clic destro per un elenco delle versioni."
 
-#: menu.c:185 tips:28
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Errore durante la creazione di «%s»: %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Salva come:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Visualizza"
 
-#: menu.c:186 tips:33
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "Vista a icone"
 
-#: menu.c:187
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "Icone, con..."
 
-#: menu.c:188 tips:52
-msgid "Sizes"
-msgstr "Dimensioni"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Tema icone"
 
-#: menu.c:190 tips:226
-msgid "Types"
-msgstr "Tipi"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Permessi"
 
-#: menu.c:191 tips:55
-msgid "Times"
-msgstr "Tempi"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Icone, con..."
 
-#: menu.c:192 tips:34 tips:70
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "Vista a lista"
 
-#: menu.c:194
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "Icone enormi"
 
-#: menu.c:195
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "Icone piccole"
 
-#: menu.c:196 tips:49
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Automatico"
 
-#: menu.c:198
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Ordina per nome"
 
-#: menu.c:199
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Ordina per tipo"
 
-#: menu.c:200
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Ordina per data"
 
-#: menu.c:201
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Ordina per data"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Ordina per data"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Ordina per dimensione"
 
-#: menu.c:202
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Permessi"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "Ordina per proprietario"
 
-#: menu.c:203
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "Ordina per gruppo"
 
-#: menu.c:204
+#: menu.c:671
 msgid "Reversed"
 msgstr "Invertito"
 
-#: menu.c:206
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "Mostra nascosti"
 
-#: menu.c:207
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Mostra i file di aiuto"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "nessuna directory)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "Filtra i file..."
 
-#: menu.c:208
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Filtra i file..."
+
+#: menu.c:681
 msgid "Filter Directories With Files"
 msgstr "Filtra le directory con i file"
 
-#: menu.c:209
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "Mostra miniature"
 
-#: menu.c:210
+#: menu.c:683
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: menu.c:211
-msgid "Save Current Display Settings..."
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Aggiorna"
+
+#: menu.c:686
+#, fuzzy
+msgid "Save Display Settings..."
 msgstr "Salva le attuali impostazioni di visualizzazione..."
 
-#: menu.c:213
-msgid "Copy..."
-msgstr "Copia..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Salva le attuali impostazioni di visualizzazione..."
 
-#: menu.c:214
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Spazio usato"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "Rinomina..."
 
-#: menu.c:215
+#: menu.c:700
 msgid "Link..."
 msgstr "Collegamento..."
 
-#: menu.c:219
+#: menu.c:708
 msgid "Send To..."
 msgstr "Invia a..."
 
-#: menu.c:224
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Attributi estesi"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Spazio usato"
 
-#: menu.c:225
+#: menu.c:723
 msgid "Set Type..."
 msgstr "Tipo di file..."
 
-#: menu.c:229 toolbar.c:154
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Seleziona"
 
-#: menu.c:230
+#: menu.c:733
 msgid "Select All"
 msgstr "Seleziona tutto"
 
-#: menu.c:231
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "Annulla la selezione"
 
-#: menu.c:232
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "Inverti la selezione"
 
-#: menu.c:233
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "Seleziona per nome..."
 
-#: menu.c:234
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Seleziona se..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Seleziona se..."
 
-#: menu.c:236
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Nuovo"
 
-#: menu.c:238
+#: menu.c:752
 msgid "Blank file"
 msgstr "File vuoto"
 
-#: menu.c:240 tasklist.c:309
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Finestra"
 
-#: menu.c:241
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "Directory genitore, nuova finestra"
 
-#: menu.c:242
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "Directory genitore, stessa finestra"
 
-#: menu.c:243
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "Nuova finestra"
 
-#: menu.c:245
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "Mostra i segnalibri"
 
-#: menu.c:246
+#: menu.c:766
 msgid "Show Log"
 msgstr "Mostra i log"
 
-#: menu.c:247
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "Segui i collegamenti simbolici"
 
-#: menu.c:248
+#: menu.c:769
 msgid "Resize Window"
 msgstr "Ridimensiona finestra"
 
-#: menu.c:251
+#: menu.c:771
 msgid "Close Window"
 msgstr "Chiudi finestra"
 
-#: menu.c:253
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Inserisci percorso..."
 
-#: menu.c:254
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Comando shell..."
 
-#: menu.c:255
+#: menu.c:780
 msgid "Terminal Here"
 msgstr "Terminale qui"
 
-#: menu.c:256
+#: menu.c:782
 msgid "Switch to Terminal"
 msgstr "Scambia con il terminale"
 
-#: menu.c:725
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr ""
-"Si deve usare Shift+clic su un file per inviarlo a qualche applicazione"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Personalizza il menù..."
 
-#: menu.c:764
+#: menu.c:976
 msgid "Next Click"
 msgstr "Prossimo clic"
 
-#: menu.c:786
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d elementi"
 
-#: menu.c:874
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "Apri smontato"
 
-#: menu.c:877
+#: menu.c:1097
 msgid "Show Target"
 msgstr "Mostra destinazione"
 
-#: menu.c:879
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "Guarda all'interno"
 
-#: menu.c:881
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "Apri come testo"
 
-#: menu.c:1052
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2365,15 +2542,15 @@ msgstr ""
 "system o della libreria C, oppure potrebbe semplicemente essere che il file "
 "system deve essere montato con la giusta opzione («user_xattr» per Linux)."
 
-#: menu.c:1058
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr "Impostazione del tipo di file non supportata per alcuni di questi file"
 
-#: menu.c:1095
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "Collegamento _relativo"
 
-#: menu.c:1101
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2386,45 +2563,58 @@ msgstr ""
 "Se disattivato, memorizza il percorso assoluto. Da usare se il collegamento "
 "simbolico viene spostato, ma la destinazione no."
 
-#: menu.c:1171
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "Il nuovo percorso non è assoluto"
 
-#: menu.c:1239
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr ""
 "Il collegamento simbolico «%s» esiste già. Sostituirlo con uno verso «%s»?"
 
-#: menu.c:1245
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Sostituisci"
 
-#: menu.c:1365 menu.c:1406 menu.c:1468
-msgid "Create"
-msgstr "Crea"
-
-#: menu.c:1366
+#: menu.c:1704
 msgid "NewDir"
 msgstr "NuovaDir"
 
-#: menu.c:1380 menu.c:1386
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Errore durante la creazione di «%s»: %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Crea"
 
-#: menu.c:1407
+#: menu.c:1755
 msgid "NewFile"
 msgstr "NuovoFile"
 
-#: menu.c:1425
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr ""
 "Errore durante la creazione del file: impossibile trovare il template per %s"
 
-#: menu.c:1498
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Mettere in questa directory i collegamenti simbolici ai programmi. "
+"Appariranno nel menù degli elementi di questo tipo (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2436,8 +2626,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "Il menù «Invia a...» fornisce un modo rapido per inviare i file ad "
 "un'applicazione. Le applicazioni elencate sono quelle nelle seguenti "
@@ -2445,14 +2636,14 @@ msgstr ""
 "\n"
 "%s\n"
 "%s\n"
-"Il menù «Invia a...» può essere aperto tenendo premuto «Shift» e facendo clic "
-"col tasto destro del mouse.\n"
+"Il menù «Invia a...» può essere aperto tenendo premuto «Shift» e facendo "
+"clic col tasto destro del mouse.\n"
 "Uso avanzato:\n"
 "È possibile creare sottodirectory chiamate «.text_html», «.text», che sono "
 "mostrate solo per i file di quel tipo. «.group» è mostrata solo quando sono "
 "selezionati file multipli."
 
-#: menu.c:1509
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
@@ -2460,11 +2651,11 @@ msgstr ""
 "Adesso viene mostrata la directory «SendTo»; è possibile creare un "
 "collegamento simbolico (Ctrl+Shift trascina) a qualsiasi applicazione."
 
-#: menu.c:1512 menu.c:1552
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr "La variabile CHOICESPATH impedisce personalizzazioni."
 
-#: menu.c:1545
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2475,15 +2666,16 @@ msgid ""
 "%s\n"
 "%s\n"
 msgstr ""
-"Ogni file della directory «Templates» appare nel menù «Nuovo». Selezionandone "
-"uno, viene creato un nuovo file copiandolo da quello selezionato.\n"
+"Ogni file della directory «Templates» appare nel menù «Nuovo». "
+"Selezionandone uno, viene creato un nuovo file copiandolo da quello "
+"selezionato.\n"
 "\n"
 "Le seguenti directory contengono i template:\n"
 "\n"
 "%s\n"
 "%s\n"
 
-#: menu.c:1550
+#: menu.c:1936
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
@@ -2491,15 +2683,21 @@ msgstr ""
 "Adesso viene mostrata la directory «Templates»: i file template che si "
 "desiderano devono essere messi qui dentro."
 
-#: menu.c:1667
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Personalizza"
 
-#: menu.c:1740
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Personalizza il menù..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Questo è già il nome canonico di questa directory."
 
-#: menu.c:1771
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2507,71 +2705,103 @@ msgstr ""
 "Impossibile aprire una seconda vista su questa directory perché nella "
 "finestra «Opzioni» è attiva l'opzione «Finestre uniche»."
 
-#: menu.c:1897
-msgid "Copy ... ?"
-msgstr "Copia... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1900
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Copiare %s come %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Copiare %s come %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Rinomina... ?"
 
-#: menu.c:1903
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Collegamento simbolico... ?"
 
-#: menu.c:1906
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Apri con Shift... ?"
 
-#: menu.c:1909
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Proprietà di... ?"
 
-#: menu.c:1912
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Attributi estesi"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Impostare il tipo di... ?"
 
-#: menu.c:1915
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Impostare l'azione per... ?"
 
-#: menu.c:1918
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Impostare l'icona per... ?"
 
-#: menu.c:1921
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Inviare... a... ?"
 
-#: menu.c:1924
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "ELIMINARE... ?"
 
-#: menu.c:1927
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Calcolare la dimensione di... ?"
 
-#: menu.c:1930
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Impostare i permessi per... ?"
 
-#: menu.c:1933
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Cercare all'interno... ?"
 
-#: menu.c:1997
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Copia... ?"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Non è possibile fare questo a più di un elemento alla volta"
 
-#: menu.c:2029
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Rinomina"
 
-#: menu.c:2034
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Collegamento simbolico"
 
-#: menu.c:2063
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2591,7 +2821,7 @@ msgstr ""
 "2) aggiungendo questa riga in «~/.gtkrc-2.0»:\n"
 "\tgtk-can-change-accels = 1\t(funziona solo se NON si usa XSETTINGS)"
 
-#: menu.c:2074
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2611,31 +2841,40 @@ msgstr ""
 "Il tasto appare vicino alla voce di menù e da questo momento è possibile "
 "premere solo quel tasto anziché attivare il menù."
 
-#: menu.c:2089
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Imposta le scorciatoie da tastiera"
 
-#: minibuffer.c:129
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Vai a:"
 
-#: minibuffer.c:130
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Shell:"
 
-#: minibuffer.c:131
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Seleziona se:"
 
-#: minibuffer.c:132
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Seleziona per nome:"
 
-#: minibuffer.c:133
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Seleziona se:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Modello:"
 
-#: minibuffer.c:265
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
@@ -2643,14 +2882,34 @@ msgstr ""
 "Inserire il nome di un file da visualizzare. Premere «Tab» per avere la "
 "migliore corrispondenza, «Esc» per chiudere il minibuffer."
 
-#: minibuffer.c:271
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
 "Inserire un comando di shell da eseguire. Fare clic su un file per "
 "aggiungerlo nel buffer."
 
-#: minibuffer.c:276
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Inserire un modello di nome per selezionare tutti i file che corrispondono:\n"
+"\n"
+"? significa un qualunque carattere\n"
+"* significa zero o più caratteri\n"
+"[aA] significa «a» o «A»\n"
+"[a-z] significa un qualunque carattere dalla «a» alla «z» (in minuscolo)\n"
+"*.png significa un qualunque nome che termina per «.png»"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2668,7 +2927,7 @@ msgstr ""
 "[a-z] significa un qualunque carattere dalla «a» alla «z» (in minuscolo)\n"
 "*.png significa un qualunque nome che termina per «.png»"
 
-#: minibuffer.c:288
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
@@ -2676,7 +2935,16 @@ msgstr ""
 "Inserire un modello per far corrispondere i file da visualizzare. Per "
 "disattivare, lasciare vuoto il filtro."
 
-#: minibuffer.c:908
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Inserire un modello per far corrispondere i file da visualizzare. Per "
+"disattivare, lasciare vuoto il filtro."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Condizione di ricerca non valida"
 
@@ -2692,33 +2960,34 @@ msgstr ""
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s totale, %s usati, %s liberi (%.1f %%)"
 
-#: options.c:275
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "ROX-Filer ha convertito il file delle opzioni nel nuovo formato XML"
 
-#: options.c:535 options.c:1256
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(usa il valore predefinito)"
 
-#: options.c:805
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Errore interno: %s non leggibile"
 
-#: options.c:914
+#: options.c:929
 msgid "Options"
 msgstr "Opzioni"
 
-#: options.c:959
+#: options.c:974
 msgid "_Revert"
 msgstr "_Ripristina"
 
-#: options.c:965
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr ""
-"Rimette le preferenze come erano prima dell'apertura della finestra «Opzioni»."
+"Rimette le preferenze come erano prima dell'apertura della finestra "
+"«Opzioni»."
 
-#: options.c:980
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2727,34 +2996,34 @@ msgstr ""
 "Le preferenze vengono salvate in:\n"
 "%s"
 
-#: options.c:988
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(salvataggio disabilitato da CHOICESPATH)"
 
-#: options.c:1161 usericons.c:452
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Errore nel salvare %s: %s"
 
-#: options.c:1793
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Manca «=»"
 
-#: panel.c:322
+#: panel.c:326
 #, c-format
 msgid "Unable to replace '%s'"
 msgstr "Impossibile sostituire «%s»"
 
-#: panel.c:326
+#: panel.c:330
 #, c-format
 msgid "Unable to save '%s'"
 msgstr "Impossibile salvare «%s»"
 
-#: panel.c:529
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "Il file del vecchio pannello è stato convertito nel nuovo formato XML."
 
-#: panel.c:637
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
@@ -2762,20 +3031,20 @@ msgstr ""
 "Tentativo di chiusura di un pannello attraverso il window manager. "
 "Solitamente questo avviene in maniera accidentale: chiuderlo veramente?"
 
-#: panel.c:738
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Mancano < o > nel file di configurazione del pannello"
 
-#: panel.c:1610
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Errore nel salvare il pannello %s: %s"
 
-#: panel.c:1925
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "L'applet è terminata senza aver mai creato un widget."
 
-#: panel.c:2021
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2784,44 +3053,44 @@ msgstr ""
 "Errore durante l'esecuzione dell'applet:\n"
 "%s"
 
-#: panel.c:2646
+#: panel.c:2751
 msgid "Are you sure you want to remove this panel from the desktop?"
 msgstr "Rimuovere veramente questo pannello dal desktop?"
 
-#: panel.c:2649 panel.c:2676
+#: panel.c:2754 panel.c:2781
 msgid "Remove Panel"
 msgstr "Rimuovi pannello"
 
-#: panel.c:2672
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Opzioni pannello..."
 
-#: panel.c:2757
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Monitor %d di Xinerama non disponibile"
 
-#: panel.c:2787
+#: panel.c:2897
 msgid "Top"
 msgstr "In alto"
 
-#: panel.c:2789
+#: panel.c:2899
 msgid "Bottom"
 msgstr "In basso"
 
-#: panel.c:2791
+#: panel.c:2901
 msgid "Left"
 msgstr "A sinistra"
 
-#: panel.c:2793
+#: panel.c:2903
 msgid "Right"
 msgstr "A destra"
 
-#: panel.c:2795
+#: panel.c:2905
 msgid "Default"
 msgstr "Predefinito"
 
-#: panel.c:2799
+#: panel.c:2909
 msgid "Unknown side"
 msgstr "Dimensione sconosciuta"
 
@@ -2927,28 +3196,28 @@ msgstr ""
 "Solo i file (e alcune applicazioni) possono essere usati per impostare lo "
 "sfondo."
 
-#: pinboard.c:1602
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Manca «>» nell'etichetta dell'icona"
 
-#: pinboard.c:1611
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Manca «,» dopo l'etichetta dell'icona"
 
-#: pinboard.c:1699
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Errore durante il salvataggio della bacheca %s: %s"
 
-#: pinboard.c:2244
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Sfondo..."
 
-#: pinboard.c:2247
+#: pinboard.c:2250
 msgid "Add Panel"
 msgstr "Aggiungi pannello"
 
-#: pinboard.c:2341
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2959,7 +3228,7 @@ msgstr ""
 "%s\n"
 "Sfondo rimosso."
 
-#: pixmaps.c:969
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2968,70 +3237,93 @@ msgstr ""
 "Impossibile eliminare le miniature in %s:\n"
 "%s"
 
-#: pixmaps.c:990
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Non ci sono miniature da eliminare"
 
-#: pixmaps.c:1003
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Elimina la cache delle miniature"
 
-#: remote.c:722
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Stile «%s» sconosciuto"
 
-#: remote.c:744
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Tipo di dettagli «%s» sconosciuto"
 
-#: remote.c:772
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Tipo di ordinamento «%s» sconosciuto"
 
-#: remote.c:1247
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "È stato invocato un metodo SOAP sconosciuto «%s»"
 
-#: run.c:99 run.c:152
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "Programma %s non trovato. È stato eliminato?"
 
-#: run.c:302
+#: run.c:359
+#, c-format
+msgid ""
+"No run action specified for files of this type (%s/%s) - you can set a run "
+"action by choosing `Set Run Action' from the File menu, or you can just drag "
+"the file to an application.%s"
+msgstr ""
+"Non è stata specificata alcuna azione per i file di questo tipo (%s/%s): "
+"impostarne una usando «Imposta azione...» dal menù «File» o trascinare il "
+"file su un'applicazione.%s"
+
+#: run.c:365
+msgid ""
+"\n"
+"\n"
+"Note: If this is a computer program which you want to run, you need to set "
+"the execute bit by choosing Permissions from the File menu."
+msgstr ""
+"\n"
+"\n"
+"Nota: se è un programma che si desidera eseguire, è necessario renderlo "
+"eseguibile selezionando «Permessi» dal menù «File»."
+
+#: run.c:373
 #, c-format
 msgid "File doesn't exist, or I can't access it: %s"
 msgstr "Il file non esiste o non è accessibile: %s"
 
-#: run.c:307
+#: run.c:378
 #, c-format
 msgid "I don't know how to open '%s'"
 msgstr "Non so come aprire «%s»"
 
-#: run.c:338
+#: run.c:409
 #, c-format
 msgid "'%s' is not a valid URI"
 msgstr "«%s» non è un URI valido"
 
-#: run.c:349
+#: run.c:420
 #, c-format
 msgid "%s not accessable"
 msgstr "«%s» non è accessibile"
 
-#: run.c:357
+#: run.c:428
 #, c-format
 msgid "Non-local URL %s"
 msgstr "URL %s non locale"
 
-#: run.c:374
+#: run.c:445
 #, c-format
 msgid "%s: no handler for %s"
 msgstr "%s: nessun handler per %s"
 
-#: run.c:394
+#: run.c:465
 msgid ""
 "Application:\n"
 "This is an application directory - you can run it as a program, or open it "
@@ -3044,46 +3336,23 @@ msgstr ""
 "mentre si tenta di aprirla). Molte applicazioni forniscono qui il loro "
 "aiuto, ma questa no."
 
-#: run.c:478
+#: run.c:549
 #, c-format
 msgid "Could not send data to program: %s"
 msgstr "Impossibile inviare dati al programma: %s"
 
-#: run.c:508
+#: run.c:578
 #, c-format
 msgid "Could not read link: %s"
 msgstr "Impossibile leggere il collegamento: %s"
 
-#: run.c:536
+#: run.c:606
 #, c-format
 msgid "Broken symlink (or you don't have permission to follow it): %s"
 msgstr ""
 "Collegamento simbolico interrotto (o non ci sono i permessi per seguirlo): %s"
 
-#: run.c:573
-#, c-format
-msgid ""
-"No run action specified for files of this type (%s/%s) - you can set a run "
-"action by choosing `Set Run Action' from the File menu, or you can just drag "
-"the file to an application.%s"
-msgstr ""
-"Non è stata specificata alcuna azione per i file di questo tipo (%s/%s): "
-"impostarne una usando «Imposta azione...» dal menù «File» o trascinare il file "
-"su un'applicazione.%s"
-
-#: run.c:579
-msgid ""
-"\n"
-"\n"
-"Note: If this is a computer program which you want to run, you need to set "
-"the execute bit by choosing Permissions from the File menu."
-msgstr ""
-"\n"
-"\n"
-"Nota: se è un programma che si desidera eseguire, è necessario renderlo "
-"eseguibile selezionando «Permessi» dal menù «File»."
-
-#: run.c:753
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3109,93 +3378,131 @@ msgstr ""
 "bisogna preoccuparsi. Altrimenti, si devono controllare o addirittura "
 "eliminare tutti questi eseguibili."
 
-#: run.c:766
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Corregge il problema di sicurezza)"
 
-#: support.c:272
-msgid "B"
-msgstr "B"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:351
+#: support.c:381
 msgid "byte"
 msgstr "byte"
 
-#: support.c:1596 support.c:1650
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
 msgstr "Apertura e stat del file «%s» fallito: %s"
 
-#: support.c:1607 support.c:1661
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
 msgstr "Mmap del file «%s» fallito: %s"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close"
 msgstr "Chiudi"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close filer window"
 msgstr "Chiude la finestra del filer"
 
-#: toolbar.c:117
+#: toolbar.c:120
 msgid "Up"
 msgstr "Su"
 
-#: toolbar.c:117
-msgid "Change to parent directory"
-msgstr "Va nella directory genitore"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:121
+#: toolbar.c:126
 msgid "Home"
 msgstr "Home"
 
-#: toolbar.c:121
-msgid "Change to home directory"
-msgstr "Va nella directory home"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks"
-msgstr "Segnalibri"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks menu"
-msgstr "Menù segnalibri"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:129
+#: toolbar.c:138
 msgid "Scan"
 msgstr "Aggiorna"
 
-#: toolbar.c:129
-msgid "Rescan directory contents"
-msgstr "Aggiorna il contenuto della directory"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:133
-msgid "Change icon size"
-msgstr "Cambia le dimensioni delle icone"
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Dimensioni"
 
-#: toolbar.c:137
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automatico"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
 msgstr "Modalità di ridimensionamento automatico"
 
-#: toolbar.c:141
-msgid "Show extra details"
-msgstr "Mostra dettagli extra"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Vista a lista"
 
-#: toolbar.c:145
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
 msgstr "Ordina"
 
-#: toolbar.c:145
+#: toolbar.c:165
 msgid "Change sort criteria"
 msgstr "Cambia i criteri di ordinamento"
 
-#: toolbar.c:149
-msgid "Hidden"
-msgstr "Nascosti"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:149
+#: toolbar.c:169
 msgid ""
 "Left: Show/hide hidden files\n"
 "Right: Show/hide thumbnails"
@@ -3203,110 +3510,154 @@ msgstr ""
 "Clic sinistro: mostra/nasconde i file nascosti\n"
 "Clic destro: mostra/nasconde le miniature"
 
-#: toolbar.c:154
-msgid "Select all/invert selection"
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+#, fuzzy
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+"Clic sinistro: mostra/nasconde i file nascosti\n"
+"Clic destro: mostra/nasconde le miniature"
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
 msgstr "Seleziona tutto/Inverte la selezione"
 
-#: toolbar.c:158
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
 msgstr "Mostra i file di aiuto di ROX-Filer"
 
-#: toolbar.c:221
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
 msgstr " (%u nascosti)"
 
-#: toolbar.c:229 tips:58
+#: toolbar.c:276 tips:79
 msgid "items"
 msgstr "elementi"
 
-#: toolbar.c:229
+#: toolbar.c:276
 msgid "item"
 msgstr "elemento"
 
-#: toolbar.c:232
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
 msgstr "Nessun elemento%s"
 
-#: toolbar.c:251
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
 msgstr "%u selezionati (%s)"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by name"
 msgstr "Ordina per nome"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by type"
 msgstr "Ordina per tipo"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by date"
 msgstr "Ordina per data"
 
-#: toolbar.c:446
+#: toolbar.c:535
 msgid "Sort by size"
 msgstr "Ordina per dimensione"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by owner"
 msgstr "Ordina per proprietario"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by group"
 msgstr "Ordina per gruppo"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "ascending"
 msgstr "ascendente"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "descending"
 msgstr "discendente"
 
-#: type.c:214
+#: toolbar.c:891
+#, fuzzy
+msgid "_N_Items_"
+msgstr "Elemento"
+
+#: type.c:221
 msgid "Sym link"
 msgstr "Coll. simb."
 
-#: type.c:216
+#: type.c:223
 msgid "Mount point"
 msgstr "Punto di montaggio"
 
-#: type.c:218
+#: type.c:225
 msgid "App dir"
 msgstr "Dir app"
 
-#: type.c:225
+#: type.c:232
 msgid "Dir"
 msgstr "Dir"
 
-#: type.c:227
+#: type.c:234
 msgid "Char dev"
 msgstr "Char dev"
 
-#: type.c:229
+#: type.c:236
 msgid "Block dev"
 msgstr "Block dev"
 
-#: type.c:231
+#: type.c:238
 msgid "Pipe"
 msgstr "Pipe"
 
-#: type.c:233
+#: type.c:240
 msgid "Socket"
 msgstr "Socket"
 
-#: type.c:235
+#: type.c:242
 msgid "Door"
 msgstr "Door"
 
-#: type.c:238
+#: type.c:245
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: type.c:554
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3316,88 +3667,88 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:735
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Questa non è un'applicazione. Specificare un'applicazione."
 
-#: type.c:795
+#: type.c:839
 msgid "No run action defined"
 msgstr "Nessuna azione definita"
 
-#: type.c:799
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Errore nell'handler %s: %s"
 
-#: type.c:814
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Applicazione %s non valida (AppRun errato)"
 
-#: type.c:825
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "%s non eseguibile"
 
-#: type.c:858
+#: type.c:902
 msgid "Set run action"
 msgstr "Imposta azione"
 
-#: type.c:864
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 "Se il gestore di un tipo specifico non è impostato, usa questo come "
 "predefinito."
 
-#: type.c:866
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr ""
 "Impostare come azione predefinita per tutti i file di tipo «%s/<anything>»"
 
-#: type.c:870
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Usa questa applicazione per tutti i file con questo tipo di MIME."
 
-#: type.c:872
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Solo per il tipo «%s» (%s/%s)"
 
-#: type.c:878
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Trascinare qui un'applicazione adatta"
 
-#: type.c:893
+#: type.c:963
 msgid "OR"
 msgstr "O"
 
-#: type.c:900
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Inserire un comando di shell:"
 
-#: type.c:929
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Usa il comando"
 
-#: type.c:959
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
 msgstr "Un'azione esiste già ed è un programma. Eliminarla veramente?"
 
-#: type.c:970
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Impossibile eliminare %s: %s"
 
-#: type.c:1007
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr ""
 "Il salvataggio delle preferenze è disabilitato dalla variabile CHOICESPATH"
 
-#: type.c:1309
+#: type.c:1395
 #, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
@@ -3406,11 +3757,11 @@ msgstr ""
 "Creazione del collegamento simbolico «%s» fallita:\n"
 "%s"
 
-#: usericons.c:179
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "Il percorso specificato non esiste. L'icona non è cambiata."
 
-#: usericons.c:189 usericons.c:618
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3420,12 +3771,12 @@ msgstr ""
 "incomprensibile o che i permessi non siano corretti.\n"
 "L'icona non è cambiata."
 
-#: usericons.c:235
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Eliminare veramente l'icona «%s»?"
 
-#: usericons.c:239
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3434,32 +3785,32 @@ msgstr ""
 "Impossibile eliminare «%s»:\n"
 "%s"
 
-#: usericons.c:272
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Imposta icona"
 
-#: usericons.c:281
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr ""
 "Usa una copia dell'immagine come la predefinita per tutti i file di questo "
 "tipo di MIME."
 
-#: usericons.c:283
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Imposta l'icona per tutti i file di tipo «%s/<anything>»"
 
-#: usericons.c:288
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "Usa una copia dell'immagine per tutti i file di questo tipo di MIME."
 
-#: usericons.c:290
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Per tutti i file di tipo «%s» (%s/%s)"
 
-#: usericons.c:296
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
@@ -3467,35 +3818,35 @@ msgstr ""
 "Aggiunge il file e il nome dell'immagine alla lista personale. "
 "L'impostazione viene persa se il file o l'immagine vengono spostati."
 
-#: usericons.c:299
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Solo per il file «%s»"
 
-#: usericons.c:307
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
 "This is usually the best option if you can write to the directory."
 msgstr ""
-"Copia l'immagine dentro la directory, con un nome di file nascosto chiamato «."
-"DirIcon». Tutti gli utenti vedono l'icona ed è possibile spostare la "
+"Copia l'immagine dentro la directory, con un nome di file nascosto chiamato "
+"«.DirIcon». Tutti gli utenti vedono l'icona ed è possibile spostare la "
 "directory in maniera sicura. Questa è normalmente la migliore opzione se è "
 "possibile scrivere nella directory."
 
-#: usericons.c:313
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Copiare l'immagine nella directory"
 
-#: usericons.c:319
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Trascinare qui un'icona"
 
-#: usericons.c:589
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "Impostazione icona disabilitata dalla variabile CHOICESPATH"
 
-#: usericons.c:633
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3504,42 +3855,58 @@ msgstr ""
 "Errore durante la creazione dell'immagine «%s»:\n"
 "%s"
 
-#: view_details.c:957
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
 msgid "Mono font"
 msgstr "Font mono"
 
-#: view_details.c:958
+#: view_details.c:1019
 msgid "Font for displaying mono-spaced text"
 msgstr ""
 "Tipo di carattere da usare per visualizzare il testo a spaziatura fissa"
 
-#: view_details.c:1059
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Nome"
 
-#: view_details.c:1062
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Tipo"
 
-#: view_details.c:1065
-msgid "_Permissions"
-msgstr "_Permessi"
-
-#: view_details.c:1070
-msgid "_Owner"
-msgstr "Proprietari_o"
-
-#: view_details.c:1072
-msgid "_Group"
-msgstr "_Gruppo"
-
-#: view_details.c:1074
+#: view_details.c:1238
 msgid "_Size"
 msgstr "Dimen_sioni"
 
-#: view_details.c:1080
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Permessi"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "Proprietari_o"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Gruppo"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "Ultima _modifica"
+
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Attributi estesi"
 
 #: tips:1
 msgid "Filer windows"
@@ -3590,7 +3957,8 @@ msgstr ""
 msgid "Largest window size:"
 msgstr "Larghezza massima della finestra:"
 
-#: tips:10
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
@@ -3599,29 +3967,44 @@ msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
 msgstr ""
-"La dimensione massima, come percentuale dello schermo, a cui la finestra sarà ridimensionata."
+"La dimensione massima, come percentuale dello schermo, a cui la finestra "
+"sarà ridimensionata."
 
 #: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Larghezza massima della finestra:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"La dimensione massima, come percentuale dello schermo, a cui la finestra "
+"sarà ridimensionata."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Comportamento delle finestre"
 
-#: tips:13
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Flag corti nella barra del titolo"
 
-#: tips:14
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
 msgstr ""
-"Usa una sola lettera al posto delle parole «Scansione», «Tutti» e «Miniature» "
-"nella barra del titolo."
+"Usa una sola lettera al posto delle parole «Scansione», «Tutti» e "
+"«Miniature» nella barra del titolo."
 
-#: tips:15
+#: tips:18
 msgid "Unique windows"
 msgstr "Finestre uniche"
 
-#: tips:16
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3629,11 +4012,34 @@ msgstr ""
 "Se si apre una directory che è già stata aperta in un'altra finestra, questa "
 "opzione fa chiudere la finestra vecchia."
 
-#: tips:17
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Finestra"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Nuova finestra con il pulsante 1"
 
-#: tips:18
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3643,25 +4049,25 @@ msgstr ""
 "aperta la directory in una nuova finestra. Facendo clic con il pulsante 2 "
 "(quello centrale) viene invece usata la finestra corrente."
 
-#: tips:19
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Navigazione a singolo clic"
 
-#: tips:20 tips:116
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
 "things."
 msgstr ""
-"Se attivata, un singolo clic su un elemento lo apre. Tenere premuto «Ctrl» per "
-"selezionarlo. Se disattivata, un singolo clic seleziona l'elemento, mentre "
-"un doppio clic lo apre."
+"Se attivata, un singolo clic su un elemento lo apre. Tenere premuto «Ctrl» "
+"per selezionarlo. Se disattivata, un singolo clic seleziona l'elemento, "
+"mentre un doppio clic lo apre."
 
-#: tips:21
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Ridimensionare con un doppio clic sullo sfondo"
 
-#: tips:22
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
@@ -3670,15 +4076,15 @@ msgstr ""
 "accade facendo clic sul pulsante «Modalità di ridimensionamento automatico» "
 "della barra degli strumenti."
 
-#: tips:23
+#: tips:30
 msgid "Sorting"
 msgstr "Ordinamento"
 
-#: tips:24
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Le directory vengono sempre prima (ordinate per nome)"
 
-#: tips:25
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
@@ -3686,11 +4092,11 @@ msgstr ""
 "Se attivata, durante l'ordinamento per nome le directory vengono prima di "
 "ogni altra cosa."
 
-#: tips:26
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "I nomi maiuscoli prima (nell'ordinamento per nome)"
 
-#: tips:27
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
@@ -3698,15 +4104,59 @@ msgstr ""
 "Se attivata, tutti i file che iniziano per lettera maiuscola vengono prima "
 "di quelli che iniziano per lettera minuscola."
 
-#: tips:29
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Le directory vengono sempre prima (ordinate per nome)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sec"
+
+#: tips:38
+msgid "Show extended attribute indicator"
+msgstr "Mostra l'indicatore di attributi estesi"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+"Se attivata, i file che hanno uno o più set di attributi estesi avranno un "
+"simbolo aggiunto per indicare questo."
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "Impostazioni predefinite per le nuove finestre"
 
-#: tips:30
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "Ereditare le opzioni dalla finestra d'origine"
 
-#: tips:31
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
@@ -3715,27 +4165,38 @@ msgstr ""
 "ereditate dalla finestra da cui è stata generata, altrimenti vengono usate "
 "le impostazioni predefinite (vedere sotto)."
 
-#: tips:32
+#: tips:48
 msgid "View type:"
 msgstr "Tipo di vista:"
 
-#: tips:35
+#: tips:51
 msgid "Sort by:"
 msgstr "Ordina per:"
 
-#: tips:37 tips:54
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Tipo"
 
-#: tips:38
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Data"
 
-#: tips:40
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Data"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Data"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Mostrare i file nascosti"
 
-#: tips:41
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
@@ -3743,55 +4204,75 @@ msgstr ""
 "Se attivata, anche i file i cui nomi iniziano per punto («.») vengono "
 "mostrati, altrimenti rimangono nascosti."
 
-#: tips:42
-msgid "Show extended attribute indicator"
-msgstr "Mostra l'indicatore di attributi estesi"
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Mostrare i file nascosti"
 
-#: tips:43
+#: tips:61
+#, fuzzy
 msgid ""
-"If this is on then files which have one or more extended attributes set will "
-"have an emblem added to indicate this."
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
 msgstr ""
-"Se attivata, i file che hanno uno o più set di attributi estesi avranno un "
-"simbolo aggiunto per indicare questo."
+"Se attivata, anche i file i cui nomi iniziano per punto («.») vengono "
+"mostrati, altrimenti rimangono nascosti."
 
-#: tips:44
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Icone enormi"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "pixel"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "Vista a icone"
 
-#: tips:45
+#: tips:67
 msgid "Default size:"
 msgstr "Dimensioni predefinite:"
 
-#: tips:46
+#: tips:68
 msgid "Huge Icons"
 msgstr "Icone enormi"
 
-#: tips:47 tips:217
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Icone grandi"
 
-#: tips:48 tips:216
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "Icone piccole"
 
-#: tips:50
+#: tips:72
 msgid "Default details:"
 msgstr "Dettagli predefiniti:"
 
-#: tips:51
+#: tips:73
 msgid "No details"
 msgstr "Nessun dettaglio"
 
-#: tips:56
-msgid "Automatic small icons:"
+#: tips:74
+msgid "Sizes"
+msgstr "Dimensioni"
+
+#: tips:77
+msgid "Times"
+msgstr "Tempi"
+
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "Icone automaticamente piccole:"
 
-#: tips:57
-msgid "Change at:"
-msgstr "Cambiare con:"
-
-#: tips:59
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3801,65 +4282,91 @@ msgstr ""
 "directory contiene molti elementi allora sono usate le icone piccole, "
 "altrimenti quelle grandi."
 
-#: tips:60
-msgid "Max width (Large icons):"
-msgstr "Larghezza massima (icone grandi):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Icone grandi"
 
-#: tips:61 tips:64
-msgid "pixels"
-msgstr "pixel"
-
-#: tips:62
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "Nella visualizzazione con icone grandi, il testo più largo del numero di "
 "pixel specificati viene spezzato su due righe. Con le icone enormi, il testo "
 "viene spezzato se supera del 50% questo limite."
 
-#: tips:63
-msgid "(Small Icons):"
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
+
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
+#: tips:88
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr ""
+"Se attivata, le icone grandi vengono ordinate in colonne, non in righe."
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
 msgstr "(icone piccole):"
 
-#: tips:65
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "Larghezza massima per il testo accanto alle icone piccole."
 
-#: tips:66
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "Ordinare verticalmente le icone piccole"
 
-#: tips:67
+#: tips:93
 msgid ""
 "If this option is on, then small icons are arranged in columns, not rows."
 msgstr ""
 "Se attivata, le icone piccole vengono ordinate in colonne, non in righe."
 
-#: tips:68
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "Ordinare verticalmente le icone grandi"
 
-#: tips:69
+#: tips:95
 msgid ""
 "If this option is on, then large icons are arranged in columns, not rows."
 msgstr ""
 "Se attivata, le icone grandi vengono ordinate in colonne, non in righe."
 
-#: tips:71
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Mostrare le intestazioni delle colonne"
 
-#: tips:72
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr ""
 "Se attivata, le intestazioni delle colonne sono mostrate nella vista a lista."
 
-#: tips:73
+#: tips:102
 msgid "Show full type"
 msgstr "Descrizione completa del tipo"
 
-#: tips:74
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
@@ -3867,39 +4374,142 @@ msgstr ""
 "Se attivata, viene mostrata la descrizione completa del tipo di oggetto "
 "invece di una breve."
 
-#: tips:75
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Larghezza massima per il testo accanto alle icone piccole."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Mostrare le intestazioni delle colonne"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Se attivata, le intestazioni delle colonne sono mostrate nella vista a lista."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Se attivata, le intestazioni delle colonne sono mostrate nella vista a lista."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Se attivata, le intestazioni delle colonne sono mostrate nella vista a lista."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Se attivata, le intestazioni delle colonne sono mostrate nella vista a lista."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Se attivata, le intestazioni delle colonne sono mostrate nella vista a lista."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Se attivata, le intestazioni delle colonne sono mostrate nella vista a lista."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "Ultima _modifica"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Se attivata, le intestazioni delle colonne sono mostrate nella vista a lista."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Se attivata, le intestazioni delle colonne sono mostrate nella vista a lista."
+
+#: tips:128
+#, fuzzy
+msgid "Last Accessed"
+msgstr "«%s» non è accessibile"
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Se attivata, le intestazioni delle colonne sono mostrate nella vista a lista."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Strumenti/Minibuffer"
 
-#: tips:76
+#: tips:131
 msgid "Toolbar"
 msgstr "Barra degli strumenti"
 
-#: tips:77
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Tipo di barra degli strumenti:"
 
-#: tips:78
+#: tips:133
 msgid "No toolbar"
 msgstr "Nessuna"
 
-#: tips:79
+#: tips:134
 msgid "Icons only"
 msgstr "Solo icone"
 
-#: tips:80
+#: tips:135
 msgid "Text under icons"
 msgstr "Testo sotto le icone"
 
-#: tips:81
+#: tips:136
 msgid "Text beside icons"
 msgstr "Testo accanto alle icone"
 
-#: tips:82
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Solo il pannello"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Mostrare il numero di elementi"
 
-#: tips:83
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3909,15 +4519,15 @@ msgstr ""
 "ne sono, il numero di quelli nascosti. Quando c'è una selezione, mostra il "
 "numero di elementi selezionati e la loro dimensione."
 
-#: tips:84
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Selezionare i pulsanti da mettere sulla barra:"
 
-#: tips:85
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "La barra degli strumenti imposta la larghezza minima della finestra"
 
-#: tips:86
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
@@ -3925,15 +4535,15 @@ msgstr ""
 "Ciascuna finestra del filer è obbligata a essere larga abbastanza da "
 "mostrare l'intera barra degli strumenti"
 
-#: tips:87
+#: tips:143
 msgid "Minibuffer"
 msgstr "Minibuffer"
 
-#: tips:88
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Segnale acustico se il completamento con il «Tab» fallisce"
 
-#: tips:89
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
@@ -3943,11 +4553,11 @@ msgstr ""
 "viene emesso un segnale acustico per avvisare che non è accaduto niente (es. "
 "perché ci sono diverse possibilità al variare della lettera successiva)."
 
-#: tips:90
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Segnale acustico se esistono più corrispondenze"
 
-#: tips:91
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
@@ -3956,19 +4566,39 @@ msgstr ""
 "viene emesso un segnale acustico per avvisare che c'è più di una "
 "corrispondenza, perfino se più lettere sono state aggiunte."
 
-#: tips:94
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Gestore degli scaricamenti"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Errore nell'handler %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
 msgstr ""
-"Se le miniature sono state attivate, in una directory ogni immagine viene caricata "
-"e viene mostrata una sua piccola miniatura."
+"Se le miniature sono state attivate, in una directory ogni immagine viene "
+"caricata e viene mostrata una sua piccola miniatura."
 
-#: tips:95
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Mostrare le miniature delle immagini"
 
-#: tips:96
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
@@ -3977,33 +4607,102 @@ msgstr ""
 "«Visualizza» per attivare e disattivare le miniature per le finestre "
 "individuali."
 
-#: tips:97
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Mostrare le miniature delle immagini"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "Miniature dei video"
 
-#: tips:98
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Cache delle miniature"
 
-#: tips:99
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "Per rendere tutto più veloce, le miniature generate sono memorizzate nella "
 "directory nascosta «~/.thumbnails». Fare clic qui per rimuovere tutte le "
 "miniature in cache. Saranno create ancora se ce ne sarà bisogno."
 
-#: tips:100
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
 msgid "Manage thumbnails"
 msgstr "Gestione miniature"
 
-#: tips:101 tips:158
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Miniature dei video"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sec"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Bacheca"
 
-#: tips:102
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
@@ -4011,47 +4710,47 @@ msgstr ""
 "Se si attiva la bacheca, è possibile trascinare file e applicazioni sul "
 "desktop per creare scorciatoie."
 
-#: tips:103 tips:213
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Aspetto"
 
-#: tips:104
+#: tips:179
 msgid "Foreground:"
 msgstr "Primo piano:"
 
-#: tips:105
+#: tips:180
 msgid "Text shadow:"
 msgstr "Ombra del testo:"
 
-#: tips:106
+#: tips:181
 msgid "Background:"
 msgstr "Sfondo:"
 
-#: tips:107
+#: tips:182
 msgid "No shadow"
 msgstr "Nessuna ombra"
 
-#: tips:108
+#: tips:183
 msgid "Thin"
 msgstr "Sottile"
 
-#: tips:109
+#: tips:184
 msgid "Thick"
 msgstr "Spessa"
 
-#: tips:110
+#: tips:185
 msgid "Use custom font:"
 msgstr "Usare il carattere personalizzato:"
 
-#: tips:111
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Il carattere usato per visualizzare il testo sotto le icone"
 
-#: tips:112
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Scalare velocemente le immagini"
 
-#: tips:113
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
@@ -4059,19 +4758,19 @@ msgstr ""
 "Sceglie tra il metodo veloce e lento per scalare le immagini. Quello lento "
 "dà risultati migliori."
 
-#: tips:114
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Comportamento bacheca"
 
-#: tips:115
+#: tips:190
 msgid "Single-click to open"
 msgstr "Singolo clic per aprire"
 
-#: tips:117
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Mantenere le icone dentro i limiti dello schermo"
 
-#: tips:118
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
@@ -4079,53 +4778,53 @@ msgstr ""
 "Se attivata, le icone della bacheca e le loro etichette sono sempre tenute "
 "completamente all'interno dello schermo."
 
-#: tips:119
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Passo griglia:"
 
-#: tips:120
+#: tips:195
 msgid "Fine"
 msgstr "Sottile"
 
-#: tips:121
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "Usa una griglia di 2 pixel per posizionare le icone sul desktop."
 
-#: tips:122
+#: tips:197
 msgid "Medium"
 msgstr "Medio"
 
-#: tips:123
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "Usa una griglia di 16 pixel per posizionare le icone sul desktop."
 
-#: tips:124
+#: tips:199
 msgid "Coarse"
 msgstr "Grosso"
 
-#: tips:125
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "Usa una griglia di 32 pixel per posizionare le icone sul desktop."
 
-#: tips:126 tips:128
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Finestre ridotte ad icona"
 
-#: tips:127
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
 "windows."
 msgstr ""
 "La maggior parte dei window manager permette di ridurre a icona (o "
-"«minimizzare») le finestre. Vari programmi, incluso ROX-Filer, possono essere "
-"usati per visualizzare le finestre ridotte a icona."
+"«minimizzare») le finestre. Vari programmi, incluso ROX-Filer, possono "
+"essere usati per visualizzare le finestre ridotte a icona."
 
-#: tips:129
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Mostrare le finestre ridotte ad icona"
 
-#: tips:130
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
@@ -4135,11 +4834,11 @@ msgstr ""
 "come un pulsante. Richiede un window manager compatibile e la bacheca deve "
 "essere attiva."
 
-#: tips:131
+#: tips:206
 msgid "Show per workspace"
 msgstr "Area di lavoro attuale"
 
-#: tips:132
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
@@ -4147,39 +4846,39 @@ msgstr ""
 "Se attivata, il filer mostra sulla bacheca solo le finestre ridotte a icona "
 "dell'attuale area di lavoro."
 
-#: tips:133
+#: tips:208
 msgid "Iconify to the"
 msgstr "Ridurre ad icona in"
 
-#: tips:134
+#: tips:209
 msgid "top-left"
 msgstr "alto a sinistra"
 
-#: tips:135
+#: tips:210
 msgid "top-right"
 msgstr "alto a destra"
 
-#: tips:136
+#: tips:211
 msgid "bottom-left"
 msgstr "basso a sinistra"
 
-#: tips:137
+#: tips:212
 msgid "bottom-right"
 msgstr "basso a destra"
 
-#: tips:138
+#: tips:213
 msgid ", going"
 msgstr ", con andamento"
 
-#: tips:139
+#: tips:214
 msgid "horizontally"
 msgstr "orizzontale"
 
-#: tips:140
+#: tips:215
 msgid "vertically"
 msgstr "verticale"
 
-#: tips:141
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4191,43 +4890,43 @@ msgstr ""
 "margine in alto e uno in basso in modo da evitare di mettere lì le icone. Il "
 "filer conosce già le dimensioni dei suoi pannelli."
 
-#: tips:142
+#: tips:217
 msgid "Top margin"
 msgstr "Margine in alto"
 
-#: tips:143
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Altezza dell'area vietata dall'alto dello schermo."
 
-#: tips:144
+#: tips:219
 msgid "Bottom margin"
 msgstr "Margine in basso"
 
-#: tips:145
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "Altezza dell'area vietata dal basso dello schermo."
 
-#: tips:146
+#: tips:221
 msgid "Left margin"
 msgstr "Margine a sinistra"
 
-#: tips:147
+#: tips:222
 msgid "Width of no-go area at left of screen."
 msgstr "Larghezza dell'area vietata dalla sinistra dello schermo."
 
-#: tips:148
+#: tips:223
 msgid "Right margin"
 msgstr "Margine a destra"
 
-#: tips:149
+#: tips:224
 msgid "Width of no-go area at right of screen."
 msgstr "Larghezza·dell'area·vietata·dalla·destra·dello·schermo."
 
-#: tips:150
+#: tips:225
 msgid "Desktop"
 msgstr "Desktop"
 
-#: tips:151
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
@@ -4235,63 +4934,52 @@ msgstr ""
 "Quando viene eseguito da un manager di sessione (come ROX-Session), il filer "
 "può aprire un pannello e/o una bacheca. Qui si configura questo."
 
-#: tips:152
+#: tips:227
 msgid "Panel only"
 msgstr "Solo il pannello"
 
-#: tips:153
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Viene mostrato solo un pannello"
 
-#: tips:154
+#: tips:229
 msgid "Pinboard only"
 msgstr "Solo la bacheca"
 
-#: tips:155
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "Viene mostrata solo la bacheca."
 
-#: tips:156
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "Pannello e bacheca"
 
-#: tips:157
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "Viene mostrato sia il pannello che la bacheca."
 
-#: tips:159
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "Inserire qui il nome della bacheca da usare."
 
-#: tips:160
-msgid "Panel (obsolete)"
-msgstr "Pannello (obsoleto)"
-
-#: tips:161
-msgid ""
-"Enter the name of the panel to show here. This option is now only used when "
-"upgrading from an old version."
-msgstr ""
-"Inserire il nome del pannello da mostrare. Questa opzione è ora usata solo "
-"durante l'aggiornamento da una versione precendente."
-
-#: tips:162
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr "Le modifiche avranno effetto al prossimo riavvio del filer."
 
-#: tips:163
+#: tips:236
+#, fuzzy
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 "Il manager di sessione attiva queste opzioni passando a rox l'argomento «-S» "
 "o «--rox-session»."
 
-#: tips:164
+#: tips:237
 msgid "Action windows"
 msgstr "Finestre d'azione"
 
-#: tips:165
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4299,98 +4987,111 @@ msgstr ""
 "Le finestre d'azione appaiono quando inizia un'operazione in background,\n"
 "come la copia o l'eliminazione dei file."
 
-#: tips:166
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Eseguire automaticamente queste azioni"
 
-#: tips:168
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Copia i file senza chiedere conferma."
 
-#: tips:170
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Sposta i file senza chiedere conferma."
 
-#: tips:172
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Crea i collegamenti senza chiedere conferma."
 
-#: tips:174
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Elimina i file senza chiedere conferma."
 
-#: tips:175
+#: tips:248
 msgid "Mount"
 msgstr "Monta"
 
-#: tips:176
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Monta e smonta i file system senza chiedere conferma."
 
-#: tips:177
+#: tips:250
 msgid "Default settings"
 msgstr "Impostazioni predefinite"
 
-#: tips:179
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Forza"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr ""
 "Non chiede conferma dell'eliminazione di elementi protetti da scrittura."
 
-#: tips:181
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Non visualizza troppe informazioni nell'area messaggi."
 
-#: tips:183
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Cambia anche il contenuto delle sottodirectory."
 
-#: tips:186
+#: tips:263
 msgid "Mount commands"
 msgstr "Comandi per montare e smontare"
 
-#: tips:187
+#: tips:264
 msgid "Mount command"
 msgstr "Comando di mount"
 
-#: tips:188
+#: tips:265
 msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
 msgstr ""
 "Il comando usato per montare un file system. Gli insicuri usino «mount»."
 
-#: tips:189
+#: tips:266
 msgid "Unmount command"
 msgstr "Comando di umount"
 
-#: tips:190
+#: tips:267
 msgid ""
 "The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
 "without the first \"n\")."
 msgstr ""
 "Il comando usato per smontare un file system. Gli insicuri usino «umount»."
 
-#: tips:191
+#: tips:268
 msgid "Eject command"
 msgstr "Comando di espulsione"
 
-#: tips:192
+#: tips:269
 msgid "The command used to eject removable media. If unsure, use \"eject\"."
 msgstr ""
 "Il comando usato per espellere un media removibile. Gli insicuri usino "
 "«eject»."
 
-#: tips:193
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Trascinamento"
 
-#: tips:194
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Trascinamento icone"
 
-#: tips:195
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Permettere il trascinamento delle icone del filer"
 
-#: tips:196
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
@@ -4401,11 +5102,11 @@ msgstr ""
 "rilasciandolo viene messo in quella directory, oppure viene caricato dal "
 "programma scelto."
 
-#: tips:197
+#: tips:276
 msgid "Directories spring open"
 msgstr "Apertura automatica directory"
 
-#: tips:198
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
@@ -4415,15 +5116,15 @@ msgstr ""
 "attiva l'apertura automatica della directory dopo che il file viene "
 "mantenuto sopra l'icona per un breve periodo di tempo."
 
-#: tips:199
+#: tips:278
 msgid "Spring delay:"
 msgstr "Ritardo apertura automatica:"
 
-#: tips:200
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:201
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
@@ -4433,19 +5134,19 @@ msgstr ""
 "una directory prima che questa venga aperta automaticamente. Per avere "
 "effetto, deve essere stata attivata anche l'opzione sopra."
 
-#: tips:202
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Quando si trascinano i file con il pulsante sinistro del mouse"
 
-#: tips:203 tips:207
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Mostrare un menù di azioni possibili"
 
-#: tips:204
+#: tips:283
 msgid "Copy the files"
 msgstr "Copiare i file"
 
-#: tips:205
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
@@ -4453,15 +5154,15 @@ msgstr ""
 "Notare che è ancora possibile far apparire il menù, trascinando e tenendo "
 "premuto il tasto «Alt»."
 
-#: tips:206
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Quando si trascinano i file con il pulsante centrale del mouse"
 
-#: tips:208
+#: tips:287
 msgid "Move the files"
 msgstr "Spostare i file"
 
-#: tips:209
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
@@ -4469,11 +5170,11 @@ msgstr ""
 "Notare che è ancora possibile far apparire il menù, trascinando i file con "
 "il pulsante sinistro e tenendo premuto il tasto «Alt»."
 
-#: tips:210
+#: tips:289
 msgid "Download handler"
 msgstr "Gestore degli scaricamenti"
 
-#: tips:211
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4485,35 +5186,35 @@ msgstr ""
 "filer e la directory attuale è la destinazione. Es:\n"
 "xterm -e wget $1"
 
-#: tips:212
+#: tips:291
 msgid "Menus"
 msgstr "Menù"
 
-#: tips:214
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Dimensione delle icone nei menù:"
 
-#: tips:215
+#: tips:294
 msgid "No Icons"
 msgstr "Nessuna icona"
 
-#: tips:218
+#: tips:297
 msgid "Same as current window"
 msgstr "Le stesse della finestra attuale"
 
-#: tips:219
+#: tips:298
 msgid "Same as default"
 msgstr "Quelle predefinite"
 
-#: tips:220
+#: tips:299
 msgid "Behaviour"
 msgstr "Comportamento"
 
-#: tips:221
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Menù file col clic destro"
 
-#: tips:222
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
@@ -4521,24 +5222,28 @@ msgstr ""
 "Mostra il menù «File» invece del menù principale col clic destro dei file "
 "selezionati (per avere il menù principale tenere premuto il tasto «Ctrl»)."
 
-#: tips:223
+#: tips:302
 msgid "Terminal emulator program"
 msgstr "Programma di emulatore terminale"
 
-#: tips:224
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr ""
 "Il programma da lanciare quando si sceglie dal menù la voce «Terminale qui»."
 
-#: tips:225
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Scorciatoie da tastiera"
 
-#: tips:227
+#: tips:305
+msgid "Types"
+msgstr "Tipi"
+
+#: tips:306
 msgid "MIME types"
 msgstr "Tipi di MIME"
 
-#: tips:228
+#: tips:307
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
@@ -4546,65 +5251,65 @@ msgstr ""
 "Il filer usa una serie di regole per stabilire il corretto tipo di MIME per "
 "ogni file regolare e poi sceglie un'icona adatta per quel tipo."
 
-#: tips:229
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "Modifica regole MIME"
 
-#: tips:230
+#: tips:309
 msgid "Themes"
 msgstr "Temi"
 
-#: tips:231
+#: tips:310
 msgid "Icon theme"
 msgstr "Tema icone"
 
-#: tips:232
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "I temi vanno messi nella directory «~/.icons»."
 
-#: tips:233
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
 msgstr ""
-"Usare la finestra di dialogo «Imposta icona...» per impostare l'icona di ogni "
-"tipo di MIME. Notare che le icone definite in questo modo prevalgono su "
+"Usare la finestra di dialogo «Imposta icona...» per impostare l'icona di "
+"ogni tipo di MIME. Notare che le icone definite in questo modo prevalgono su "
 "quelle del tema selezionato."
 
-#: tips:234
+#: tips:313
 msgid "Colours"
 msgstr "Colori"
 
-#: tips:235
+#: tips:314
 msgid "File type colours"
 msgstr "Colori per i tipi di file"
 
-#: tips:236
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Colorare i file in base al tipo"
 
-#: tips:237
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr ""
 "I nomi dei file (e i dettagli) vengono colorati in base al tipo di file."
 
-#: tips:238
+#: tips:317
 msgid "Directory:"
 msgstr "Directory:"
 
-#: tips:239
+#: tips:318
 msgid "Regular file:"
 msgstr "File regolare:"
 
-#: tips:240
+#: tips:319
 msgid "Pipe:"
 msgstr "Pipe:"
 
-#: tips:241
+#: tips:320
 msgid "Socket:"
 msgstr "Socket:"
 
-#: tips:243
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
@@ -4612,50 +5317,78 @@ msgstr ""
 "Errore, come un collegamento simbolico che punta ad un file inesistente, o "
 "ad un file per il quale non si hanno i permessi."
 
-#: tips:244
+#: tips:323
 msgid "Character device:"
 msgstr "Device a caratteri:"
 
-#: tips:245
+#: tips:324
 msgid "Block device:"
 msgstr "Device a blocchi:"
 
-#: tips:246
+#: tips:325
 msgid "Door:"
 msgstr "Door:"
 
-#: tips:247
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
 msgstr ""
 "I file door sono simili a socket o pipe e sono utilizzati solo in Solaris."
 
-#: tips:248
+#: tips:327
 msgid "Executable file:"
 msgstr "File eseguibile:"
 
-#: tips:249
+#: tips:328
 msgid "Application directory:"
 msgstr "Directory applicativa:"
 
-#: tips:250
+#: tips:329
 msgid "Unknown type:"
 msgstr "Tipo sconosciuto:"
 
-#: tips:251
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Sfondo:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Usare il carattere personalizzato:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Compatibilità"
 
-#: tips:252
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Problemi del window manager"
 
-#: tips:253
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "Ignorare il controllo del window manager sulla bacheca e sui pannelli"
 
-#: tips:254
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4669,11 +5402,11 @@ msgstr ""
 "quando ci si fa clic sopra, le barre dei titoli e le altre decorazioni "
 "attorno alle finestre, o se queste appaiono nell'elenco delle finestre."
 
-#: tips:255
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "Inviare al window manager tutti i clic del mouse fatti sullo sfondo"
 
-#: tips:256
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
@@ -4684,11 +5417,11 @@ msgstr ""
 "selezione. Attivare questa opzione per inviare gli eventi al window manager. "
 "I clic sulle icone non vengono inviati."
 
-#: tips:257
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Compatibilità con Blackbox"
 
-#: tips:258
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4701,11 +5434,11 @@ msgstr ""
 "comportamento nella prossima versione e così questa opzione non sarà più "
 "necessaria."
 
-#: tips:259
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "Il pannello è un \"dock\""
 
-#: tips:260
+#: tips:346
 msgid ""
 "Makes sure panels stay against screen edges. Disable this option if the "
 "panel stays above other windows against your wishes. Requires a restart to "
@@ -4715,11 +5448,11 @@ msgstr ""
 "questa opzione se non si desidera che il pannello stìa sopra le altre "
 "finestre. Per avere effetto, richiede un riavvio."
 
-#: tips:261
+#: tips:347
 msgid "Panel stays on top"
 msgstr "Il pannello sta in alto"
 
-#: tips:262
+#: tips:348
 msgid ""
 "Keeps the panel above other windows. Enable this option to make sure the "
 "dock option works correctly in some versions of compiz. May require a "
@@ -4729,15 +5462,25 @@ msgstr ""
 "assicurarsi che l'opzione \"dock\" funzioni correttamente con alcune "
 "versioni di compiz. Per avere effetto, potrebbe richiedere un riavvio."
 
-#: tips:263
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Trascinamento"
 
-#: tips:264
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Non usare i nomi di rete"
 
-#: tips:265
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4747,15 +5490,11 @@ msgstr ""
 "bisogno di questa opzione. Usarla se il trascinamento dei file su "
 "un'applicazione mostra il segno + sul puntatore, ma non funziona."
 
-#: tips:266
-msgid "Extended attributes"
-msgstr "Attributi estesi"
-
-#: tips:267
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Non usare gli attributi estesi"
 
-#: tips:268
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4768,32 +5507,89 @@ msgstr ""
 "dedotto solo dal nome del file e la finestra «Proprietà» non riporta gli "
 "attributi estesi."
 
-#: ../Templates.glade:7
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "In basso"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "A destra"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
 msgid "ROX-Filer log viewer"
 msgstr "Visualizzatore dei log di ROX-Filer"
 
-#: ../Templates.glade:22
+#: ../Templates.ui.h:2
 msgid "Recently performed actions..."
 msgstr "Azioni eseguite recentemente..."
 
-#: ../Templates.glade:77
+#: ../Templates.ui.h:3
 msgid "Open Directory"
 msgstr "Apri directory"
 
-#: ../Templates.glade:129
+#: ../Templates.ui.h:4
 msgid "Panel Options"
 msgstr "Opzioni pannello"
 
-#: ../Templates.glade:169
+#: ../Templates.ui.h:5
+msgid "Image and Text"
+msgstr "Immagine e testo"
+
+#: ../Templates.ui.h:6
 msgid "Every icon on this panel is shown with an image and some text."
 msgstr ""
 "Ogni icona di questo pannello è visualizzata con un'immagine e del testo."
 
-#: ../Templates.glade:170
-msgid "Image and Text"
-msgstr "Immagine e testo"
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Solo icone per le applicazioni"
 
-#: ../Templates.glade:186
+#: ../Templates.ui.h:8
 msgid ""
 "Applications in this panel have just an image, everything else has both an "
 "image and text."
@@ -4801,31 +5597,41 @@ msgstr ""
 "Le applicazioni in questo pannello hanno solo un'immagine, tutto il resto ha "
 "sia l'immagine che il testo."
 
-#: ../Templates.glade:187
-msgid "Image only for applications"
-msgstr "Solo icone per le applicazioni"
-
-#: ../Templates.glade:205
-msgid "Only the image is shown for icons in this panel."
-msgstr "Per le icone di questo pannello viene mostrata solo l'immagine."
-
-#: ../Templates.glade:206
+#: ../Templates.ui.h:9
 msgid "Image only"
 msgstr "Solo immagine"
 
-#: ../Templates.glade:235
+#: ../Templates.ui.h:10
+msgid "Only the image is shown for icons in this panel."
+msgstr "Per le icone di questo pannello viene mostrata solo l'immagine."
+
+#: ../Templates.ui.h:11
 msgid "Panel width"
 msgstr "Larghezza del pannello"
 
-#: ../Templates.glade:247
+#: ../Templates.ui.h:12
 msgid "The size of this panel."
 msgstr "La dimensione di questo pannello."
 
-#: ../Templates.glade:259
+#: ../Templates.ui.h:13
 msgid "px"
 msgstr "px"
 
-#: ../Templates.glade:278
+#: ../Templates.ui.h:14
+msgid "Transparency"
+msgstr ""
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "Non coprire il pannello"
+
+#: ../Templates.ui.h:19
 msgid ""
 "Ask the window manager not to cover this panel when maximising windows, "
 "otherwise leave just 2 pixels at the edge of the screen to allow auto-"
@@ -4837,15 +5643,15 @@ msgstr ""
 "automatico. Alcuni window manager potrebbero non rispettare questa "
 "impostazione."
 
-#: ../Templates.glade:279
-msgid "Do not cover panel"
-msgstr "Non coprire il pannello"
-
-#: ../Templates.glade:297
+#: ../Templates.ui.h:20
 msgid "<b>Panel style</b>"
 msgstr "<b>Stile del pannello</b>"
 
-#: ../Templates.glade:331
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Limitare il monitor di Xinerama"
+
+#: ../Templates.ui.h:22
 msgid ""
 "If you use multiple monitors with Xinerama, use this option to confine the "
 "panel to one monitor."
@@ -4853,37 +5659,114 @@ msgstr ""
 "Se si usano più monitor con Xinerama, usare questa opzione per limitare il "
 "pannello a un monitor."
 
-#: ../Templates.glade:332
-msgid "Confine to Xinerama monitor"
-msgstr "Limitare il monitor di Xinerama"
-
-#: ../Templates.glade:347
+#: ../Templates.ui.h:23
 msgid ""
 "The monitor this panel is confined to when using Xinerama. The numbering "
 "starts from zero."
 msgstr ""
 "Questo pannello è limitato nella modalità Xinerama. Il conteggio inizia da 0."
 
-#: ../Templates.glade:372
+#: ../Templates.ui.h:24
 msgid "<b>Xinerama</b>"
 msgstr "<b>Xinerama</b>"
 
-#: ../Templates.glade:407
+#: ../Templates.ui.h:25
 msgid "Right edge"
 msgstr "A destra"
 
-#: ../Templates.glade:426
+#: ../Templates.ui.h:26
 msgid "Left edge"
 msgstr "A sinistra"
 
-#: ../Templates.glade:443
+#: ../Templates.ui.h:27
 msgid "Bottom edge"
 msgstr "In basso"
 
-#: ../Templates.glade:462
+#: ../Templates.ui.h:28
 msgid "Top edge"
 msgstr "In alto"
 
-#: ../Templates.glade:496
+#: ../Templates.ui.h:29
 msgid "<b>Position</b>"
 msgstr "<b>Posizione</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<dir>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?«%s» esiste già: sovrascrivere?"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Errore durante la scansione di «%s»:\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Directory mancante o eliminata"
+
+#~ msgid "Directory '%s' is not accessible"
+#~ msgstr "La directory «%s» non è accessibile"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Directory «%s» non trovata."
+
+#~ msgid "Cancel"
+#~ msgstr "Annulla"
+
+#~ msgid "All, "
+#~ msgstr "Tutti, "
+
+#~ msgid "Inotify support"
+#~ msgstr "Supporto a Inotify"
+
+#~ msgid "Dnotify support"
+#~ msgstr "Supporto a Dnotify"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Si deve usare Shift+clic su un file per inviarlo a qualche applicazione"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Va nella directory genitore"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Va nella directory home"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Segnalibri"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Menù segnalibri"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Aggiorna il contenuto della directory"
+
+#~ msgid "Change icon size"
+#~ msgstr "Cambia le dimensioni delle icone"
+
+#~ msgid "Show extra details"
+#~ msgstr "Mostra dettagli extra"
+
+#~ msgid "Hidden"
+#~ msgstr "Nascosti"
+
+#~ msgid "Change at:"
+#~ msgstr "Cambiare con:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Larghezza massima (icone grandi):"
+
+#~ msgid "Panel (obsolete)"
+#~ msgstr "Pannello (obsoleto)"
+
+#~ msgid ""
+#~ "Enter the name of the panel to show here. This option is now only used "
+#~ "when upgrading from an old version."
+#~ msgstr ""
+#~ "Inserire il nome del pannello da mostrare. Questa opzione è ora usata "
+#~ "solo durante l'aggiornamento da una versione precendente."

--- a/ROX-Filer/src/po/ja.po
+++ b/ROX-Filer/src/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ROX-Filer 2.11\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-10-12 01:33+0900\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2011-10-12 01:30+0900\n"
 "Last-Translator: team OKATANA<mkato@par.odn.ne.jp,mosaicist@par.odn.ne.jp> "
 "<>\n"
@@ -19,31 +19,35 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: abox.c:125
-msgid "<dir>"
-msgstr "<dir>"
+#: abox.c:127
+msgid "<src>"
+msgstr ""
 
-#: abox.c:218
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "確認しない(_Q)"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Quiet"
 msgstr "確認しない"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "操作ごとに確認を求めません"
 
-#: abox.c:454 infobox.c:792 tips:36
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "名前"
 
-#: abox.c:460 menu.c:237
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "ディレクトリ"
 
-#: abox.c:549
+#: abox.c:546
 msgid "Expression:"
 msgstr "検索式:"
 
@@ -59,11 +63,11 @@ msgstr "詳細は fsattr の man page (5)をご覧下さい。"
 msgid "You do not appear to have OS support."
 msgstr "OS にサポートされていないようです。"
 
-#: action.c:191
+#: action.c:198
 msgid "Find expression reference"
 msgstr "検索式 リファレンス"
 
-#: action.c:202
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -154,11 +158,11 @@ msgstr ""
 "    が成立する検索対象に一致します → ※1\n"
 "<b>Not (又は !)</b> (直後の検索式の否定。 not 式 は、式の意味を反転します。"
 
-#: action.c:249
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "パーミッション変更 リファレンス"
 
-#: action.c:260
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -216,11 +220,11 @@ msgstr ""
 "\n"
 "※詳細は chmod(1) man page を見て下さい。"
 
-#: action.c:301
+#: action.c:308
 msgid "Set type reference"
 msgstr "MIME形式設定リファレンス"
 
-#: action.c:312
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -249,48 +253,55 @@ msgstr ""
 "ファイルに対してのみサポートされます。\n"
 "\n"
 
-#: action.c:419
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "プロセスが完了しました\n"
 
-#: action.c:435
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "1 個のエラーが発生しました。\n"
 
-#: action.c:437
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "%d 個のエラーが発生しました。\n"
 
-#: action.c:461
+#: action.c:516
 msgid "ERROR reading"
 msgstr "読み込みエラー"
 
-#: action.c:504
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "完了\n"
 
-#: action.c:560 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "エラー"
 
-#: action.c:714 main.c:702 main.c:709 main.c:716 main.c:730
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "はい"
 
-#: action.c:717 main.c:704 main.c:711 main.c:718 main.c:730
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "いいえ"
 
-#: action.c:735
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -298,7 +309,7 @@ msgstr ""
 "\n"
 "子プロセス終了処理中...\n"
 
-#: action.c:742
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -306,41 +317,41 @@ msgstr ""
 "\n"
 "暴走プロセス終了を試行中...\n"
 
-#: action.c:895
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?%s の内容を数えますか?"
 
-#: action.c:931
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?%s'%s' を削除しますか?"
 
-#: action.c:932
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "書き込み禁止です"
 
-#: action.c:939
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "''%s' を削除中\n"
 
-#: action.c:952
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'ディレクトリ '%s' を削除しました\n"
 
-#: action.c:985
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?'%s' をイジェクトしますか?"
 
-#: action.c:992
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'%s' をイジェクト'\n"
 
-#: action.c:1011
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -349,95 +360,95 @@ msgstr ""
 "!%s\n"
 "イジェクトに失敗しました\n"
 
-#: action.c:1030 action.c:1049
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?'%s' を調べますか?"
 
-#: action.c:1046
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "! 無効な検索条件です。条件を変更し再試行してください\n"
 
-#: action.c:1056
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'('%s' を検索中)\n"
 
-#: action.c:1130 action.c:1155
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?'%s' のパーミッションを変更しますか?"
 
-#: action.c:1136
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "''%s' のパーミッションを変更中\n"
 
-#: action.c:1153
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!無効なモードコマンドです - 設定を変更して再試行してください\n"
 
-#: action.c:1211
+#: action.c:1332
 #, c-format
 msgid "?Change contents of '%s'?"
 msgstr "?'%s' の項目を変更しますか?"
 
-#: action.c:1214 action.c:1234
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?'%s' のMIME形式を変更しますか?"
 
-#: action.c:1231
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!無効なMIME形式です - 設定を変更して再試行してください\n"
 
-#: action.c:1253
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'MIME形式 '%s' を '%s' に変更中'\n"
 
-#: action.c:1276
+#: action.c:1397
 #, c-format
 msgid "'Not changing type of directory '%s'\n"
 msgstr "ディレクトリ '%s' の MIME形式を変更しません'\n"
 
-#: action.c:1282
+#: action.c:1403
 #, c-format
 msgid "'Non-regular file '%s' not changed\n"
 msgstr "通常ファイルでない '%s' は変更されません\n"
 
-#: action.c:1342
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' は既に存在しています - %sしますか?"
 
-#: action.c:1344
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "内容を結合"
 
-#: action.c:1345
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "上書き"
 
-#: action.c:1361
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'とにかくコピーする...\n"
 
-#: action.c:1370
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?%s を %s としてコピーしますか?"
 
-#: action.c:1374
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'?%s を %sとしてコピー中\n"
 
-#: action.c:1389
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!エラー: 対象が既に存在しますが、ディレクトリではありません\n"
 
-#: action.c:1461
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -446,26 +457,7 @@ msgstr ""
 "!%s\n"
 "'%s'の コピーに失敗\n"
 
-#: action.c:1505
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s'は既に存在します - 上書きしますか?"
-
-#: action.c:1520
-msgid "'Trying move anyway...\n"
-msgstr "'とにかく移動します...\n"
-
-#: action.c:1528
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "? %s から %s に置き換え(移動/リネーム)しますか?"
-
-#: action.c:1532
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'%s を %s として移動中\n"
-
-#: action.c:1540
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -474,45 +466,59 @@ msgstr ""
 "!%s\n"
 "%s を %s として移動するのに失敗\n"
 
-#: action.c:1561
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'とにかく移動します...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "? %s から %s に置き換え(移動/リネーム)しますか?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'%s を %s として移動中\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!エラー: コピー元へのコピーは出来ません\n"
 
-#: action.c:1576
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!エラー: 元ファイルへの移動/リネームはできません\n"
 
-#: action.c:1588
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'%s にリンク %s を作成中\n"
 
-#: action.c:1593
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "? %s へのリンク %s を作成しますか?"
 
-#: action.c:1636
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'%s をマウント中\n"
 
-#: action.c:1637
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'%s をアンマウント中\n"
 
-#: action.c:1640
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?%s をマウントしますか?"
 
-#: action.c:1641
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?%s をアンマウントしますか?"
 
-#: action.c:1662
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -521,7 +527,7 @@ msgstr ""
 "!%s\n"
 "マウント失敗\n"
 
-#: action.c:1663
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -530,11 +536,11 @@ msgstr ""
 "!%s\n"
 "アンマウント失敗\n"
 
-#: action.c:1671
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(マウントされているようです)\n"
 
-#: action.c:1717
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -543,205 +549,229 @@ msgstr ""
 "'\n"
 "合計: %s ("
 
-#: action.c:1723
+#: action.c:2108
 msgid "file"
 msgstr "ファイル"
 
-#: action.c:1723
+#: action.c:2108
 msgid "files"
 msgstr "ファイル"
 
-#: action.c:1727
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "ディレクトリが有りません)\n"
 
-#: action.c:1731
+#: action.c:2116
 msgid "directory"
 msgstr "ディレクトリ"
 
-#: action.c:1732
+#: action.c:2117
 msgid "directories"
 msgstr "ディレクトリ"
 
-#: action.c:1773
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!マウントポイントが選択されていません!\n"
 
-#: action.c:1858
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?他を検索?"
 
-#: action.c:1888 action.c:1919
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' はシンボリックリンクです\n"
 
-#: action.c:1959
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "検索するアイテムを選んでください"
 
-#: action.c:1969 menu.c:228
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "検索"
 
-#: action.c:2002
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "計算対象(複数可)を指定してください"
 
-#: action.c:2006
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "ディスク使用量"
 
-#: action.c:2042
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "マウント/アンマウント"
 
-#: action.c:2059
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr "ROX-Filer はこのマウントポイントをサポートできていません。ごめん!"
 
-#: action.c:2073 menu.c:216 tips:173
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "削除"
 
-#: action.c:2085 tips:178
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "強行"
 
-#: action.c:2085
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "書き込み禁止アイテムの削除を確認しません"
 
-#: action.c:2088 action.c:2147 action.c:2210 action.c:2283 action.c:2323
-#: tips:180
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "簡略"
 
-#: action.c:2088
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "ディレクトリを削除するときのみログを表示します"
 
-#: action.c:2107
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "パーミッション変更対象(複数可))を選択してください"
 
-#: action.c:2115
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (実行可能/検索可能属性を付加)"
 
-#: action.c:2117
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (実行可能/検索可能属性を削除)"
 
-#: action.c:2119
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (所有者の読み書きを許可)"
 
-#: action.c:2121
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (個人用 - 所有者のみアクセス可)"
 
-#: action.c:2123
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (所有者の属性から書込み権を除き、グループ、他人の属性に)"
 
-#: action.c:2134 menu.c:189 menu.c:226 tips:53
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "パーミッション"
 
-#: action.c:2147 action.c:2210
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "作業中のファイルを表示しません"
 
-#: action.c:2150 action.c:2213 tips:182
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "再帰"
 
-#: action.c:2150
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "サブディレクトリ以下の内容も変更します"
 
-#: action.c:2154
+#: action.c:2547
 msgid "Command:"
 msgstr "コマンド:"
 
-#: action.c:2184
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "パーミッション変更対象(複数可))を選択してください"
 
-#: action.c:2197
+#: action.c:2590
 msgid "Set type"
 msgstr "MIME形式設定"
 
-#: action.c:2213
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "サブディレクトリ以下の内容も変更します"
 
-#: action.c:2220 infobox.c:648
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "種類:"
 
-#: action.c:2267 dnd.c:122 menu.c:2024 tips:167
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "コピー"
 
-#: action.c:2279 action.c:2319 tips:184
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "操作ごとに確認を求めません"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "対象より新しいときだけ上書きします"
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "新しいとき"
 
-#: action.c:2280 action.c:2320 tips:185
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "対象より新しいときだけ上書きします"
 
-#: action.c:2283
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "ディレクトリ"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "ディレクトリをコピーするときのみログを表示します"
 
-#: action.c:2307 dnd.c:123 tips:169
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "移動"
 
-#: action.c:2323
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "各ファイルの移動時にログを表示しません"
 
-#: action.c:2346 tips:171
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "リンク"
 
-#: action.c:2369 appmenu.c:111 filer.c:646 infobox.c:1061
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "イジェクト"
 
-#: action.c:2437
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "以下のアイテムを削除 "
 
-#: action.c:2441
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "アイテムを削除中 "
 
-#: action.c:2443
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "アイテムを削除中 "
 
-#: action.c:2462
+#: action.c:2900
 msgid " and "
 msgstr " and "
 
-#: action.c:2471
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr " ピンボードやパネルのアイテムに影響します - それでも削除しますか?"
 
-#: action.c:2478
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr " ピンボードやパネルのアイテムに影響します - それでも削除しますか?"
 
-#: appmenu.c:197
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<見当たらないラベル>"
 
-#: appmenu.c:319
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
@@ -751,82 +781,82 @@ msgstr ""
 "らは同形式 (%s/%s) アイテムを指定して開かれたメニューの先頭に専用メニューとし"
 "て追加されます"
 
-#: appmenu.c:363 menu.c:239
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "メニューをカスタマイズ..."
 
-#: appmenu.c:420 menu.c:257 toolbar.c:158
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "ヘルプ"
 
-#: bookmarks.c:148 log.c:161
-msgid "Path"
-msgstr "パス"
-
-#: bookmarks.c:156
+#: bookmarks.c:268
 msgid "Title"
 msgstr "タイトル"
 
-#: bookmarks.c:305
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "パス"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "'%s' はローカルに存在しないのでブックマークできません。\n"
 
-#: bookmarks.c:313 bookmarks.c:631
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' はディレクトリではありません"
 
-#: bookmarks.c:519
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "まず削除する項目を選んでください"
 
-#: bookmarks.c:543
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "移動するにはリストの項目にカーソルを置いてください"
 
-#: bookmarks.c:563
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "これ以上移動できません"
 
-#: bookmarks.c:637
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "'%s' はローカルディレクトリではないのでブックマークできません。"
 
-#: bookmarks.c:779
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "ブックマークに追加"
 
-#: bookmarks.c:786
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "ブックマークの管理"
 
-#: bookmarks.c:791
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "最近開いたディレクトリ"
 
-#: bulk_rename.c:66
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "複数ファイルリネーム"
 
-#: bulk_rename.c:69
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "戻す"
 
-#: bulk_rename.c:74
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "'新しい名前'欄を最初の状態に戻します"
 
-#: bulk_rename.c:79
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "リネーム(_R)"
 
-#: bulk_rename.c:92
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "リネーム対象:"
 
-#: bulk_rename.c:99
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -846,11 +876,11 @@ msgstr ""
 "[a-zA-Z]{2}_[0-9]  ab_01.txt の 'ab_0' や cde_5.jpg の 'de_5'\n"
 "(※正規表現に関しては、jman 7 regex などをご覧ください)"
 
-#: bulk_rename.c:107
+#: bulk_rename.c:109
 msgid "With:"
 msgstr "置換文字列:"
 
-#: bulk_rename.c:114
+#: bulk_rename.c:116
 msgid ""
 "The first match in each filename will be replaced by this string. The only "
 "special characters are back-references from \\0 to \\9. To use them "
@@ -874,11 +904,11 @@ msgstr ""
 "  西暦表記風の名前 → 元号表記風にし、拡張子を log に変更\n"
 "※先頭へのパスの付加で、同ファイルシステム内の移動も可能。"
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "適用"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
@@ -892,45 +922,45 @@ msgstr ""
 "[リネーム]を押すと '古い名前' の '新しい名前' へのリネー\n"
 "ムを実行し、このダイアログを閉じます。"
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "古い名前"
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "新しい名前"
 
-#: bulk_rename.c:293
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr ""
 "('新しい名前'欄には)リネーム対象欄の正規表現にマッチする文字列はありません"
 
-#: bulk_rename.c:298
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "1 個のアイテムがパターンに一致しますが、変更の前後が同じです"
 
-#: bulk_rename.c:301
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d 個のアイテムがパターンに一致しますが、変更の前後が同じです"
 
-#: bulk_rename.c:327
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr "変換対象に一致する正規表現と、置き換える文字列を指定して下さい"
 
-#: bulk_rename.c:344
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s ('%s' において)"
 
-#: bulk_rename.c:377
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr ""
 "'%s' という名前のファイルは既に存在します。複数ファイルリネームは中断します。"
 
-#: bulk_rename.c:382
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -941,12 +971,12 @@ msgstr ""
 "%s\n"
 "複数ファイルリネームを中断します。"
 
-#: bulk_rename.c:444
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "'%s' は既に存在しています。"
 
-#: bulk_rename.c:455
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
@@ -955,7 +985,7 @@ msgstr ""
 "いくつかの'新しい名前'の中に / が含まれています (例えば  '%s')。これは、ファ"
 "イルが別のディレクトリに置かれることを意味しますが、処理を続けますか?"
 
-#: bulk_rename.c:470
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "いずれの名前も変更されませんでした。なにも行いませんでした。"
 
@@ -979,42 +1009,62 @@ msgstr ""
 "に移動されました\n"
 "%s"
 
-#: dir.c:1041
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "ディレクトリの情報が得られません: %s"
 
-#: dir.c:1050
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "ディレクトリを開けません: %s"
 
-#: display.c:659
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "サイズ"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) 失敗: %s"
 
-#: dnd.c:124
-msgid "Link (relative)"
-msgstr "Link (相対パス)"
-
-#: dnd.c:125
-msgid "Link (absolute)"
-msgstr "Link (絶対パス)"
-
-#: dnd.c:424
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "内部エラー - bad info type"
 
-#: dnd.c:563
+#: dnd.c:565
 msgid "Drag a directory here to bookmark it."
 msgstr "ブックマークするにはディレクトリをここにドラッグします"
 
-#: dnd.c:578
+#: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
 msgstr "XDS protocol error: leafname-ファイル名は '/' を含んでいないようです\n"
 
-#: dnd.c:603
+#: dnd.c:605
 msgid ""
 "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
 "plain) did not contain a leafname\n"
@@ -1022,17 +1072,17 @@ msgstr ""
 "XdndDirectSave0 は指示通りの操作を行いましたが、要素 XDS (type text/plain) "
 "は leafname-ファイル名を含んでいません\n"
 
-#: dnd.c:616
+#: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
 msgstr "text/uri-list 又は XdndDirectSave0形式のターゲットを指定して下さい."
 
-#: dnd.c:619
+#: dnd.c:621
 msgid ""
 "Sorry - I require a target type of text/uri-list or application/octet-stream."
 msgstr ""
 "text/uri-list 又は application/octet-stream 形式のターゲットを指定して下さい."
 
-#: dnd.c:689
+#: dnd.c:691
 #, c-format
 msgid ""
 "Failed to add some items to the pinboard, because they are on a remote "
@@ -1044,50 +1094,50 @@ msgstr ""
 "\n"
 "%s"
 
-#: dnd.c:764
+#: dnd.c:766
 msgid "Unknown target"
 msgstr "不明な対象"
 
-#: dnd.c:797
+#: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
 msgstr "リモートのアプリケーションはデータを送って来ません - 悪しからず"
 
-#: dnd.c:810
+#: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
 msgstr ""
 "XDS プロトコルエラー: リターンコードは 'S', 'F', 'E' でなければいけません\n"
 
-#: dnd.c:843
+#: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
 msgstr "リモートファイル / raw data の動作メニューは表示できません."
 
-#: dnd.c:859
+#: dnd.c:861
 msgid "UntitledData"
 msgstr "名無しのデータ"
 
-#: dnd.c:886
+#: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
 msgstr "エラー救済用ファイル: %s"
 
-#: dnd.c:959
+#: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
 msgstr "text/uri-list に URI がありません(何も出来ません!)"
 
-#: dnd.c:991
+#: dnd.c:993
 msgid ""
 "Can't get data from remote machine (application/octet-stream not provided)"
 msgstr ""
 "リモートマシンからデータを取得できません(application/octet-stream が提供され"
 "ていません)"
 
-#: dnd.c:1014
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
 "幾つかのファイルは別のマシン上にあります(それらは無視されます)。ごめんね!"
 
-#: dnd.c:1021
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
@@ -1095,14 +1145,32 @@ msgstr ""
 "これらのファイルはローカルマシン上にはありません(複数リモート上のファイルは取"
 "り扱えません、ごめん!)"
 
-#: dnd.c:1034
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "不明なアクションの要求です"
 
-#: dnd.c:1042
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "エラーを起こしたファイルの一覧: %s"
+
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Link (相対パス)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Link (絶対パス)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Link (相対パス)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Link (絶対パス)"
 
 #: dropbox.c:112
 msgid "Show"
@@ -1142,7 +1210,7 @@ msgstr ""
 "'%s' にアクセスできません:\n"
 "%s"
 
-#: filer.c:461
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1151,16 +1219,7 @@ msgstr ""
 "スキャンエラー '%s':\n"
 "%s\n"
 
-#: filer.c:465
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"スキャンエラー '%s':\n"
-"%s"
-
-#: filer.c:621
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1170,23 +1229,19 @@ msgstr ""
 "\n"
 "デバイスをアンマウントすると安全にディスクを取り出すことができます"
 
-#: filer.c:626
+#: filer.c:889
 msgid "Perform the same action in future for this mount point"
 msgstr "@@今後このマウントポイントに対し、同じ動作を実行する"
 
-#: filer.c:633
+#: filer.c:896
 msgid "No change"
 msgstr "このまま"
 
-#: filer.c:639 infobox.c:1059 menu.c:872
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "アンマウント"
 
-#: filer.c:743
-msgid "Directory missing/deleted"
-msgstr "ディレクトリがありません/削除されています"
-
-#: filer.c:1107
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
@@ -1197,106 +1252,144 @@ msgstr ""
 "定して下さい。 その後にファイルを再選択するには %s を押してください。\n"
 "10キーで設定するなら NumLock が on であることを確認してください。"
 
-#: filer.c:1343
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "ディレクトリ'%s' にアクセスできません"
-
-#: filer.c:1495
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "ディレクトリ '%s' が見つかりません"
-
-#: filer.c:1795
-msgid "Cancel"
-msgstr "キャンセル"
-
-#: filer.c:2076
+#: filer.c:2655
 msgid "A"
 msgstr "A"
 
-#: filer.c:2078 find.c:923
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr "G"
 
-#: filer.c:2083
+#: filer.c:2664
 msgid "S"
 msgstr "S"
 
-#: filer.c:2085
+#: filer.c:2669
 msgid "T"
 msgstr "T"
 
-#: filer.c:2095
-msgid "All, "
-msgstr "全て ,"
+#: filer.c:2670
+msgid "D"
+msgstr ""
 
-#: filer.c:2098
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
 msgstr "(%s)に合致,"
 
-#: filer.c:2106
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "走査中, "
 
-#: filer.c:2108
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "サムネイル, "
 
-#: filer.c:2384
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "サムネイル, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "シンボリックリンク -> "
 
-#: filer.c:2426
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "不適切な UTF-8 のファイル名です。リネームしてください\n"
 
-#: filer.c:2743 menu.c:2014
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "アイテムは存在しません"
 
-#: filer.c:3549
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "保存する表示属性の選択"
 
-#: filer.c:3553
+#: filer.c:4712
+#, fuzzy
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr "<b>このディレクトリ表示設定の保存</b>"
+
+#: filer.c:4713
 msgid "<b>Save display settings for directory</b>"
 msgstr "<b>このディレクトリ表示設定の保存</b>"
 
-#: filer.c:3560
+#: filer.c:4720
 msgid "Select settings to save"
 msgstr "設定を保存する項目"
 
-#: filer.c:3567
+#: filer.c:4727
 msgid "Position"
 msgstr "位置"
 
-#: filer.c:3572 toolbar.c:133 toolbar.c:137 tips:39
-msgid "Size"
-msgstr "サイズ"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "ウィンドウ"
 
-#: filer.c:3577
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "隠しファイルを表示"
 
-#: filer.c:3583
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "表示スタイル"
 
-#: filer.c:3589
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "ソート方法と順序"
 
-#: filer.c:3594 toolbar.c:141
+#: filer.c:4754
 msgid "Details"
 msgstr "詳細表示"
 
-#: filer.c:3599 tips:92 tips:93
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "サムネイル"
 
-#: filer.c:3605
+#: filer.c:4765
 msgid "Filter"
 msgstr "フィルタ"
 
@@ -1520,11 +1613,11 @@ msgstr "blocks"
 msgid "Save As:"
 msgstr "名前を付けて保存:"
 
-#: gtksavebox.c:395
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "名前がありません"
 
-#: gtksavebox.c:471
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
@@ -1532,7 +1625,7 @@ msgstr ""
 "リモートアプリケーションは Direct Save を使用したいのですが、 "
 "XdndDirectSave0 プロパティ(text/plain 形式)を読み込めません。\n"
 
-#: gtksavebox.c:596
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1572,16 +1665,16 @@ msgstr ""
 "されるような操作を行う)。\n"
 "以降、エラーは無くなるでしょう。"
 
-#: gui_support.c:1134
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "text/uri-listデータの,不正又は不明な改行です"
 
-#: gui_support.c:1471
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "'%s'のオープンに失敗しました : %s"
 
-#: gui_support.c:1515
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
@@ -1589,7 +1682,7 @@ msgstr ""
 "イメージ '%s' を読み出せません:理由は不明ですが、恐らく壊れたファイルだと思わ"
 "れます。"
 
-#: gui_support.c:1580
+#: gui_support.c:1583
 #, c-format
 msgid ""
 "This program (%s) cannot be run, as the 0launch command is not available. It "
@@ -1610,133 +1703,133 @@ msgstr ""
 "注意: 新しい言語設定を完全に有効にするには、 選択を保存してファイラを再起動し"
 "てください。"
 
-#: icon.c:76
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(クリックでセット)"
 
-#: icon.c:131
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:132 menu.c:258
-msgid "About ROX-Filer..."
-msgstr "ROX-Filer について.."
-
-#: icon.c:133 menu.c:259
-msgid "Show Help Files"
-msgstr "ヘルプファイルを表示"
-
-#: icon.c:134 menu.c:260
-msgid "Manual"
-msgstr "マニュアル"
-
-#: icon.c:136 menu.c:235
-msgid "Options..."
-msgstr "オプション設定"
-
-#: icon.c:137 menu.c:244
-msgid "Home Directory"
-msgstr "ホームディレクトリ"
-
-#: icon.c:138 icon.c:1410 menu.c:212 type.c:223
-msgid "File"
-msgstr "ファイル"
-
-#: icon.c:139 menu.c:218 menu.c:885
-msgid "Shift Open"
-msgstr "［Shift］+で開く"
-
-#: icon.c:140 menu.c:223
-msgid "Properties"
-msgstr "プロパティ"
-
-#: icon.c:141 menu.c:221
-msgid "Set Run Action..."
-msgstr "対応アプリの設定"
-
-#: icon.c:142 menu.c:222
-msgid "Set Icon..."
-msgstr "アイコンを設定"
-
-#: icon.c:143 icon.c:867
-msgid "Edit Item"
-msgstr "アイテムを編集"
-
-#: icon.c:144
-msgid "Show Location"
-msgstr "アイテムの場所を表示"
-
-#: icon.c:145
-msgid "Remove Item(s)"
-msgstr "アイテムを削除"
-
-#: icon.c:318 log.c:109 menu.c:774
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:331
+#: icon.c:311
 msgid "Nothing"
 msgstr "なし"
 
-#: icon.c:592
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "アイテムの在処は最低１文字以上でなければいけません！"
 
-#: icon.c:657
+#: icon.c:641
 #, c-format
 msgid "You must unlock '%s' before removing it"
 msgstr ""
 "%s はロックされています。「アイテムを編集」でロックを外してから削除してくださ"
 "い"
 
-#: icon.c:667
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "まず削除するアイテムを選んでください"
 
-#: icon.c:673
+#: icon.c:657
 msgid "An item must be unlocked before it can be removed."
 msgstr "削除出来るようにするには、先にアイテムをアンロックする必要が有ります"
 
-#: icon.c:687
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "メニューはアイテムの上で開いてください"
 
-#: icon.c:712 menu.c:1285
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "「対応アプリを設定」はファイルに対してのみ行えます"
 
-#: icon.c:798
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "ショートカットを入力してください(例: Control+F1)"
 
-#: icon.c:820
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "キー入力の取得に失敗しました"
 
-#: icon.c:870
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "アイテムを編集"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "アイコンクリックで開くファイル:"
 
-#: icon.c:880
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "プログラムに渡す引数(実行可能アイテムの場合):"
 
-#: icon.c:894
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "アイコンの下に表示するテキスト:"
 
-#: icon.c:907
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "キーボードのショートカット:"
 
-#: icon.c:927
+#: icon.c:910
 msgid "Locked"
 msgstr "ロックする"
 
-#: icon.c:932
+#: icon.c:915
 msgid "Locking an item prevents it from being accidentally removed"
 msgstr "不用意に削除されないように、アイテムをロックします"
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "ROX-Filer について.."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "ヘルプファイルを表示"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "マニュアル"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "オプション設定"
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "ホームディレクトリ"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "ファイル"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "［Shift］+で開く"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "プロパティ"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "対応アプリの設定"
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "アイコンを設定"
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "アイテムの場所を表示"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "アイテムを削除"
 
 #: infobox.c:113
 #, c-format
@@ -1747,40 +1840,40 @@ msgstr "本当に %d 個のウィンドウを開きますか？"
 msgid "Show Info"
 msgstr "情報を表示"
 
-#: infobox.c:136 menu.c:779
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(不正なutf-8)"
 
-#: infobox.c:271
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "ヘルプファイルを表示"
 
-#: infobox.c:284
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>パーミッション</b>"
 
-#: infobox.c:302
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>項目を表示</b>"
 
-#: infobox.c:312
+#: infobox.c:319
 msgid "<b>When all directories are closed</b>"
 msgstr "<b>すべてのディレクトリが閉じられるとき</b>"
 
-#: infobox.c:448 infobox.c:589 support.c:349
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "bytes"
 
-#: infobox.c:471
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "サイズ取得に失敗"
 
-#: infobox.c:532
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' は既に symlink では無くなっています。"
 
-#: infobox.c:539
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1789,7 +1882,7 @@ msgstr ""
 "'%s'のシンボリックリンクを削除できません:\n"
 "%s"
 
-#: infobox.c:544
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1801,158 +1894,158 @@ msgstr ""
 "%s\n"
 "(注意:古いリンクは削除されました。)"
 
-#: infobox.c:568 tips:242
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "エラー:"
 
-#: infobox.c:575
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "通常のディレクトリ:"
 
-#: infobox.c:578
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "所有者, グループ:"
 
-#: infobox.c:585 infobox.c:600 infobox.c:609
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "サイズ:"
 
-#: infobox.c:610
+#: infobox.c:621
 msgid "Scanning"
 msgstr "スキャン中, "
 
-#: infobox.c:635
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "スキャンに失敗"
 
-#: infobox.c:642
+#: infobox.c:653
 msgid "Change time:"
 msgstr "変更した日時:"
 
-#: infobox.c:644
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "修正した日時:"
 
-#: infobox.c:646
+#: infobox.c:657
 msgid "Access time:"
 msgstr "アクセスした日時:"
 
-#: infobox.c:654
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "拡張属性:"
 
-#: infobox.c:656
+#: infobox.c:667
 msgid "Present"
 msgstr "あります"
 
-#: infobox.c:657
+#: infobox.c:668
 msgid "None"
 msgstr "ありません"
 
-#: infobox.c:658
+#: infobox.c:669
 msgid "Not supported"
 msgstr "サポートされていません"
 
-#: infobox.c:670
+#: infobox.c:681
 msgid "Link target:"
 msgstr "リンク対象:"
 
-#: infobox.c:682 infobox.c:685
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "対応アプリ:"
 
-#: infobox.c:682
+#: infobox.c:693
 msgid "Execute file"
 msgstr "ファイルを実行"
 
-#: infobox.c:794
+#: infobox.c:805
 msgid "Comment"
 msgstr "コメント"
 
-#: infobox.c:796
+#: infobox.c:807
 msgid "Execute"
 msgstr "実行"
 
-#: infobox.c:810
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<未だ何も>"
 
-#: infobox.c:881
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "file(1) says... %s"
 
-#: infobox.c:938
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "%s'のパーミッションを変更できません: "
 
-#: infobox.c:956
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "所有者"
 
-#: infobox.c:958
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "グループ"
 
-#: infobox.c:960
+#: infobox.c:974
 msgid "World"
 msgstr "他人"
 
-#: infobox.c:963
+#: infobox.c:977
 msgid "Read"
 msgstr "読み込み"
 
-#: infobox.c:966
+#: infobox.c:980
 msgid "Write"
 msgstr "書き込み"
 
-#: infobox.c:969
+#: infobox.c:983
 msgid "Exec"
 msgstr "実行"
 
-#: infobox.c:987
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID ビット"
 
-#: infobox.c:994
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID ビット"
 
-#: infobox.c:1001
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky ビット"
 
-#: infobox.c:1057
+#: infobox.c:1071
 msgid "Do nothing"
 msgstr "何もしない"
 
-#: infobox.c:1063
+#: infobox.c:1077
 msgid "Ask"
 msgstr "問い合わせる"
 
-#: infobox.c:1075
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "シンボリックリンク"
 
-#: infobox.c:1078
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX アプリケーション"
 
-#: infobox.c:1086
+#: infobox.c:1100
 msgid "mounted"
 msgstr "マウント済み"
 
-#: infobox.c:1086
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "アンマウント済み"
 
-#: infobox.c:1090
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "%s (%s) のマウントポイント"
 
-#: infobox.c:1093
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "マウントポイント (%s)"
@@ -1961,24 +2054,29 @@ msgstr "マウントポイント (%s)"
 msgid "ROX-Filer started"
 msgstr "ROX-Filer 開始"
 
-#: log.c:111
+#: log.c:115
 #, c-format
 msgid "%s on %d items"
 msgstr "%s: %d 件"
 
-#: log.c:124
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "コピー"
+
+#: log.c:139
 msgid "Item"
 msgstr "対象"
 
-#: log.c:150
+#: log.c:165
 msgid "Time"
 msgstr "日時"
 
-#: log.c:155
+#: log.c:170
 msgid "Action"
 msgstr "操作"
 
-#: main.c:97
+#: main.c:95
 msgid ""
 "Copyright (C) 2005 Thomas Leonard.\n"
 "ROX-Filer comes with ABSOLUTELY NO WARRANTY,\n"
@@ -1994,15 +2092,15 @@ msgstr ""
 "under the terms of the GNU General Public License.\n"
 "For more information about these matters, see the file named COPYING.\n"
 
-#: main.c:106
+#: main.c:104
 msgid "Try `ROX-Filer/AppRun --help' for more information.\n"
 msgstr "詳しくは `rox --help' で確認してください\n"
 
-#: main.c:109
+#: main.c:107
 msgid "Try `ROX-Filer/AppRun -h' for more information.\n"
 msgstr "詳しくは `rox -h' で確認してください\n"
 
-#: main.c:111
+#: main.c:109
 msgid ""
 "NOTE: Your system does not support long options - \n"
 "you must use the short versions instead.\n"
@@ -2012,7 +2110,7 @@ msgstr ""
 "ショートバージョンを使ってください\n"
 "\n"
 
-#: main.c:117
+#: main.c:115
 #, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
@@ -2069,7 +2167,7 @@ msgstr ""
 "バグ報告は %s まで.\n"
 "Home page (最新バージョンを置いてあります): http://rox.sourceforge.net/\n"
 
-#: main.c:240
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -2081,7 +2179,7 @@ msgstr ""
 "show_bug.cgi?id=152151\n"
 "再試行してみて下さい..."
 
-#: main.c:404
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
@@ -2089,59 +2187,51 @@ msgstr ""
 " -o オプションは現在使われなくなりました(ウィンドウマネージャによるパネル制"
 "御)。  代わりにオプションボックスから設定可能です。"
 
-#: main.c:533
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "ユーザ '%s' で実行"
 
-#: main.c:694
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "GTKバージョン %s でコンパイル\n"
 
-#: main.c:695
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "GTKバージョン %d.%d.%d で実行\n"
 
-#: main.c:699
+#: main.c:693
 msgid "features set at compile time"
 msgstr "機能はコンパイル時に設定します"
 
-#: main.c:700
+#: main.c:694
 msgid "Large File Support"
 msgstr "Large File サポート"
 
-#: main.c:707
-msgid "Inotify support"
-msgstr "Inotify(ファイルシステム監視機能)サポート"
-
-#: main.c:714
-msgid "Dnotify support"
-msgstr "Dnotify(ディレクトリ通知機能)サポート"
-
-#: main.c:721
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "バイナリ互換性"
 
-#: main.c:723
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "はい (より古いバージョンの glibc で実行可能)"
 
-#: main.c:725
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "いいえ (apsymbols.h がみつかりません)"
 
-#: main.c:729
+#: main.c:709
 msgid "Extended attribute support"
 msgstr "拡張属性サポート"
 
-#: main.c:880
+#: main.c:856
 #, c-format
 msgid "Unable to read '%s': %s"
 msgstr "'%s'を読み込めませんでした : %s"
 
-#: main.c:922
+#: main.c:895
 #, c-format
 msgid ""
 "Left-click to run %s.\n"
@@ -2150,20 +2240,20 @@ msgstr ""
 "左クリックで %s を実行。\n"
 "右クリックでバージョン一覧を表示。"
 
-#: main.c:969 menu.c:1380 menu.c:1386
+#: main.c:942 menu.c:1723 menu.c:1729
 #, c-format
 msgid "Error creating '%s': %s"
 msgstr "作成失敗 '%s': %s"
 
-#: main.c:998 main.c:1007
-msgid "Start script"
-msgstr "起動スクリプト"
-
-#: main.c:1002
+#: main.c:973
 msgid "Save"
 msgstr "保存"
 
-#: main.c:1032
+#: main.c:978
+msgid "Start script"
+msgstr "起動スクリプト"
+
+#: main.c:1003
 msgid ""
 "Click to save a script to run ROX-Filer.\n"
 "If you are using Zero Install you should use 0alias instead."
@@ -2171,236 +2261,302 @@ msgstr ""
 "クリックして ROX-Filer 起動スクリプトを保存して下さい\n"
 "Zero Install を使用している場合は 0alias で代用してください"
 
-#: menu.c:185 tips:28
+#: menu.c:639
 msgid "Display"
 msgstr "表示"
 
-#: menu.c:186 tips:33
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "アイコン表示"
 
-#: menu.c:187
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "アイコン &"
 
-#: menu.c:188 tips:52
-msgid "Sizes"
-msgstr "サイズ"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "アイコンテーマ"
 
-#: menu.c:190 tips:226
-msgid "Types"
-msgstr "タイプ"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "パーミッション"
 
-#: menu.c:191 tips:55
-msgid "Times"
-msgstr "日付"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "アイコン &"
 
-#: menu.c:192 tips:34 tips:70
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "詳細表示"
 
-#: menu.c:194
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "アイコン拡大"
 
-#: menu.c:195
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "アイコン縮小"
 
-#: menu.c:196 tips:49
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "自動"
 
-#: menu.c:198
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "名前でソート"
 
-#: menu.c:199
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "種類でソート"
 
-#: menu.c:200
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "日付でソート"
 
-#: menu.c:201
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "日付でソート"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "日付でソート"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "サイズでソート"
 
-#: menu.c:202
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "パーミッション"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "所有者でソート"
 
-#: menu.c:203
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "グループでソート"
 
-#: menu.c:204
+#: menu.c:671
 msgid "Reversed"
 msgstr "逆順にソート"
 
-#: menu.c:206
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "隠しファイルを表示"
 
-#: menu.c:207
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "ヘルプファイルを表示"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "ディレクトリが有りません)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "ファイルをフィルタリング"
 
-#: menu.c:208
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "ファイルをフィルタリング"
+
+#: menu.c:681
 msgid "Filter Directories With Files"
 msgstr "フィルタリングをディレクトリにも適用"
 
-#: menu.c:209
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "サムネイルを表示"
 
-#: menu.c:210
+#: menu.c:683
 msgid "Refresh"
 msgstr "更新"
 
-#: menu.c:211
-msgid "Save Current Display Settings..."
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "更新"
+
+#: menu.c:686
+#, fuzzy
+msgid "Save Display Settings..."
 msgstr "現在の表示設定を保存"
 
-#: menu.c:213
-msgid "Copy..."
-msgstr "コピー"
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "現在の表示設定を保存"
 
-#: menu.c:214
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "ディスク使用量"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "リネーム"
 
-#: menu.c:215
+#: menu.c:700
 msgid "Link..."
 msgstr "リンク"
 
-#: menu.c:219
+#: menu.c:708
 msgid "Send To..."
 msgstr "アプリに送る"
 
-#: menu.c:224
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "拡張属性"
+
+#: menu.c:721
 msgid "Count"
 msgstr "ディスク使用量"
 
-#: menu.c:225
+#: menu.c:723
 msgid "Set Type..."
 msgstr "MIME 形式設定"
 
-#: menu.c:229 toolbar.c:154
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "選択"
 
-#: menu.c:230
+#: menu.c:733
 msgid "Select All"
 msgstr "全て選択"
 
-#: menu.c:231
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "選択をキャンセル"
 
-#: menu.c:232
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "選択を反転"
 
-#: menu.c:233
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "名前で選択"
 
-#: menu.c:234
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "条件附き選択"
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "条件附き選択"
 
-#: menu.c:236
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "新規作成"
 
-#: menu.c:238
+#: menu.c:752
 msgid "Blank file"
 msgstr "空のファイル"
 
-#: menu.c:240 tasklist.c:305
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "ウィンドウ"
 
-#: menu.c:241
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "親ディレクトリを新規ウィンドウで"
 
-#: menu.c:242
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "親ディレクトリを同じウィンドウで"
 
-#: menu.c:243
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "新規ウィンドウ"
 
-#: menu.c:245
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "ブックマークを表示"
 
-#: menu.c:246
+#: menu.c:766
 msgid "Show Log"
 msgstr "ログを表示"
 
-#: menu.c:247
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "シンボリックリンクを追跡"
 
-#: menu.c:248
+#: menu.c:769
 msgid "Resize Window"
 msgstr "ウィンドウをリサイズ"
 
-#: menu.c:251
+#: menu.c:771
 msgid "Close Window"
 msgstr "ウィンドウを閉じる"
 
-#: menu.c:253
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "パス入力..."
 
-#: menu.c:254
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "シェルコマンド..."
 
-#: menu.c:255
+#: menu.c:780
 msgid "Terminal Here"
 msgstr "ここでXtermを起動"
 
-#: menu.c:256
+#: menu.c:782
 msgid "Switch to Terminal"
 msgstr "Xtermに切り替える"
 
-#: menu.c:725
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "アプリに送るには Shift を押しながらメニューボタンをクリックして下さい"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "メニューをカスタマイズ..."
 
-#: menu.c:764
+#: menu.c:976
 msgid "Next Click"
 msgstr "次のクリック"
 
-#: menu.c:786
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d 個のアイテム"
 
-#: menu.c:874
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "マウントされてない状態で開く"
 
-#: menu.c:877
+#: menu.c:1097
 msgid "Show Target"
 msgstr "リンク先を表示"
 
-#: menu.c:879
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "内容を見る"
 
-#: menu.c:881
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "テキストとして開く"
 
-#: menu.c:1052
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2414,15 +2570,15 @@ msgstr ""
 "ルシステムは拡張属性をサポートしているが、マウントオプションで拡張属性を指定"
 "していない事によるものと思われます(Linux の場合 'user_xattr')。"
 
-#: menu.c:1058
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr "設定されたタイプは選択されたファイル中の幾つかをサポートしていません。"
 
-#: menu.c:1095
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "相対リンク(_R)"
 
-#: menu.c:1101
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2434,38 +2590,57 @@ msgstr ""
 "'OFF'の場合,'/'からの絶対パスが保持されます。シンボリックリンクのみを\n"
 "移動し、ターゲットは移動しないような場合は'OFF'にして下さい。"
 
-#: menu.c:1171
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "新パス名は絶対パスでは有りません"
 
-#: menu.c:1239
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr "'%s' のシンボリックリンクは既に存在します。置き換えますか?"
 
-#: menu.c:1245
+#: menu.c:1546
 msgid "_Replace"
 msgstr "置き換え(_R)"
 
-#: menu.c:1365 menu.c:1406 menu.c:1468
-msgid "Create"
-msgstr "作成"
-
-#: menu.c:1366
+#: menu.c:1704
 msgid "NewDir"
 msgstr "新規ディレクトリ"
 
-#: menu.c:1407
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "作成"
+
+#: menu.c:1755
 msgid "NewFile"
 msgstr "新規ファイル"
 
-#: menu.c:1425
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "ファイル作成失敗: %s 用のテンプレートが見つかりません。"
 
-#: menu.c:1498
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"このディレクトリに指定アイテムを開くプログラムの Symlink を置いて下さい。それ"
+"らは同形式 (%s/%s) アイテムを指定して開かれたメニューの先頭に専用メニューとし"
+"て追加されます"
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2477,8 +2652,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "'アプリに送る'メニューは、ファイル(複数可)をアプリを指定して迅速に開く方法で"
 "す。以下の専用ディレクトリに登録されたアプリが 'アプリに送る'メニューで使用可"
@@ -2494,7 +2670,7 @@ msgstr ""
 "と、その形式のファイルが選択されたときに表示されます。.group' は複数形式の"
 "ファイルが選択されたときに表示されます。"
 
-#: menu.c:1509
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
@@ -2503,11 +2679,11 @@ msgstr ""
 "へ Ctrl+Shift+ ドラッグ & ドロップして下さい(シンボリックリンクを作成できま"
 "す)"
 
-#: menu.c:1512 menu.c:1552
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr "環境変数 CHOICESPATH の設定がカスタマイズを妨げています．残念！"
 
-#: menu.c:1545
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2527,7 +2703,7 @@ msgstr ""
 "%s\n"
 "%s\n"
 
-#: menu.c:1550
+#: menu.c:1936
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
@@ -2535,15 +2711,21 @@ msgstr ""
 "OK を押せばテンプレート・ディレクトリを開きます。登録したいテンプレートファイ"
 "ルをそこへコピーして下さい。"
 
-#: menu.c:1667
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "カスタマイズ"
 
-#: menu.c:1740
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "メニューをカスタマイズ..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "これは、このディレクトリの規範的な名称です。"
 
-#: menu.c:1771
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2551,71 +2733,103 @@ msgstr ""
 "このディレクトリのウィンドウをもうひとつ開くことはできません。オプション設定"
 "で `重複したウィンドウを開かない'オプションが有効になっています。"
 
-#: menu.c:1897
-msgid "Copy ... ?"
-msgstr "どれをコピー?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1900
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?%s を %s としてコピーしますか?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?%s を %s としてコピーしますか?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "どれをリネーム?"
 
-#: menu.c:1903
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "どれをシンボリックリンク?"
 
-#: menu.c:1906
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "どれを［Shift］+で開く?"
 
-#: menu.c:1909
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "どれのプロパティを...?"
 
-#: menu.c:1912
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "拡張属性"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "どれの MIME 形式を...?"
 
-#: menu.c:1915
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "どれに対応アプリを設定...?"
 
-#: menu.c:1918
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "どれにアイコンを設定?"
 
-#: menu.c:1921
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "どれをアプリに送る?"
 
-#: menu.c:1924
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "どれを削除する?"
 
-#: menu.c:1927
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "どれの容量を計算する?"
 
-#: menu.c:1930
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "どれのパーミッションを設定?"
 
-#: menu.c:1933
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "どれを検索?"
 
-#: menu.c:1997
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "どれをコピー?"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "複数アイテムに同時にこの処理を行うことはできません"
 
-#: menu.c:2029
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "リネーム"
 
-#: menu.c:2034
+#: menu.c:2619
 msgid "Symlink"
 msgstr "シンボリックリンク"
 
-#: menu.c:2063
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2641,7 +2855,7 @@ msgstr ""
 "※ ショートカット設定を有効にするには、上記の設定終了後 rox のウィンドウ、パネ"
 "ル、ピンボードを一旦すべて終了する必要が有ります"
 
-#: menu.c:2074
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2661,31 +2875,40 @@ msgstr ""
 "設定したショートカットはメニュー項目の横に表示され、以後はメニューを開かなく"
 "てもショートカットキーにより、その機能を呼び出せます。"
 
-#: menu.c:2089
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "キーボードショートカットを設定"
 
-#: minibuffer.c:129
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Goto:"
 
-#: minibuffer.c:130
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "シェル:"
 
-#: minibuffer.c:131
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "条件選択:"
 
-#: minibuffer.c:132
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "名前選択:"
 
-#: minibuffer.c:133
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "条件選択:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "パターン"
 
-#: minibuffer.c:265
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
@@ -2693,14 +2916,34 @@ msgstr ""
 "ファイル/パス名を入力すれば該当するものを表示します。tab キーによる補完が可能"
 "です。ミニバッファの閉じるには 'Escape' キーを押して下さい。"
 
-#: minibuffer.c:271
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
 "シェルコマンドを入力して下さい。ファイル/ディレクトリをあらかじめ選択しておく"
 "か、クリックするとパラメ-タとしてコマンドラインに追加されます。"
 
-#: minibuffer.c:276
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"選択を希望するファイル総てに適合するパターンを入力して下さい：\n"
+"\n"
+"?  任意の1文字に一致します\n"
+"*  ゼロ文字以上の総ての文字列に一致します\n"
+"[aA]  'a' 又は 'A' に一致します\n"
+"[a-z] 'a' から 'z' まで(小文字)のいずれか1文字に一致します\n"
+"*.png '.png'で終わる総てのアイテムに適合します"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2718,7 +2961,7 @@ msgstr ""
 "[a-z] 'a' から 'z' まで(小文字)のいずれか1文字に一致します\n"
 "*.png '.png'で終わる総てのアイテムに適合します"
 
-#: minibuffer.c:288
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
@@ -2731,7 +2974,21 @@ msgstr ""
 "象になります。\n"
 "(ワイルドカードやメタキャラクタが使用可能。参照 : (j)man 7 glob )"
 
-#: minibuffer.c:908
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"表示したいファイルに合致するパターンを入力して下さい。パターンを指定しない場"
+"合はフィルタリングを解除します。\n"
+"\n"
+"パターンによるファイルグロブが行われ、合致したものだけが表示されます。'フィル"
+"タリングをディレクトリにも適用' が 'ON' の時のみ、ディレクトリもグロビング対"
+"象になります。\n"
+"(ワイルドカードやメタキャラクタが使用可能。参照 : (j)man 7 glob )"
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "無効な検索条件です"
 
@@ -2747,32 +3004,32 @@ msgstr ""
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s 合計, %s 使用中, %s 空き (%.1f %%)"
 
-#: options.c:275
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "ROX-Filer はオプション設定ファイルを、新規 XML 形式に変換しました"
 
-#: options.c:535 options.c:1256
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(デフォルトを使用)"
 
-#: options.c:805
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "内部エラー: %s は読めません"
 
-#: options.c:914
+#: options.c:929
 msgid "Options"
 msgstr "オプション"
 
-#: options.c:959
+#: options.c:974
 msgid "_Revert"
 msgstr "戻す(_R)"
 
-#: options.c:965
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr "全ての設定をオプションダイアログを開いたときの状態に戻します。"
 
-#: options.c:980
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2781,34 +3038,34 @@ msgstr ""
 "設定は以下に保存されます:\n"
 "%s"
 
-#: options.c:988
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(環境変数 CHOICESPATHにより保存できません)"
 
-#: options.c:1161 usericons.c:452
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "保存エラー %s: %s"
 
-#: options.c:1793
+#: options.c:1813
 msgid "Missing '='"
 msgstr "'=' がありません"
 
-#: panel.c:325
+#: panel.c:326
 #, c-format
 msgid "Unable to replace '%s'"
 msgstr "'%s'の置き換えに失敗しました"
 
-#: panel.c:329
+#: panel.c:330
 #, c-format
 msgid "Unable to save '%s'"
 msgstr "'%s' を保存できません"
 
-#: panel.c:532
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "今までのパネル設定ファイルは新規 XML 形式に変換されました。"
 
-#: panel.c:640
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
@@ -2816,20 +3073,20 @@ msgstr ""
 "おそらく何かのアクシデントと思われますが、ウィンドウマネージャがパネルを閉じ"
 "ようとしています。 ...本当に閉じますか?"
 
-#: panel.c:741
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "パネル設定ファイル内で '<' 又は '>' が、欠けています"
 
-#: panel.c:1613
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "パネル %s を保存できません: %s"
 
-#: panel.c:1938
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "アプレットはウィジェットを作成せずに終了されました!"
 
-#: panel.c:2034
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2838,44 +3095,44 @@ msgstr ""
 "アプレットの実行エラー:\n"
 "%s"
 
-#: panel.c:2690
+#: panel.c:2751
 msgid "Are you sure you want to remove this panel from the desktop?"
 msgstr "本当にこのパネルをデスクトップから取り除きますか?"
 
-#: panel.c:2693 panel.c:2720
+#: panel.c:2754 panel.c:2781
 msgid "Remove Panel"
 msgstr "パネルを削除"
 
-#: panel.c:2716
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "パネル・オプション..."
 
-#: panel.c:2801
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Xinerama モニタ %d は利用できません"
 
-#: panel.c:2836
+#: panel.c:2897
 msgid "Top"
 msgstr "上端"
 
-#: panel.c:2838
+#: panel.c:2899
 msgid "Bottom"
 msgstr "下端"
 
-#: panel.c:2840
+#: panel.c:2901
 msgid "Left"
 msgstr "左端"
 
-#: panel.c:2842
+#: panel.c:2903
 msgid "Right"
 msgstr "右端"
 
-#: panel.c:2844
+#: panel.c:2905
 msgid "Default"
 msgstr "デフォルト"
 
-#: panel.c:2848
+#: panel.c:2909
 msgid "Unknown side"
 msgstr "不明な端部"
 
@@ -2987,28 +3244,28 @@ msgid ""
 msgstr ""
 "画像ファイル(または特定のアプリケーション)だけが背景に設定できます。 image."
 
-#: pinboard.c:1602
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "アイコン名に '>' が見つかりません"
 
-#: pinboard.c:1611
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "アイコン名の後に ',' が見つかりません"
 
-#: pinboard.c:1699
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "ピンボード %s の保存に失敗: %s"
 
-#: pinboard.c:2244
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "背景を設定"
 
-#: pinboard.c:2247
+#: pinboard.c:2250
 msgid "Add Panel"
 msgstr "パネルを追加"
 
-#: pinboard.c:2341
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -3019,7 +3276,7 @@ msgstr ""
 "%s\n"
 "背景は削除されました。"
 
-#: pixmaps.c:999
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -3028,99 +3285,40 @@ msgstr ""
 "%s のサムネイルを削除できません:\n"
 "%s"
 
-#: pixmaps.c:1020
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "削除するサムネイルはありません"
 
-#: pixmaps.c:1033
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "サムネイルのキャッシュを削除"
 
-#: remote.c:722
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "不明なスタイル'%s'"
 
-#: remote.c:744
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "不明な詳細の種類'%s'"
 
-#: remote.c:772
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "不明な並べ変え方法'%s'"
 
-#: remote.c:1247
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "不明な SOAP 方式 '%s' を試します。"
 
-#: run.c:99 run.c:152
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "プログラム %s がありません - 削除しましたか？"
 
-#: run.c:302
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "ファイルが存在していないかアクセスできません: %s"
-
-#: run.c:307
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "'%s'を開く方法が分かりません"
-
-#: run.c:338
-#, c-format
-msgid "'%s' is not a valid URI"
-msgstr "'%s' は有効な URI では有りません。"
-
-#: run.c:349
-#, c-format
-msgid "%s not accessable"
-msgstr "'%s' にアクセスできません"
-
-#: run.c:357
-#, c-format
-msgid "Non-local URL %s"
-msgstr "非ローカル URL %s"
-
-#: run.c:374
-#, c-format
-msgid "%s: no handler for %s"
-msgstr "%s: %s へのハンドラでは有りません"
-
-#: run.c:394
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"アプリケーション:\n"
-"これはプログラムとして実行可能なアプリケーションディレクトリです(内容を 確認"
-"するには Shift キーを押しながらクリックします)。 ここには通常、アプリケーショ"
-"ンのヘルプも格納されますが、これには含まれていません。"
-
-#: run.c:478
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "データをプログラムに送れません: %s"
-
-#: run.c:508
-#, c-format
-msgid "Could not read link: %s"
-msgstr "リンクを読めません: %s"
-
-#: run.c:536
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr ""
-"壊れたシンボリックリンク(もしくはリンク元に対するパーミッションがありませ"
-"ん): %s"
-
-#: run.c:573
+#: run.c:359
 #, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
@@ -3131,7 +3329,7 @@ msgstr ""
 "クリックして「対応アプリの設定」を選んでください。もしくはアイコンを直接アプ"
 "リにドラッグしてください。%s"
 
-#: run.c:579
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -3143,7 +3341,66 @@ msgstr ""
 "注意:もしこれが実行可能なプログラムなら、ファイルメニューの'パーミッション'、"
 "又は、'プロパティ' の項で、実行ビットをセットする必要が有ります。"
 
-#: run.c:753
+#: run.c:373
+#, c-format
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "ファイルが存在していないかアクセスできません: %s"
+
+#: run.c:378
+#, c-format
+msgid "I don't know how to open '%s'"
+msgstr "'%s'を開く方法が分かりません"
+
+#: run.c:409
+#, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' は有効な URI では有りません。"
+
+#: run.c:420
+#, c-format
+msgid "%s not accessable"
+msgstr "'%s' にアクセスできません"
+
+#: run.c:428
+#, c-format
+msgid "Non-local URL %s"
+msgstr "非ローカル URL %s"
+
+#: run.c:445
+#, c-format
+msgid "%s: no handler for %s"
+msgstr "%s: %s へのハンドラでは有りません"
+
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
+msgstr ""
+"アプリケーション:\n"
+"これはプログラムとして実行可能なアプリケーションディレクトリです(内容を 確認"
+"するには Shift キーを押しながらクリックします)。 ここには通常、アプリケーショ"
+"ンのヘルプも格納されますが、これには含まれていません。"
+
+#: run.c:549
+#, c-format
+msgid "Could not send data to program: %s"
+msgstr "データをプログラムに送れません: %s"
+
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "リンクを読めません: %s"
+
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
+msgstr ""
+"壊れたシンボリックリンク(もしくはリンク元に対するパーミッションがありませ"
+"ん): %s"
+
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3167,93 +3424,131 @@ msgstr ""
 "利用する全てのユ-ザが信頼できるなら心配はいりませんが、そうでない場合は完璧な"
 "チェックを行うか、わずかでも不安の残るプログラムは全て削除すべきです。"
 
-#: run.c:766
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (セキュリティ的処置)"
 
-#: support.c:272
-msgid "B"
-msgstr "B"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:351
+#: support.c:381
 msgid "byte"
 msgstr "byte"
 
-#: support.c:1596 support.c:1650
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
 msgstr "'%s'のオープンと調査に失敗しました : %s"
 
-#: support.c:1607 support.c:1661
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
 msgstr "ファイル '%s' のメモリへの割付けに失敗しました : %s"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close"
 msgstr "閉じる"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close filer window"
 msgstr "ファイラーウィンドウを閉じる"
 
-#: toolbar.c:117
+#: toolbar.c:120
 msgid "Up"
 msgstr "上へ"
 
-#: toolbar.c:117
-msgid "Change to parent directory"
-msgstr "親ディレクトリに移動"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:121
+#: toolbar.c:126
 msgid "Home"
 msgstr "ホーム"
 
-#: toolbar.c:121
-msgid "Change to home directory"
-msgstr "ホームディレクトリに移動"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks"
-msgstr "ブックマーク"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks menu"
-msgstr "ブックマークメニュー"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:129
+#: toolbar.c:138
 msgid "Scan"
 msgstr "スキャン"
 
-#: toolbar.c:129
-msgid "Rescan directory contents"
-msgstr "ディレクトリの内容を読み直す"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:133
-msgid "Change icon size"
-msgstr "アイコンを拡大/縮小(左/右クリック)"
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "サイズ"
 
-#: toolbar.c:137
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "自動"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
 msgstr "ウィンドウのサイズを最適化"
 
-#: toolbar.c:141
-msgid "Show extra details"
-msgstr "詳細を表示/非表示"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "詳細表示"
 
-#: toolbar.c:145
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
 msgstr "ソート"
 
-#: toolbar.c:145
+#: toolbar.c:165
 msgid "Change sort criteria"
 msgstr "ソート条件を変更"
 
-#: toolbar.c:149
-msgid "Hidden"
-msgstr "隠しファイル"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:149
+#: toolbar.c:169
 msgid ""
 "Left: Show/hide hidden files\n"
 "Right: Show/hide thumbnails"
@@ -3261,110 +3556,154 @@ msgstr ""
 "左クリック: 隠しファイルの表示/非表示\n"
 "右クリック: サムネイルの表示/非表示"
 
-#: toolbar.c:154
-msgid "Select all/invert selection"
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+#, fuzzy
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+"左クリック: 隠しファイルの表示/非表示\n"
+"右クリック: サムネイルの表示/非表示"
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
 msgstr "全てを選択/選択を反転(左/右クリック)"
 
-#: toolbar.c:158
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
 msgstr "ROX-Filerのヘルプを表示"
 
-#: toolbar.c:221
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
 msgstr " (%u 個の隠しファイル)"
 
-#: toolbar.c:229 tips:58
+#: toolbar.c:276 tips:79
 msgid "items"
 msgstr "アイテム"
 
-#: toolbar.c:229
+#: toolbar.c:276
 msgid "item"
 msgstr "アイテム"
 
-#: toolbar.c:232
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
 msgstr "アイテム無し%s"
 
-#: toolbar.c:251
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
 msgstr "%u 個を選択(%s)"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by name"
 msgstr "名前でソート"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by type"
 msgstr "種類でソート"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by date"
 msgstr "日付でソート"
 
-#: toolbar.c:446
+#: toolbar.c:535
 msgid "Sort by size"
 msgstr "サイズでソート"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by owner"
 msgstr "所有者でソート"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by group"
 msgstr "グループでソート"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "ascending"
 msgstr "昇順"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "descending"
 msgstr "降順"
 
-#: type.c:214
+#: toolbar.c:891
+#, fuzzy
+msgid "_N_Items_"
+msgstr "対象"
+
+#: type.c:221
 msgid "Sym link"
 msgstr "シンボリックリンク"
 
-#: type.c:216
+#: type.c:223
 msgid "Mount point"
 msgstr "マウントポイント"
 
-#: type.c:218
+#: type.c:225
 msgid "App dir"
 msgstr "アプリケーションディレクトリ"
 
-#: type.c:225
+#: type.c:232
 msgid "Dir"
 msgstr "Dir"
 
-#: type.c:227
+#: type.c:234
 msgid "Char dev"
 msgstr "キャラクタデバイス"
 
-#: type.c:229
+#: type.c:236
 msgid "Block dev"
 msgstr "ブロックデバイス"
 
-#: type.c:231
+#: type.c:238
 msgid "Pipe"
 msgstr "パイプ"
 
-#: type.c:233
+#: type.c:240
 msgid "Socket"
 msgstr "ソケット"
 
-#: type.c:235
+#: type.c:242
 msgid "Door"
 msgstr "Door"
 
-#: type.c:238
+#: type.c:245
 msgid "Unknown"
 msgstr "不明"
 
-#: type.c:554
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3375,71 +3714,71 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:735
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "これはプログラムではありません。別のアプリを指定してください。"
 
-#: type.c:795
+#: type.c:839
 msgid "No run action defined"
 msgstr "対応アプリが設定されていません"
 
-#: type.c:799
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "%s にエラ-: %s"
 
-#: type.c:814
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "無効なアプリケーション %s (AppRun 不良)"
 
-#: type.c:825
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "実行属性の無い %s"
 
-#: type.c:858
+#: type.c:902
 msgid "Set run action"
 msgstr "対応アプリを設定"
 
-#: type.c:864
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 "このファイル形式の取扱いが設定されていない場合、これをデフォルトの動作に使用"
 "します。"
 
-#: type.c:866
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "`%s/<anything>' 全てに適用する"
 
-#: type.c:870
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "この MIME 形式のファイル全てにこのアプリを対応させる。"
 
-#: type.c:872
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "`%s'形式(%s/%s)のみに適用する"
 
-#: type.c:878
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "関連づけるアプリケーションをここにドロップ"
 
-#: type.c:893
+#: type.c:963
 msgid "OR"
 msgstr "もしくは"
 
-#: type.c:900
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "シェルコマンドを入力してください:"
 
-#: type.c:929
+#: type.c:1000
 msgid "_Use Command"
 msgstr "使用コマンド(_U)"
 
-#: type.c:959
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
@@ -3447,16 +3786,16 @@ msgstr ""
 "既に対応アプリが定義されており、かなり大きなプログラムになっています。本当に"
 "削除しますか?"
 
-#: type.c:970
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "%s を削除できません: %s"
 
-#: type.c:1007
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "環境変数 CHOICESPATH により、選択は保存されません。"
 
-#: type.c:1309
+#: type.c:1395
 #, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
@@ -3465,11 +3804,11 @@ msgstr ""
 "シンボリックリンク '%s' が作れませんでした :\n"
 "%s"
 
-#: usericons.c:179
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "指定されたパスは存在しません。アイコンは変更されません。"
 
-#: usericons.c:189 usericons.c:618
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3479,12 +3818,12 @@ msgstr ""
 "適切でないかでしょう\n"
 "アイコンは変更されません。"
 
-#: usericons.c:235
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "アイコン'%s'を削除しますか？"
 
-#: usericons.c:239
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3493,30 +3832,30 @@ msgstr ""
 "'%s'を削除できません:\n"
 "%s"
 
-#: usericons.c:272
+#: usericons.c:281
 msgid "Set icon"
 msgstr "アイコンを設定"
 
-#: usericons.c:281
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr "画像をこの MIME 形式全般のアイコンに設定します。"
 
-#: usericons.c:283
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "アイコンを全ての`%s/<anything>' に適用する"
 
-#: usericons.c:288
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "画像をこの MIME 形式全般のデフォルトアイコンに設定します。"
 
-#: usericons.c:290
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "総ての`%s'形式(%s/%s)に適用する"
 
-#: usericons.c:296
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
@@ -3524,12 +3863,12 @@ msgstr ""
 "このファイルとアイコンの名前はユーザー用個人リストに追加登録されます。設定画"
 "像またはこのファイルを移動すると設定は失われます。"
 
-#: usericons.c:299
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "`%s' のみに適用する"
 
-#: usericons.c:307
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
@@ -3539,19 +3878,19 @@ msgstr ""
 "ザにアイコンが表示され、移動してもアイコンは失われません。書き込み権限を与え"
 "られている場合、この設定を選ぶ事をお薦めします。"
 
-#: usericons.c:313
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "画像をディレクトリにコピー"
 
-#: usericons.c:319
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "アイコンファイルをここにドロップ"
 
-#: usericons.c:589
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr " 環境変数 CHOICESPATH により、アイコンが設定できません"
 
-#: usericons.c:633
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3560,41 +3899,57 @@ msgstr ""
 "画像 '%s' 作成エラー:\n"
 "%s"
 
-#: view_details.c:957
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
 msgid "Mono font"
 msgstr "等幅フォント"
 
-#: view_details.c:958
+#: view_details.c:1019
 msgid "Font for displaying mono-spaced text"
 msgstr "テキスト表示用の固定幅フォント"
 
-#: view_details.c:1059
+#: view_details.c:1233
 msgid "_Name"
 msgstr "名前(_N)"
 
-#: view_details.c:1062
+#: view_details.c:1236
 msgid "_Type"
 msgstr "タイプ(_T)"
 
-#: view_details.c:1065
-msgid "_Permissions"
-msgstr "パーミッション(_P)"
-
-#: view_details.c:1070
-msgid "_Owner"
-msgstr "所有者(_O)"
-
-#: view_details.c:1072
-msgid "_Group"
-msgstr "グループ(_G)"
-
-#: view_details.c:1074
+#: view_details.c:1238
 msgid "_Size"
 msgstr "サイズ(_S)"
 
-#: view_details.c:1080
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "パーミッション(_P)"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "所有者(_O)"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "グループ(_G)"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "最終変更日(_M)"
+
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "拡張属性"
 
 #: tips:1
 msgid "Filer windows"
@@ -3645,7 +4000,8 @@ msgstr ""
 msgid "Largest window size:"
 msgstr "ウィンドウの最大サイズ:"
 
-#: tips:10
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
@@ -3658,14 +4014,28 @@ msgstr ""
 "ズ。"
 
 #: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "ウィンドウの最大サイズ:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"画面全体に対する最大のサイズ。自動的にサイズを変更する際に許可する最大のサイ"
+"ズ。"
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "ウィンドウの動作"
 
-#: tips:13
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "タイトルバーへの状態表示を略記する"
 
-#: tips:14
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
@@ -3673,11 +4043,11 @@ msgstr ""
 "タイトルバーに、スキャン中は'+S'、全て表示は'+A'、サムネイル表示は'+T' とファ"
 "イラーの状態の簡略表示を追加します。"
 
-#: tips:15
+#: tips:18
 msgid "Unique windows"
 msgstr "重複したウィンドウを開かない"
 
-#: tips:16
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3685,11 +4055,34 @@ msgstr ""
 "開こうとしたディレクトリが、既に別ウィンドウとして開かれている場合、旧ウィン"
 "ドウを自動的に閉じます。"
 
-#: tips:17
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "ウィンドウ"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "左ボタン(第 1 ボタン)で新しいウィンドウを開く"
 
-#: tips:18
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3698,11 +4091,11 @@ msgstr ""
 "'ON' の場合、第 1 ボタン(通常は左ボタン)でディレクトリをクリックすると、新し"
 "いウィンドウで開き、中ボタンをクリックすると現在のウィンドウで開きます。"
 
-#: tips:19
+#: tips:26
 msgid "Single-click navigation"
 msgstr "シングルクリックで操作する"
 
-#: tips:20 tips:116
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
@@ -3712,11 +4105,11 @@ msgstr ""
 "キーを押しながらクリック。'OFF' の場合は シングルクリックで選択、ダブルクリッ"
 "クでアイテムを開きます。"
 
-#: tips:21
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "背景のダブルクリックでウィンドウをリサイズする"
 
-#: tips:22
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
@@ -3724,25 +4117,25 @@ msgstr ""
 "ファイラーウィンドウ背景のダブルクリックで、ツールバーのウィンドウサイズ最適"
 "化ボタンをクリックしたのと同様に、ウィンドウをリサイズします。"
 
-#: tips:23
+#: tips:30
 msgid "Sorting"
 msgstr "ソート"
 
-#: tips:24
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "ディレクトリを先に表示(名前で並べ変える場合)"
 
-#: tips:25
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
 msgstr "'ON' で「名前でソ-ト」の場合、常にディレクトリを先に表示します。"
 
-#: tips:26
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "大文字を先に表示(名前でソートの場合)"
 
-#: tips:27
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
@@ -3750,15 +4143,59 @@ msgstr ""
 "'ON' の場合、総ての大文字から始まるファイル名のものを、小文字から始まるファイ"
 "ルよりも先に表示します。"
 
-#: tips:29
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "ディレクトリを先に表示(名前で並べ変える場合)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sec"
+
+#: tips:38
+msgid "Show extended attribute indicator"
+msgstr "拡張属性インジケータを表示"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+"'ON' の場合、一つ以上の拡張属性をセットされたファイルは、それを明示する為、エ"
+"ンブレムが付け加えられます。"
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "新規ウィンドウのデフォルト設定"
 
-#: tips:30
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "元のウィンドウのオプションを引き継ぐ"
 
-#: tips:31
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
@@ -3767,27 +4204,38 @@ msgstr ""
 "ぎ、'OFF' の場合、親ウィンドウの現在の表示法にかかわらず、デフォルトのオプ"
 "ション設定に従います。"
 
-#: tips:32
+#: tips:48
 msgid "View type:"
 msgstr "表示形式:"
 
-#: tips:35
+#: tips:51
 msgid "Sort by:"
 msgstr "ソート条件:"
 
-#: tips:37 tips:54
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "タイプ"
 
-#: tips:38
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "日付"
 
-#: tips:40
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "日付"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "日付"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "隠しファイルを表示"
 
-#: tips:41
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
@@ -3795,55 +4243,75 @@ msgstr ""
 "'ON' の場合、ドットで始まる隠し属性ファイルも表示し、'OFF' の場合は表示しませ"
 "ん。"
 
-#: tips:42
-msgid "Show extended attribute indicator"
-msgstr "拡張属性インジケータを表示"
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "隠しファイルを表示"
 
-#: tips:43
+#: tips:61
+#, fuzzy
 msgid ""
-"If this is on then files which have one or more extended attributes set will "
-"have an emblem added to indicate this."
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
 msgstr ""
-"'ON' の場合、一つ以上の拡張属性をセットされたファイルは、それを明示する為、エ"
-"ンブレムが付け加えられます。"
+"'ON' の場合、ドットで始まる隠し属性ファイルも表示し、'OFF' の場合は表示しませ"
+"ん。"
 
-#: tips:44
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "特大アイコン"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "ピクセル"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "アイコン表示"
 
-#: tips:45
+#: tips:67
 msgid "Default size:"
 msgstr "デフォルトのサイズ:"
 
-#: tips:46
+#: tips:68
 msgid "Huge Icons"
 msgstr "特大アイコン"
 
-#: tips:47 tips:217
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "大きいアイコン"
 
-#: tips:48 tips:216
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "小さいアイコン"
 
-#: tips:50
+#: tips:72
 msgid "Default details:"
 msgstr "デフォルトの表示情報:"
 
-#: tips:51
+#: tips:73
 msgid "No details"
 msgstr "なし"
 
-#: tips:56
-msgid "Automatic small icons:"
+#: tips:74
+msgid "Sizes"
+msgstr "サイズ"
+
+#: tips:77
+msgid "Times"
+msgstr "日付"
+
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "小さいアイコンに自動的に変更:"
 
-#: tips:57
-msgid "Change at:"
-msgstr "この数で変更:"
-
-#: tips:59
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3852,101 +4320,229 @@ msgstr ""
 "デフォルトのサイズが「自動」の場合、アイテム数がこの数値を越えた時、小さいア"
 "イコンで表示します。「自動」以外の場合は指定サイズのままで表示します。"
 
-#: tips:60
-msgid "Max width (Large icons):"
-msgstr "ファイル名の最大幅(大きいアイコン):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "大きいアイコン"
 
-#: tips:61 tips:64
-msgid "pixels"
-msgstr "ピクセル"
-
-#: tips:62
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "'大きいアイコンモード'の時、ファイル/ディレクトリ名表示がこの幅より広いと折り"
 "返します。'特大アイコンモード'の時の折り返し幅は 50%増しとなります。"
 
-#: tips:63
-msgid "(Small Icons):"
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
+
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
+#: tips:88
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr "'ON' の場合、横方向順ではなく、縦方向順に大きいアイコンをならべます"
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
 msgstr "(小さいアイコン):"
 
-#: tips:65
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "「小さいアイコン」の横に表示するファイル名の最大幅"
 
-#: tips:66
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "小さいアイコンを縦方向順に配置"
 
-#: tips:67
+#: tips:93
 msgid ""
 "If this option is on, then small icons are arranged in columns, not rows."
 msgstr "'ON' の場合、横方向順ではなく、縦方向順に小さいアイコンをならべます"
 
-#: tips:68
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "大きいアイコンを縦方向順に配置"
 
-#: tips:69
+#: tips:95
 msgid ""
 "If this option is on, then large icons are arranged in columns, not rows."
 msgstr "'ON' の場合、横方向順ではなく、縦方向順に大きいアイコンをならべます"
 
-#: tips:71
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "項目の標題を表示"
 
-#: tips:72
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr ""
 "'ON' の場合、詳細表示の際、ツールバー下部に情報項目の標題バーを表示します。"
 
-#: tips:73
+#: tips:102
 msgid "Show full type"
 msgstr "タイプの詳細を表示"
 
-#: tips:74
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr ""
 "'ON' の場合、アイテムのタイプを基本形の要約ではなく、詳細に表示します。"
 
-#: tips:75
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "「小さいアイコン」の横に表示するファイル名の最大幅"
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "項目の標題を表示"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"'ON' の場合、詳細表示の際、ツールバー下部に情報項目の標題バーを表示します。"
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"'ON' の場合、詳細表示の際、ツールバー下部に情報項目の標題バーを表示します。"
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"'ON' の場合、詳細表示の際、ツールバー下部に情報項目の標題バーを表示します。"
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"'ON' の場合、詳細表示の際、ツールバー下部に情報項目の標題バーを表示します。"
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"'ON' の場合、詳細表示の際、ツールバー下部に情報項目の標題バーを表示します。"
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"'ON' の場合、詳細表示の際、ツールバー下部に情報項目の標題バーを表示します。"
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "最終変更日(_M)"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"'ON' の場合、詳細表示の際、ツールバー下部に情報項目の標題バーを表示します。"
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"'ON' の場合、詳細表示の際、ツールバー下部に情報項目の標題バーを表示します。"
+
+#: tips:128
+#, fuzzy
+msgid "Last Accessed"
+msgstr "'%s' にアクセスできません"
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"'ON' の場合、詳細表示の際、ツールバー下部に情報項目の標題バーを表示します。"
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "ツールバー/ミニバッファ"
 
-#: tips:76
+#: tips:131
 msgid "Toolbar"
 msgstr "ツールバー"
 
-#: tips:77
+#: tips:132
 msgid "Toolbar type:"
 msgstr "ツールバーの種類:"
 
-#: tips:78
+#: tips:133
 msgid "No toolbar"
 msgstr "ツールバーなし"
 
-#: tips:79
+#: tips:134
 msgid "Icons only"
 msgstr "アイコンのみ"
 
-#: tips:80
+#: tips:135
 msgid "Text under icons"
 msgstr "アイコンの下に文字を表示"
 
-#: tips:81
+#: tips:136
 msgid "Text beside icons"
 msgstr "アイコンの横に文字を表示"
 
-#: tips:82
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "パネルのみ"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "アイテムの総数を表示"
 
-#: tips:83
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3956,15 +4552,15 @@ msgstr ""
 "がある場合、その数も表示されます。アイテムが選択されている場合は、その数と合"
 "計サイズを表示します。"
 
-#: tips:84
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "ツールバーに表示するボタンを選んでください:"
 
-#: tips:85
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "小さなウィンドウの時もツールバーをすべて表示"
 
-#: tips:86
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
@@ -3973,15 +4569,15 @@ msgstr ""
 "ンドウサイズになるよう強制します(アイテム数が少ない場合でも総てのツールが表示"
 "されます)"
 
-#: tips:87
+#: tips:143
 msgid "Minibuffer"
 msgstr "ミニバッファ"
 
-#: tips:88
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "タブ補完に失敗したときは警告音を鳴らす"
 
-#: tips:89
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
@@ -3990,11 +4586,11 @@ msgstr ""
 "'パス入力'ミニバッファ内で、タブキーを押しても変化が無い時(次の文字侯補が複数"
 "有る場合など)、警告音を鳴らします。"
 
-#: tips:90
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "補完候補が複数あるときは音を鳴らす"
 
-#: tips:91
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
@@ -4002,7 +4598,27 @@ msgstr ""
 "'パス入力'ミニバッファ内で、タブキーを押した時、文字入力をさらに追加しても複"
 "数のファイルに適合するような場合、警告音を鳴らします。"
 
-#: tips:94
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "ダウンロード実行コマンド"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "%s にエラ-: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
@@ -4010,11 +4626,11 @@ msgstr ""
 "サムネイルを有効にすると、ディレクトリ内の画像ファイルが小さなサムネイルで表"
 "示されます。"
 
-#: tips:95
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "画像のサムネイルを表示"
 
-#: tips:96
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
@@ -4022,33 +4638,102 @@ msgstr ""
 "これが新規ウィンドウ起動時のデフォルト設定になりますが、 表示メニューにより、"
 "各ウィンドウのサムネイル表示を、個別に ON/OFF することも出来ます。"
 
-#: tips:97
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "画像のサムネイルを表示"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "ビデオ・サムネイル"
 
-#: tips:98
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "サムネイルのキャッシュ"
 
-#: tips:99
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "速度を上げるため、生成したサムネイルは隠しディレクトリ ~/.thumbnails に保存さ"
 "れます。ここをクリックすると保存したサムネイルを削除します。それらは必要に応"
 "じて再生成されるでしょう。"
 
-#: tips:100
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
 msgid "Manage thumbnails"
 msgstr "サムネイルの管理"
 
-#: tips:101 tips:158
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "ビデオ・サムネイル"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sec"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "ピンボード"
 
-#: tips:102
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
@@ -4058,47 +4743,47 @@ msgstr ""
 "ます。ピンボード使用時(rox -h 参照)は、ファイラー画面上のアイテムをデスクトッ"
 "プにドロップして、デスクトップアイコンを作ることが出来ます"
 
-#: tips:103 tips:213
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "外観"
 
-#: tips:104
+#: tips:179
 msgid "Foreground:"
 msgstr "文字の色:"
 
-#: tips:105
+#: tips:180
 msgid "Text shadow:"
 msgstr "文字の影:"
 
-#: tips:106
+#: tips:181
 msgid "Background:"
 msgstr "背景の色:"
 
-#: tips:107
+#: tips:182
 msgid "No shadow"
 msgstr "文字の影なし"
 
-#: tips:108
+#: tips:183
 msgid "Thin"
 msgstr "細い"
 
-#: tips:109
+#: tips:184
 msgid "Thick"
 msgstr "太い"
 
-#: tips:110
+#: tips:185
 msgid "Use custom font:"
 msgstr "カスタムフォントを使う:"
 
-#: tips:111
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "アイコンのテキスト(ラベル名)のフォントを指定します。"
 
-#: tips:112
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "画像のサイズ調整を高速にする"
 
-#: tips:113
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
@@ -4106,19 +4791,19 @@ msgstr ""
 "'ON' の場合、背景画像のサイズ調整が高速になります。'OFF' の場合、速度は低下す"
 "るがより高画質です。"
 
-#: tips:114
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "ピンボードの動作"
 
-#: tips:115
+#: tips:190
 msgid "Single-click to open"
 msgstr "シングルクリックで開く"
 
-#: tips:117
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "アイコンを画面内に収める"
 
-#: tips:118
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
@@ -4126,39 +4811,39 @@ msgstr ""
 "これを指定すると、デスクトップのアイコンが(テキスト)ラベルも含めて常に画面内"
 "に収まるようになります。"
 
-#: tips:119
+#: tips:194
 msgid "Icon grid step:"
 msgstr "アイコンのグリッド間隔:"
 
-#: tips:120
+#: tips:195
 msgid "Fine"
 msgstr "細かい"
 
-#: tips:121
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "デスクトップ上でアイコンを 2 ピクセル単位で移動、配置。"
 
-#: tips:122
+#: tips:197
 msgid "Medium"
 msgstr "中間"
 
-#: tips:123
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "デスクトップ上でアイコンを 16 ピクセル単位で移動、配置。"
 
-#: tips:124
+#: tips:199
 msgid "Coarse"
 msgstr "粗い"
 
-#: tips:125
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "デスクトップ上でアイコンを 32 ピクセル単位で移動、配置。"
 
-#: tips:126 tips:128
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "最小化ウィンドウのアイコン表示"
 
-#: tips:127
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
@@ -4167,11 +4852,11 @@ msgstr ""
 "ピンボードを有効にした時、ROXファイラーを含む様々な起動中のプログラムは、デス"
 "クトップにアイコン化することが出来ます"
 
-#: tips:129
+#: tips:204
 msgid "Show iconified windows"
 msgstr "アイコン化したウィンドウを表示"
 
-#: tips:130
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
@@ -4181,11 +4866,11 @@ msgstr ""
 "にアイコンとして表示されるようになります。(機能をサポートするウィンドウマネー"
 "ジャ上でピンボードを使用している場合)。 "
 
-#: tips:131
+#: tips:206
 msgid "Show per workspace"
 msgstr "ワークスペース毎に表示"
 
-#: tips:132
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
@@ -4193,39 +4878,39 @@ msgstr ""
 "このオプションを利用すると、最小化アイコンは、カレントワークスペースのものの"
 "みが表示されるようになります。"
 
-#: tips:133
+#: tips:208
 msgid "Iconify to the"
 msgstr "アイコン化する場所"
 
-#: tips:134
+#: tips:209
 msgid "top-left"
 msgstr "左上"
 
-#: tips:135
+#: tips:210
 msgid "top-right"
 msgstr "右上"
 
-#: tips:136
+#: tips:211
 msgid "bottom-left"
 msgstr "左下"
 
-#: tips:137
+#: tips:212
 msgid "bottom-right"
 msgstr "右下"
 
-#: tips:138
+#: tips:213
 msgid ", going"
 msgstr ", 並びかた"
 
-#: tips:139
+#: tips:214
 msgid "horizontally"
 msgstr "水平に"
 
-#: tips:140
+#: tips:215
 msgid "vertically"
 msgstr "垂直に"
 
-#: tips:141
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4236,43 +4921,43 @@ msgstr ""
 "ンドウ(のアイコン)を置くような場合も有ります。下の上部余白、下部余白の設定に"
 "よりこれを回避することが出来ます。ROX パネルに関しては常に正常に認識されます"
 
-#: tips:142
+#: tips:217
 msgid "Top margin"
 msgstr "上端余白"
 
-#: tips:143
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "画面最上部の表示禁止区域の高さ"
 
-#: tips:144
+#: tips:219
 msgid "Bottom margin"
 msgstr "下端余白"
 
-#: tips:145
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "画面最下部の表示禁止区域の高さ"
 
-#: tips:146
+#: tips:221
 msgid "Left margin"
 msgstr "左端余白"
 
-#: tips:147
+#: tips:222
 msgid "Width of no-go area at left of screen."
 msgstr "画面左端部の表示禁止区域の幅"
 
-#: tips:148
+#: tips:223
 msgid "Right margin"
 msgstr "右端余白"
 
-#: tips:149
+#: tips:224
 msgid "Width of no-go area at right of screen."
 msgstr "画面右端部の表示禁止区域の幅"
 
-#: tips:150
+#: tips:225
 msgid "Desktop"
 msgstr "デスクトップ"
 
-#: tips:151
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
@@ -4281,51 +4966,39 @@ msgstr ""
 "時、ファイラーはパネル、ピンボードのいずれか、又は両方を開くことができます。"
 "下のいずれかを選んで下さい。"
 
-#: tips:152
+#: tips:227
 msgid "Panel only"
 msgstr "パネルのみ"
 
-#: tips:153
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "パネルのみを表示します。"
 
-#: tips:154
+#: tips:229
 msgid "Pinboard only"
 msgstr "ピンボードのみ"
 
-#: tips:155
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "ピンボードのみを表示します。"
 
-#: tips:156
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "パネルとピンボード"
 
-#: tips:157
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "パネルとピンボードを共に表示します。"
 
-#: tips:159
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "表示するピンボードの名前を入力して下さい。"
 
-#: tips:160
-msgid "Panel (obsolete)"
-msgstr "パネル (廃止)"
-
-#: tips:161
-msgid ""
-"Enter the name of the panel to show here. This option is now only used when "
-"upgrading from an old version."
-msgstr ""
-"表示するパネルの名前を入力して下さい(この項目は旧バージョンからのアップグレー"
-"ドの為だけに有ります)"
-
-#: tips:162
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr "変更は次回の rox 起動時に有効になります。"
 
-#: tips:163
+#: tips:236
 msgid ""
 "The session manager activates these options by\n"
 "using the -S or --rox-session argument to rox."
@@ -4333,11 +5006,11 @@ msgstr ""
 "rox を -S 又は --rox-session オプションで起動した場合に、\n"
 "セッション・マネージャは これらのオプションを有効にします"
 
-#: tips:164
+#: tips:237
 msgid "Action windows"
 msgstr "確認ダイアログ"
 
-#: tips:165
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4345,59 +5018,64 @@ msgstr ""
 "確認ダイアログは、バックグラウンド操作(ファイルのコピーや削除など)を始めよう"
 "とした時に表示されます。"
 
-#: tips:166
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "以下を実行するときに確認を求めない:"
 
-#: tips:168
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "ファイルをコピーするときに確認を求ません"
 
-#: tips:170
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "ファイルを移動/リネームするときに確認を求めません"
 
-#: tips:172
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "リンクを張るときに確認を求めません"
 
-#: tips:174
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "ファイルを削除するときに確認を求めません"
 
-#: tips:175
+#: tips:248
 msgid "Mount"
 msgstr "マウント"
 
-#: tips:176
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "マウント/アンマウントするときに確認を求めません"
 
-#: tips:177
+#: tips:250
 msgid "Default settings"
 msgstr "デフォルトの設定"
 
-#: tips:179
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "強行"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "書き込み禁止アイテムを削除するときも確認を求めません"
 
-#: tips:181
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "ログメッセージの表示を簡略化します"
 
-#: tips:183
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "サブディレクトリ以下の内容にも、作動を適用します"
 
-#: tips:186
+#: tips:263
 msgid "Mount commands"
 msgstr "マウント コマンド"
 
-#: tips:187
+#: tips:264
 msgid "Mount command"
 msgstr "マウント コマンド"
 
-#: tips:188
+#: tips:265
 msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
 msgstr ""
 "ファイルシステムのマウントを行うコマンドです。\n"
@@ -4406,11 +5084,11 @@ msgstr ""
 "よく分からない場合は \"mount\" コマンドを利用\n"
 "してください。"
 
-#: tips:189
+#: tips:266
 msgid "Unmount command"
 msgstr "アンマウント コマンド"
 
-#: tips:190
+#: tips:267
 msgid ""
 "The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
 "without the first \"n\")."
@@ -4421,29 +5099,37 @@ msgstr ""
 "よく分からない場合は \"umount\" コマンドを利用して\n"
 "ください。(u \"n\" mount ではないですよ)。"
 
-#: tips:191
+#: tips:268
 msgid "Eject command"
 msgstr "イジェクト コマンド"
 
-#: tips:192
+#: tips:269
 msgid "The command used to eject removable media. If unsure, use \"eject\"."
 msgstr ""
 "リムーバブルメディアのイジェクトを行うコマンドです。よく分からない場合は "
 "\"eject\" コマンドを利用してください。"
 
-#: tips:193
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "ドラッグ＆ドロップ"
 
-#: tips:194
+#: tips:273
 msgid "Dragging to icons"
 msgstr "アイコンへのドラッグ"
 
-#: tips:195
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "ファイラーウィンドウでアイコンへのドラッグ動作を可能にする"
 
-#: tips:196
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
@@ -4453,11 +5139,11 @@ msgstr ""
 "のドラッグが可能になります。操作中、アイテムは強調表示され、指定ディレクトリ"
 "に コピー(又は移動かリンク作成)されるか、指定プログラムで開かれます。"
 
-#: tips:197
+#: tips:276
 msgid "Directories spring open"
 msgstr "ディレクトリのスプリングオープン"
 
-#: tips:198
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
@@ -4467,15 +5153,15 @@ msgstr ""
 "ファイルをドラッグしてディレクトリの上に保持すると、そのディレクトリが '跳ね"
 "開け' られます。"
 
-#: tips:199
+#: tips:278
 msgid "Spring delay:"
 msgstr "開くまでの時間:"
 
-#: tips:200
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:201
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
@@ -4484,19 +5170,19 @@ msgstr ""
 "ドラッグしたファイルでディレクトリをスプリングオープンする際の保持時間を(ミリ"
 "セコンド単位で)設定します。'スプリングオープン'が'ON'の場合に有効です。"
 
-#: tips:202
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "マウスの左ボタンでファイルをドラッグしたときの動作"
 
-#: tips:203 tips:207
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "実行可能なメニューを表示"
 
-#: tips:204
+#: tips:283
 msgid "Copy the files"
 msgstr "ファイルをコピー"
 
-#: tips:205
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
@@ -4504,15 +5190,15 @@ msgstr ""
 "'ON'にした場合には、'Alt'キーを押しながら左ボタンでドラッグすれば、オプション"
 "メニューを表示できます。"
 
-#: tips:206
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "マウスの中ボタンでファイルをドラッグしたときの動作"
 
-#: tips:208
+#: tips:287
 msgid "Move the files"
 msgstr "ファイルを移動"
 
-#: tips:209
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
@@ -4520,11 +5206,11 @@ msgstr ""
 "'ON'にした場合には、'Alt'キーを押しながら左ボタンでドラッグすれば、オプション"
 "メニューを表示できます。"
 
-#: tips:210
+#: tips:289
 msgid "Download handler"
 msgstr "ダウンロード実行コマンド"
 
-#: tips:211
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4537,35 +5223,35 @@ msgstr ""
 "ドされます。\n"
 "例：xterm -e wget $1"
 
-#: tips:212
+#: tips:291
 msgid "Menus"
 msgstr "メニュー"
 
-#: tips:214
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "メニューのアイコンの大きさ:"
 
-#: tips:215
+#: tips:294
 msgid "No Icons"
 msgstr "アイコンなし"
 
-#: tips:218
+#: tips:297
 msgid "Same as current window"
 msgstr "現在のウィンドウのアイコンと同じ"
 
-#: tips:219
+#: tips:298
 msgid "Same as default"
 msgstr "デフォルトのアイコンと同じ"
 
-#: tips:220
+#: tips:299
 msgid "Behaviour"
 msgstr "動作"
 
-#: tips:221
+#: tips:300
 msgid "File menu on right-click"
 msgstr "右クリックでアイテム用メニュー"
 
-#: tips:222
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
@@ -4573,23 +5259,27 @@ msgstr ""
 "アイテム上で右クリックした時、メインメニューの代わりにアイテム用メニューを開"
 "きます。(Ctrl キーを押す事によりメインメニューも開けます)"
 
-#: tips:223
+#: tips:302
 msgid "Terminal emulator program"
 msgstr "常用ターミナルエミュレータ"
 
-#: tips:224
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr "メニューの`ここでxtermを起動'を選んだときに起動するプログラム"
 
-#: tips:225
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "キーボードショートカット"
 
-#: tips:227
+#: tips:305
+msgid "Types"
+msgstr "タイプ"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME 形式"
 
-#: tips:228
+#: tips:307
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
@@ -4597,23 +5287,23 @@ msgstr ""
 "ROX は標準的なルールに従ってファイルの MIME 形式を判別し、適切なアイコンを設"
 "定します。"
 
-#: tips:229
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "MIME ルール編集"
 
-#: tips:230
+#: tips:309
 msgid "Themes"
 msgstr "テーマ"
 
-#: tips:231
+#: tips:310
 msgid "Icon theme"
 msgstr "アイコンテーマ"
 
-#: tips:232
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "テーマは ~/.icons ディレクトリに置いて下さい"
 
-#: tips:233
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
@@ -4621,97 +5311,117 @@ msgstr ""
 "MIME 型式ごとにアイコンを設定するのは 'アイコンを設定...' ダイアログを使用し"
 "ます。標準に設定されるアイコンより優先されます。"
 
-#: tips:234
+#: tips:313
 msgid "Colours"
 msgstr "色"
 
-#: tips:235
+#: tips:314
 msgid "File type colours"
 msgstr "ファイルの色分け"
 
-#: tips:236
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "タイプごとにファイルを色分けする"
 
-#: tips:237
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr "ファイル名(及び詳細情報)はアイテムの種別に従って色分け表示されます。"
 
-#: tips:238
+#: tips:317
 msgid "Directory:"
 msgstr "ディレクトリ:"
 
-#: tips:239
+#: tips:318
 msgid "Regular file:"
 msgstr "通常ファイル:"
 
-#: tips:240
+#: tips:319
 msgid "Pipe:"
 msgstr "パイプ:"
 
-#: tips:241
+#: tips:320
 msgid "Socket:"
 msgstr "ソケット:"
 
-#: tips:243
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
 msgstr ""
 "エラー、存在しない、あるいは参照許可のないファイルへのシンボリックリンク。"
 
-#: tips:244
+#: tips:323
 msgid "Character device:"
 msgstr "キャラクタデバイス:"
 
-#: tips:245
+#: tips:324
 msgid "Block device:"
 msgstr "ブロックデバイス:"
 
-#: tips:246
+#: tips:325
 msgid "Door:"
 msgstr "Door:"
 
-#: tips:247
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
 msgstr ""
 "Doorファイルは 'ソケットやパイプ類似のもので、Solaris のみで使われます。"
 
-#: tips:248
+#: tips:327
 msgid "Executable file:"
 msgstr "実行可能ファイル:"
 
-#: tips:249
+#: tips:328
 msgid "Application directory:"
 msgstr "アプリケーションディレクトリ:"
 
-#: tips:250
+#: tips:329
 msgid "Unknown type:"
 msgstr "不明な種類:"
 
-#: tips:251
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "背景の色:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "カスタムフォントを使う:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "互換性"
 
-#: tips:252
+#: tips:336
 msgid "Command line program"
 msgstr "コマンドライン・プログラム"
 
-#: tips:253
+#: tips:337
 msgid "Make script"
 msgstr "スクリプト作成"
 
-#: tips:254
+#: tips:338
 msgid "Window manager problems"
 msgstr "ウィンドウマネージャ関連の問題"
 
-#: tips:255
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "ピンボードとパネルの制御をウィンドウマネージャの支配下に置かない"
 
-#: tips:256
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4727,11 +5437,11 @@ msgstr ""
 "※ 'Extended Window Manager Hints' の詳細については、以下を。\n"
 "http://standards.freedesktop.org/wm-spec/wm-spec-latest.html"
 
-#: tips:257
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "デスクトップの背景でのマウスクリックはウィンドウマネージャに渡す"
 
-#: tips:258
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
@@ -4741,11 +5451,11 @@ msgstr ""
 "クリックで消えます。ここを ON にすれば、マウスイベントはウィンドウマネージャ"
 "に渡されます。この場合もアイコン上でのクリックは ROX に渡されます"
 
-#: tips:259
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Blackbox の root メニューの改善"
 
-#: tips:260
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4757,11 +5467,11 @@ msgstr ""
 "らのウィンドウマネージャの新版ではこのオプションが不要になるよう修正されるで"
 "しょう。"
 
-#: tips:261
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "パネルを'dock'として扱う"
 
-#: tips:262
+#: tips:346
 msgid ""
 "Makes sure panels stay against screen edges. Disable this option if the "
 "panel stays above other windows against your wishes. Requires a restart to "
@@ -4771,11 +5481,11 @@ msgstr ""
 "なるような事が有る場合は、このオプションを'OFF'にして下さい。有効にするには再"
 "起動が必要です"
 
-#: tips:263
+#: tips:347
 msgid "Panel stays on top"
 msgstr "パネルを最上層に配置"
 
-#: tips:264
+#: tips:348
 msgid ""
 "Keeps the panel above other windows. Enable this option to make sure the "
 "dock option works correctly in some versions of compiz. May require a "
@@ -4785,27 +5495,27 @@ msgstr ""
 "事で、compiz の幾つかのバージョンにおいても 'パネルを dock として扱う' オプ"
 "ションが正しく機能するように出来ます。有効にするには再起動が必要です"
 
-#: tips:265
+#: tips:349
 msgid "Panel confined to work area"
 msgstr "パネルをワークエリア内に収める"
 
-#: tips:266
+#: tips:350
 msgid ""
 "Keeps the panel confined to the work area specified by the Extended Window "
 "Manager Specification. Applies to new panels."
 msgstr ""
-"パネル位置を拡張ウィンドウマネージャ仕様(EWMH)のワークエリア内"
-"に制限します。新規パネルから適用されます"
+"パネル位置を拡張ウィンドウマネージャ仕様(EWMH)のワークエリア内に制限します。"
+"新規パネルから適用されます"
 
-#: tips:267
+#: tips:351
 msgid "Drag and drop"
 msgstr "ドラッグ＆ドロップ"
 
-#: tips:268
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "ホスト名を使わない"
 
-#: tips:269
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4816,15 +5526,11 @@ msgstr ""
 "ラッグした際、ポインタが + マークになってもドロップが機能しない場合に使用して"
 "ください"
 
-#: tips:270
-msgid "Extended attributes"
-msgstr "拡張属性"
-
-#: tips:271
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "拡張属性を使わない"
 
-#: tips:272
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4836,93 +5542,262 @@ msgstr ""
 "になり、MIME型の決定はファイル名のみによりなされ、プロパティダイアログには拡"
 "張属性はレポートされません"
 
-#~ msgid "ROX-Filer log viewer"
-#~ msgstr "ROX-Filer ログビュワー"
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
 
-#~ msgid "Recently performed actions..."
-#~ msgstr "最近実行された操作"
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
 
-#~ msgid "Open Directory"
-#~ msgstr "ディレクトリを開く"
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
 
-#~ msgid "Panel Options"
-#~ msgstr "パネル・オプション"
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
 
-#~ msgid "Every icon on this panel is shown with an image and some text."
-#~ msgstr "このパネルでは、全てのアイテムにアイコンとテキストを表示します。"
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
 
-#~ msgid "Image and Text"
-#~ msgstr "アイコンとテキスト"
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "下端"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "右端"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer ログビュワー"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr "最近実行された操作"
+
+#: ../Templates.ui.h:3
+msgid "Open Directory"
+msgstr "ディレクトリを開く"
+
+#: ../Templates.ui.h:4
+msgid "Panel Options"
+msgstr "パネル・オプション"
+
+#: ../Templates.ui.h:5
+msgid "Image and Text"
+msgstr "アイコンとテキスト"
+
+#: ../Templates.ui.h:6
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "このパネルでは、全てのアイテムにアイコンとテキストを表示します。"
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "アプリケーションの場合はアイコンのみ"
+
+#: ../Templates.ui.h:8
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"このパネルでは、アプリケーションの場合はアイコンのみ、その他の場合はアイコン"
+"とテキストを表示します"
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "アイコンのみ"
+
+#: ../Templates.ui.h:10
+msgid "Only the image is shown for icons in this panel."
+msgstr "このパネルでは、アイコンのみを表示します"
+
+#: ../Templates.ui.h:11
+msgid "Panel width"
+msgstr "パネルの幅"
+
+#: ../Templates.ui.h:12
+msgid "The size of this panel."
+msgstr "このパネルのサイズ"
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr "ピクセル"
+
+#: ../Templates.ui.h:14
+msgid "Transparency"
+msgstr ""
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "パネルを隠さない"
+
+#: ../Templates.ui.h:19
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"ウィンドウ最大化時にパネルを隠さないようウィンドウマネージャに依頼します。"
+"ウィンドウマネージャには、これに従わないものも有りますが、ウィンドウを2 ピク"
+"セルずらせばパネルをオートライズ(自動ポップアップ)が可能です。"
+
+#: ../Templates.ui.h:20
+msgid "<b>Panel style</b>"
+msgstr "<b>パネルスタイル</b>"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Xinerama でモニタを制限"
+
+#: ../Templates.ui.h:22
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Xinerama で、複数モニタを使用している場合、このパネルを一つのモニタのみで使用"
+"するよう制限します"
+
+#: ../Templates.ui.h:23
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr "Xinerama  使用時、このパネルをつかうモニタ(番号付けは 0 から)"
+
+#: ../Templates.ui.h:24
+msgid "<b>Xinerama</b>"
+msgstr "<b>Xinerama</b>"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr "右端"
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr "左端"
+
+#: ../Templates.ui.h:27
+msgid "Bottom edge"
+msgstr "下端"
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr "上端"
+
+#: ../Templates.ui.h:29
+msgid "<b>Position</b>"
+msgstr "<b>位置</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<dir>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s'は既に存在します - 上書きしますか?"
 
 #~ msgid ""
-#~ "Applications in this panel have just an image, everything else has both "
-#~ "an image and text."
+#~ "Error scanning '%s':\n"
+#~ "%s"
 #~ msgstr ""
-#~ "このパネルでは、アプリケーションの場合はアイコンのみ、その他の場合はアイコ"
-#~ "ンとテキストを表示します"
+#~ "スキャンエラー '%s':\n"
+#~ "%s"
 
-#~ msgid "Image only for applications"
-#~ msgstr "アプリケーションの場合はアイコンのみ"
+#~ msgid "Directory missing/deleted"
+#~ msgstr "ディレクトリがありません/削除されています"
 
-#~ msgid "Only the image is shown for icons in this panel."
-#~ msgstr "このパネルでは、アイコンのみを表示します"
+#~ msgid "Directory '%s' is not accessible"
+#~ msgstr "ディレクトリ'%s' にアクセスできません"
 
-#~ msgid "Image only"
-#~ msgstr "アイコンのみ"
+#~ msgid "Directory '%s' not found."
+#~ msgstr "ディレクトリ '%s' が見つかりません"
 
-#~ msgid "Panel width"
-#~ msgstr "パネルの幅"
+#~ msgid "Cancel"
+#~ msgstr "キャンセル"
 
-#~ msgid "The size of this panel."
-#~ msgstr "このパネルのサイズ"
+#~ msgid "All, "
+#~ msgstr "全て ,"
 
-#~ msgid "px"
-#~ msgstr "ピクセル"
+#~ msgid "Inotify support"
+#~ msgstr "Inotify(ファイルシステム監視機能)サポート"
 
-#~ msgid ""
-#~ "Ask the window manager not to cover this panel when maximising windows, "
-#~ "otherwise leave just 2 pixels at the edge of the screen to allow auto-"
-#~ "raising. Some window managers may not honour this setting."
+#~ msgid "Dnotify support"
+#~ msgstr "Dnotify(ディレクトリ通知機能)サポート"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
 #~ msgstr ""
-#~ "ウィンドウ最大化時にパネルを隠さないようウィンドウマネージャに依頼します。"
-#~ "ウィンドウマネージャには、これに従わないものも有りますが、ウィンドウを2 ピ"
-#~ "クセルずらせばパネルをオートライズ(自動ポップアップ)が可能です。"
+#~ "アプリに送るには Shift を押しながらメニューボタンをクリックして下さい"
 
-#~ msgid "Do not cover panel"
-#~ msgstr "パネルを隠さない"
+#~ msgid "B"
+#~ msgstr "B"
 
-#~ msgid "<b>Panel style</b>"
-#~ msgstr "<b>パネルスタイル</b>"
+#~ msgid "Change to parent directory"
+#~ msgstr "親ディレクトリに移動"
+
+#~ msgid "Change to home directory"
+#~ msgstr "ホームディレクトリに移動"
+
+#~ msgid "Bookmarks"
+#~ msgstr "ブックマーク"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "ブックマークメニュー"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "ディレクトリの内容を読み直す"
+
+#~ msgid "Change icon size"
+#~ msgstr "アイコンを拡大/縮小(左/右クリック)"
+
+#~ msgid "Show extra details"
+#~ msgstr "詳細を表示/非表示"
+
+#~ msgid "Hidden"
+#~ msgstr "隠しファイル"
+
+#~ msgid "Change at:"
+#~ msgstr "この数で変更:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "ファイル名の最大幅(大きいアイコン):"
+
+#~ msgid "Panel (obsolete)"
+#~ msgstr "パネル (廃止)"
 
 #~ msgid ""
-#~ "If you use multiple monitors with Xinerama, use this option to confine "
-#~ "the panel to one monitor."
+#~ "Enter the name of the panel to show here. This option is now only used "
+#~ "when upgrading from an old version."
 #~ msgstr ""
-#~ "Xinerama で、複数モニタを使用している場合、このパネルを一つのモニタのみで"
-#~ "使用するよう制限します"
-
-#~ msgid "Confine to Xinerama monitor"
-#~ msgstr "Xinerama でモニタを制限"
-
-#~ msgid ""
-#~ "The monitor this panel is confined to when using Xinerama. The numbering "
-#~ "starts from zero."
-#~ msgstr "Xinerama  使用時、このパネルをつかうモニタ(番号付けは 0 から)"
-
-#~ msgid "<b>Xinerama</b>"
-#~ msgstr "<b>Xinerama</b>"
-
-#~ msgid "Right edge"
-#~ msgstr "右端"
-
-#~ msgid "Left edge"
-#~ msgstr "左端"
-
-#~ msgid "Bottom edge"
-#~ msgstr "下端"
-
-#~ msgid "Top edge"
-#~ msgstr "上端"
-
-#~ msgid "<b>Position</b>"
-#~ msgstr "<b>位置</b>"
+#~ "表示するパネルの名前を入力して下さい(この項目は旧バージョンからのアップグ"
+#~ "レードの為だけに有ります)"

--- a/ROX-Filer/src/po/nl.po
+++ b/ROX-Filer/src/po/nl.po
@@ -14,7 +14,7 @@
 #
 # Bijgewerkt Jan 2002 en Mei 2002
 # Copyright (C) 2002 Wilbert Berendsen <wbsoft@xs4all.nl>
-# 
+#
 # Bijgewerkt Dec 2002, Maa Mei Okt 2003, Jan Feb Mei Nov 2004, 
 #            Jan Jul Aug 2005
 # Copyright (C) 2005 Jan Wagemakers <janw@easynet.be>
@@ -24,59 +24,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ROX-Filer 2.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-08-09 14:02+0100\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Jan Wagemakers <janw@easynet.be>\n"
 "Language-Team: ROX Mailing List <rox-devel@sourceforge.net>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 
 #: abox.c:127
-msgid "<dir>"
-msgstr "<map>"
+msgid "<src>"
+msgstr ""
 
-#: abox.c:219
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Stil"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Quiet"
 msgstr "Stil"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Niet alle bewerkingen bevestigen"
 
-#: abox.c:455 tips:60
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Naam"
 
-#: abox.c:461 menu.c:232
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Map"
 
-#: abox.c:550
+#: abox.c:546
 msgid "Expression:"
 msgstr "Uitdrukking:"
 
-#: action.c:58
+#: action.c:57
 msgid "See the attr(5) man page for full details."
 msgstr "Raadpleeg de attr(5) man pagina voor de volledige details"
 
-#: action.c:60
+#: action.c:59
 msgid "See the fsattr(5) man page for full details."
 msgstr "Raadpleeg de fsattr(5) man pagina voor de volledige details"
 
-#: action.c:62
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr "Blijkbaar is er geen OS ondersteuning"
 
-#: action.c:188
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Uitleg zoek-uitdrukking"
 
-#: action.c:199
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -151,11 +156,11 @@ msgstr ""
 "bestand)\n"
 "<b>negeren</b> (onwaar, en voorkomt het doorzoeken van de map-inhoud)."
 
-#: action.c:246
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Toelichting toegangsrechten aanpassen"
 
-#: action.c:257
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -216,11 +221,11 @@ msgstr ""
 "\n"
 "Zie de chmod(1) manual page voor de volledige uitleg."
 
-#: action.c:298
+#: action.c:308
 msgid "Set type reference"
 msgstr "Zet type referentie"
 
-#: action.c:309
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -249,48 +254,55 @@ msgstr ""
 "bij bepaalde bestands-systemen en daar waar het OS ze ondersteunt.\n"
 "\n"
 
-#: action.c:416
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Proces afgebroken.\n"
 
-#: action.c:432
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Er was een fout.\n"
 
-#: action.c:434
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Er waren %d fouten.\n"
 
-#: action.c:458
+#: action.c:516
 msgid "ERROR reading"
 msgstr "FOUT tijdens lezen"
 
-#: action.c:501
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Klaar\n"
 
-#: action.c:557 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "FOUT"
 
-#: action.c:711 main.c:674 main.c:681 main.c:688
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Ja"
 
-#: action.c:714 main.c:676 main.c:690
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Nee"
 
-#: action.c:732
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -298,7 +310,7 @@ msgstr ""
 "\n"
 "Probeer child proces te stoppen...\n"
 
-#: action.c:739
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -306,41 +318,41 @@ msgstr ""
 "\n"
 "Poging om op hol geslagen proces te KILL'en...\n"
 
-#: action.c:892
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Tel inhoud van %s?"
 
-#: action.c:928
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Verwijder %s'%s'?"
 
-#: action.c:929
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "SCHRIJF-BEVEILIGD "
 
-#: action.c:936
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'Bezig met verwijderen '%s'\n"
 
-#: action.c:949
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'Map '%s' verwijderd\n"
 
-#: action.c:982
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?Uitwerpen '%s'?"
 
-#: action.c:989
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Uitwerpen '%s'\n"
 
-#: action.c:1008
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -349,80 +361,95 @@ msgstr ""
 "!%s\n"
 "Uitwerpen mislukt\n"
 
-#: action.c:1027 action.c:1046
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Controleer '%s'?"
 
-#: action.c:1043
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Ongeldige zoekvoorwaarde - pas aan en probeer opnieuw\n"
 
-#: action.c:1053
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(tijdens het controleren van '%s')\n"
 
-#: action.c:1127 action.c:1152
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Verander de toegangsrechten van '%s'?"
 
-#: action.c:1133
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Toegangsrechten aanpassen van'%s'\n"
 
-#: action.c:1150
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Ongeldige mode - pas aan en probeer opnieuw\n"
 
-#: action.c:1207 action.c:1227
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?Verander type van '%s'?"
+
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Verander type van '%s'?"
 
-#: action.c:1224
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Ongeldige type - pas aan en probeer opnieuw\n"
 
-#: action.c:1246
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Type aanpassen van'%s' naar '%s'\n"
 
-#: action.c:1325
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'Type aanpassen van'%s' naar '%s'\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' bestaat reeds - %s?"
 
-#: action.c:1327
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "inhoud samenvoegen"
 
-#: action.c:1328
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "overschrijven"
 
-#: action.c:1344
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Probeer toch te kopiëren...\n"
 
-#: action.c:1353
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Kopiëer %s als %s?"
 
-#: action.c:1357
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "Kopiëren %s als %s\n"
 
-#: action.c:1372
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!FOUT: Doel bestaat reeds, maar is geen map\n"
 
-#: action.c:1444
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -431,26 +458,7 @@ msgstr ""
 "!%s\n"
 "Mislukt om '%s' te kopiëren\n"
 
-#: action.c:1488
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' bestaat reeds - overschrijven?"
-
-#: action.c:1503
-msgid "'Trying move anyway...\n"
-msgstr "'Probeer toch te verplaatsen...\n"
-
-#: action.c:1511
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Verplaats %s naar %s?"
-
-#: action.c:1515
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Verplaatsen %s naar %s\n"
-
-#: action.c:1523
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -459,45 +467,59 @@ msgstr ""
 "!%s\n"
 "Verplaatsen %s naar %s mislukt\n"
 
-#: action.c:1544
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Probeer toch te verplaatsen...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Verplaats %s naar %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Verplaatsen %s naar %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!FOUT: Kan object niet naar zichzelf kopiëren\n"
 
-#: action.c:1559
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!FOUT: Kan object niet verplaatsen/hernoemen naar zichzelf\n"
 
-#: action.c:1571
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Maak symlink %s naar %s\n"
 
-#: action.c:1576
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Maak symlink %s naar %s?"
 
-#: action.c:1618
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Aankoppelen %s\n"
 
-#: action.c:1619
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Afkoppelen %s\n"
 
-#: action.c:1622
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?%s aankoppelen?"
 
-#: action.c:1623
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?%s afkoppelen?"
 
-#: action.c:1643
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -506,7 +528,7 @@ msgstr ""
 "!%s\n"
 "Aankoppelen mislukt\n"
 
-#: action.c:1644
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -515,11 +537,11 @@ msgstr ""
 "!%s\n"
 "Afkoppelen mislukt\n"
 
-#: action.c:1652
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(lijkt nu in elk geval aangekoppeld te zijn)\n"
 
-#: action.c:1698
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -528,207 +550,231 @@ msgstr ""
 "'\n"
 "Totaal: %s ("
 
-#: action.c:1704
+#: action.c:2108
 msgid "file"
 msgstr "bestand"
 
-#: action.c:1704
+#: action.c:2108
 msgid "files"
 msgstr "bestanden"
 
-#: action.c:1708
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "geen mappen)\n"
 
-#: action.c:1712
+#: action.c:2116
 msgid "directory"
 msgstr "map"
 
-#: action.c:1713
+#: action.c:2117
 msgid "directories"
 msgstr "mappen"
 
-#: action.c:1754
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Geen aankoppelpunten geselecteerd!\n"
 
-#: action.c:1839
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Opnieuw zoeken?"
 
-#: action.c:1869 action.c:1900
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' is een symbolische link\n"
 
-#: action.c:1940
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "Selecteer eerst de items om te doorzoeken"
 
-#: action.c:1950 menu.c:223
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Zoek"
 
-#: action.c:1983
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Selecteer eerst de items om te tellen"
 
-#: action.c:1987
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Schijfgebruik"
 
-#: action.c:2021
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Aankoppelen / Afkoppelen"
 
-#: action.c:2034
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr "ROX-Filer ondersteunt nog geen aankoppelpunten op uw systeem. Sorry."
 
-#: action.c:2048 menu.c:210 tips:208
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: action.c:2058 tips:213
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Forceren"
 
-#: action.c:2058
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Geen bevestiging vragen voor verwijderen van niet-schrijfbare items"
 
-#: action.c:2061 action.c:2116 action.c:2175 action.c:2228 action.c:2264
-#: tips:215
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Beknopt"
 
-#: action.c:2061
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Toon alleen mappen die verwijderd worden"
 
-#: action.c:2078
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "Selecteer de items om de toegangsrechten aan te passen"
 
-#: action.c:2086
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Maak uitvoerbaar/zoekbaar)"
 
-#: action.c:2088
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (Maak onuitvoerbaar/onzoekbaar)"
 
-#: action.c:2090
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Geef eigenaar lees+schrijf toegang)"
 
-#: action.c:2092
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Privé - enkel eigenaar toegang)"
 
-#: action.c:2094
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Publieke toegang, onschrijfbaar)"
 
-#: action.c:2105 menu.c:184 menu.c:221 tips:75
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Toegangsrechten"
 
-#: action.c:2116 action.c:2175
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Toon geen verwerkte bestanden"
 
-#: action.c:2119 action.c:2178 tips:217
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Doorlopen"
 
-#: action.c:2119
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Ook de inhoud van sub-mappen veranderen"
 
-#: action.c:2123
+#: action.c:2547
 msgid "Command:"
 msgstr "Opdracht:"
 
-#: action.c:2151
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Selecteer de items waarvan het type aangepast dient te worden"
 
-#: action.c:2164
+#: action.c:2590
 msgid "Set type"
 msgstr "Zet type"
 
-#: action.c:2178
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Verander de inhoud van sub-mappen"
 
-#: action.c:2185 infobox.c:615
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Type:"
 
-#: action.c:2214 dnd.c:124 menu.c:1999 tips:202
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: action.c:2224 action.c:2260 tips:219
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Niet alle bewerkingen bevestigen"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Alleen overschrijven als het bronbestand nieuwer is dan de bestemming."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Nieuwer"
 
-#: action.c:2225 action.c:2261 tips:220
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Alleen overschrijven als het bronbestand nieuwer is dan de bestemming."
 
-#: action.c:2228
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "mappen"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Enkel mappen tonen als deze gekopieerd worden"
 
-#: action.c:2250 dnd.c:125 tips:204
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Verplaatsen"
 
-#: action.c:2264
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Niet elk bestand tonen terwijl het verplaatst wordt"
 
-#: action.c:2284 tips:206
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Symlink"
 
-#: action.c:2303 appmenu.c:113
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Uitwerpen"
 
-#: action.c:2360
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Verwijderen items zoals "
 
-#: action.c:2364
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Verwijderen item "
 
-#: action.c:2366
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Verwijderen items "
 
-#: action.c:2385
+#: action.c:2900
 msgid " and "
 msgstr " en "
 
-#: action.c:2394
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr ""
 " zal bepaalde items op het paneel of prikbord beïnvloeden - echt verwijderen?"
 
-#: action.c:2401
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr ""
 " zal bepaalde items op het paneel of prikbord beïnvloeden - echt verwijderen?"
 
-#: appmenu.c:198
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<label ontbreekt>"
 
-#: appmenu.c:295
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
@@ -737,82 +783,82 @@ msgstr ""
 "Symlink eenders welk programma in deze map en het zal verschijnen in het "
 "menu voor elk item van het type (%s/%s)."
 
-#: appmenu.c:339 menu.c:234
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Menu aanpassen..."
 
-#: appmenu.c:396 menu.c:251 toolbar.c:159
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Help"
 
-#: bookmarks.c:147
-msgid "Path"
-msgstr "Pad"
-
-#: bookmarks.c:155
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Titel"
 
-#: bookmarks.c:304
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Pad"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Kan geen bladwijzer maken van een niet lokale bron '%s'\n"
 
-#: bookmarks.c:312 bookmarks.c:630
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' is geen map"
 
-#: bookmarks.c:518
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Selecteer eerst een paar rijen om te verwijderen"
 
-#: bookmarks.c:542
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Plaats de cursor op een invoerveld in de lijst om het te verplaatsen"
 
-#: bookmarks.c:562
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Dit item staat al achteraan"
 
-#: bookmarks.c:636
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Kan geen bladwijzer maken van niet lokale mappen zoals '%s'"
 
-#: bookmarks.c:778
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Voeg een nieuwe bladwijzer toe"
 
-#: bookmarks.c:785
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Pas bladwijzers aan"
 
-#: bookmarks.c:790
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Recent bekeken"
 
-#: bulk_rename.c:68
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Meerdere bestanden hernoemen"
 
-#: bulk_rename.c:71
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Reset"
 
-#: bulk_rename.c:76
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "Maak de Nieuwe-kolom hetzelfde als de Oude-kolom"
 
-#: bulk_rename.c:81
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "_Hernoemen"
 
-#: bulk_rename.c:94
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Vervangen:"
 
-#: bulk_rename.c:101
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -831,18 +877,20 @@ msgid "With:"
 msgstr "Met:"
 
 #: bulk_rename.c:116
+#, fuzzy
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 "De eerste overeenkomst in elk bestandsnaam zal vervangen worden door deze "
 "string.Er zijn geen speciale karakters."
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Toepassen"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
@@ -850,48 +898,48 @@ msgstr ""
 "Doe een zoek-en-vervang in de Nieuw-kolom. De bestanden worden pas "
 "daadwerkelijk hernoemd als er beneden op de Hernoem knop geklikt wordt."
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Oude naam"
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Nieuwe naam"
 
-#: bulk_rename.c:259
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr ""
 "Geen enkele string (in de Nieuw-kolom) komt overeen met de gegeven expressie"
 
-#: bulk_rename.c:264
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Eén overeenkomst, maar het resultaat was hetzelfde"
 
-#: bulk_rename.c:267
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d overeenkomsten, maar de resultaten waren allemaal hetzelfde"
 
-#: bulk_rename.c:293
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr ""
 "Geef een reguliere expressie om aan te passen, en een string om "
 "overeenkomsten door te vervangen."
 
-#: bulk_rename.c:310
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (voor '%s')"
 
-#: bulk_rename.c:343
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr ""
 "Een bestand '%s' bestaat reeds. Meerdere bestanden hernoemen wordt "
 "afgebroken."
 
-#: bulk_rename.c:348
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -902,12 +950,12 @@ msgstr ""
 "%s\n"
 "Meerdere bestanden hernoemen wordt afgebroken."
 
-#: bulk_rename.c:410
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "Een bestand '%s' bestaat reeds "
 
-#: bulk_rename.c:421
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
@@ -916,56 +964,73 @@ msgstr ""
 "Sommige van de Nieuwe namen bevatten / karakters (bv '%s'). Hierdoor zullen "
 "deze bestanden in een andere map terecht komen. Doorgaan?"
 
-#: bulk_rename.c:436
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Geen enkele naam is veranderd. Niets te doen!"
 
-#: choices.c:428
-msgid "Choices migration"
-msgstr "'Choices' (keuze-instellingen) verhuizing"
+#: choices.c:434
+#, c-format
+msgid "%d directories could not be migrated"
+msgstr "%d mappen konden niet verplaatst worden"
 
 #: choices.c:436
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Choices have been moved from \n"
-"<b>%s</b>\n"
+"%s\n"
 " to the new location \n"
-"<b>%s</b>\n"
+"%s\n"
+"%s"
 msgstr ""
 "Keuze-instellingen (Choices) zijn verplaatst van \n"
 "<b>%s</b>\n"
 " naar een nieuwe locatie \n"
 "<b>%s</b>\n"
 
-#: choices.c:447
-#, c-format
-msgid "%d directories could not be migrated"
-msgstr "%d mappen konden niet verplaatst worden"
-
-#: dir.c:982
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Kan map status niet verkrijgen: %s"
 
-#: dir.c:991
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Kan map niet openen: %s"
 
-#: display.c:588
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Grootte"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) mislukt: %s"
 
-#: dnd.c:126
-msgid "Link (relative)"
-msgstr "Link (relatief)"
-
-#: dnd.c:127
-msgid "Link (absolute)"
-msgstr "Link (absoluut)"
-
-#: dnd.c:426
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Interne fout - verkeerd info type"
 
@@ -1047,14 +1112,14 @@ msgstr ""
 "Kan geen data verkrijgen van remote machine (application/octet-stream niet "
 "geleverd)"
 
-#: dnd.c:1016
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
 "Sommige van deze bestanden bevinden zich op een andere machine - zij zullen "
 "overgeslagen worden - sorry"
 
-#: dnd.c:1023
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
@@ -1062,28 +1127,46 @@ msgstr ""
 "Geen van deze bestanden is aanwezig op de lokale machine - Ik kan meerdere "
 "remote bestanden niet verwerken - sorry."
 
-#: dnd.c:1036
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Onbekende actie aangevraagd"
 
-#: dnd.c:1044
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Fout tijdens het verkrijgen van de bestandenlijst: %s"
 
-#: dropbox.c:114
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Link (relatief)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Link (absoluut)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Link (relatief)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Link (absoluut)"
+
+#: dropbox.c:112
 msgid "Show"
 msgstr "Toon"
 
-#: dropbox.c:120
+#: dropbox.c:118
 msgid "Show the current choice in a filer window"
 msgstr "Toon de huidige keuze in een bestands-venster"
 
-#: dropbox.c:174
+#: dropbox.c:172
 msgid "<nothing>"
 msgstr "<niets>"
 
-#: dropbox.c:239
+#: dropbox.c:237
 msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
@@ -1091,16 +1174,16 @@ msgstr ""
 "Vermits er niets is ingesteld, kan ik de huidige instelling niet tonen. "
 "Sleep iets over mij!"
 
-#: dropbox.c:263
+#: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
 msgstr "Sorry, het is enkel mogelijk om hier slechts 1 bestand te droppen."
 
-#: dropbox.c:273
+#: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr "Sorry, Ik kan '%s' niet gebruiken omdat het geen lokaal bestand is."
 
-#: dropbox.c:280 pinboard.c:853
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1109,7 +1192,7 @@ msgstr ""
 "Geen toegang tot '%s':\n"
 "%s"
 
-#: filer.c:453
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1118,16 +1201,7 @@ msgstr ""
 "Fout tijdens doorzoeken '%s':\n"
 "%s\n"
 
-#: filer.c:457
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Fout tijdens doorzoeken '%s':\n"
-"%s"
-
-#: filer.c:562
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1137,19 +1211,19 @@ msgstr ""
 "\n"
 "Bij een afgekoppeld toestel is het veilig om de diskette te verwijderen."
 
-#: filer.c:566
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 msgid "No change"
 msgstr "Geen verandering"
 
-#: filer.c:572 menu.c:862
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Afkoppelen"
 
-#: filer.c:669
-msgid "Directory missing/deleted"
-msgstr "Map ontbreekt/verwijderd"
-
-#: filer.c:1031
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
@@ -1161,314 +1235,373 @@ msgstr ""
 "selecteren.\n"
 "Zorg ervoor dat Numlock aanstaat bij gebruik van het nummerieke klavier"
 
-#: filer.c:1267
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Map '%s' is niet toegankelijk"
+#: filer.c:2655
+msgid "A"
+msgstr ""
 
-#: filer.c:1419
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Map '%s' niet gevonden."
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
 
-#: filer.c:1713
-msgid "Cancel"
-msgstr "Afbreken"
+#: filer.c:2659 find.c:923
+msgid "G"
+msgstr ""
 
-#: filer.c:2002
+#: filer.c:2664
 msgid "S"
 msgstr "S"
 
-#: filer.c:2004
+#: filer.c:2669
 msgid "T"
 msgstr "M"
 
-#: filer.c:2026
+#: filer.c:2670
+msgid "D"
+msgstr ""
+
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
+#, c-format
+msgid "Glob (%s), "
+msgstr ""
+
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Scannen, "
 
-#: filer.c:2028
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Miniaturen, "
 
-#: filer.c:2304
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Miniaturen, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Symbolische link naar "
 
-#: filer.c:2335
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr ""
 "Dit bestand heeft geen geldige UTF-8 naam.  U zou het moeten hernoemen.\n"
 
-#: filer.c:2643 menu.c:1989
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "Item bestaat niet meer!"
 
-#: filer.c:3327
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Selecteer weergave eigenschappen om te bewaren"
 
-#: filer.c:3334
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Selecteer weergave eigenschappen om te bewaren"
+
+#: filer.c:4727
 msgid "Position"
 msgstr "Positie"
 
-#: filer.c:3339 toolbar.c:135 toolbar.c:139 tips:63
-msgid "Size"
-msgstr "Grootte"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Venster"
 
-#: filer.c:3344
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Toon verborgen"
 
-#: filer.c:3350
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Weergave stijl"
 
-#: filer.c:3356
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Sorteer op type en volgorde"
 
-#: filer.c:3361 toolbar.c:143
+#: filer.c:4754
 msgid "Details"
 msgstr "Details"
 
-#: filer.c:3366 tips:114 tips:115
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Miniaturen"
 
-#: filer.c:3372
+#: filer.c:4765
 msgid "Filter"
 msgstr "Filter"
 
-#: find.c:487
+#: find.c:485
 msgid "And"
 msgstr "En"
 
-#: find.c:511
+#: find.c:509
 msgid "Not"
 msgstr "Niet"
 
-#: find.c:554
+#: find.c:552
 msgid "system"
 msgstr "systeem"
 
-#: find.c:562
+#: find.c:560
 msgid "prune"
 msgstr "negeren"
 
-#: find.c:650
+#: find.c:648
 msgid "After"
 msgstr "Na"
 
-#: find.c:652
+#: find.c:650
 msgid "Before"
 msgstr "Voor"
 
-#: find.c:746
+#: find.c:744
 msgid "IsReg"
 msgstr ""
 
-#: find.c:748
+#: find.c:746
 msgid "IsLink"
 msgstr ""
 
-#: find.c:750
+#: find.c:748
 msgid "IsDir"
 msgstr ""
 
-#: find.c:752
+#: find.c:750
 msgid "IsChar"
 msgstr ""
 
-#: find.c:754
+#: find.c:752
 msgid "IsBlock"
 msgstr ""
 
-#: find.c:756
+#: find.c:754
 msgid "IsDev"
 msgstr ""
 
-#: find.c:758
+#: find.c:756
 msgid "IsPipe"
 msgstr ""
 
-#: find.c:760
+#: find.c:758
 msgid "IsSocket"
 msgstr ""
 
-#: find.c:762
+#: find.c:760
 msgid "IsDoor"
 msgstr ""
 
-#: find.c:764
+#: find.c:762
 msgid "IsSUID"
 msgstr ""
 
-#: find.c:766
+#: find.c:764
 msgid "IsSGID"
 msgstr ""
 
-#: find.c:768
+#: find.c:766
 msgid "IsSticky"
 msgstr ""
 
-#: find.c:770
+#: find.c:768
 msgid "IsReadable"
 msgstr ""
 
-#: find.c:772
+#: find.c:770
 msgid "IsWriteable"
 msgstr ""
 
-#: find.c:774
+#: find.c:772
 msgid "IsExecutable"
 msgstr ""
 
-#: find.c:776
+#: find.c:774
 msgid "IsEmpty"
 msgstr ""
 
-#: find.c:778
+#: find.c:776
 msgid "IsMine"
 msgstr ""
 
-#: find.c:906
+#: find.c:904
 msgid "Now"
 msgstr "Nu"
 
-#: find.c:919
+#: find.c:917
 msgid "Byte"
 msgstr "Byte"
 
-#: find.c:919
+#: find.c:917
 msgid "Bytes"
 msgstr "Bytes"
 
-#: find.c:921
+#: find.c:919
 msgid "Kb"
 msgstr ""
 
-#: find.c:921
+#: find.c:919
 msgid "K"
 msgstr ""
 
-#: find.c:923
+#: find.c:921
 msgid "Mb"
 msgstr ""
 
-#: find.c:923
+#: find.c:921
 msgid "M"
 msgstr ""
 
-#: find.c:925
+#: find.c:923
 msgid "Gb"
 msgstr ""
 
 #: find.c:925
-msgid "G"
-msgstr ""
-
-#: find.c:927
 msgid "Sec"
 msgstr "Sec"
 
-#: find.c:927
+#: find.c:925
 msgid "Secs"
 msgstr "Seconden"
 
-#: find.c:929
+#: find.c:927
 msgid "Min"
 msgstr "Min"
 
-#: find.c:929
+#: find.c:927
 msgid "Mins"
 msgstr "Minuten"
 
-#: find.c:931
+#: find.c:929
 msgid "Hour"
 msgstr "Uur"
 
-#: find.c:931
+#: find.c:929
 msgid "Hours"
 msgstr "Uren"
 
-#: find.c:933
+#: find.c:931
 msgid "Day"
 msgstr "Dag"
 
-#: find.c:933
+#: find.c:931
 msgid "Days"
 msgstr "Dagen"
 
-#: find.c:935
+#: find.c:933
 msgid "Week"
 msgstr "Week"
 
-#: find.c:935
+#: find.c:933
 msgid "Weeks"
 msgstr "Weken"
 
-#: find.c:937
+#: find.c:935
 msgid "Year"
 msgstr "Jaar"
 
-#: find.c:937
+#: find.c:935
 msgid "Years"
 msgstr "Jaren"
 
-#: find.c:946
+#: find.c:944
 msgid "Ago"
 msgstr "Geleden"
 
-#: find.c:948
+#: find.c:946
 msgid "Hence"
 msgstr "Sinds"
 
-#: find.c:963
+#: find.c:961
 msgid "atime"
 msgstr "atime"
 
-#: find.c:965
+#: find.c:963
 msgid "ctime"
 msgstr "ctime"
 
-#: find.c:967
+#: find.c:965
 msgid "mtime"
 msgstr "mtime"
 
-#: find.c:969
+#: find.c:967
 msgid "size"
 msgstr "grootte"
 
-#: find.c:971
+#: find.c:969
 msgid "inode"
 msgstr "inode"
 
-#: find.c:973
+#: find.c:971
 msgid "nlinks"
 msgstr "nlinks"
 
-#: find.c:975
+#: find.c:973
 msgid "uid"
 msgstr "uid"
 
-#: find.c:977
+#: find.c:975
 msgid "gid"
 msgstr "gid"
 
-#: find.c:979
+#: find.c:977
 msgid "blocks"
 msgstr "blokken"
 
-#: gtksavebox.c:251
+#: gtksavebox.c:249
 msgid "Save As:"
 msgstr "Bewaren Als:"
 
-#: gtksavebox.c:397
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Naamloos"
 
-#: gtksavebox.c:473
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
@@ -1476,7 +1609,7 @@ msgstr ""
 "Remote applicatie wil Direct Bewaren gebruiken, maar ik kan de "
 "XdndDirectSave0 (type text/plain) eigenschap niet lezen.\n"
 
-#: gtksavebox.c:598
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1484,25 +1617,26 @@ msgstr ""
 "Sleep het icoon naar een map\n"
 "(of geef een volledig pad-naam)"
 
-#: gui_support.c:331
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
 msgstr ""
 
-#: gui_support.c:400
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr ""
 "Probeer XML bestand als tekst te lezen. Bestand '%s' kan beschadigd zijn."
 
-#: gui_support.c:417
-#, c-format
+#: gui_support.c:542
+#, fuzzy, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
 "This may be due to upgrading from a previous version of ROX-Filer. Open the "
-"Options window and click on Save.\n"
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
 "Fout in '%s' bestand op regel %d: \n"
@@ -1511,16 +1645,16 @@ msgstr ""
 "Filer. Open het Optievenster en druk op Bewaren.\n"
 "Verdere fouten zullen genegeerd worden."
 
-#: gui_support.c:1000
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Onjuist of ontbrekend regeleinde in text/uri-lijst data"
 
-#: gui_support.c:1332
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "Mislukt om bestand te openen '%s': %s"
 
-#: gui_support.c:1376
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
@@ -1528,10 +1662,11 @@ msgstr ""
 "Mislukt om afbeelding te laden '%s': reden onbekend, waarschijnlijk een "
 "beschadigd bestand"
 
-#: gui_support.c:1427
+#: gui_support.c:1583
+#, fuzzy, c-format
 msgid ""
-"This program cannot be run, as the 0launch command is not available. It can "
-"be downloaded from here:\n"
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
@@ -1540,7 +1675,7 @@ msgstr ""
 "\n"
 "http://0install.net/injector.html"
 
-#: i18n.c:38
+#: i18n.c:39
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
@@ -1548,154 +1683,177 @@ msgstr ""
 "Sla uw instellingen op en herstart ROX-Filer om de nieuwe taalinstelling "
 "effect te laten hebben."
 
-#: icon.c:78
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(klik om te in te stellen)"
 
-#: icon.c:133
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:134 menu.c:252
-msgid "About ROX-Filer..."
-msgstr "Over ROX-Filer..."
-
-#: icon.c:135 menu.c:253
-msgid "Show Help Files"
-msgstr "Toon Help Bestanden"
-
-#: icon.c:136 menu.c:254
-msgid "Manual"
-msgstr "Handboek"
-
-#: icon.c:138 menu.c:230
-msgid "Options..."
-msgstr "Opties..."
-
-#: icon.c:139 menu.c:239
-msgid "Home Directory"
-msgstr "Thuis map"
-
-#: icon.c:140 icon.c:1340 menu.c:206 type.c:212
-msgid "File"
-msgstr "Bestand"
-
-#: icon.c:141 menu.c:212 menu.c:875
-msgid "Shift Open"
-msgstr "Shift Open"
-
-#: icon.c:142 menu.c:218
-msgid "Properties"
-msgstr "Eigenschappen"
-
-#: icon.c:143 menu.c:216
-msgid "Set Run Action..."
-msgstr "Startactie instellen..."
-
-#: icon.c:144 menu.c:217
-msgid "Set Icon..."
-msgstr "Icoon instellen..."
-
-#: icon.c:145 icon.c:806
-msgid "Edit Item"
-msgstr "Item bewerken"
-
-#: icon.c:146
-msgid "Show Location"
-msgstr "Locatie tonen"
-
-#: icon.c:147
-msgid "Remove Item(s)"
-msgstr "Item(s) verwijderen"
-
-#: icon.c:278 menu.c:764
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr ""
 
-#: icon.c:291
+#: icon.c:311
 msgid "Nothing"
 msgstr "Niets"
 
-#: icon.c:547
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "De locatie moet minstens één letterteken bevatten!"
 
-#: icon.c:613
+#: icon.c:641
+#, c-format
+msgid "You must unlock '%s' before removing it"
+msgstr ""
+
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Selecteer eerst de items om te verwijderen"
 
-#: icon.c:627
+#: icon.c:657
+msgid "An item must be unlocked before it can be removed."
+msgstr ""
+
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Open het menu boven een item"
 
-#: icon.c:652 menu.c:1260
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "De startactie kan alleen ingesteld worden voor een gewoon bestand"
 
-#: icon.c:738
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Druk op de gewenste sneltoets (bv, Control+F1)"
 
-#: icon.c:760
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Mislukt om het toetsenbord te lezen!"
 
-#: icon.c:809
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Item bewerken"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Klikken op het icoon opent:"
 
-#: icon.c:819
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Door te geven argumenten (voor uitvoerbare bestanden):"
 
-#: icon.c:833
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "De tekst onder het icoon is:"
 
-#: icon.c:846
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "De sneltoets is:"
 
-#: infobox.c:112
+#: icon.c:910
+#, fuzzy
+msgid "Locked"
+msgstr "Socket"
+
+#: icon.c:915
+msgid "Locking an item prevents it from being accidentally removed"
+msgstr ""
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Over ROX-Filer..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Toon Help Bestanden"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Handboek"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Opties..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Thuis map"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Bestand"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Shift Open"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Eigenschappen"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Startactie instellen..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Icoon instellen..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Locatie tonen"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Item(s) verwijderen"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
 msgstr "Wilt u echt %d vensters openen?"
 
-#: infobox.c:113
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Toon Informatie"
 
-#: infobox.c:135 menu.c:769
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(Slechte utf-8)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Toon _Help Bestanden"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Toegangsrechten</b>"
 
-#: infobox.c:286
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>Inhoud geeft aan...</b>"
 
-#: infobox.c:423 infobox.c:560 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Enkel mappen tonen als deze gekopieerd worden"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "bytes"
 
-#: infobox.c:446
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Mislukt om grootte te lezen"
 
-#: infobox.c:504
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' is geen symbolische link meer"
 
-#: infobox.c:511
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1704,7 +1862,7 @@ msgstr ""
 "Mislukt om een link ongedaan te maken '%s':\n"
 "%s"
 
-#: infobox.c:516
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1715,145 +1873,194 @@ msgstr ""
 "%s\n"
 "(nota: oude link is gewist)"
 
-#: infobox.c:539 tips:270
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Fout:"
 
-#: infobox.c:546
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Echte map:"
 
-#: infobox.c:549
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Eigenaar, Groep:"
 
-#: infobox.c:556 infobox.c:571 infobox.c:580
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Grootte:"
 
-#: infobox.c:581
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Scannen"
 
-#: infobox.c:602
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Scannen mislukt"
 
-#: infobox.c:609
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Laatst status veranderd:"
 
-#: infobox.c:611
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Laatst gewijzigd:"
 
-#: infobox.c:613
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Laatst geopend:"
 
-#: infobox.c:621
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Uitgebreide attributen:"
 
-#: infobox.c:623
+#: infobox.c:667
 msgid "Present"
 msgstr "Aanwezig"
 
-#: infobox.c:624
+#: infobox.c:668
 msgid "None"
 msgstr "Geen"
 
-#: infobox.c:625
+#: infobox.c:669
 msgid "Not supported"
 msgstr "Niet ondersteund"
 
-#: infobox.c:637
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Link doel:"
 
-#: infobox.c:649 infobox.c:652
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Startactie:"
 
-#: infobox.c:649
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Bestand uitvoeren"
 
-#: infobox.c:744
+#: infobox.c:805
+#, fuzzy
+msgid "Comment"
+msgstr "Opdracht:"
+
+#: infobox.c:807
+#, fuzzy
+msgid "Execute"
+msgstr "Bestand uitvoeren"
+
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<nog niets>"
 
-#: infobox.c:814
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "file(1) zegt... %s"
 
-#: infobox.c:871
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Kan toegangsrechten niet aanpassen: %s"
 
-#: infobox.c:889
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Eigenaar"
 
-#: infobox.c:891
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Groep"
 
-#: infobox.c:893
+#: infobox.c:974
 msgid "World"
 msgstr "Wereld"
 
-#: infobox.c:896
+#: infobox.c:977
 msgid "Read"
 msgstr "Lezen"
 
-#: infobox.c:898
+#: infobox.c:980
 msgid "Write"
 msgstr "Schrijven"
 
-#: infobox.c:900
+#: infobox.c:983
 msgid "Exec"
 msgstr ""
 
-#: infobox.c:917
+#: infobox.c:1001
 msgid "SUID"
 msgstr ""
 
-#: infobox.c:924
+#: infobox.c:1008
 msgid "SGID"
 msgstr ""
 
-#: infobox.c:931
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky"
 
-#: infobox.c:953
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<niets>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Symbolische link"
 
-#: infobox.c:956
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX applicatie"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "mounted"
 msgstr "Aangekoppeld"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "Afgekoppeld"
 
-#: infobox.c:968
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Aankoppelpunt voor %s (%s)"
 
-#: infobox.c:971
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Aankoppelpunt (%s)"
+
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d items"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Kopiëren..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "Item bewerken"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Tijden"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Opties"
 
 #: main.c:95
 msgid ""
@@ -1889,6 +2096,7 @@ msgstr ""
 "gebruik in plaats daarvan de korte versies.\n"
 
 #: main.c:115
+#, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Open each directory or file listed, or the current working\n"
@@ -1910,10 +2118,12 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
-"Report bugs to "
+"Report bugs to %s.\n"
+"Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
 "Gebruik: ROX-Filer/AppRun [OPTIES]... [BESTAND]...\n"
 "Open de opgegeven mappen en bestanden of de huidige map als er geen \n"
@@ -1941,15 +2151,7 @@ msgstr ""
 "\n"
 "Rapporteer bugs aan "
 
-#: main.c:136
-msgid ""
-".\n"
-"Home page (including updated versions): http://rox.sourceforge.net/\n"
-msgstr ""
-".\n"
-"Home page (inclusief nieuwe versies): http://rox.sourceforge.net/\n"
-
-#: main.c:234
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1961,7 +2163,7 @@ msgstr ""
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Poging om verder te gaan..."
 
-#: main.c:382
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
@@ -1969,279 +2171,376 @@ msgstr ""
 "Het -o argument wordt niet meer gebruikt. Aanzetten kan nu d.m.v. 'controle "
 "overnemen' vanuit het Opties-venster."
 
-#: main.c:489
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Lopend als gebruiker '%s'"
 
-#: main.c:666
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Gecompileerd met GTK versie %s\n"
 
-#: main.c:667
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Lopende onder GTK versie %d.%d.%d\n"
 
-#: main.c:671
+#: main.c:693
 msgid "features set at compile time"
 msgstr "mogelijkheden ingesteld tijdens het compileren"
 
-#: main.c:672
+#: main.c:694
 msgid "Large File Support"
 msgstr "Ondersteuning voor grote bestanden"
 
-#: main.c:679
-msgid "GNOME-VFS library"
-msgstr "GNOME-VFS bibliotheek"
-
-#: main.c:683
-msgid "No (need 2.8.0 or later)"
-msgstr "Nee (2.8.0 of hoger nodig)"
-
-#: main.c:686
-msgid "Dnotify support"
-msgstr "Dnotify ondersteuning"
-
-#: main.c:693
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Binaire uitwisselbaarheid"
 
-#: main.c:695
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Ja (kan werken met oudere glibc versies)"
 
-#: main.c:697
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Nee (apsymbols.h niet gevonden)"
 
-#: menu.c:180 tips:52
+#: main.c:709
+#, fuzzy
+msgid "Extended attribute support"
+msgstr "Uitgebreide attributen"
+
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr "Mislukt om bestand te openen '%s': %s"
+
+#: main.c:895
+#, c-format
+msgid ""
+"Left-click to run %s.\n"
+"Right-click for a list of versions."
+msgstr ""
+
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Fout tijdens maken bestand '%s': %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Bewaren Als:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Weergave"
 
-#: menu.c:181 tips:57
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "Iconen Weergave"
 
-#: menu.c:182
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "Iconen, Met..."
 
-#: menu.c:183 tips:74
-msgid "Sizes"
-msgstr "Grootte"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Iconen thema"
 
-#: menu.c:185 tips:254
-msgid "Types"
-msgstr "Types"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Toegangsrechten"
 
-#: menu.c:186 tips:77
-msgid "Times"
-msgstr "Tijden"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Iconen, Met..."
 
-#: menu.c:187 tips:58 tips:92
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "Lijst weergave"
 
-#: menu.c:189
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "Grotere iconen"
 
-#: menu.c:190
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "Kleinere iconen"
 
-#: menu.c:191 tips:71
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: menu.c:193
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Sorteer op naam"
 
-#: menu.c:194
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Sorteer op type"
 
-#: menu.c:195
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Sorteer op datum"
 
-#: menu.c:196
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Sorteer op datum"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Sorteer op datum"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Sorteer op grootte"
 
-#: menu.c:197
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Toegangsrechten"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "Sorteer op eigenaar"
 
-#: menu.c:198
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "Sorteer op groep"
 
-#: menu.c:199
+#: menu.c:671
 msgid "Reversed"
 msgstr "Omgekeerd"
 
-#: menu.c:201
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "Toon verborgen"
 
-#: menu.c:202
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Toon Help Bestanden"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "geen mappen)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "Filter Bestanden..."
 
-#: menu.c:203
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Filter Bestanden..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "Toon miniaturen"
 
-#: menu.c:204
+#: menu.c:683
 msgid "Refresh"
 msgstr "Verversen"
 
-#: menu.c:205
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Verversen"
+
+#: menu.c:686
 msgid "Save Display Settings..."
 msgstr "Bewaar Weergave Instellingen..."
 
-#: menu.c:207
-msgid "Copy..."
-msgstr "Kopiëren..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Bewaar Weergave Instellingen..."
 
-#: menu.c:208
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Tellen"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "Hernoemen..."
 
-#: menu.c:209
+#: menu.c:700
 msgid "Link..."
 msgstr "Symlink..."
 
-#: menu.c:213
-msgid "Open AVFS"
-msgstr "Open AVFS"
-
-#: menu.c:214
+#: menu.c:708
 msgid "Send To..."
 msgstr "Zenden naar..."
 
-#: menu.c:219
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Uitgebreide attributen"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Tellen"
 
-#: menu.c:220
+#: menu.c:723
 msgid "Set Type..."
 msgstr "Zet Type..."
 
-#: menu.c:224 toolbar.c:155
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Selecteer"
 
-#: menu.c:225
+#: menu.c:733
 msgid "Select All"
 msgstr "Alles selecteren"
 
-#: menu.c:226
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "Selectie wissen"
 
-#: menu.c:227
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "Selectie inverteren"
 
-#: menu.c:228
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "Selecteer op Naam..."
 
-#: menu.c:229
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Selecteren Als..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Selecteren Als..."
 
-#: menu.c:231
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Nieuw"
 
-#: menu.c:233
+#: menu.c:752
 msgid "Blank file"
 msgstr "Leeg bestand"
 
-#: menu.c:235 tasklist.c:308
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Venster"
 
-#: menu.c:236
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "Hogere map, nieuw venster"
 
-#: menu.c:237
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "Hogere map, zelfde venster"
 
-#: menu.c:238
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "Nieuw venster"
 
-#: menu.c:240
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "Toon Bladwijzers"
 
-#: menu.c:241
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Toon Informatie"
+
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "Symbolische links volgen"
 
-#: menu.c:242
+#: menu.c:769
 msgid "Resize Window"
 msgstr "Afmeting venster aanpassen"
 
-#: menu.c:245
+#: menu.c:771
 msgid "Close Window"
 msgstr "Venster sluiten"
 
-#: menu.c:247
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Pad opgeven..."
 
-#: menu.c:248
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Shell Opdracht..."
 
-#: menu.c:249
-msgid "Xterm Here"
+#: menu.c:780
+#, fuzzy
+msgid "Terminal Here"
 msgstr "Xterm hier"
 
-#: menu.c:250
-msgid "Switch to xterm"
+#: menu.c:782
+#, fuzzy
+msgid "Switch to Terminal"
 msgstr "Schakel over naar xterm"
 
-#: menu.c:718
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "Gebruik menu-muisknop + Shift om het bestand ergens naartoe te zenden"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Menu aanpassen..."
 
-#: menu.c:754
+#: menu.c:976
 msgid "Next Click"
 msgstr "Volgende klik"
 
-#: menu.c:776
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d items"
 
-#: menu.c:864
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "Open afgekoppelde"
 
-#: menu.c:867
+#: menu.c:1097
 msgid "Show Target"
 msgstr "Doel tonen"
 
-#: menu.c:869
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "Binnenin kijken"
 
-#: menu.c:871
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "Als tekst openen"
 
-#: menu.c:1031
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2256,15 +2555,15 @@ msgstr ""
 "gekoppeld dient te worden met de juiste 'mount' optie ('user_xattr' on "
 "Linux)."
 
-#: menu.c:1037
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr "Zetten van type niet ondersteund voor sommige van deze bestanden"
 
-#: menu.c:1072
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "_Relatieve link"
 
-#: menu.c:1078
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2278,44 +2577,57 @@ msgstr ""
 "bevatten; gebruik dit als de link verplaatst kan worden en het \n"
 "doelbestand niet."
 
-#: menu.c:1148
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "Nieuwe padnaam is niet absoluut"
 
-#: menu.c:1214
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr ""
 "Symbolische link van '$s' bestaat reeds. Vervangen door link naar '%s'?"
 
-#: menu.c:1220
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Vervangen"
 
-#: menu.c:1351 menu.c:1392 menu.c:1452
-msgid "Create"
-msgstr "Nieuw"
-
-#: menu.c:1352
+#: menu.c:1704
 msgid "NewDir"
 msgstr "NieuweMap"
 
-#: menu.c:1366 menu.c:1372
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Fout tijdens maken bestand '%s': %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Nieuw"
 
-#: menu.c:1393
+#: menu.c:1755
 msgid "NewFile"
 msgstr "NieuwBestand"
 
-#: menu.c:1411
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "Fout bij aanmaken bestand: Kon masker niet vinden voor %s"
 
-#: menu.c:1482
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Symlink eenders welk programma in deze map en het zal verschijnen in het "
+"menu voor elk item van het type (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2327,8 +2639,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "Het `Zenden naar` menu is een snelle manier om bestanden naar een applicatie "
 "te sturen. De applicaties komen uit de volgende mappen:\n"
@@ -2343,7 +2656,7 @@ msgstr ""
 "alleen worden getoond bij bestanden van dat type. `.group' wordt alleen "
 "getoond als meer dan 1 bestand geselecteerd is."
 
-#: menu.c:1493
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
@@ -2351,11 +2664,11 @@ msgstr ""
 "Ik zal nu de SendTo map laten zien; maak een symbolische link (Ctrl+Shift "
 "slepen) voor de gewenste applicaties."
 
-#: menu.c:1496 menu.c:1536
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr "Uw CHOICESPATH variable laat geen aanpassingen toe - sorry."
 
-#: menu.c:1529
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2375,7 +2688,7 @@ msgstr ""
 "%s\n"
 "%s\n"
 
-#: menu.c:1534
+#: menu.c:1936
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
@@ -2383,15 +2696,21 @@ msgstr ""
 "Ik zal nu de Templates map laten zien; plaats 'template bestanden' in deze "
 "map."
 
-#: menu.c:1651
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Aanpassen"
 
-#: menu.c:1717
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Menu aanpassen..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Dit is reeds de gebruikelijke naam voor deze map."
 
-#: menu.c:1748
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2399,75 +2718,103 @@ msgstr ""
 "Kan geen tweede venster met deze map openen omdat de 'Unieke vensters' optie "
 "ingesteld is in het Opties venster."
 
-#: menu.c:1869
-msgid "Copy ... ?"
-msgstr "Kopiëren ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1872
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Kopiëer %s als %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Kopiëer %s als %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Hernoemen ... ?"
 
-#: menu.c:1875
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Symlink ... ?"
 
-#: menu.c:1878
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Shift Open ... ?"
 
-#: menu.c:1881
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Eigenschappen van ... ?"
 
-#: menu.c:1884
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Uitgebreide attributen"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Zet type van ... ?"
 
-#: menu.c:1887
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Start actie instellen voor ... ?"
 
-#: menu.c:1890
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Icoon instellen voor ... ?"
 
-#: menu.c:1893
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Zend ... naar ... ?"
 
-#: menu.c:1896
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "VERWIJDER ... ?"
 
-#: menu.c:1899
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Geef de grootte van ... ?"
 
-#: menu.c:1902
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Toegangsrechten instellen voor ... ?"
 
-#: menu.c:1905
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Binnenin zoeken ... ?"
 
-#: menu.c:1908
-msgid "Look inside ... ?"
-msgstr "Binnenin kijken ... ?"
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Kopiëren ... ?"
 
-#: menu.c:1972
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Dit is niet mogelijk voor meer dan één item tegelijk"
 
-#: menu.c:2004
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Hernoemen"
 
-#: menu.c:2009
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Symlink"
 
-#: menu.c:2041
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2488,7 +2835,7 @@ msgstr ""
 "\tgtk-can-change-accels = 1\n"
 "\t(dit werkt alleen als XSETTINGS niet wordt gebruikt)"
 
-#: menu.c:2052
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2507,31 +2854,40 @@ msgstr ""
 "In het vervolg is het mogelijk deze sneltoets te gebruiken zonder het menu "
 "te optenen."
 
-#: menu.c:2067
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Toetsenbord sneltoetsen instellen"
 
-#: minibuffer.c:131
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Ga naar:"
 
-#: minibuffer.c:132
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Shell:"
 
-#: minibuffer.c:133
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Selecteren Als:"
 
-#: minibuffer.c:134
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Selecteer Genoemde:"
 
-#: minibuffer.c:135
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Selecteren Als:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Patroon:"
 
-#: minibuffer.c:264
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
@@ -2539,14 +2895,34 @@ msgstr ""
 "Geef een bestandsnaam en ik zal het tonen. Druk op Tab om het d.m.v. de "
 "langste overeenkomst aan te vullen. Esc om de minibuffer te sluiten."
 
-#: minibuffer.c:270
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
 "Geef een uit te voeren shell opdracht. Klik op een bestand om het aan de "
 "buffer toe te voegen."
 
-#: minibuffer.c:275
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Geef een bestandsnaam patroon om overeenstemmende bestanden te selecteren:\n"
+"\n"
+"? betekend elk karakter\n"
+"* betekend geen of meer karakters\n"
+"[aA] betekend 'a' of 'A'\n"
+"[a-z] betekend elk karakter van a tot z (kleine letters)\n"
+"*.png betekend elke bestandsnaam eindigen op '.png'"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2564,7 +2940,7 @@ msgstr ""
 "[a-z] betekend elk karakter van a tot z (kleine letters)\n"
 "*.png betekend elke bestandsnaam eindigen op '.png'"
 
-#: minibuffer.c:287
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
@@ -2572,44 +2948,58 @@ msgstr ""
 "Geef een patroon om overeenstemmende bestanden te tonen. Een lege filter "
 "schakelt de filter uit."
 
-#: minibuffer.c:895
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Geef een patroon om overeenstemmende bestanden te tonen. Een lege filter "
+"schakelt de filter uit."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Ongeldige zoekconditie"
 
-#: mount.c:374
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s totaal, %s gebruikt, %s vrij (%.1f %%)"
 
-#: options.c:277
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr ""
 "ROX-Filer heeft uw oude Options-bestand omgezet naar het nieuwe XML formaat"
 
-#: options.c:535 options.c:1258
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(gebruik standaard)"
 
-#: options.c:806
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Interne fout: %s onleesbaar"
 
-#: options.c:917
+#: options.c:929
 msgid "Options"
 msgstr "Opties"
 
-#: options.c:962
+#: options.c:974
 msgid "_Revert"
 msgstr "O_ngedaan maken"
 
-#: options.c:968
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr ""
 "Zet alle instellingen terug naar de toestand toen het Opties venster werd "
 "geopend."
 
-#: options.c:983
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2618,24 +3008,34 @@ msgstr ""
 "Instellingen zullen worden bewaard als:\n"
 "%s"
 
-#: options.c:991
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(opslaan is uitgezet door de CHOICESPATH variabele)"
 
-#: options.c:1164 usericons.c:450
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Fout tijdens bewaren bestand %s: %s"
 
-#: options.c:1794
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Ontbrekende '='"
 
-#: panel.c:439
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr "Mislukt om bestand te openen '%s': %s"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "Je oude paneel-bestand is omgezet naar het nieuwe XML formaat."
 
-#: panel.c:546
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
@@ -2643,20 +3043,20 @@ msgstr ""
 "Poging tot sluiten paneel via window manager - Meestal is dit per ongeluk... "
 "echt sluiten?"
 
-#: panel.c:639
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Ontbrekende < of > in paneel configuratie bestand"
 
-#: panel.c:1519
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Fout tijdens bewaren paneel %s: %s"
 
-#: panel.c:1835
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "Applet afgesloten zonder dat het een venster aanmaakte!"
 
-#: panel.c:1934
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2665,65 +3065,59 @@ msgstr ""
 "Fout bij starten applet:\n"
 "%s"
 
-#: panel.c:2335
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "Wilt u echt %d vensters openen?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Item(s) verwijderen"
+
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Paneel Opties..."
 
-#: panel.c:2427
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Xinerama monitor %d niet beschikbaar"
 
-#: panel.c:2502
-msgid "Panel Options"
-msgstr "Paneel Opties"
+#: panel.c:2897
+msgid "Top"
+msgstr ""
 
-#: panel.c:2517
-#, c-format
-msgid "Panel: %s"
-msgstr "Paneel: %s"
-
-#: panel.c:2525
-msgid "Select the panel's position:"
-msgstr "Kies de positie van het paneel:"
-
-#: panel.c:2531
-msgid "Top-edge panel"
-msgstr "Paneel bovenaan"
-
-#: panel.c:2532
-msgid "Top edge"
-msgstr "Boven"
-
-#: panel.c:2533
-msgid "Bottom edge panel"
-msgstr "Paneel onderaan"
-
-#: panel.c:2534
-msgid "Bottom edge"
+#: panel.c:2899
+#, fuzzy
+msgid "Bottom"
 msgstr "Onder"
 
-#: panel.c:2535
-msgid "Left edge panel"
-msgstr "Paneel links"
-
-#: panel.c:2536
-msgid "Left edge"
+#: panel.c:2901
+#, fuzzy
+msgid "Left"
 msgstr "Links"
 
-#: panel.c:2537
-msgid "Right-edge panel"
-msgstr "Paneel rechts"
-
-#: panel.c:2538
-msgid "Right edge"
+#: panel.c:2903
+#, fuzzy
+msgid "Right"
 msgstr "Rechts"
+
+#: panel.c:2905
+#, fuzzy
+msgid "Default"
+msgstr "Standaard grootte:"
+
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "Onbekend"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
 msgstr "Uw oude prikbord-bestand is omgezet naar het nieuwe XML formaat."
 
-#: pinboard.c:635
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
@@ -2733,7 +3127,7 @@ msgstr ""
 "map naar het Zet Achtergrond dialoog venster, of (voor programmeurs) geef "
 "het door aan de SOAP SetBackdropApp methode."
 
-#: pinboard.c:654
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2746,52 +3140,65 @@ msgstr ""
 "Programmeurs: de AppInfo.xml van de applicatie dient een CanSetBackdrop "
 "element te bevatten, zoals beschreven in het ROX-Filer handboek."
 
-#: pinboard.c:674
+#: pinboard.c:750
 msgid "Set backdrop"
 msgstr "Achtergrond instellen"
 
-#: pinboard.c:685
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
 msgstr "Kies een stijl en sleep dan een afbeelding naar:"
 
-#: pinboard.c:698
+#: pinboard.c:774
 msgid "Centre the image without scaling it"
 msgstr "Centreer de afbeelding zonder te herschalen"
 
-#: pinboard.c:699
+#: pinboard.c:775
 msgid "Centre"
 msgstr "Centreren"
 
-#: pinboard.c:700
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr ""
 "Herschaal de afbeelding naar de achtergrond afmeting, zonder te vervormen"
 
-#: pinboard.c:702
+#: pinboard.c:778
 msgid "Scale"
 msgstr "Schalen"
 
-#: pinboard.c:703
+#: pinboard.c:779
+#, fuzzy
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr ""
+"Herschaal de afbeelding naar de achtergrond afmeting, zonder te vervormen"
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Filter"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
 msgstr "Rek de afbeelding naar verhouding van de achtergrond afmeting"
 
-#: pinboard.c:704
+#: pinboard.c:783
 msgid "Stretch"
 msgstr "Rekken"
 
-#: pinboard.c:705
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr "Herhaal de afbeelding om de achtergrond te vullen"
 
-#: pinboard.c:706
+#: pinboard.c:785
 msgid "Tile"
 msgstr "Herhalen"
 
-#: pinboard.c:711
+#: pinboard.c:790
 msgid "Drop an image here"
 msgstr "Sleep hier een afbeelding"
 
-#: pinboard.c:772
+#: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
@@ -2799,7 +3206,7 @@ msgstr ""
 "Er is geen prikbord in gebruik... het 'Default' prikbord is geselecteerd. "
 "Gebruik 'rox -p=Default' om het in het vervolg in te schakelen."
 
-#: pinboard.c:866
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
@@ -2807,24 +3214,29 @@ msgstr ""
 "Alleen bestanden (en bepaalde programma's) kunnen worden gebruikt om de "
 "achtergrond in te stellen."
 
-#: pinboard.c:1471
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Ontbrekende '>' in icoon label"
 
-#: pinboard.c:1480
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Ontbrekende ',' na icoon label"
 
-#: pinboard.c:1565
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Fout tijdens bewaren van prikbord %s: %s"
 
-#: pinboard.c:2109
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Achtergrond..."
 
-#: pinboard.c:2202
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Paneel"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2835,7 +3247,7 @@ msgstr ""
 "%s\n"
 "Achtergrond verwijderd."
 
-#: pixmaps.c:991
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2844,88 +3256,40 @@ msgstr ""
 "Kan miniaturen in %s niet wissen:\n"
 "%s"
 
-#: pixmaps.c:1012
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Er zijn geen miniaturen om te wissen"
 
-#: pixmaps.c:1025
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Ledig miniaturen disk cache"
 
-#: remote.c:624
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Onbekende stijl '%s'"
 
-#: remote.c:646
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Onbekend detail type '%s'"
 
-#: remote.c:674
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Onbekend sorteer type '%s'"
 
-#: remote.c:1117
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Poging onbekende SOAP methode '%s' aan te roepen"
 
-#: rox_gettext.c:95
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Ongeldig .gmo vertalingsbestand (te kort): %s"
-
-#: rox_gettext.c:108
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Ongeldig .gmo vertalingsbestand (GNU magisch nummer niet gevonden): %s"
-
-#: run.c:96 run.c:141
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "Programma %s niet gevonden - verwijderd?"
 
-#: run.c:287
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "Bestand bestaat niet, of is ontoegankelijk: %s"
-
-#: run.c:292
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "Ik weet niet hoe ik '%s' moet openen"
-
-#: run.c:323
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"Applicatie map:\n"
-"Dit is een applicatie-map - Het is mogelijk om de map te starten als een "
-"programma, of te openen als map (houd Shift ingedrukt terwijl je het opent). "
-"De meeste applicaties leveren hun eigen hulp hier, maar deze applicatie doet "
-"dit niet."
-
-#: run.c:407
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "Kon data niet zenden aan programma: %s"
-
-#: run.c:437
-#, c-format
-msgid "Could not read link: %s"
-msgstr "Kon link niet lezen: %s"
-
-#: run.c:465
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr "Verbroken symbolische link (of je hebt er geen toegang naar)."
-
-#: run.c:502
+#: run.c:359
 #, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
@@ -2936,7 +3300,7 @@ msgstr ""
 "een start-actie door 'Start-actie instellen' te kiezen in het Bestand menu, "
 "of sleep het bestand gewoon naar een geschikte applicatie.%s"
 
-#: run.c:508
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -2949,186 +3313,65 @@ msgstr ""
 "uitvoer-bit gezet worden. Dit kan gedaan worden door toegangsrechten in het "
 "Bestands-menu te kiezen."
 
-#: support.c:272
-msgid "B"
-msgstr "B"
-
-#: support.c:351
-msgid "byte"
-msgstr "byte"
-
-#: toolbar.c:115
-msgid "Close"
-msgstr "Sluiten"
-
-#: toolbar.c:115
-msgid "Close filer window"
-msgstr "Bestandsvenster sluiten"
-
-#: toolbar.c:119
-msgid "Up"
-msgstr "Omhoog"
-
-#: toolbar.c:119
-msgid "Change to parent directory"
-msgstr "Ga naar bovenliggende map"
-
-#: toolbar.c:123
-msgid "Home"
-msgstr "Thuis"
-
-#: toolbar.c:123
-msgid "Change to home directory"
-msgstr "Ga naar thuismap"
-
-#: toolbar.c:127
-msgid "Bookmarks"
-msgstr "Bladwijzers"
-
-#: toolbar.c:127
-msgid "Bookmarks menu"
-msgstr "Bladwijzers menu"
-
-#: toolbar.c:131
-msgid "Scan"
-msgstr "Scan"
-
-#: toolbar.c:131
-msgid "Rescan directory contents"
-msgstr "Map inhoud verversen"
-
-#: toolbar.c:135
-msgid "Change icon size"
-msgstr "Icoon-grootte veranderen"
-
-#: toolbar.c:139
-msgid "Automatic size mode"
-msgstr "Afmeting automatisch aanpassen"
-
-#: toolbar.c:143
-msgid "Show extra details"
-msgstr "Extra details tonen"
-
-#: toolbar.c:147
-msgid "Sort"
-msgstr "Sorteren"
-
-#: toolbar.c:147
-msgid "Change sort criteria"
-msgstr "Pas sorteer criteria aan"
-
-#: toolbar.c:151
-msgid "Hidden"
-msgstr "Verborgen"
-
-#: toolbar.c:151
-msgid "Show/hide hidden files"
-msgstr "Toon/verberg verborgen bestanden"
-
-#: toolbar.c:155
-msgid "Select all/invert selection"
-msgstr "Selecteer alles/inverteer selectie"
-
-#: toolbar.c:159
-msgid "Show ROX-Filer help"
-msgstr "Toon ROX-Filer help"
-
-#: toolbar.c:220
+#: run.c:373
 #, c-format
-msgid " (%u hidden)"
-msgstr " (%u verborgen)"
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "Bestand bestaat niet, of is ontoegankelijk: %s"
 
-#: toolbar.c:228 tips:80
-msgid "items"
-msgstr "items"
-
-#: toolbar.c:228
-msgid "item"
-msgstr "item"
-
-#: toolbar.c:231
+#: run.c:378
 #, c-format
-msgid "No items%s"
-msgstr "Geen items %s"
+msgid "I don't know how to open '%s'"
+msgstr "Ik weet niet hoe ik '%s' moet openen"
 
-#: toolbar.c:250
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' is geen symbolische link meer"
+
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "Map '%s' is niet toegankelijk"
+
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "Niet-uitvoerbaar %s"
+
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Fout in afhandeling %s: %s"
+
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
+msgstr ""
+"Applicatie map:\n"
+"Dit is een applicatie-map - Het is mogelijk om de map te starten als een "
+"programma, of te openen als map (houd Shift ingedrukt terwijl je het opent). "
+"De meeste applicaties leveren hun eigen hulp hier, maar deze applicatie doet "
+"dit niet."
+
+#: run.c:549
 #, c-format
-msgid "%u selected (%s)"
-msgstr "%u geselecteerd (%s)"
+msgid "Could not send data to program: %s"
+msgstr "Kon data niet zenden aan programma: %s"
 
-#: toolbar.c:422
-msgid "Sort by name"
-msgstr "Sorteer op naam"
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "Kon link niet lezen: %s"
 
-#: toolbar.c:422
-msgid "Sort by type"
-msgstr "Sorteer op type"
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
+msgstr "Verbroken symbolische link (of je hebt er geen toegang naar)."
 
-#: toolbar.c:422
-msgid "Sort by date"
-msgstr "Sorteer op datum"
-
-#: toolbar.c:423
-msgid "Sort by size"
-msgstr "Sorteer op grootte"
-
-#: toolbar.c:423
-msgid "Sort by owner"
-msgstr "Sorteer op eigenaar"
-
-#: toolbar.c:423
-msgid "Sort by group"
-msgstr "Sorteer op groep"
-
-#: toolbar.c:457
-msgid "ascending"
-msgstr "stijgend"
-
-#: toolbar.c:457
-msgid "descending"
-msgstr "dalend"
-
-#: type.c:203
-msgid "Sym link"
-msgstr "Symlink"
-
-#: type.c:205
-msgid "Mount point"
-msgstr "Aankoppelpunt"
-
-#: type.c:207
-msgid "App dir"
-msgstr "Applicatiemap"
-
-#: type.c:214
-msgid "Dir"
-msgstr "Map"
-
-#: type.c:216
-msgid "Char dev"
-msgstr "Char dev"
-
-#: type.c:218
-msgid "Block dev"
-msgstr "Block dev"
-
-#: type.c:220
-msgid "Pipe"
-msgstr "Pipe"
-
-#: type.c:222
-msgid "Socket"
-msgstr "Socket"
-
-#: type.c:224
-msgid "Door"
-msgstr "Door"
-
-#: type.c:227
-msgid "Unknown"
-msgstr "Onbekend"
-
-#: type.c:355
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3153,11 +3396,280 @@ msgstr ""
 "Maak u geen zorgen indien iedereen die naar deze bestanden kan schrijven te "
 "vertrouwen is. Anders, controleer, of wis, alle bestaande start acties."
 
-#: type.c:368
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Los veiligheids probleem op)"
 
-#: type.c:498
+#: support.c:288
+msgid " "
+msgstr ""
+
+#: support.c:381
+msgid "byte"
+msgstr "byte"
+
+#: support.c:1531 support.c:1585
+#, fuzzy, c-format
+msgid "Failed to open and stat file '%s': %s"
+msgstr "Mislukt om bestand te openen '%s': %s"
+
+#: support.c:1542 support.c:1596
+#, fuzzy, c-format
+msgid "Failed to mmap file '%s': %s"
+msgstr "Mislukt om bestand te openen '%s': %s"
+
+#: toolbar.c:116
+msgid "Close"
+msgstr "Sluiten"
+
+#: toolbar.c:116
+msgid "Close filer window"
+msgstr "Bestandsvenster sluiten"
+
+#: toolbar.c:120
+msgid "Up"
+msgstr "Omhoog"
+
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
+
+#: toolbar.c:126
+msgid "Home"
+msgstr "Thuis"
+
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
+
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
+
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
+
+#: toolbar.c:138
+msgid "Scan"
+msgstr "Scan"
+
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
+
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Grootte"
+
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automatisch"
+
+#: toolbar.c:155
+msgid "Automatic size mode"
+msgstr "Afmeting automatisch aanpassen"
+
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Lijst weergave"
+
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
+msgid "Sort"
+msgstr "Sorteren"
+
+#: toolbar.c:165
+msgid "Change sort criteria"
+msgstr "Pas sorteer criteria aan"
+
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
+
+#: toolbar.c:169
+msgid ""
+"Left: Show/hide hidden files\n"
+"Right: Show/hide thumbnails"
+msgstr ""
+
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "Selecteer alles/inverteer selectie"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
+msgid "Show ROX-Filer help"
+msgstr "Toon ROX-Filer help"
+
+#: toolbar.c:270
+#, c-format
+msgid " (%u hidden)"
+msgstr " (%u verborgen)"
+
+#: toolbar.c:276 tips:79
+msgid "items"
+msgstr "items"
+
+#: toolbar.c:276
+msgid "item"
+msgstr "item"
+
+#: toolbar.c:279
+#, c-format
+msgid "No items%s"
+msgstr "Geen items %s"
+
+#: toolbar.c:298
+#, c-format
+msgid "%u selected (%s)"
+msgstr "%u geselecteerd (%s)"
+
+#: toolbar.c:535
+msgid "Sort by name"
+msgstr "Sorteer op naam"
+
+#: toolbar.c:535
+msgid "Sort by type"
+msgstr "Sorteer op type"
+
+#: toolbar.c:535
+msgid "Sort by date"
+msgstr "Sorteer op datum"
+
+#: toolbar.c:535
+msgid "Sort by size"
+msgstr "Sorteer op grootte"
+
+#: toolbar.c:536
+msgid "Sort by owner"
+msgstr "Sorteer op eigenaar"
+
+#: toolbar.c:536
+msgid "Sort by group"
+msgstr "Sorteer op groep"
+
+#: toolbar.c:568
+msgid "ascending"
+msgstr "stijgend"
+
+#: toolbar.c:568
+msgid "descending"
+msgstr "dalend"
+
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
+msgid "Sym link"
+msgstr "Symlink"
+
+#: type.c:223
+msgid "Mount point"
+msgstr "Aankoppelpunt"
+
+#: type.c:225
+msgid "App dir"
+msgstr "Applicatiemap"
+
+#: type.c:232
+msgid "Dir"
+msgstr "Map"
+
+#: type.c:234
+msgid "Char dev"
+msgstr "Char dev"
+
+#: type.c:236
+msgid "Block dev"
+msgstr "Block dev"
+
+#: type.c:238
+msgid "Pipe"
+msgstr "Pipe"
+
+#: type.c:240
+msgid "Socket"
+msgstr "Socket"
+
+#: type.c:242
+msgid "Door"
+msgstr "Door"
+
+#: type.c:245
+msgid "Unknown"
+msgstr "Onbekend"
+
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3168,71 +3680,71 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:679
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Dit is geen programma! Geef me een applicatie in plaats daarvan!"
 
-#: type.c:740
+#: type.c:839
 msgid "No run action defined"
 msgstr "Geen startactie ingesteld"
 
-#: type.c:766
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Fout in afhandeling %s: %s"
 
-#: type.c:781
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Ongeldige applicatie %s (foute AppRun)"
 
-#: type.c:792
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "Niet-uitvoerbaar %s"
 
-#: type.c:825
+#: type.c:902
 msgid "Set run action"
 msgstr "Startactie instellen"
 
-#: type.c:831
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 "Gebruik dit als de standaard, indien er voor het specifieke type geen "
 "startactie is ingesteld."
 
-#: type.c:833
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Gebruiken voor alle `%s/<willekeurig>'"
 
-#: type.c:837
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Gebruik deze toepassing voor alle bestanden met dit MIME type."
 
-#: type.c:839
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Alleen voor het type `%s' (%s/%s)"
 
-#: type.c:845
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Sleep een geschikte toepassing naar hier"
 
-#: type.c:860
+#: type.c:963
 msgid "OR"
 msgstr "OF"
 
-#: type.c:867
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Geef een shell opdracht:"
 
-#: type.c:896
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Gebruik Opdracht"
 
-#: type.c:926
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
@@ -3240,43 +3752,29 @@ msgstr ""
 "Er bestaat reeds een start-actie in de vorm van een vrij groot programma - "
 "echt verwijderen?"
 
-#: type.c:937
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Kan %s niet verwijderen: %s"
 
-#: type.c:974
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "Bewaren van instellingen is uitgezet door de CHOICESPATH variabele"
 
-#: type.c:1249
-#, c-format
-msgid ""
-"Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr ""
-"Iconen thema '%s' bevat geen MIME iconen. Zal gebruik maken van het "
-"standaard ROX theme."
-
-#: type.c:1263
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason)"
+"%s"
 msgstr ""
-"Aanmaak van symlink '%s' mislukt:\n"
-"%s\n"
-"\n"
-"(het kan zijn dat dit ROX thema hier reeds bestaat, maar het 'mime-"
-"application:postscript' ikoon om een bepaalde reden niet geladen kon worden)"
+"Mislukt om een link ongedaan te maken '%s':\n"
+"%s"
 
-#: usericons.c:181
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "De opgegeven pad-naam bestaat niet. Het icoon is niet veranderd."
 
-#: usericons.c:191 usericons.c:616
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3286,12 +3784,12 @@ msgstr ""
 "of de toegangsrechten zijn onjuist?\n"
 "Het icoon is niet veranderd."
 
-#: usericons.c:238
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Ikoon '%s' echt wissen?"
 
-#: usericons.c:242
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3300,33 +3798,33 @@ msgstr ""
 "Kan '%s' niet wissen:\n"
 "%s"
 
-#: usericons.c:270
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Icoon instellen"
 
-#: usericons.c:279
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr ""
 "Gebruik een kopie van deze afbeelding als standaard voor alle bestand met "
 "dit MIME type."
 
-#: usericons.c:281
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Gebruiken voor alle `%s/<willekeurig>'"
 
-#: usericons.c:286
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr ""
 "Gebruik een kopie van deze afbeelding voor alle bestanden met dit MIME type."
 
-#: usericons.c:288
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Voor alle bestanden van het type `%s' (%s/%s)"
 
-#: usericons.c:294
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
@@ -3335,12 +3833,12 @@ msgstr ""
 "persoonlijke lijst. Deze instelling gaat verloren als de afbeelding of het "
 "bestand wordt verplaatst."
 
-#: usericons.c:297
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Alleen voor het bestand `%s'"
 
-#: usericons.c:305
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
@@ -3351,19 +3849,19 @@ msgstr ""
 "verplaatsen. Dit is normaal gesproken de beste optie als u schrijftoegang "
 "tot de map heeft."
 
-#: usericons.c:311
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Kopieer afbeelding naar map"
 
-#: usericons.c:317
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Sleep hier een icoon bestand"
 
-#: usericons.c:587
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "Instellen icoon is uitgezet door de CHOICESPATH variabele"
 
-#: usericons.c:631
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3372,143 +3870,71 @@ msgstr ""
 "Fout tijdens maken afbeelding '%s':\n"
 "%s"
 
-#: view_details.c:1009
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
+msgid "Mono font"
+msgstr ""
+
+#: view_details.c:1019
+msgid "Font for displaying mono-spaced text"
+msgstr ""
+
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Naam"
 
-#: view_details.c:1012
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Type"
 
-#: view_details.c:1015
-msgid "_Permissions"
-msgstr "Toegangs_rechten"
-
-#: view_details.c:1016
-msgid "_Owner"
-msgstr "_Eigenaar"
-
-#: view_details.c:1018
-msgid "_Group"
-msgstr "_Groep"
-
-#: view_details.c:1020
+#: view_details.c:1238
 msgid "_Size"
 msgstr "G_rootte"
 
-#: view_details.c:1022
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "Toegangs_rechten"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_Eigenaar"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Groep"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "Laatst _Aangepast"
 
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Uitgebreide attributen"
+
 #: tips:1
-msgid "Translation"
-msgstr "Vertaling"
-
-#: tips:2
-msgid "Language"
-msgstr "Taal"
-
-#: tips:3
-msgid "Use the LANG environment variable"
-msgstr "Gebruik de LANG ongevingsvariabele"
-
-#: tips:4
-msgid "Basque"
-msgstr "Baskisch"
-
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Chinees (traditioneel)"
-
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Chinees (vereenvoudigd)"
-
-#: tips:7
-msgid "Czech"
-msgstr "Tsjechisch"
-
-#: tips:8
-msgid "Danish"
-msgstr "Deens"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Nederlands"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Engels (geen vertaling)"
-
-#: tips:11
-msgid "Estonian"
-msgstr "Estlands"
-
-#: tips:12
-msgid "Finnish"
-msgstr "Fins"
-
-#: tips:13
-msgid "French"
-msgstr "Frans"
-
-#: tips:14
-msgid "German"
-msgstr "Duits"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Hongaars"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Japans"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "Noors"
-
-#: tips:18
-msgid "Italian"
-msgstr "Italiaans"
-
-#: tips:19
-msgid "Polish"
-msgstr "Pools"
-
-#: tips:20
-msgid "Portuguese (Brasil)"
-msgstr "Portugees (Brazilië)"
-
-#: tips:21
-msgid "Romanian"
-msgstr "Roemeens"
-
-#: tips:22
-msgid "Russian"
-msgstr "Russisch"
-
-#: tips:23
-msgid "Spanish"
-msgstr "Spaans"
-
-#: tips:24
-msgid "Swedish"
-msgstr "Zweeds"
-
-#: tips:25
 msgid "Filer windows"
 msgstr "Bestandsvensters"
 
-#: tips:26
+#: tips:2
 msgid "Auto-resize filer windows"
 msgstr "Automatisch afmetingen aanpassen"
 
-#: tips:27
+#: tips:3
 msgid "Never automatically resize"
 msgstr "Nooit automatisch afmeting aanpassen"
 
-#: tips:28
+#: tips:4
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
@@ -3517,11 +3943,11 @@ msgstr ""
 "`Afmeting venster aanpassen' optie uit het menu of door te dubbelklikken op "
 "de vensterachtergrond."
 
-#: tips:29
+#: tips:5
 msgid "Resize when changing the display style"
 msgstr "Aanpassen wanneer de weergavestijl verandert"
 
-#: tips:30
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
@@ -3529,11 +3955,11 @@ msgstr ""
 "Vensterafmetingen worden aangepast als de grootte van de iconen verandert of "
 "de weergegeven details."
 
-#: tips:31
+#: tips:7
 msgid "Always resize"
 msgstr "Altijd aanpassen"
 
-#: tips:32
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
@@ -3541,15 +3967,16 @@ msgstr ""
 "De afmetingen van een venster worden aangepast wanneer dit handig lijkt (dat "
 "wil zeggen bij verandering van map of weergave stijl)."
 
-#: tips:33
+#: tips:9
 msgid "Largest window size:"
 msgstr "Maximale venstergrootte:"
 
-#: tips:34
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:35
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
@@ -3557,15 +3984,29 @@ msgstr ""
 "De grootste afmeting als percentage van de schermgrootte die een venster "
 "automatisch mag krijgen."
 
-#: tips:36
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Maximale venstergrootte:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"De grootste afmeting als percentage van de schermgrootte die een venster "
+"automatisch mag krijgen."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Venster gedrag"
 
-#: tips:37
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Korte vlaggen in titelbalk"
 
-#: tips:38
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
@@ -3573,11 +4014,11 @@ msgstr ""
 "Gebruik enkele lettertekens in plaats van woorden voor Scannen, Alle en "
 "Miniaturen in de titelbalk."
 
-#: tips:39
+#: tips:18
 msgid "Unique windows"
 msgstr "Unieke vensters"
 
-#: tips:40
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3585,11 +4026,34 @@ msgstr ""
 "Als je een map opent en deze map wordt reeds getoond in een ander venster, "
 "dan zal deze optie ervoor zorgen dat dit andere venster gesloten wordt."
 
-#: tips:41
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Venster"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Nieuw venster op knop 1"
 
-#: tips:42
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3599,11 +4063,11 @@ msgstr ""
 "map in een nieuw venster openen. Klikken met de 2de knop (midden) zal het "
 "huidige venster hergebruiken."
 
-#: tips:43
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Enkel klik navigatie"
 
-#: tips:44 tips:137
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
@@ -3613,11 +4077,11 @@ msgstr ""
 "ingedrukt om het item te selecteren.  Indien uit, enkel klikken selecteert; "
 "dubbel klikken opent."
 
-#: tips:45
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Dubbel-klikken op achtergrond herschaald"
 
-#: tips:46
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
@@ -3625,15 +4089,15 @@ msgstr ""
 "Als 'aan', het venster zal herschalen bij het dubbelklikken op zijn "
 "achtergrond, vergelijkbaar de Automatische herschaal knop op de knoppenbalk."
 
-#: tips:47
+#: tips:30
 msgid "Sorting"
 msgstr "Sorteren"
 
-#: tips:48
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Mappen altijd eerst (voor sorteren op naam)"
 
-#: tips:49
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
@@ -3641,11 +4105,11 @@ msgstr ""
 "Indien aan zullen mappen altijd eerst getoond worden wanneer op naam "
 "gesorteerd wordt."
 
-#: tips:50
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Hoofdletters altijd eerst (voor sorteren op naam)"
 
-#: tips:51
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
@@ -3653,15 +4117,58 @@ msgstr ""
 "Indien aan zullen alle bestanden die beginnen met een hoofdletter getoond "
 "worden voor bestanden met een kleine letter."
 
-#: tips:53
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Mappen altijd eerst (voor sorteren op naam)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sec"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "Uitgebreide attributen"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "Standaard instellingen voor nieuwe vensters"
 
-#: tips:54
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "Erf opties over van bronvenster"
 
-#: tips:55
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
@@ -3670,27 +4177,38 @@ msgstr ""
 "venster waarvandaan het nieuwe venster werd geopend, anders heeft het nieuwe "
 "venster de standaardinstellingen."
 
-#: tips:56
+#: tips:48
 msgid "View type:"
 msgstr "Toon type:"
 
-#: tips:59
+#: tips:51
 msgid "Sort by:"
 msgstr "Sorteren op:"
 
-#: tips:61 tips:76
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Type"
 
-#: tips:62
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Datum"
 
-#: tips:64
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Datum"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Datum"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Toon verborgen bestanden"
 
-#: tips:65
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
@@ -3698,7 +4216,34 @@ msgstr ""
 "Indien aan worden bestanden waarvan de naam met een punt begint (.) ook "
 "afgebeeld, anders zijn ze verborgen."
 
-#: tips:66
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Toon verborgen bestanden"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Indien aan worden bestanden waarvan de naam met een punt begint (.) ook "
+"afgebeeld, anders zijn ze verborgen."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Reusachtige iconen"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "pixels"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "Iconen Weergave"
 
@@ -3710,11 +4255,11 @@ msgstr "Standaard grootte:"
 msgid "Huge Icons"
 msgstr "Reusachtige iconen"
 
-#: tips:69 tips:245
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Grote iconen"
 
-#: tips:70 tips:244
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "Kleine iconen"
 
@@ -3726,15 +4271,20 @@ msgstr "Standaard details:"
 msgid "No details"
 msgstr "Geen details"
 
+#: tips:74
+msgid "Sizes"
+msgstr "Grootte"
+
+#: tips:77
+msgid "Times"
+msgstr "Tijden"
+
 #: tips:78
-msgid "Automatic small icons:"
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "Automatisch kleine iconen:"
 
-#: tips:79
-msgid "Change at:"
-msgstr "Verander bij:"
-
-#: tips:81
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3744,68 +4294,92 @@ msgstr ""
 "items bevat dan zullen ze getoond worden d.m.v. Kleine Iconen, anders zullen "
 "Grote Iconen gebruikt worden."
 
-#: tips:82
-msgid "Max width (Large icons):"
-msgstr "Max afmeting (Grote iconen):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Grote iconen"
 
-#: tips:83 tips:86
-msgid "pixels"
-msgstr "pixels"
-
-#: tips:84
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "Tekst breder dan dit wordt gesplitst over meer regels in Grote iconen modus. "
 "In Reusachtige iconen modus wordt tekst afgebroken als het 50% breder is dan "
 "dit."
 
-#: tips:85
-msgid "(Small Icons):"
-msgstr "(Kleine iconen):"
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
 
 #: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
+#: tips:88
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr ""
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "(Kleine iconen):"
+
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "Maximale breedte van de tekst onder een klein icoon."
 
-#: tips:88
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "Sorteer kleine iconen verticaal"
 
-#: tips:89
+#: tips:93
+#, fuzzy
 msgid ""
-"If this option is on, then small icons are ordered vertically, not "
-"horizontally."
+"If this option is on, then small icons are arranged in columns, not rows."
 msgstr ""
 "Als deze optie aan staat, worden kleine iconen verticaal gesorteerd i.p.v. "
 "horizontaal."
 
-#: tips:90
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "Sorteer grote iconen verticaal"
 
-#: tips:91
+#: tips:95
+#, fuzzy
 msgid ""
-"If this option is on, then large icons are sorted vertically, not "
-"horizontally."
+"If this option is on, then large icons are arranged in columns, not rows."
 msgstr ""
 "Als deze optie aan staat, worden grote iconen verticaal gesorteerd i.p.v. "
 "horizontaal."
 
-#: tips:93
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Toon kolom hoofddingen"
 
-#: tips:94
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr "Indien aan, zullen kolom hoofddingen getoond worden in lijst weergave."
 
-#: tips:95
+#: tips:102
 msgid "Show full type"
 msgstr "Toon volledig type"
 
-#: tips:96
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
@@ -3813,39 +4387,132 @@ msgstr ""
 "Indien 'aan', toon de volledige beschrijving van het type van elk object, in "
 "de plaats van een korte samenvating met enkel het basis type."
 
-#: tips:97
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Maximale breedte van de tekst onder een klein icoon."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Toon kolom hoofddingen"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr "Indien aan, zullen kolom hoofddingen getoond worden in lijst weergave."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr "Indien aan, zullen kolom hoofddingen getoond worden in lijst weergave."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr "Indien aan, zullen kolom hoofddingen getoond worden in lijst weergave."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr "Indien aan, zullen kolom hoofddingen getoond worden in lijst weergave."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr "Indien aan, zullen kolom hoofddingen getoond worden in lijst weergave."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr "Indien aan, zullen kolom hoofddingen getoond worden in lijst weergave."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "Laatst _Aangepast"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr "Indien aan, zullen kolom hoofddingen getoond worden in lijst weergave."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr "Indien aan, zullen kolom hoofddingen getoond worden in lijst weergave."
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr "Indien aan, zullen kolom hoofddingen getoond worden in lijst weergave."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Gereedschap/Minibuffers"
 
-#: tips:98
+#: tips:131
 msgid "Toolbar"
 msgstr "Werkbalk"
 
-#: tips:99
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Werkbalk type:"
 
-#: tips:100
+#: tips:133
 msgid "No toolbar"
 msgstr "Geen werkbalk"
 
-#: tips:101
+#: tips:134
 msgid "Icons only"
 msgstr "Alleen plaatjes"
 
-#: tips:102
+#: tips:135
 msgid "Text under icons"
 msgstr "Tekst onder iconen"
 
-#: tips:103
+#: tips:136
 msgid "Text beside icons"
 msgstr "Tekst naast iconen"
 
-#: tips:104
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Alleen plaatjes"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Toon totaal aantal items"
 
-#: tips:105
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3855,30 +4522,30 @@ msgstr ""
 "(indien aanwezig). Als er een selectie is, toon het aantal geselecteerde "
 "items en hun gecombineerde grootte."
 
-#: tips:106
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Selecteer de knoppen die op de knoppenbalk moet verschijnen:"
 
-#: tips:107
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "Breedte werkbalk bepaald minimum breedte venster"
 
-#: tips:108
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
 msgstr ""
 "Elk ROX-Filer venster blijft breed genoeg om de gehele werkbalk te tonen"
 
-#: tips:109
+#: tips:143
 msgid "Minibuffer"
 msgstr "Minibuffer"
 
-#: tips:110
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Piep als Tab-aanvulling mislukt"
 
-#: tips:111
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
@@ -3888,11 +4555,11 @@ msgstr ""
 "niets verandert (bijvoorbeeld omdat er meerdere mogelijkheden zijn en de "
 "voldgende letter varieert)."
 
-#: tips:112
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Piep als er meerdere items overeenkomen"
 
-#: tips:113
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
@@ -3900,7 +4567,27 @@ msgstr ""
 "Als Tab wordt ingedrukt in de `Geef pad...' minibufer, geef een piep als er "
 "meer items overeenkomen zelfs als er wel letters toegevoegd worden."
 
-#: tips:116
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Download afhandeling"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Fout in afhandeling %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
@@ -3908,11 +4595,11 @@ msgstr ""
 "Wanneer miniaturen aanstaan zal elke afbeelding in een map geladen worden en "
 "een miniatuur ervan zal getoond worden."
 
-#: tips:117
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Toon voorbeeldplaatjes"
 
-#: tips:118
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
@@ -3920,29 +4607,103 @@ msgstr ""
 "Dit is de standaard instelling voor nieuwe vensters. Gebruik het Weergave "
 "menu om miniaturen aan of uit te schakelen voor individuele vensters."
 
-#: tips:119
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Toon voorbeeldplaatjes"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "Video miniaturen"
 
-#: tips:120
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Miniaturen cache"
 
-#: tips:121
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "Uit snelheids-overwegingen worden de aangemaakte miniaturen opgeslagen in "
 "een verborgen ~/.thumnails (miniatuur) map. Klik hier om all opgeslagen "
 "miniaturen te verwijderen. Ze zullen indien nodig terug aangemaakt worden."
 
-#: tips:122 tips:195
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
+#, fuzzy
+msgid "Manage thumbnails"
+msgstr "Toon voorbeeldplaatjes"
+
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Video miniaturen"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sec"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Prikbord"
 
-#: tips:123
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
@@ -3950,47 +4711,47 @@ msgstr ""
 "Als u een prikbord gebruikt kunt u bestanden en programma's naar het "
 "bureaublad slepen om daar snelkoppelingen aan te maken."
 
-#: tips:124 tips:241
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Uiterlijk"
 
-#: tips:125
+#: tips:179
 msgid "Foreground:"
 msgstr "Voorgrond:"
 
-#: tips:126
+#: tips:180
 msgid "Text shadow:"
 msgstr "Tekst schaduw:"
 
-#: tips:127
+#: tips:181
 msgid "Background:"
 msgstr "Achtergrond:"
 
-#: tips:128
+#: tips:182
 msgid "No shadow"
 msgstr "Geen schaduw"
 
-#: tips:129
+#: tips:183
 msgid "Thin"
 msgstr "Dun"
 
-#: tips:130
+#: tips:184
 msgid "Thick"
 msgstr "Dik"
 
-#: tips:131
+#: tips:185
 msgid "Use custom font:"
 msgstr "Gebruik aangepast lettertype:"
 
-#: tips:132
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Het lettertype waarmee de tekst onder de iconen getoond wordt"
 
-#: tips:133
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Snel schalen van afbeeldingen"
 
-#: tips:134
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
@@ -3998,19 +4759,19 @@ msgstr ""
 "Kies tussen een snelle of trage methode om achtergrond afbeeldingen te "
 "schalen. De trage methode geeft soms betere resultaten."
 
-#: tips:135
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Prikbord gedrag"
 
-#: tips:136
+#: tips:190
 msgid "Single-click to open"
 msgstr "Enkel klikken om te openen"
 
-#: tips:138
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Hou iconen binnen het scherm"
 
-#: tips:139
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
@@ -4018,39 +4779,39 @@ msgstr ""
 "Als dit ingesteld is zullen prikbord-iconen, inclusief label, altijd "
 "volledig binnen het scherm gehouden worden."
 
-#: tips:140
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Icoon uitlijn-raster:"
 
-#: tips:141
+#: tips:195
 msgid "Fine"
 msgstr "Fijn"
 
-#: tips:142
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "Gebruik een 2-pixel raster om iconen op de desktop te plaatsen."
 
-#: tips:143
+#: tips:197
 msgid "Medium"
 msgstr "Midden"
 
-#: tips:144
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "Gebruik een 16-pixel raster om iconen op de desktop te plaatsen."
 
-#: tips:145
+#: tips:199
 msgid "Coarse"
 msgstr "Grof"
 
-#: tips:146
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "Gebruik een 32-pixel raster om iconen op de desktop te plaatsen."
 
-#: tips:147 tips:149
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Geminimaliseerde vensters"
 
-#: tips:148
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
@@ -4060,11 +4821,11 @@ msgstr ""
 "verschillende programma's, inclusief ROX-Filer, kunnen worden gebruikt om de "
 "geminimaliseerde vensters te tonen."
 
-#: tips:150
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Toon geminimaliseerde vensters"
 
-#: tips:151
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
@@ -4074,11 +4835,11 @@ msgstr ""
 "kleine knop op het prikbord. Dit vereist een compatibele window manager, en "
 "het prikbord moet in gebruik zijn."
 
-#: tips:152
+#: tips:206
 msgid "Show per workspace"
 msgstr "Toon per werkplek"
 
-#: tips:153
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
@@ -4086,39 +4847,39 @@ msgstr ""
 "Als deze optie aan staat zal ROX enkel geminimaliseerde vensters tonen die "
 "behoren to het huidige werkplek."
 
-#: tips:154
+#: tips:208
 msgid "Iconify to the"
 msgstr "Minimaliseer naar"
 
-#: tips:155
+#: tips:209
 msgid "top-left"
 msgstr "linksboven"
 
-#: tips:156
+#: tips:210
 msgid "top-right"
 msgstr "rechtsboven"
 
-#: tips:157
+#: tips:211
 msgid "bottom-left"
 msgstr "linksonder"
 
-#: tips:158
+#: tips:212
 msgid "bottom-right"
 msgstr "rechtsonder"
 
-#: tips:159
+#: tips:213
 msgid ", going"
 msgstr ", in"
 
-#: tips:160
+#: tips:214
 msgid "horizontally"
 msgstr "horizontale richting"
 
-#: tips:161
+#: tips:215
 msgid "vertically"
 msgstr "vertikale richting"
 
-#: tips:162
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4130,119 +4891,47 @@ msgstr ""
 "geplaatst worden. Dit kan vermeden worden door een boven en onder grens in "
 "te stellen. ROX-Filer is reeds bewust van zijn eigen paneel."
 
-#: tips:163
+#: tips:217
 msgid "Top margin"
 msgstr "Bovengrens"
 
-#: tips:164
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Afmeting van het niet-gebruiken gebied vanaf bovenkant scherm"
 
-#: tips:165
+#: tips:219
 msgid "Bottom margin"
 msgstr "Ondergrens"
 
-#: tips:166
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "Afmeting van het niet-gebruiken gebied vanaf onderkant scherm"
 
-#: tips:167
-msgid "Panels"
-msgstr "Panelen"
+#: tips:221
+#, fuzzy
+msgid "Left margin"
+msgstr "Bovengrens"
 
-#: tips:168
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr ""
-"Panelen zijn balken met iconen aan een zijde van het scherm. Zie de "
-"handleiding voor informatie over het gebruik van panelen."
+#: tips:222
+#, fuzzy
+msgid "Width of no-go area at left of screen."
+msgstr "Afmeting van het niet-gebruiken gebied vanaf bovenkant scherm"
 
-#: tips:169
-msgid "Panel style"
-msgstr "Paneel stijl"
+#: tips:223
+#, fuzzy
+msgid "Right margin"
+msgstr "Ondergrens"
 
-#: tips:170
-msgid "Image and text"
-msgstr "Plaatje en tekst"
+#: tips:224
+#, fuzzy
+msgid "Width of no-go area at right of screen."
+msgstr "Afmeting van het niet-gebruiken gebied vanaf bovenkant scherm"
 
-#: tips:171
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Ieder icoon op het paneel wordt getoond met een plaatje en tekst."
-
-#: tips:172
-msgid "Image only for applications"
-msgstr "Alleen een plaatje voor applicaties"
-
-#: tips:173
-msgid ""
-"Applications have just an image, everything else has both an image and text."
-msgstr "Applicaties hebben alleen een plaatje, de rest een plaatje met tekst."
-
-#: tips:174
-msgid "Image only"
-msgstr "Alleen plaatjes"
-
-#: tips:175
-msgid "Only the image is shown."
-msgstr "Alleen plaatjes worden getoond."
-
-#: tips:176
-msgid "Panel width (thin)"
-msgstr "Paneel afmeting (klein)"
-
-#: tips:177
-msgid "(thick)"
-msgstr "(groot)"
-
-#: tips:178
-msgid "The size of the panels."
-msgstr "Afmeting van de panelen."
-
-#: tips:179
-msgid "Do not cover panel"
-msgstr "Paneel niet bedekken"
-
-#: tips:180
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
-msgstr ""
-"Vraag aan de window-manager om panelen bij het maximaliseren van vensters "
-"niet te bedekken. Merk op dat dit bij sommige window-managers niet zal "
-"werken. Zonder deze optie zal ROX-Filer enkel vragen dat een paar pixels "
-"niet bedekt worden zodat panelen automatisch naar voren kunnen komen."
-
-#: tips:181
-msgid "Xinerama"
-msgstr "Xinerama"
-
-#: tips:182
-msgid "Confine to Xinerama monitor"
-msgstr "Beperk to Xinerama monitor"
-
-#: tips:183
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
-msgstr ""
-"Gebruik deze optie om bij een Xinerama multi-monitor opstelling de panelen "
-"te beperken tot één monitor i.p.v. ze uit te breiden."
-
-#: tips:184
-msgid ""
-"The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr ""
-"De monitor waartoe de panelen beperkt zijn in Xinerama mode (genummerd vanaf "
-"0)."
-
-#: tips:185
+#: tips:225
 msgid "Desktop"
 msgstr "Desktop"
 
-#: tips:186
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
@@ -4250,59 +4939,52 @@ msgstr ""
 "Wanneer een sessie-beheer programma (zoals ROX-Session) gebruikt wordt, kan "
 "ROX-Filer een paneel en/of prikbord tonen. Dit kan je hier instellen."
 
-#: tips:187
+#: tips:227
 msgid "Panel only"
 msgstr "Enkel een paneel"
 
-#: tips:188
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Alleen het paneel wordt getoond."
 
-#: tips:189
+#: tips:229
 msgid "Pinboard only"
 msgstr "Enkel een prikbord"
 
-#: tips:190
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "Alleen het prikbord wordt getoond."
 
-#: tips:191
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "Paneel en Prikbord"
 
-#: tips:192
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "Zowel paneel als prikbord worden getoond."
 
-#: tips:193
-msgid "Panel"
-msgstr "Paneel"
-
-#: tips:194
-msgid "Enter the name of the panel to show here."
-msgstr "Geef de naam van het te tonen paneel."
-
-#: tips:196
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "Geef de naam van het te tonen prikbord."
 
-#: tips:197
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr "Aanpassing zijn van toepassing vanaf ROX-filer opnieuw gestart wordt."
 
-#: tips:198
+#: tips:236
+#, fuzzy
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 "De sessie-manager activeert deze opties d.m.v. het -S of --rox-session "
 "argument van ROX."
 
-#: tips:199
+#: tips:237
 msgid "Action windows"
 msgstr "Actie-venster"
 
-#: tips:200
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4310,63 +4992,110 @@ msgstr ""
 "Actie-vensters verschijnen bij achtergrond-bewerkingen\n"
 "zoals kopiëren en verwijderen."
 
-#: tips:201
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Auto-start deze acties (Stil)"
 
-#: tips:203
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Bestanden kopiëren zonder bevestiging."
 
-#: tips:205
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Bestanden verplaatsen zonder bevestiging."
 
-#: tips:207
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Symbolische links maken zonder bevestiging."
 
-#: tips:209
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Bestanden verwijderen zonder bevestiging."
 
-#: tips:210
+#: tips:248
 msgid "Mount"
 msgstr "Aankoppelen"
 
-#: tips:211
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Aan- en afkoppelen bestandssystemen zonder bevestiging."
 
-#: tips:212
+#: tips:250
 msgid "Default settings"
 msgstr "Standaardinstellingen"
 
-#: tips:214
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Forceren"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "Geen bevestiging vragen voor verwijderen van niet-schrijfbare items."
 
-#: tips:216
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Minder informatie weergeven."
 
-#: tips:218
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Ook de inhoud van sub-mappen veranderen."
 
-#: tips:221
+#: tips:263
+#, fuzzy
+msgid "Mount commands"
+msgstr "Aankoppelpunt"
+
+#: tips:264
+#, fuzzy
+msgid "Mount command"
+msgstr "Aankoppelpunt"
+
+#: tips:265
+msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
+msgstr ""
+
+#: tips:266
+#, fuzzy
+msgid "Unmount command"
+msgstr "Afkoppelen"
+
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "_Gebruik Opdracht"
+
+#: tips:269
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Sleep en Drop"
 
-#: tips:222
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Slepen naar iconen"
 
-#: tips:223
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Laat het slepen naar iconen in het bestandsvenster toe"
 
-#: tips:224
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
@@ -4377,11 +5106,11 @@ msgstr ""
 "en het droppen van het bestand zal het in die map plaatsen, of laden in het "
 "programma"
 
-#: tips:225
+#: tips:276
 msgid "Directories spring open"
 msgstr "Mappen springen open"
 
-#: tips:226
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
@@ -4391,15 +5120,15 @@ msgstr ""
 "de opgelichte map 'open springt' nadat het bestand er voor een korte periode "
 "over werd gehouden."
 
-#: tips:227
+#: tips:278
 msgid "Spring delay:"
 msgstr "Openspring vertraging:"
 
-#: tips:228
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:229
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
@@ -4409,19 +5138,19 @@ msgstr ""
 "alvorens deze open springt. Bovenstaande optie moet aanstaan voordat dit "
 "hier enig effect kan hebben."
 
-#: tips:230
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Wanneer bestanden gesleept worden met de linker muisknop"
 
-#: tips:231 tips:235
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Toon een menu met mogelijke acties"
 
-#: tips:232
+#: tips:283
 msgid "Copy the files"
 msgstr "Kopieer de bestanden"
 
-#: tips:233
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
@@ -4429,15 +5158,15 @@ msgstr ""
 "Het menu kan ook worden opgeroepen door te slepen terwijl de Alt toets wordt "
 "ingedrukt"
 
-#: tips:234
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Wanneer bestanden gesleept worden met de middelste muisknop"
 
-#: tips:236
+#: tips:287
 msgid "Move the files"
 msgstr "Verplaatst de bestanden"
 
-#: tips:237
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
@@ -4445,11 +5174,11 @@ msgstr ""
 "Het menu kan nog steeds worden opgeroepen door te slepen met de linker knop "
 "terwijl de Alt toets wordt ingedrukt"
 
-#: tips:238
+#: tips:289
 msgid "Download handler"
 msgstr "Download afhandeling"
 
-#: tips:239
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4461,35 +5190,35 @@ msgstr ""
 "gesleept naar ROX-Filer, en de huidige map is het doel. Bv.:\n"
 "xterm -e wget $1"
 
-#: tips:240
+#: tips:291
 msgid "Menus"
 msgstr "Menus"
 
-#: tips:242
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Grootte van iconen in menus:"
 
-#: tips:243
+#: tips:294
 msgid "No Icons"
 msgstr "Geen iconen"
 
-#: tips:246
+#: tips:297
 msgid "Same as current window"
 msgstr "Zelfde als huidig venster"
 
-#: tips:247
+#: tips:298
 msgid "Same as default"
 msgstr "Zelfde als standaard"
 
-#: tips:248
+#: tips:299
 msgid "Behaviour"
 msgstr "Gedrag"
 
-#: tips:249
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Bestands menu op rechter-klik"
 
-#: tips:250
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
@@ -4498,23 +5227,29 @@ msgstr ""
 "met geselecteerde bestanden (het hoofdmenu is beschikbaar via de Control-"
 "toets)."
 
-#: tips:251
-msgid "`Xterm Here' program"
+#: tips:302
+#, fuzzy
+msgid "Terminal emulator program"
 msgstr "`Xterm hier' programma"
 
-#: tips:252
-msgid "The program to launch when you choose `Xterm Here' from the menu."
+#: tips:303
+#, fuzzy
+msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr "Het programma dat moet starten als je `Xterm hier' kiest van het menu."
 
-#: tips:253
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Toetsenbord sneltoetsen"
 
-#: tips:255
+#: tips:305
+msgid "Types"
+msgstr "Types"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME types"
 
-#: tips:256
+#: tips:307
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
@@ -4522,23 +5257,23 @@ msgstr ""
 "ROX gebruikt een set van regels om het juiste MIME-type te bepalen voor elk "
 "gewoon bestand, en kiest dan een passend icoon."
 
-#: tips:257
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "Pas MIME-regels aan"
 
-#: tips:258
+#: tips:309
 msgid "Themes"
 msgstr "Thema's"
 
-#: tips:259
+#: tips:310
 msgid "Icon theme"
 msgstr "Iconen thema"
 
-#: tips:260
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "Thema's kunnen in de ~/.icons map geplaatst worden."
 
-#: tips:261
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
@@ -4547,40 +5282,40 @@ msgstr ""
 "MIME type. Merk op dat iconen die op deze manier zijn ingesteld voorang "
 "hebben op het geselecteerde thema"
 
-#: tips:262
+#: tips:313
 msgid "Colours"
 msgstr "Kleuren"
 
-#: tips:263
+#: tips:314
 msgid "File type colours"
 msgstr "Kleuren bestandstypen"
 
-#: tips:264
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Kleur bestanden op basis van hun type"
 
-#: tips:265
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr ""
 "Bestandsnamen (en details) worden gekleurd naargelang hun bestandstype."
 
-#: tips:266
+#: tips:317
 msgid "Directory:"
 msgstr "Map:"
 
-#: tips:267
+#: tips:318
 msgid "Regular file:"
 msgstr "Normaal bestand:"
 
-#: tips:268
+#: tips:319
 msgid "Pipe:"
 msgstr "Pipe:"
 
-#: tips:269
+#: tips:320
 msgid "Socket:"
 msgstr "Socket:"
 
-#: tips:271
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
@@ -4588,19 +5323,19 @@ msgstr ""
 "Fout, zoals wanneer een symlink wijst naar een niet bestaand bestand, of "
 "naar een bestand waar geen toegang toe te krijgen is."
 
-#: tips:272
+#: tips:323
 msgid "Character device:"
 msgstr "Karakter device:"
 
-#: tips:273
+#: tips:324
 msgid "Block device:"
 msgstr "Blok device:"
 
-#: tips:274
+#: tips:325
 msgid "Door:"
 msgstr "Door:"
 
-#: tips:275
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
@@ -4608,32 +5343,60 @@ msgstr ""
 "Door bestanden zijn een beetje zoals sockets or pipes, en komen enkel voor "
 "onder Solaris."
 
-#: tips:276
+#: tips:327
 msgid "Executable file:"
 msgstr "Uitvoerbaar bestand:"
 
-#: tips:277
+#: tips:328
 msgid "Application directory:"
 msgstr "Applicatie map:"
 
-#: tips:278
+#: tips:329
 msgid "Unknown type:"
 msgstr "Onbekend type:"
 
-#: tips:279
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Achtergrond:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Gebruik aangepast lettertype:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Uitwisselbaarheid"
 
-#: tips:280
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Window manager (Venster Beheerder) problemen"
 
-#: tips:281
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr ""
 "Neem de controle van de window manager over voor het prikbord en de panelen"
 
-#: tips:282
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4647,11 +5410,11 @@ msgstr ""
 "komt wanneer je er op klikt, of titelbalken of andere decoraties die rond "
 "vensters verschijnen, of wanneer ze getoond worden in de venster-lijst."
 
-#: tips:283
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "Geef all achtergrond muis klikken door aan de window manager"
 
-#: tips:284
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
@@ -4662,11 +5425,11 @@ msgstr ""
 "in om de muisklik naar de window manager door te sturen. Klikken op iconen "
 "zullen niet worden doorgestuurd."
 
-#: tips:285
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr ""
 
-#: tips:286
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4678,27 +5441,51 @@ msgstr ""
 "gewerkt.Er van uit gaande dat deze window managers hun gedrag in een "
 "nieuwere versie zullen aanpassen kan het zijn dat dit niet meer nodig is."
 
-#: tips:287
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "Paneel is een 'dock'"
 
-#: tips:288
+#: tips:346
+#, fuzzy
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 "Schakel deze optie uit als het paneel ongewenst boven andere vensters staat. "
 "Herstarten is nodig om effect te hebben."
 
-#: tips:289
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Paneel stijl"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Sleep en Drop"
 
-#: tips:290
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Gebruik geen 'host'-namen"
 
-#: tips:291
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4709,15 +5496,11 @@ msgstr ""
 "van een applicatie een + teken toont op de aanwijzer maar het droppen niet "
 "werkt."
 
-#: tips:292
-msgid "Extended attributes"
-msgstr "Uitgebreide attributen"
-
-#: tips:293
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Gebruik geen 'extended attributes'"
 
-#: tips:294
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4729,3 +5512,416 @@ msgstr ""
 "menu uitgeschakeld, en wordt het MIME type van een bestand enkel afgeleid "
 "van de bestandsnaam en zal het eigenschappen venster geen 'extended "
 "attributes' tonen."
+
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Onder"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "Rechts"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "Thuis map"
+
+#: ../Templates.ui.h:4
+msgid "Panel Options"
+msgstr "Paneel Opties"
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Plaatje en tekst"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Ieder icoon op het paneel wordt getoond met een plaatje en tekst."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Alleen een plaatje voor applicaties"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr "Applicaties hebben alleen een plaatje, de rest een plaatje met tekst."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Alleen plaatjes"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Alleen plaatjes worden getoond."
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Paneel afmeting (klein)"
+
+#: ../Templates.ui.h:12
+#, fuzzy
+msgid "The size of this panel."
+msgstr "Afmeting van de panelen."
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Vertaling"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "Paneel niet bedekken"
+
+#: ../Templates.ui.h:19
+#, fuzzy
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Vraag aan de window-manager om panelen bij het maximaliseren van vensters "
+"niet te bedekken. Merk op dat dit bij sommige window-managers niet zal "
+"werken. Zonder deze optie zal ROX-Filer enkel vragen dat een paar pixels "
+"niet bedekt worden zodat panelen automatisch naar voren kunnen komen."
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Paneel stijl"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Beperk to Xinerama monitor"
+
+#: ../Templates.ui.h:22
+#, fuzzy
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Gebruik deze optie om bij een Xinerama multi-monitor opstelling de panelen "
+"te beperken tot één monitor i.p.v. ze uit te breiden."
+
+#: ../Templates.ui.h:23
+#, fuzzy
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+"De monitor waartoe de panelen beperkt zijn in Xinerama mode (genummerd vanaf "
+"0)."
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "Xinerama"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr "Rechts"
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr "Links"
+
+#: ../Templates.ui.h:27
+msgid "Bottom edge"
+msgstr "Onder"
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr "Boven"
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "<b>Toegangsrechten</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<map>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' bestaat reeds - overschrijven?"
+
+#~ msgid "Choices migration"
+#~ msgstr "'Choices' (keuze-instellingen) verhuizing"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Fout tijdens doorzoeken '%s':\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Map ontbreekt/verwijderd"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Map '%s' niet gevonden."
+
+#~ msgid "Cancel"
+#~ msgstr "Afbreken"
+
+#~ msgid ""
+#~ ".\n"
+#~ "Home page (including updated versions): http://rox.sourceforge.net/\n"
+#~ msgstr ""
+#~ ".\n"
+#~ "Home page (inclusief nieuwe versies): http://rox.sourceforge.net/\n"
+
+#~ msgid "GNOME-VFS library"
+#~ msgstr "GNOME-VFS bibliotheek"
+
+#~ msgid "No (need 2.8.0 or later)"
+#~ msgstr "Nee (2.8.0 of hoger nodig)"
+
+#~ msgid "Dnotify support"
+#~ msgstr "Dnotify ondersteuning"
+
+#~ msgid "Open AVFS"
+#~ msgstr "Open AVFS"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Gebruik menu-muisknop + Shift om het bestand ergens naartoe te zenden"
+
+#~ msgid "Look inside ... ?"
+#~ msgstr "Binnenin kijken ... ?"
+
+#~ msgid "Panel: %s"
+#~ msgstr "Paneel: %s"
+
+#~ msgid "Select the panel's position:"
+#~ msgstr "Kies de positie van het paneel:"
+
+#~ msgid "Top-edge panel"
+#~ msgstr "Paneel bovenaan"
+
+#~ msgid "Bottom edge panel"
+#~ msgstr "Paneel onderaan"
+
+#~ msgid "Left edge panel"
+#~ msgstr "Paneel links"
+
+#~ msgid "Right-edge panel"
+#~ msgstr "Paneel rechts"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Ongeldig .gmo vertalingsbestand (te kort): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr ""
+#~ "Ongeldig .gmo vertalingsbestand (GNU magisch nummer niet gevonden): %s"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Ga naar bovenliggende map"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Ga naar thuismap"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Bladwijzers"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Bladwijzers menu"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Map inhoud verversen"
+
+#~ msgid "Change icon size"
+#~ msgstr "Icoon-grootte veranderen"
+
+#~ msgid "Show extra details"
+#~ msgstr "Extra details tonen"
+
+#~ msgid "Hidden"
+#~ msgstr "Verborgen"
+
+#~ msgid "Show/hide hidden files"
+#~ msgstr "Toon/verberg verborgen bestanden"
+
+#~ msgid ""
+#~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
+#~ "instead."
+#~ msgstr ""
+#~ "Iconen thema '%s' bevat geen MIME iconen. Zal gebruik maken van het "
+#~ "standaard ROX theme."
+
+#~ msgid ""
+#~ "Failed to create symlink '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(this may mean that the ROX theme already exists there, but the 'mime-"
+#~ "application:postscript' icon couldn't be loaded for some reason)"
+#~ msgstr ""
+#~ "Aanmaak van symlink '%s' mislukt:\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(het kan zijn dat dit ROX thema hier reeds bestaat, maar het 'mime-"
+#~ "application:postscript' ikoon om een bepaalde reden niet geladen kon "
+#~ "worden)"
+
+#~ msgid "Language"
+#~ msgstr "Taal"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "Gebruik de LANG ongevingsvariabele"
+
+#~ msgid "Basque"
+#~ msgstr "Baskisch"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Chinees (traditioneel)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Chinees (vereenvoudigd)"
+
+#~ msgid "Czech"
+#~ msgstr "Tsjechisch"
+
+#~ msgid "Danish"
+#~ msgstr "Deens"
+
+#~ msgid "Dutch"
+#~ msgstr "Nederlands"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Engels (geen vertaling)"
+
+#~ msgid "Estonian"
+#~ msgstr "Estlands"
+
+#~ msgid "Finnish"
+#~ msgstr "Fins"
+
+#~ msgid "French"
+#~ msgstr "Frans"
+
+#~ msgid "German"
+#~ msgstr "Duits"
+
+#~ msgid "Hungarian"
+#~ msgstr "Hongaars"
+
+#~ msgid "Japanese"
+#~ msgstr "Japans"
+
+#~ msgid "Norwegian"
+#~ msgstr "Noors"
+
+#~ msgid "Italian"
+#~ msgstr "Italiaans"
+
+#~ msgid "Polish"
+#~ msgstr "Pools"
+
+#~ msgid "Portuguese (Brasil)"
+#~ msgstr "Portugees (Brazilië)"
+
+#~ msgid "Romanian"
+#~ msgstr "Roemeens"
+
+#~ msgid "Russian"
+#~ msgstr "Russisch"
+
+#~ msgid "Spanish"
+#~ msgstr "Spaans"
+
+#~ msgid "Swedish"
+#~ msgstr "Zweeds"
+
+#~ msgid "Change at:"
+#~ msgstr "Verander bij:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Max afmeting (Grote iconen):"
+
+#~ msgid "Panels"
+#~ msgstr "Panelen"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Panelen zijn balken met iconen aan een zijde van het scherm. Zie de "
+#~ "handleiding voor informatie over het gebruik van panelen."
+
+#~ msgid "(thick)"
+#~ msgstr "(groot)"
+
+#~ msgid "Enter the name of the panel to show here."
+#~ msgstr "Geef de naam van het te tonen paneel."

--- a/ROX-Filer/src/po/no.po
+++ b/ROX-Filer/src/po/no.po
@@ -6,62 +6,67 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-08-09 14:02+0100\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Sigve Indregard <sigve@elev.no>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: abox.c:127
-msgid "<dir>"
-msgstr "<mappe>"
+msgid "<src>"
+msgstr ""
 
-#: abox.c:219
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 #, fuzzy
 msgid "_Quiet"
 msgstr "Stille"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Quiet"
 msgstr "Stille"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr ""
 
-#: abox.c:455 tips:60
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Navn"
 
-#: abox.c:461 menu.c:232
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Mappe"
 
-#: abox.c:550
+#: abox.c:546
 msgid "Expression:"
 msgstr "Uttrykk:"
 
-#: action.c:58
+#: action.c:57
 #, fuzzy
 msgid "See the attr(5) man page for full details."
 msgstr "Se ROX-Filer-manualen for detaljer."
 
-#: action.c:60
+#: action.c:59
 #, fuzzy
 msgid "See the fsattr(5) man page for full details."
 msgstr "Se ROX-Filer-manualen for detaljer."
 
-#: action.c:62
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr ""
 
-#: action.c:188
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Finn uttrykksreferanse"
 
-#: action.c:199
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -100,12 +105,12 @@ msgid ""
 "<b>prune</b> (false, and prevents searching the contents of a directory)."
 msgstr ""
 
-#: action.c:246
+#: action.c:256
 #, fuzzy
 msgid "Change permissions reference"
 msgstr "Finn uttrykksreferanse"
 
-#: action.c:257
+#: action.c:267
 #, fuzzy
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
@@ -136,40 +141,40 @@ msgid ""
 "\n"
 "See the chmod(1) man page for full details."
 msgstr ""
-"Vanligvis kan du velge en kommando fra menyen (klikk pÂ \n"
+"Vanligvis kan du velge en kommando fra menyen (klikk p√• \n"
 "pilen ved siden av kommando-boksen). Noen ganger kreves det mer...\n"
 "\n"
-"Formatet pÂ en kommando er:\n"
+"Formatet p√• en kommando er:\n"
 "ENDRING, ENDRING, ...\n"
 "Hver ENDRING er:\n"
 "HVEM, HVORDAN, TILLATELSER\n"
 "HVEM er en kombinasjon av u, g og o som bestemmer om vi skal endre\n"
 "tillatelser for User (eieren), Group (gruppen) eller Others (andre).\n"
-"HVORDAN er +, - eller = for Â tilf¯ye, fjerne eller sette spesifiserte "
+"HVORDAN er +, - eller = for √• tilf√∏ye, fjerne eller sette spesifiserte "
 "tillatelser.\n"
 "TILLATELSER er en kombinasjon av bokstavene 'rwxXstugo'\n"
 "\n"
 "Tekst mellem { og } og mellomrom blir oversett.\n"
 "\n"
 "Eksempler:\n"
-"u+rw \t(filens eier fÂr lese- og skrivetillatelser)\n"
+"u+rw \t(filens eier f√•r lese- og skrivetillatelser)\n"
 "g=u\t(gruppens tillatelser blir de samme som eierens)\n"
-"o=u-w\t(andre fÂr samme tillatelser som eieren, men ikke skrive-tillatelse)\n"
-"a+x\t(alle fÂr utf¯r- og tilgangstillatelser - det samme som 'ugo+x')\n"
+"o=u-w\t(andre f√•r samme tillatelser som eieren, men ikke skrive-tillatelse)\n"
+"a+x\t(alle f√•r utf√∏r- og tilgangstillatelser - det samme som 'ugo+x')\n"
 "a+X\t(mapper blir tilgjengelige for alle; filer som var\n"
-"kj¯rbare af noen blir kj¯rbare av alle)\n"
-"u+rw, go+r\t(to kommandoer pÂ en gang!)\n"
-"u+s\t(sett SetUID-delen - har ofte ingen effekt pÂ skript-filer)\n"
+"kj√∏rbare af noen blir kj√∏rbare av alle)\n"
+"u+rw, go+r\t(to kommandoer p√• en gang!)\n"
+"u+s\t(sett SetUID-delen - har ofte ingen effekt p√• skript-filer)\n"
 "755\t(sett tillatelsene direkte)\n"
 "\n"
 "Se chmod(1)s manside for detaljer."
 
-#: action.c:298
+#: action.c:308
 #, fuzzy
 msgid "Set type reference"
 msgstr "Finn uttrykksreferanse"
 
-#: action.c:309
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -185,92 +190,98 @@ msgid ""
 "on certain file systems and where the OS implements them.\n"
 msgstr ""
 
-#: action.c:416
+#: action.c:459
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 
-#: action.c:432
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "En feil oppstod.\n"
 
-#: action.c:434
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "%d feil oppstod.\n"
 
-#: action.c:458
+#: action.c:516
 msgid "ERROR reading"
 msgstr "Lesefeil"
 
-#: action.c:501
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Ferdig\n"
 
-#: action.c:557 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "FEIL"
 
-#: action.c:711 main.c:674 main.c:681 main.c:688
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Ja"
 
-#: action.c:714 main.c:676 main.c:690
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Nei"
 
-#: action.c:732
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
 msgstr ""
 
-#: action.c:739
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
 msgstr ""
 
-#: action.c:892
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Tell inneholdet i %s?"
 
-#: action.c:928
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Slett %s'%s'?"
 
-#: action.c:929
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "SKRIVEBESKYTTET "
 
-#: action.c:936
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'Sletter '%s'\n"
 
-#: action.c:949
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'Mappen '%s' er slettet\n"
 
-#: action.c:982
+#: action.c:1104
 #, fuzzy, c-format
 msgid "?Eject '%s'?"
 msgstr "?Sjekk '%s'?"
 
-#: action.c:989
+#: action.c:1111
 #, fuzzy, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Sletter '%s'\n"
 
-#: action.c:1008
+#: action.c:1130
 #, fuzzy, c-format
 msgid ""
 "!%s\n"
@@ -279,81 +290,96 @@ msgstr ""
 "!%s\n"
 "Montering mislyktes\n"
 
-#: action.c:1027 action.c:1046
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Sjekk '%s'?"
 
-#: action.c:1043
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
-msgstr "!Ugyldige s¯keparametre - rett dem og pr¯v igjen\n"
+msgstr "!Ugyldige s√∏keparametre - rett dem og pr√∏v igjen\n"
 
-#: action.c:1053
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(mens '%s' ble sjekket)\n"
 
-#: action.c:1127 action.c:1152
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Endre tillatelsene til '%s'?"
 
-#: action.c:1133
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Endrer tillatelsene til '%s'\n"
 
-#: action.c:1150
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
-msgstr "!Ugyldig moduskommando - rett den og pr¯v igjen\n"
+msgstr "!Ugyldig moduskommando - rett den og pr√∏v igjen\n"
 
-#: action.c:1207 action.c:1227
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?Endre tillatelsene til '%s'?"
+
+#: action.c:1335 action.c:1355
 #, fuzzy, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Endre tillatelsene til '%s'?"
 
-#: action.c:1224
+#: action.c:1352
 #, fuzzy
 msgid "!Invalid type - change it and try again\n"
-msgstr "!Ugyldig moduskommando - rett den og pr¯v igjen\n"
+msgstr "!Ugyldig moduskommando - rett den og pr√∏v igjen\n"
 
-#: action.c:1246
+#: action.c:1374
 #, fuzzy, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Endrer tillatelsene til '%s'\n"
 
-#: action.c:1325
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'Endrer tillatelsene til '%s'\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' finnes allerede - %s?"
 
-#: action.c:1327
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "smelt sammen innholdet"
 
-#: action.c:1328
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "skriv over"
 
-#: action.c:1344
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
-msgstr "'Pr¯ver Â kopiere allikevel...\n"
+msgstr "'Pr√∏ver √• kopiere allikevel...\n"
 
-#: action.c:1353
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Kopier %s som %s?"
 
-#: action.c:1357
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Kopierer %s som %s\n"
 
-#: action.c:1372
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
-msgstr "!FEIL: MÂlet finnes allerede, men er ikke en mappe\n"
+msgstr "!FEIL: M√•let finnes allerede, men er ikke en mappe\n"
 
-#: action.c:1444
+#: action.c:1686
 #, fuzzy, c-format
 msgid ""
 "!%s\n"
@@ -362,26 +388,7 @@ msgstr ""
 "!%s\n"
 "Mislykket kopiering av '%s'"
 
-#: action.c:1488
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' finnes allerede - skriv over?"
-
-#: action.c:1503
-msgid "'Trying move anyway...\n"
-msgstr "'Pr¯ver Â flytte allikevel...\n"
-
-#: action.c:1511
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Flytt %s som %s?"
-
-#: action.c:1515
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Flytter %s som %s\n"
-
-#: action.c:1523
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -390,45 +397,59 @@ msgstr ""
 "!%s\n"
 "!FEIL: Mislykket flytting av %s som %s\n"
 
-#: action.c:1544
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Pr√∏ver √• flytte allikevel...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Flytt %s som %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Flytter %s som %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!FEIL: Kan ikke kopiere objektet til seg selv\n"
 
-#: action.c:1559
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
-msgstr "!FEIL: Kan ikke flytte/omd¯pe objektet til seg selv\n"
+msgstr "!FEIL: Kan ikke flytte/omd√∏pe objektet til seg selv\n"
 
-#: action.c:1571
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Opretter lenke til %s som %s\n"
 
-#: action.c:1576
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Oprett lenke til %s som %s?"
 
-#: action.c:1618
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Monterer %s\n"
 
-#: action.c:1619
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Demonterer %s\n"
 
-#: action.c:1622
+#: action.c:2025
 #, fuzzy, c-format
 msgid "?Mount %s?"
-msgstr "?MontÈr %s?\n"
+msgstr "?Mont√©r %s?\n"
 
-#: action.c:1623
+#: action.c:2026
 #, fuzzy, c-format
 msgid "?Unmount %s?"
-msgstr "?DemontÈr %s?\n"
+msgstr "?Demont√©r %s?\n"
 
-#: action.c:1643
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -437,7 +458,7 @@ msgstr ""
 "!%s\n"
 "Montering mislyktes\n"
 
-#: action.c:1644
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -446,11 +467,11 @@ msgstr ""
 "!%s\n"
 "Demontering mislyktes\n"
 
-#: action.c:1652
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr ""
 
-#: action.c:1698
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -459,302 +480,326 @@ msgstr ""
 "'\n"
 "Totalt: %s ("
 
-#: action.c:1704
+#: action.c:2108
 msgid "file"
 msgstr "fil"
 
-#: action.c:1704
+#: action.c:2108
 msgid "files"
 msgstr "filer"
 
-#: action.c:1708
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "ingen mapper)\n"
 
-#: action.c:1712
+#: action.c:2116
 msgid "directory"
 msgstr "mappe"
 
-#: action.c:1713
+#: action.c:2117
 msgid "directories"
 msgstr "mapper"
 
-#: action.c:1754
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Ingen monteringspunkter er valgt!\n"
 
-#: action.c:1839
+#: action.c:2231
 msgid "?Another search?"
-msgstr "?Nytt s¯k?"
+msgstr "?Nytt s√∏k?"
 
-#: action.c:1869 action.c:1900
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' er en symbolsk lenke\n"
 
-#: action.c:1940
+#: action.c:2342
 msgid "You need to select some items to search through"
-msgstr "Du mÂ velge noen objekter som skal s¯kes gjennom"
+msgstr "Du m√• velge noen objekter som skal s√∏kes gjennom"
 
-#: action.c:1950 menu.c:223
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Finn"
 
-#: action.c:1983
+#: action.c:2387
 msgid "You need to select some items to count"
-msgstr "Du mÂ velge noen objekter som skal telles"
+msgstr "Du m√• velge noen objekter som skal telles"
 
-#: action.c:1987
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Diskbruk"
 
-#: action.c:2021
+#: action.c:2429
 msgid "Mount / Unmount"
-msgstr "MontÈr / DemontÈr"
+msgstr "Mont√©r / Demont√©r"
 
-#: action.c:2034
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr ""
-"ROX-Filer st¯tter desverre enda ikke monteringspunkter pÂ ditt system. "
+"ROX-Filer st√∏tter desverre enda ikke monteringspunkter p√• ditt system. "
 "Beklager."
 
-#: action.c:2048 menu.c:210 tips:208
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Slett"
 
-#: action.c:2058 tips:213
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Tving"
 
-#: action.c:2058
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
-msgstr "Ikke sp¯r igjen om sletting av ikke-skrivbare objekter."
+msgstr "Ikke sp√∏r igjen om sletting av ikke-skrivbare objekter."
 
-#: action.c:2061 action.c:2116 action.c:2175 action.c:2228 action.c:2264
-#: tips:215
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Kort"
 
-#: action.c:2061
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Lag bare logg for sletting av mapper"
 
-#: action.c:2078
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
-msgstr "Du mÂ velge hvilke objekter du vil endre tillatelsene pÂ"
+msgstr "Du m√• velge hvilke objekter du vil endre tillatelsene p√•"
 
-#: action.c:2086
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
-msgstr "a+x (Gj¯r kj¯rbar/s¯kbar)"
+msgstr "a+x (Gj√∏r kj√∏rbar/s√∏kbar)"
 
-#: action.c:2088
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
-msgstr "a-x (Gj¯r ukj¯rbar/us¯kbar)"
+msgstr "a-x (Gj√∏r ukj√∏rbar/us√∏kbar)"
 
-#: action.c:2090
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Gi eier lese+skrive)"
 
-#: action.c:2092
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Privat - kun eier har tilgang)"
 
-#: action.c:2094
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Offentlig tilgang, ikke skrivbar)"
 
-#: action.c:2105 menu.c:184 menu.c:221 tips:75
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Tillatelser"
 
-#: action.c:2116 action.c:2175
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Ikke list opp bearbeidede filer"
 
-#: action.c:2119 action.c:2178 tips:217
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Rekursivt"
 
-#: action.c:2119
+#: action.c:2543
 msgid "Also change contents of subdirectories"
-msgstr "Innholdet i undermapper skal ogsÂ endres"
+msgstr "Innholdet i undermapper skal ogs√• endres"
 
-#: action.c:2123
+#: action.c:2547
 msgid "Command:"
 msgstr "Kommando:"
 
-#: action.c:2151
+#: action.c:2577
 #, fuzzy
 msgid "You need to select the items whose type you want to change"
-msgstr "Du mÂ velge hvilke objekter du vil endre tillatelsene pÂ"
+msgstr "Du m√• velge hvilke objekter du vil endre tillatelsene p√•"
 
-#: action.c:2164
+#: action.c:2590
 #, fuzzy
 msgid "Set type"
-msgstr "SortÈr etter Type"
+msgstr "Sort√©r etter Type"
 
-#: action.c:2178
+#: action.c:2608
 #, fuzzy
 msgid "Change contents of subdirectories"
-msgstr "Innholdet i undermapper skal ogsÂ endres"
+msgstr "Innholdet i undermapper skal ogs√• endres"
 
-#: action.c:2185 infobox.c:615
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Type:"
 
-#: action.c:2214 dnd.c:124 menu.c:1999 tips:202
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
-msgstr "KopiÈr"
+msgstr "Kopi√©r"
 
-#: action.c:2224 action.c:2260 tips:219
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Sp√∏rr ikke om sletting av ikke-skrivbare objekter."
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Skriv bare over hvis kildefila er nyere enn m√•lfila"
+
+#: action.c:2687 action.c:2744 tips:259
 #, fuzzy
 msgid "Newer"
 msgstr "Nyere"
 
-#: action.c:2225 action.c:2261 tips:220
-msgid "Only over-write if source is newer than destination."
-msgstr "Skriv bare over hvis kildefila er nyere enn mÂlfila"
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
+msgstr "Skriv bare over hvis kildefila er nyere enn m√•lfila"
 
-#: action.c:2228
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "mapper"
+
+#: action.c:2695
 #, fuzzy
 msgid "Only log directories as they are copied"
 msgstr "Lag bare logg for sletting av mapper"
 
-#: action.c:2250 dnd.c:125 tips:204
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Flytt"
 
-#: action.c:2264
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr ""
 
-#: action.c:2284 tips:206
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Lag Lenke"
 
-#: action.c:2303 appmenu.c:113
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr ""
 
-#: action.c:2360
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Sletter objekter som f.eks. "
 
-#: action.c:2364
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Sletter objektet "
 
-#: action.c:2366
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Sletter objektene "
 
-#: action.c:2385
+#: action.c:2900
 msgid " and "
 msgstr " og "
 
-#: action.c:2394
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
-msgstr " vil pÂvirke noen objekter pÂ tavla eller panelet - slette uansett?"
+msgstr " vil p√•virke noen objekter p√• tavla eller panelet - slette uansett?"
 
-#: action.c:2401
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
-msgstr "vil pÂvirke noen objekter pÂ tavla eller panelet - slette uansett?"
+msgstr "vil p√•virke noen objekter p√• tavla eller panelet - slette uansett?"
 
-#: appmenu.c:198
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<manglende tittel>"
 
-#: appmenu.c:295
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
 "menu for all items of this type (%s/%s)."
 msgstr ""
 
-#: appmenu.c:339 menu.c:234
+#: appmenu.c:331 menu.c:753
 #, fuzzy
 msgid "Customise Menu..."
 msgstr "Tilpass"
 
-#: appmenu.c:396 menu.c:251 toolbar.c:159
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Hjelp"
 
-#: bookmarks.c:147
-#, fuzzy
-msgid "Path"
-msgstr "Sti: "
-
-#: bookmarks.c:155
+#: bookmarks.c:268
 #, fuzzy
 msgid "Title"
 msgstr "Side ved side"
 
-#: bookmarks.c:304
+#: bookmarks.c:276 log.c:176
+#, fuzzy
+msgid "Path"
+msgstr "Sti: "
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr ""
 
-#: bookmarks.c:312 bookmarks.c:630
+#: bookmarks.c:474 bookmarks.c:823
 #, fuzzy, c-format
 msgid "'%s' isn't a directory"
 msgstr "Kan ikke finne mappen: %s"
 
-#: bookmarks.c:518
+#: bookmarks.c:711
 #, fuzzy
 msgid "You should first select some rows to delete"
-msgstr "Du mÂ f¯rst velge noen objekter som skal fjernes"
+msgstr "Du m√• f√∏rst velge noen objekter som skal fjernes"
 
-#: bookmarks.c:542
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr ""
 
-#: bookmarks.c:562
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr ""
 
-#: bookmarks.c:636
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr ""
 
-#: bookmarks.c:778
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr ""
 
-#: bookmarks.c:785
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr ""
 
-#: bookmarks.c:790
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr ""
 
-#: bulk_rename.c:68
+#: bulk_rename.c:69
 #, fuzzy
 msgid "Bulk rename files"
-msgstr "GenlÊs filer"
+msgstr "Genl√¶s filer"
 
-#: bulk_rename.c:71
+#: bulk_rename.c:72
 #, fuzzy
 msgid "Reset"
 msgstr " Angre"
 
-#: bulk_rename.c:76
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr ""
 
-#: bulk_rename.c:81
+#: bulk_rename.c:82
 #, fuzzy
 msgid "_Rename"
-msgstr "Omd¯p"
+msgstr "Omd√∏p"
 
-#: bulk_rename.c:94
+#: bulk_rename.c:95
 #, fuzzy
 msgid "Replace:"
 msgstr "Erstatt"
 
-#: bulk_rename.c:101
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -770,58 +815,59 @@ msgstr "objekt"
 
 #: bulk_rename.c:116
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
-msgstr "SlÂ til"
+msgstr "Sl√• til"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
 msgstr ""
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr ""
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 #, fuzzy
 msgid "New name"
-msgstr "Omd¯p"
+msgstr "Omd√∏p"
 
-#: bulk_rename.c:259
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr ""
 
-#: bulk_rename.c:264
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr ""
 
-#: bulk_rename.c:267
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr ""
 
-#: bulk_rename.c:293
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr ""
 
-#: bulk_rename.c:310
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr ""
 
-#: bulk_rename.c:343
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr ""
 
-#: bulk_rename.c:348
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -829,65 +875,81 @@ msgid ""
 "Aborting bulk rename."
 msgstr ""
 
-#: bulk_rename.c:410
+#: bulk_rename.c:447
 #, fuzzy, c-format
 msgid "A file called '%s' already exists"
 msgstr "?'%s' finnes allerede - %s?"
 
-#: bulk_rename.c:421
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
 "files to end up in different directories. Continue?"
 msgstr ""
 
-#: bulk_rename.c:436
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr ""
 
-#: choices.c:428
-#, fuzzy
-msgid "Choices migration"
-msgstr "Kinesisk (tradisjonell)"
+#: choices.c:434
+#, c-format
+msgid "%d directories could not be migrated"
+msgstr ""
 
 #: choices.c:436
 #, c-format
 msgid ""
 "Choices have been moved from \n"
-"<b>%s</b>\n"
+"%s\n"
 " to the new location \n"
-"<b>%s</b>\n"
+"%s\n"
+"%s"
 msgstr ""
 
-#: choices.c:447
-#, c-format
-msgid "%d directories could not be migrated"
-msgstr ""
-
-#: dir.c:982
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Kan ikke finne mappen: %s"
 
-#: dir.c:991
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
-msgstr "Kan ikke Âpne mappen: %s"
+msgstr "Kan ikke √•pne mappen: %s"
 
-#: display.c:588
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "St√∏rrelse"
+
+#: display.c:705
+msgid "‚î§"
+msgstr ""
+
+#: display.c:706
+msgid "‚îê"
+msgstr ""
+
+#: display.c:707
+msgid "‚îò"
+msgstr ""
+
+#: display.c:709
+msgid "‚îú"
+msgstr ""
+
+#: display.c:709
+msgid "‚îå"
+msgstr ""
+
+#: display.c:710
+msgid "‚îº"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) mislyktes: %s"
 
-#: dnd.c:126
-msgid "Link (relative)"
-msgstr ""
-
-#: dnd.c:127
-msgid "Link (absolute)"
-msgstr ""
-
-#: dnd.c:426
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Intern feil - inkorrekt infotype"
 
@@ -904,19 +966,19 @@ msgid ""
 "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
 "plain) did not contain a leafname\n"
 msgstr ""
-"XdndDirectSave0 mÂl gitt, men atomet XdndDirectSave0 (type text/plain) kan "
+"XdndDirectSave0 m√•l gitt, men atomet XdndDirectSave0 (type text/plain) kan "
 "ikke inneholde et bladnavn\n"
 
 #: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
 msgstr ""
-"Beklager - Jeg krever et mÂl av typen text/uri-list eller XdndDirectSave0."
+"Beklager - Jeg krever et m√•l av typen text/uri-list eller XdndDirectSave0."
 
 #: dnd.c:621
 msgid ""
 "Sorry - I require a target type of text/uri-list or application/octet-stream."
 msgstr ""
-"Beklager - Jeg krever et mÂl av typen text/uri-list eller application/octet-"
+"Beklager - Jeg krever et m√•l av typen text/uri-list eller application/octet-"
 "stream."
 
 #: dnd.c:691
@@ -930,7 +992,7 @@ msgstr ""
 
 #: dnd.c:766
 msgid "Unknown target"
-msgstr "Ukjent mÂl"
+msgstr "Ukjent m√•l"
 
 #: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
@@ -938,15 +1000,15 @@ msgstr "Det andre programmet kan eller vil ikke sende meg data - beklager"
 
 #: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
-msgstr "XDS protokollfeil: returkoden burde vÊre 'S', 'F' eller 'E'\n"
+msgstr "XDS protokollfeil: returkoden burde v√¶re 'S', 'F' eller 'E'\n"
 
 #: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
-msgstr "Beklager, kan ikke vise en handlingsmeny for en fjern fil / rÂdata."
+msgstr "Beklager, kan ikke vise en handlingsmeny for en fjern fil / r√•data."
 
 #: dnd.c:861
 msgid "UntitledData"
-msgstr "Navnl¯sData"
+msgstr "Navnl√∏sData"
 
 #: dnd.c:888
 #, c-format
@@ -955,7 +1017,7 @@ msgstr "Feil under lagring av fil: %s"
 
 #: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
-msgstr "Ingen URIer i text/uri-list (intet Â gj¯re!)"
+msgstr "Ingen URIer i text/uri-list (intet √• gj√∏re!)"
 
 #: dnd.c:993
 msgid ""
@@ -964,60 +1026,76 @@ msgstr ""
 "Kan ikke motta data fra den andre maskinen (application/octet-stream ikke "
 "gitt)"
 
-#: dnd.c:1016
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
-"Noen av disse filene er pÂ en annen maskin. De vil bli oversett. Beklager."
+"Noen av disse filene er p√• en annen maskin. De vil bli oversett. Beklager."
 
-#: dnd.c:1023
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
 msgstr ""
-"Ingen av disse filene er pÂ den lokale maskinen. Jeg kan ikke behandle flere "
+"Ingen av disse filene er p√• den lokale maskinen. Jeg kan ikke behandle flere "
 "fjerne filer. Beklager."
 
-#: dnd.c:1036
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Ukjent handling etterspurt"
 
-#: dnd.c:1044
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Feil under henting av fil-liste: %s"
 
-#: dropbox.c:114
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr ""
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr ""
+
+#: dnd.c:1109
+msgid "Link (relative, sym path)"
+msgstr ""
+
+#: dnd.c:1110
+msgid "Link (absolute, sym path)"
+msgstr ""
+
+#: dropbox.c:112
 #, fuzzy
 msgid "Show"
 msgstr "Info"
 
-#: dropbox.c:120
+#: dropbox.c:118
 #, fuzzy
 msgid "Show the current choice in a filer window"
 msgstr "Tillat draing til ikoner i 'Filer'-vinduer"
 
-#: dropbox.c:174
+#: dropbox.c:172
 #, fuzzy
 msgid "<nothing>"
-msgstr "<ingenting ennÂ>"
+msgstr "<ingenting enn√•>"
 
-#: dropbox.c:239
+#: dropbox.c:237
 msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
 msgstr ""
 
-#: dropbox.c:263
+#: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
 msgstr ""
 
-#: dropbox.c:273
+#: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr ""
 
-#: dropbox.c:280 pinboard.c:853
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1026,7 +1104,7 @@ msgstr ""
 "Ingen tilgang til %s:\n"
 "%s"
 
-#: filer.c:453
+#: filer.c:718
 #, fuzzy, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1035,359 +1113,408 @@ msgstr ""
 "Feil under oppdatering av '%s:\n"
 "%s"
 
-#: filer.c:457
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Feil under oppdatering av '%s:\n"
-"%s"
-
-#: filer.c:562
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
 "Unmounting a device makes it safe to remove the disk."
 msgstr ""
 
-#: filer.c:566
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 #, fuzzy
 msgid "No change"
 msgstr "Ingenting"
 
-#: filer.c:572 menu.c:862
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Demonter"
 
-#: filer.c:669
-msgid "Directory missing/deleted"
-msgstr "Mappe mangler/er slettet"
-
-#: filer.c:1031
+#: filer.c:1490
 #, fuzzy, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
 "Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"Gruppe %s er ikke satt. Velg noen filer og trykk Ctrl+%s for Â huske "
-"gruppen. Trykk %s alene for Â velge filene senere."
+"Gruppe %s er ikke satt. Velg noen filer og trykk Ctrl+%s for √• huske "
+"gruppen. Trykk %s alene for √• velge filene senere."
 
-#: filer.c:1267
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Mappen '%s' er ikke tilgjengelig"
+#: filer.c:2655
+msgid "A"
+msgstr "A"
 
-#: filer.c:1419
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Mappen '%s' ble ikke funnet."
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
 
-#: filer.c:1713
-msgid "Cancel"
-msgstr "Avbryt"
+#: filer.c:2659 find.c:923
+msgid "G"
+msgstr ""
 
-#: filer.c:2002
+#: filer.c:2664
 msgid "S"
 msgstr "O"
 
-#: filer.c:2004
+#: filer.c:2669
 msgid "T"
 msgstr "M"
 
-#: filer.c:2026
+#: filer.c:2670
+msgid "D"
+msgstr ""
+
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
+#, c-format
+msgid "Glob (%s), "
+msgstr ""
+
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Oppdaterer, "
 
-#: filer.c:2028
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Miniatyrer, "
 
-#: filer.c:2304
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Miniatyrer, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Symbolsk lenke til "
 
-#: filer.c:2335
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
-msgstr "Dette filnavnet er ikke gyldig UTF-8. Du burde omd¯pe den.\n"
+msgstr "Dette filnavnet er ikke gyldig UTF-8. Du burde omd√∏pe den.\n"
 
-#: filer.c:2643 menu.c:1989
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "Objektet eksisterer ikke lengre!"
 
-#: filer.c:3327
+#: filer.c:4451
+msgid "‚ñº"
+msgstr ""
+
+#: filer.c:4451
+msgid "‚ñΩ"
+msgstr ""
+
+#: filer.c:4462
+msgid "‚ñ∑"
+msgstr ""
+
+#: filer.c:4462
+msgid "‚ñ∂"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr ""
 
-#: filer.c:3334
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Standardinnstillinger"
+
+#: filer.c:4727
 msgid "Position"
 msgstr ""
 
-#: filer.c:3339 toolbar.c:135 toolbar.c:139 tips:63
-msgid "Size"
-msgstr "St¯rrelse"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Vindues-st√∏rrelse gr√¶nse"
 
-#: filer.c:3344
+#: filer.c:4737
 #, fuzzy
 msgid "Show hidden"
 msgstr "Vis Skjulte"
 
-#: filer.c:3350
+#: filer.c:4743
 #, fuzzy
-msgid "Display style"
+msgid "Display style (Icon size)"
 msgstr "Vis"
 
-#: filer.c:3356
+#: filer.c:4749
 #, fuzzy
 msgid "Sort type and order"
-msgstr "SortÈr etter St¯rrelse"
+msgstr "Sort√©r etter St√∏rrelse"
 
-#: filer.c:3361 toolbar.c:143
+#: filer.c:4754
 msgid "Details"
 msgstr "Detaljer"
 
-#: filer.c:3366 tips:114 tips:115
+#: filer.c:4759 tips:152 tips:153
 #, fuzzy
 msgid "Thumbnails"
 msgstr "Vis Miniatyrer"
 
-#: filer.c:3372
+#: filer.c:4765
 #, fuzzy
 msgid "Filter"
 msgstr "Fil"
 
-#: find.c:487
+#: find.c:485
 msgid "And"
 msgstr "Og"
 
-#: find.c:511
+#: find.c:509
 msgid "Not"
 msgstr "Ikke"
 
-#: find.c:554
+#: find.c:552
 msgid "system"
 msgstr "system"
 
-#: find.c:562
+#: find.c:560
 msgid "prune"
 msgstr "utelukket"
 
-#: find.c:650
+#: find.c:648
 msgid "After"
 msgstr "Etter"
 
-#: find.c:652
+#: find.c:650
 msgid "Before"
-msgstr "F¯r"
+msgstr "F√∏r"
 
-#: find.c:746
+#: find.c:744
 msgid "IsReg"
 msgstr "ErNormal"
 
-#: find.c:748
+#: find.c:746
 msgid "IsLink"
 msgstr "ErLenke"
 
-#: find.c:750
+#: find.c:748
 msgid "IsDir"
 msgstr "ErMappe"
 
-#: find.c:752
+#: find.c:750
 msgid "IsChar"
 msgstr "ErChar"
 
-#: find.c:754
+#: find.c:752
 msgid "IsBlock"
 msgstr "ErBlokk"
 
-#: find.c:756
+#: find.c:754
 msgid "IsDev"
 msgstr "ErDev"
 
-#: find.c:758
+#: find.c:756
 msgid "IsPipe"
 msgstr "ErPipe"
 
-#: find.c:760
+#: find.c:758
 msgid "IsSocket"
 msgstr "ErSocket"
 
-#: find.c:762
+#: find.c:760
 #, fuzzy
 msgid "IsDoor"
 msgstr "ErMappe"
 
-#: find.c:764
+#: find.c:762
 msgid "IsSUID"
 msgstr "ErSUID"
 
-#: find.c:766
+#: find.c:764
 msgid "IsSGID"
 msgstr "ErSGID"
 
-#: find.c:768
+#: find.c:766
 msgid "IsSticky"
 msgstr "ErKlebrig"
 
-#: find.c:770
+#: find.c:768
 msgid "IsReadable"
 msgstr "ErLesbar"
 
-#: find.c:772
+#: find.c:770
 msgid "IsWriteable"
 msgstr "ErSkrivbar"
 
-#: find.c:774
+#: find.c:772
 msgid "IsExecutable"
-msgstr "ErKj¯rbar"
+msgstr "ErKj√∏rbar"
 
-#: find.c:776
+#: find.c:774
 msgid "IsEmpty"
 msgstr "ErTom"
 
-#: find.c:778
+#: find.c:776
 msgid "IsMine"
 msgstr "ErMin"
 
-#: find.c:906
+#: find.c:904
 msgid "Now"
-msgstr "NÂ"
+msgstr "N√•"
 
-#: find.c:919
+#: find.c:917
 msgid "Byte"
 msgstr "Byte"
 
-#: find.c:919
+#: find.c:917
 msgid "Bytes"
 msgstr "Bytes"
 
-#: find.c:921
+#: find.c:919
 msgid "Kb"
 msgstr ""
 
-#: find.c:921
+#: find.c:919
 #, fuzzy
 msgid "K"
 msgstr "OK"
 
-#: find.c:923
+#: find.c:921
 msgid "Mb"
 msgstr ""
 
-#: find.c:923
+#: find.c:921
 msgid "M"
 msgstr ""
 
-#: find.c:925
+#: find.c:923
 msgid "Gb"
 msgstr ""
 
 #: find.c:925
-msgid "G"
-msgstr ""
-
-#: find.c:927
 msgid "Sec"
 msgstr "Sek"
 
-#: find.c:927
+#: find.c:925
 msgid "Secs"
 msgstr "Sekunder"
 
-#: find.c:929
+#: find.c:927
 msgid "Min"
 msgstr "Min"
 
-#: find.c:929
+#: find.c:927
 msgid "Mins"
 msgstr "Minutter"
 
-#: find.c:931
+#: find.c:929
 msgid "Hour"
 msgstr "Time"
 
-#: find.c:931
+#: find.c:929
 msgid "Hours"
 msgstr "Timer"
 
-#: find.c:933
+#: find.c:931
 msgid "Day"
 msgstr "Dag"
 
-#: find.c:933
+#: find.c:931
 msgid "Days"
 msgstr "Dager"
 
-#: find.c:935
+#: find.c:933
 msgid "Week"
 msgstr "Uke"
 
-#: find.c:935
+#: find.c:933
 msgid "Weeks"
 msgstr "Uker"
 
-#: find.c:937
+#: find.c:935
 msgid "Year"
-msgstr "≈r"
+msgstr "√Ör"
 
-#: find.c:937
+#: find.c:935
 msgid "Years"
-msgstr "≈r"
+msgstr "√Ör"
 
-#: find.c:946
+#: find.c:944
 msgid "Ago"
 msgstr "Siden"
 
-#: find.c:948
+#: find.c:946
 msgid "Hence"
 msgstr "Om"
 
-#: find.c:963
+#: find.c:961
 msgid "atime"
 msgstr "atid"
 
-#: find.c:965
+#: find.c:963
 msgid "ctime"
 msgstr "ctid"
 
-#: find.c:967
+#: find.c:965
 msgid "mtime"
 msgstr "mtid"
 
-#: find.c:969
+#: find.c:967
 msgid "size"
 msgstr "str"
 
-#: find.c:971
+#: find.c:969
 msgid "inode"
 msgstr "inode"
 
-#: find.c:973
+#: find.c:971
 msgid "nlinks"
 msgstr "nlenker"
 
-#: find.c:975
+#: find.c:973
 msgid "uid"
 msgstr "uid"
 
-#: find.c:977
+#: find.c:975
 msgid "gid"
 msgstr "gid"
 
-#: find.c:979
+#: find.c:977
 msgid "blocks"
 msgstr "blokker"
 
-#: gtksavebox.c:251
+#: gtksavebox.c:249
 msgid "Save As:"
 msgstr "Lagre som:"
 
-#: gtksavebox.c:397
+#: gtksavebox.c:401
 msgid "Unnamed"
-msgstr "Navnl¯s"
+msgstr "Navnl√∏s"
 
-#: gtksavebox.c:473
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
@@ -1395,7 +1522,7 @@ msgstr ""
 "Det andre programmet vil gjerne bruke Direct Save, men jeg kan ikke lese "
 "XdndDirectSave0 (type text/plain)-delen.\n"
 
-#: gtksavebox.c:598
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1403,7 +1530,7 @@ msgstr ""
 "Dra ikonet til en mappe-oversikt\n"
 "(eller skriv hele stien)"
 
-#: gui_support.c:331
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1411,376 +1538,450 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:400
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr ""
-"Fors¯k pÂ Â lese en XML fil som en tekstfil. Filen '%s' er kanskje ¯delagt."
+"Fors√∏k p√• √• lese en XML fil som en tekstfil. Filen '%s' er kanskje √∏delagt."
 
-#: gui_support.c:417
-#, c-format
+#: gui_support.c:542
+#, fuzzy, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
 "This may be due to upgrading from a previous version of ROX-Filer. Open the "
-"Options window and click on Save.\n"
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
-"Feil i filen '%s' pÂ linje %d: \n"
+"Feil i filen '%s' p√• linje %d: \n"
 "\"%s\"\n"
 "Dette kan skyldes en oppgradering fra en tidligere versjon av ROX-Filer. "
-"≈pne Innstillinger-vinduet og trykk Lagre.\n"
+"√Öpne Innstillinger-vinduet og trykk Lagre.\n"
 "Ytterligere feil vil bli oversett."
 
-#: gui_support.c:1000
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Inkorrekt eller manglende linjeavslutning i tekst/uri-liste - data."
 
-#: gui_support.c:1332
+#: gui_support.c:1473
 #, fuzzy, c-format
 msgid "Failed to open file '%s': %s"
-msgstr "Mislykkedes i at skabe en b¯rne-process"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
 
-#: gui_support.c:1376
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
 msgstr ""
 
-#: gui_support.c:1427
+#: gui_support.c:1583
+#, c-format
 msgid ""
-"This program cannot be run, as the 0launch command is not available. It can "
-"be downloaded from here:\n"
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
 
-#: i18n.c:38
+#: i18n.c:39
 #, fuzzy
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
 msgstr ""
-"Merk at du mÂ starte programmet pÂ nytt f¯r den nye sprÂkinnstillingen trer "
+"Merk at du m√• starte programmet p√• nytt f√∏r den nye spr√•kinnstillingen trer "
 "i kraft."
 
-#: icon.c:78
+#: icon.c:77
 msgid "(click to set)"
 msgstr ""
 
-#: icon.c:133
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:134 menu.c:252
-#, fuzzy
-msgid "About ROX-Filer..."
-msgstr "Om ROX-Filer"
-
-#: icon.c:135 menu.c:253
-#, fuzzy
-msgid "Show Help Files"
-msgstr "Vis hjelpefiler"
-
-#: icon.c:136 menu.c:254
-msgid "Manual"
-msgstr ""
-
-#: icon.c:138 menu.c:230
-msgid "Options..."
-msgstr "Innstillinger..."
-
-#: icon.c:139 menu.c:239
-msgid "Home Directory"
-msgstr "Hjemme-mappen"
-
-#: icon.c:140 icon.c:1340 menu.c:206 type.c:212
-msgid "File"
-msgstr "Fil"
-
-#: icon.c:141 menu.c:212 menu.c:875
-msgid "Shift Open"
-msgstr "Shift-Âpne"
-
-#: icon.c:142 menu.c:218
-msgid "Properties"
-msgstr ""
-
-#: icon.c:143 menu.c:216
-msgid "Set Run Action..."
-msgstr "Sett Kj¯r-Hendelse..."
-
-#: icon.c:144 menu.c:217
-msgid "Set Icon..."
-msgstr "Velg Ikon..."
-
-#: icon.c:145 icon.c:806
-msgid "Edit Item"
-msgstr "Rediger Objekt"
-
-#: icon.c:146
-msgid "Show Location"
-msgstr "Vis Sti"
-
-#: icon.c:147
-msgid "Remove Item(s)"
-msgstr "Fjern Objekt(er)"
-
-#: icon.c:278 menu.c:764
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr ""
 
-#: icon.c:291
+#: icon.c:311
 msgid "Nothing"
 msgstr "Ingenting"
 
-#: icon.c:547
+#: icon.c:576
 msgid "The location must contain at least one character!"
-msgstr "Stien mÂ inneholde minst ett tegn!"
+msgstr "Stien m√• inneholde minst ett tegn!"
 
-#: icon.c:613
+#: icon.c:641
+#, c-format
+msgid "You must unlock '%s' before removing it"
+msgstr ""
+
+#: icon.c:651
 msgid "You must first select some items to remove"
-msgstr "Du mÂ f¯rst velge noen objekter som skal fjernes"
+msgstr "Du m√• f√∏rst velge noen objekter som skal fjernes"
 
-#: icon.c:627
+#: icon.c:657
+msgid "An item must be unlocked before it can be removed."
+msgstr ""
+
+#: icon.c:671
 msgid "You must open the menu over an item"
-msgstr "Du mÂ Âpne menyen over et objekt"
+msgstr "Du m√• √•pne menyen over et objekt"
 
-#: icon.c:652 menu.c:1260
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
-msgstr "Du kan bare sette kj¯r-hendelsen for en normal fil"
+msgstr "Du kan bare sette kj√∏r-hendelsen for en normal fil"
 
-#: icon.c:738
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr ""
 
-#: icon.c:760
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr ""
 
-#: icon.c:809
-msgid "Clicking the icon opens:"
-msgstr "Ett klikk pÂ ikonet Âpner:"
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Rediger Objekt"
 
-#: icon.c:819
+#: icon.c:853
+msgid "Clicking the icon opens:"
+msgstr "Ett klikk p√• ikonet √•pner:"
+
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr ""
 
-#: icon.c:833
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "Teksten som blir vist under ikonet er:"
 
-#: icon.c:846
+#: icon.c:890
 #, fuzzy
 msgid "The keyboard shortcut is:"
 msgstr "Innstill tastatursnarveier"
 
-#: infobox.c:112
-#, c-format
-msgid "Are you sure you want to open %d windows?"
-msgstr "Er du sikker pÂ at du vil Âpne %d vinduer?"
+#: icon.c:910
+#, fuzzy
+msgid "Locked"
+msgstr "Socket"
+
+#: icon.c:915
+msgid "Locking an item prevents it from being accidentally removed"
+msgstr ""
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+#, fuzzy
+msgid "About ROX-Filer..."
+msgstr "Om ROX-Filer"
+
+#: icon.c:1393 menu.c:788
+#, fuzzy
+msgid "Show Help Files"
+msgstr "Vis hjelpefiler"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr ""
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Innstillinger..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Hjemme-mappen"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Fil"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Shift-√•pne"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr ""
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Sett Kj√∏r-Hendelse..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Velg Ikon..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Vis Sti"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Fjern Objekt(er)"
 
 #: infobox.c:113
+#, c-format
+msgid "Are you sure you want to open %d windows?"
+msgstr "Er du sikker p√• at du vil √•pne %d vinduer?"
+
+#: infobox.c:114
 #, fuzzy
 msgid "Show Info"
 msgstr "Info"
 
-#: infobox.c:135 menu.c:769
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr ""
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Vis hjelpefiler"
 
-#: infobox.c:272
+#: infobox.c:291
 #, fuzzy
 msgid "<b>Permissions</b>"
 msgstr "Tillatelser"
 
-#: infobox.c:286
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr ""
 
-#: infobox.c:423 infobox.c:560 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Lag bare logg for sletting av mapper"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "bytes"
 
-#: infobox.c:446
+#: infobox.c:480
 #, fuzzy
 msgid "Failed to read size"
 msgstr "fork() af barn mislykkedes"
 
-#: infobox.c:504
+#: infobox.c:543
 #, fuzzy, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "!'%s' er en symbolsk lenke\n"
 
-#: infobox.c:511
+#: infobox.c:550
 #, fuzzy, c-format
 msgid ""
 "Failed to unlink '%s':\n"
 "%s"
-msgstr "Mislykkedes i at skabe en b¯rne-process"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
 
-#: infobox.c:516
+#: infobox.c:555
 #, fuzzy, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
 "%s\n"
 "(note: old link has been deleted)"
-msgstr "Mislykkedes i at skabe en b¯rne-process"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
 
-#: infobox.c:539 tips:270
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Feil:"
 
-#: infobox.c:546
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Virkelig mappe"
 
-#: infobox.c:549
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Eier, Gruppe:"
 
-#: infobox.c:556 infobox.c:571 infobox.c:580
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
-msgstr "St¯rrelse:"
+msgstr "St√∏rrelse:"
 
-#: infobox.c:581
+#: infobox.c:621
 #, fuzzy
 msgid "Scanning"
 msgstr "Oppdaterer, "
 
-#: infobox.c:602
+#: infobox.c:646
 #, fuzzy
 msgid "Failed to scan"
 msgstr "fork() af barn mislykkedes"
 
-#: infobox.c:609
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Endre tid:"
 
-#: infobox.c:611
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Modifiser tid:"
 
-#: infobox.c:613
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Sist endret:"
 
-#: infobox.c:621
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr ""
 
-#: infobox.c:623
+#: infobox.c:667
 msgid "Present"
 msgstr ""
 
-#: infobox.c:624
+#: infobox.c:668
 msgid "None"
 msgstr "Ingen"
 
-#: infobox.c:625
+#: infobox.c:669
 #, fuzzy
 msgid "Not supported"
-msgstr "Gtk+-2.0 underst¯ttelse"
+msgstr "Gtk+-2.0 underst√∏ttelse"
 
-#: infobox.c:637
+#: infobox.c:681
 #, fuzzy
 msgid "Link target:"
-msgstr "Ukjent mÂl"
+msgstr "Ukjent m√•l"
 
-#: infobox.c:649 infobox.c:652
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
-msgstr "Kj¯r-handling:"
+msgstr "Kj√∏r-handling:"
 
-#: infobox.c:649
+#: infobox.c:693
 msgid "Execute file"
-msgstr "Kj¯rbar fil"
+msgstr "Kj√∏rbar fil"
 
-#: infobox.c:744
+#: infobox.c:805
+#, fuzzy
+msgid "Comment"
+msgstr "Kommando:"
+
+#: infobox.c:807
+#, fuzzy
+msgid "Execute"
+msgstr "Kj√∏rbar fil"
+
+#: infobox.c:822
 msgid "<nothing yet>"
-msgstr "<ingenting ennÂ>"
+msgstr "<ingenting enn√•>"
 
-#: infobox.c:814
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "fil(1) sier... %s"
 
-#: infobox.c:871
+#: infobox.c:952
 #, fuzzy, c-format
 msgid "Could not change permissions: %s"
 msgstr "Kunne ikke gemme indstillinger: %s"
 
-#: infobox.c:889
+#: infobox.c:970 tips:120
 #, fuzzy
 msgid "Owner"
 msgstr "Nyere"
 
-#: infobox.c:891
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr ""
 
-#: infobox.c:893
+#: infobox.c:974
 msgid "World"
 msgstr ""
 
-#: infobox.c:896
+#: infobox.c:977
 #, fuzzy
 msgid "Read"
-msgstr "Omd¯p"
+msgstr "Omd√∏p"
 
-#: infobox.c:898
+#: infobox.c:980
 #, fuzzy
 msgid "Write"
 msgstr "objekt"
 
-#: infobox.c:900
+#: infobox.c:983
 msgid "Exec"
 msgstr ""
 
-#: infobox.c:917
+#: infobox.c:1001
 #, fuzzy
 msgid "SUID"
 msgstr "ErSUID"
 
-#: infobox.c:924
+#: infobox.c:1008
 #, fuzzy
 msgid "SGID"
 msgstr "ErSGID"
 
-#: infobox.c:931
+#: infobox.c:1015
 #, fuzzy
 msgid "Sticky"
 msgstr "ErKlebrig"
 
-#: infobox.c:953
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<ingenting enn√•>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Symbolsk lenke"
 
-#: infobox.c:956
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX programmet"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "mounted"
 msgstr "montert"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "demontert"
 
-#: infobox.c:968
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Monteringspunkt for %s (%s)"
 
-#: infobox.c:971
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Monteringspunkt (%s)"
+
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d objekter"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Kopi√©r..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "objekt"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Tider"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Program"
 
 #: main.c:95
 #, fuzzy
@@ -1801,11 +2002,11 @@ msgstr ""
 
 #: main.c:104
 msgid "Try `ROX-Filer/AppRun --help' for more information.\n"
-msgstr "Pr¯v 'ROX-Filer/AppRun --help' for mer informasjon.\n"
+msgstr "Pr√∏v 'ROX-Filer/AppRun --help' for mer informasjon.\n"
 
 #: main.c:107
 msgid "Try `ROX-Filer/AppRun -h' for more information.\n"
-msgstr "Pr¯v 'ROX-Filer/AppRun -h' for mer informasjon.\n"
+msgstr "Pr√∏v 'ROX-Filer/AppRun -h' for mer informasjon.\n"
 
 #: main.c:109
 msgid ""
@@ -1813,11 +2014,11 @@ msgid ""
 "you must use the short versions instead.\n"
 "\n"
 msgstr ""
-"BEM∆RK: Systemet ditt st¯tter ikke lange alternativer - \n"
-"du mÂ bruke de korte i stedet.\n"
+"BEM√ÜRK: Systemet ditt st√∏tter ikke lange alternativer - \n"
+"du m√• bruke de korte i stedet.\n"
 
 #: main.c:115
-#, fuzzy
+#, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Open each directory or file listed, or the current working\n"
@@ -1839,45 +2040,41 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
-"Report bugs to "
+"Report bugs to %s.\n"
+"Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
 "Bruk: ROX-Filer/AppRun [ALTERNATIVER]... [FIL]...\n"
-"≈pne hver spesifisert mappe eller fil, eller den gjeldende\n"
+"√Öpne hver spesifisert mappe eller fil, eller den gjeldende\n"
 "mappa hvis ingenting annet er spesifisert.\n"
 "\n"
-"  -b, --bottom=PANEL\tÂpne PANEL som et bunnpanel\n"
+"  -b, --bottom=PANEL\t√•pne PANEL som et bunnpanel\n"
 "  -c, --client-id=ID\tbrukes til sesjonsbehandling\n"
-"  -d, --dir=MAPPE\t\tÂpne MAPPE som mappe (ikke program)\n"
+"  -d, --dir=MAPPE\t\t√•pne MAPPE som mappe (ikke program)\n"
 "  -D, --close=MAPPE\tlukk MAPPE og dens undermapper\n"
 "  -h, --help\t\tvis denne hjelpen og avslutt\n"
-"  -l, --left=PANEL\tÂpne PANEL som et venstrekantspanel\n"
+"  -l, --left=PANEL\t√•pne PANEL som et venstrekantspanel\n"
 "  -m, --mime-type=FIL\tskriv MIME-typen til FIL og avslutt\n"
-"  -n, --new\t\tstart en ny 'filer', selv om en kj¯rer allerede\n"
+"  -n, --new\t\tstart en ny 'filer', selv om en kj√∏rer allerede\n"
 "  -o, --override\toverse vindusbehandlerens kontroll over paneler\n"
 "  -p, --pinboard=TAVLE\tbruk tavla TAVLE som tavle\n"
-"  -r, --right=PANEL\tÂpne PANEL som et h¯yrekantspanel\n"
-"  -R, --RPC\t\tk¯r metodekall, lest fra stdin\n"
-"  -s, --show=FIL\tÂpne en mappe som viser FIL\n"
-"  -t, --top=PANEL\tÂpne PANEL som et toppkantspanel\n"
+"  -r, --right=PANEL\t√•pne PANEL som et h√∏yrekantspanel\n"
+"  -R, --RPC\t\tk√∏r metodekall, lest fra stdin\n"
+"  -s, --show=FIL\t√•pne en mappe som viser FIL\n"
+"  -t, --top=PANEL\t√•pne PANEL som et toppkantspanel\n"
 "  -u, --user\t\tvis brukerens navn i hvert vindu\n"
 "  -v, --version\t\tvis versjonsinformasjon og avslutt\n"
-"  -x, --examine=FIL\tFIL er endret - unders¯k den igjen\n"
+"  -x, --examine=FIL\tFIL er endret - unders√∏k den igjen\n"
 "\n"
-"Den nyeste versjonen finner du pÂ:\n"
+"Den nyeste versjonen finner du p√•:\n"
 "\thttp://rox.sourceforge.net\n"
 "\n"
 "Rapporter feil til <tal197@users.sourceforge.net>.\n"
 
-#: main.c:136
-msgid ""
-".\n"
-"Home page (including updated versions): http://rox.sourceforge.net/\n"
-msgstr ""
-
-#: main.c:234
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1885,297 +2082,393 @@ msgid ""
 "Trying to continue..."
 msgstr ""
 
-#: main.c:382
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
 msgstr ""
 
-#: main.c:489
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
-msgstr "Kj¯rer som bruker '%s'"
+msgstr "Kj√∏rer som bruker '%s'"
 
-#: main.c:666
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr ""
 
-#: main.c:667
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr ""
 
-#: main.c:671
+#: main.c:693
 msgid "features set at compile time"
 msgstr "funksjoner bestemt ved kompilering"
 
-#: main.c:672
+#: main.c:694
 msgid "Large File Support"
-msgstr "St¯tte for store filer"
+msgstr "St√∏tte for store filer"
 
-#: main.c:679
-msgid "GNOME-VFS library"
-msgstr "GNOME-VFS-bibliotek"
-
-#: main.c:683
-msgid "No (need 2.8.0 or later)"
-msgstr ""
-
-#: main.c:686
-msgid "Dnotify support"
-msgstr ""
-
-#: main.c:693
+#: main.c:701
 msgid "Binary compatibility"
 msgstr ""
 
-#: main.c:695
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr ""
 
-#: main.c:697
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr ""
 
-#: menu.c:180 tips:52
+#: main.c:709
+#, fuzzy
+msgid "Extended attribute support"
+msgstr "Ikke bruk vertsnavn"
+
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
+
+#: main.c:895
+#, c-format
+msgid ""
+"Left-click to run %s.\n"
+"Right-click for a list of versions."
+msgstr ""
+
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Feil under laging av: '%s': %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Lagre som:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Vis"
 
-#: menu.c:181 tips:57
+#: menu.c:641 tips:49
 #, fuzzy
 msgid "Icons View"
-msgstr "Ikonst¯rrelse:"
+msgstr "Ikonst√∏rrelse:"
 
-#: menu.c:182
+#: menu.c:642
 #, fuzzy
-msgid "Icons, With..."
+msgid "Icons With Sizes"
 msgstr "Kjempe, med..."
 
-#: menu.c:183 tips:74
-msgid "Sizes"
-msgstr "St¯rrelser"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Minimer til"
 
-#: menu.c:185 tips:254
-msgid "Types"
-msgstr "Typer"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Tillatelser"
 
-#: menu.c:186 tips:77
-msgid "Times"
-msgstr "Tider"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Kjempe, med..."
 
-#: menu.c:187 tips:58 tips:92
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr ""
 
-#: menu.c:189
+#: menu.c:651
 #, fuzzy
 msgid "Bigger Icons"
 msgstr "Kjempeikoner"
 
-#: menu.c:190
+#: menu.c:653
 #, fuzzy
 msgid "Smaller Icons"
-msgstr "SmÂ Ikoner"
+msgstr "Sm√• Ikoner"
 
-#: menu.c:191 tips:71
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr ""
 
-#: menu.c:193
+#: menu.c:661
 msgid "Sort by Name"
-msgstr "SortÈr etter Navn"
+msgstr "Sort√©r etter Navn"
 
-#: menu.c:194
+#: menu.c:662
 msgid "Sort by Type"
-msgstr "SortÈr etter Type"
+msgstr "Sort√©r etter Type"
 
-#: menu.c:195
-msgid "Sort by Date"
-msgstr "SortÈr etter Dato"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
+msgstr "Sort√©r etter Dato"
 
-#: menu.c:196
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Sort√©r etter Dato"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Sort√©r etter Dato"
+
+#: menu.c:666
 msgid "Sort by Size"
-msgstr "SortÈr etter St¯rrelse"
+msgstr "Sort√©r etter St√∏rrelse"
 
-#: menu.c:197
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Tillatelser"
+
+#: menu.c:668
 #, fuzzy
 msgid "Sort by Owner"
-msgstr "SortÈr etter St¯rrelse"
+msgstr "Sort√©r etter St√∏rrelse"
 
-#: menu.c:198
+#: menu.c:669
 #, fuzzy
 msgid "Sort by Group"
-msgstr "SortÈr etter Type"
+msgstr "Sort√©r etter Type"
 
-#: menu.c:199
+#: menu.c:671
 #, fuzzy
 msgid "Reversed"
 msgstr " Angre"
 
-#: menu.c:201
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "Vis Skjulte"
 
-#: menu.c:202
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Vis hjelpefiler"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "ingen mapper)\n"
+
+#: menu.c:679
 #, fuzzy
 msgid "Filter Files..."
 msgstr "ROX-Filer: fil(1) siger..."
 
-#: menu.c:203
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "ROX-Filer: fil(1) siger..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "Vis Miniatyrer"
 
-#: menu.c:204
+#: menu.c:683
 msgid "Refresh"
 msgstr "Oppdater"
 
-#: menu.c:205
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Oppdater"
+
+#: menu.c:686
 #, fuzzy
 msgid "Save Display Settings..."
 msgstr "Vis meddelelser i..."
 
-#: menu.c:207
-msgid "Copy..."
-msgstr "KopiÈr..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Vis meddelelser i..."
 
-#: menu.c:208
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Tell"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
-msgstr "Omd¯p..."
+msgstr "Omd√∏p..."
 
-#: menu.c:209
+#: menu.c:700
 msgid "Link..."
 msgstr "Lag lenke..."
 
-#: menu.c:213
-msgid "Open AVFS"
-msgstr "≈pne med AVFS"
-
-#: menu.c:214
+#: menu.c:708
 msgid "Send To..."
 msgstr "Send til..."
 
-#: menu.c:219
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Ikke bruk vertsnavn"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Tell"
 
-#: menu.c:220
+#: menu.c:723
 #, fuzzy
 msgid "Set Type..."
 msgstr "Send til..."
 
-#: menu.c:224 toolbar.c:155
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Velg"
 
-#: menu.c:225
+#: menu.c:733
 msgid "Select All"
 msgstr "Velg Alle"
 
-#: menu.c:226
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "Velg Ingen"
 
-#: menu.c:227
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "Velg motsatt"
 
-#: menu.c:228
+#: menu.c:737
 #, fuzzy
 msgid "Select by Name..."
-msgstr "SortÈr etter Navn"
+msgstr "Sort√©r etter Navn"
 
-#: menu.c:229
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Velg hvis..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Velg hvis..."
 
-#: menu.c:231
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Ny"
 
-#: menu.c:233
+#: menu.c:752
 msgid "Blank file"
 msgstr "Tom fil"
 
-#: menu.c:235 tasklist.c:308
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Vindu"
 
-#: menu.c:236
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "Overmappe, Nytt Vindu"
 
-#: menu.c:237
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "Overmappe, Samme Vindu"
 
-#: menu.c:238
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "Nytt Vindu"
 
-#: menu.c:240
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr ""
 
-#: menu.c:241
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Info"
+
+#: menu.c:768
 msgid "Follow Symbolic Links"
-msgstr "F¯lg symbolske lenker"
+msgstr "F√∏lg symbolske lenker"
 
-#: menu.c:242
+#: menu.c:769
 msgid "Resize Window"
-msgstr "Endre vindust¯rrelse"
+msgstr "Endre vindust√∏rrelse"
 
-#: menu.c:245
+#: menu.c:771
 msgid "Close Window"
 msgstr "Lukk Vindu"
 
-#: menu.c:247
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Skriv inn sti..."
 
-#: menu.c:248
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Shellkommando..."
 
-#: menu.c:249
-msgid "Xterm Here"
+#: menu.c:780
+#, fuzzy
+msgid "Terminal Here"
 msgstr "Xterm her"
 
-#: menu.c:250
-msgid "Switch to xterm"
+#: menu.c:782
+#, fuzzy
+msgid "Switch to Terminal"
 msgstr "Bytt til xterm"
 
-#: menu.c:718
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "Du burde Shift+Meny-klikke over en fil for Â sende den et sted"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Tilpass"
 
-#: menu.c:754
+#: menu.c:976
 msgid "Next Click"
 msgstr "Neste klikk"
 
-#: menu.c:776
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d objekter"
 
-#: menu.c:864
+#: menu.c:1094
 #, fuzzy
 msgid "Open unmounted"
 msgstr "demontert"
 
-#: menu.c:867
+#: menu.c:1097
 msgid "Show Target"
-msgstr "Vis mÂl"
+msgstr "Vis m√•l"
 
-#: menu.c:869
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "Se innhold"
 
-#: menu.c:871
+#: menu.c:1101
 msgid "Open As Text"
-msgstr "≈pne som tekst"
+msgstr "√Öpne som tekst"
 
-#: menu.c:1031
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2184,64 +2477,74 @@ msgid ""
 "mount option ('user_xattr' on Linux)."
 msgstr ""
 
-#: menu.c:1037
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr ""
 
-#: menu.c:1072
+#: menu.c:1364
 #, fuzzy
 msgid "_Relative link"
 msgstr "Relativ lenke"
 
-#: menu.c:1078
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
 "If off, the path from the root directory is stored - use this if the symlink "
 "may move but the target will stay put."
 msgstr ""
-"Hvis denne er valgt, vil lenken inneholde veien fra lenken til mÂlfilen.Bruk "
-"dette hvis lenken og mÂlet alltid flyttes sammen.\n"
+"Hvis denne er valgt, vil lenken inneholde veien fra lenken til m√•lfilen.Bruk "
+"dette hvis lenken og m√•let alltid flyttes sammen.\n"
 "Hvis denne ikke er valgt, vil hele stien bli lagret. Bruk dette hvis lenken "
-"kan bli flyttet, men mÂlfilen alltid vil vÊre pÂ samme sted."
+"kan bli flyttet, men m√•lfilen alltid vil v√¶re p√• samme sted."
 
-#: menu.c:1148
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "Nytt mappenavn er ikke absolutt"
 
-#: menu.c:1214
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr "Lenke fra '%s' finnes allerede. Erstatt den med en lenke til '%s'?"
 
-#: menu.c:1220
+#: menu.c:1546
 msgid "_Replace"
 msgstr "Erstatt"
 
-#: menu.c:1351 menu.c:1392 menu.c:1452
-msgid "Create"
-msgstr "Lag"
-
-#: menu.c:1352
+#: menu.c:1704
 msgid "NewDir"
 msgstr "Ny Mappe"
 
-#: menu.c:1366 menu.c:1372
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Feil under laging av: '%s': %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Lag"
 
-#: menu.c:1393
+#: menu.c:1755
 msgid "NewFile"
 msgstr "Ny Fil"
 
-#: menu.c:1411
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "Feil under laging av fil: kunne ikke finne malen for %s"
 
-#: menu.c:1482
-#, c-format
+#: menu.c:1847
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2253,33 +2556,34 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
-"'Send Til'-menuen er en hurtig mÂte Â sende filer til et program. "
-"Programmerne pÂ listen er i de f¯lgende mapper:\n"
+"'Send Til'-menuen er en hurtig m√•te √• sende filer til et program. "
+"Programmerne p√• listen er i de f√∏lgende mapper:\n"
 "\n"
 "%s\n"
 "%s\n"
-"'Send Til' menuen kan Âbnes ved Â Shift-klikke pÂ en fil.\n"
+"'Send Til' menuen kan √•bnes ved √• Shift-klikke p√• en fil.\n"
 "\n"
 "Avansert bruk:\n"
-"Du kan ogsÂ lage undermapper kalt `.text.html'. `.text' osv. som bare vil "
-"vises for filer av denne typen. `.group' vises bare nÂr flere filer er valgt."
+"Du kan ogs√• lage undermapper kalt `.text.html'. `.text' osv. som bare vil "
+"vises for filer av denne typen. `.group' vises bare n√•r flere filer er valgt."
 
-#: menu.c:1493
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
 msgstr ""
-"Jeg viser deg nÂ din 'Send Til'-mappe. Du b¯r lage symbolske lenker (Ctrl"
+"Jeg viser deg n√• din 'Send Til'-mappe. Du b√∏r lage symbolske lenker (Ctrl"
 "+Shift) til alle programmer du vil ha i den."
 
-#: menu.c:1496 menu.c:1536
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
-msgstr "Din CHOICESPATH-variabels innstilling umuliggj¯r endringer - desverre."
+msgstr "Din CHOICESPATH-variabels innstilling umuliggj√∏r endringer - desverre."
 
-#: menu.c:1529
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2291,102 +2595,137 @@ msgid ""
 "%s\n"
 msgstr ""
 
-#: menu.c:1534
+#: menu.c:1936
 #, fuzzy
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
 msgstr ""
-"Jeg viser deg nÂ din 'Send Til'-mappe. Du b¯r lage symbolske lenker (Ctrl"
+"Jeg viser deg n√• din 'Send Til'-mappe. Du b√∏r lage symbolske lenker (Ctrl"
 "+Shift) til alle programmer du vil ha i den."
 
-#: menu.c:1651
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Tilpass"
 
-#: menu.c:1717
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Tilpass"
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Dette er allerede det kanoniske navnet til denne mappen."
 
-#: menu.c:1748
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
 msgstr ""
-"Du kan ikke Âpne enda en oversikt over denne mappen fordi 'Unike Vinduer'-"
-"innstillingen er slÂtt pÂ i Innstillinger-vinduet."
+"Du kan ikke √•pne enda en oversikt over denne mappen fordi 'Unike Vinduer'-"
+"innstillingen er sl√•tt p√• i Innstillinger-vinduet."
 
-#: menu.c:1869
-msgid "Copy ... ?"
-msgstr "Kopier ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1872
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Kopier %s som %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Kopier %s som %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
-msgstr "Omd¯p ... ?"
+msgstr "Omd√∏p ... ?"
 
-#: menu.c:1875
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Lag symbolsk lenke ... ?"
 
-#: menu.c:1878
+#: menu.c:2465
 msgid "Shift Open ... ?"
-msgstr "Shift-Âpne ... ?"
+msgstr "Shift-√•pne ... ?"
 
-#: menu.c:1881
+#: menu.c:2468
 #, fuzzy
 msgid "Properties of ... ?"
-msgstr "Regn ut st¯rrelsen til ... ?"
+msgstr "Regn ut st√∏rrelsen til ... ?"
 
-#: menu.c:1884
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Ikke bruk vertsnavn"
+
+#: menu.c:2476
 #, fuzzy
 msgid "Set type of ... ?"
 msgstr "Velg ikon for ... ?"
 
-#: menu.c:1887
+#: menu.c:2479
 msgid "Set run action for ... ?"
-msgstr "Velg kj¯rhandling for ... ?"
+msgstr "Velg kj√∏rhandling for ... ?"
 
-#: menu.c:1890
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Velg ikon for ... ?"
 
-#: menu.c:1893
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Send ... til ... ?"
 
-#: menu.c:1896
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "SLETT ... ?"
 
-#: menu.c:1899
+#: menu.c:2491
 msgid "Count the size of ... ?"
-msgstr "Regn ut st¯rrelsen til ... ?"
+msgstr "Regn ut st√∏rrelsen til ... ?"
 
-#: menu.c:1902
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Velg tillatelser til ... ?"
 
-#: menu.c:1905
+#: menu.c:2497
 msgid "Search inside ... ?"
-msgstr "S¯k i ... ?"
+msgstr "S√∏k i ... ?"
 
-#: menu.c:1908
-msgid "Look inside ... ?"
-msgstr "Se i ... ?"
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Kopier ... ?"
 
-#: menu.c:1972
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
-msgstr "Du kan ikke gj¯re dette med mer enn et objekt om gangen"
+msgstr "Du kan ikke gj√∏re dette med mer enn et objekt om gangen"
 
-#: menu.c:2004
+#: menu.c:2609
+#, fuzzy
+msgid "Duplicate"
+msgstr "Program"
+
+#: menu.c:2614
 msgid "Rename"
-msgstr "Omd¯p"
+msgstr "Omd√∏p"
 
-#: menu.c:2009
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Lag symbolsk lenke"
 
-#: menu.c:2041
+#: menu.c:2654
 #, fuzzy
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
@@ -2400,13 +2739,13 @@ msgid ""
 "\t(this only works if NOT using XSETTINGS)"
 msgstr ""
 "Brukerdefinerte snarveier er som standard skrudd av i Gtk2, og du har ikke "
-"skrudd de pÂ. Du kan skru dette pÂ ved Â:\n"
+"skrudd de p√•. Du kan skru dette p√• ved √•:\n"
 "1) bruke en XSettings-behandler, som ROX-Session\n"
 "eller\n"
 "2) legge denne linjen til ~/.gtkrc-2.0:\n"
 "\tgtk-can-change-accels = 1"
 
-#: menu.c:2052
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2417,56 +2756,77 @@ msgid ""
 "The key will appear next to the menu item and you can just press that key "
 "without opening the menu in future."
 msgstr ""
-"For Â stille inn en tastatur-snarvei for en menyfunksjon:\n"
+"For √• stille inn en tastatur-snarvei for en menyfunksjon:\n"
 "\n"
-"- ≈pne menyen,\n"
+"- √Öpne menyen,\n"
 "- Flytt musepekeren over den funksjonen du vil bruke,\n"
-"- Trykk pÂ den tasten du vil sette av til funksjonen.\n"
+"- Trykk p√• den tasten du vil sette av til funksjonen.\n"
 "\n"
 "Tasten vil vise seg ved siden av funksjonen, og du kan trykke denne tasten "
-"uten Â Âpne menyen fra nÂ av"
+"uten √• √•pne menyen fra n√• av"
 
-#: menu.c:2067
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Innstill tastatursnarveier"
 
-#: minibuffer.c:131
+#: minibuffer.c:140
 msgid "Goto:"
-msgstr "GÂ til:"
+msgstr "G√• til:"
 
-#: minibuffer.c:132
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Skall:"
 
-#: minibuffer.c:133
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Velg hvis:"
 
-#: minibuffer.c:134
+#: minibuffer.c:143
 #, fuzzy
 msgid "Select Named:"
 msgstr "Velg hvis:"
 
-#: minibuffer.c:135
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Velg hvis:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr ""
 
-#: minibuffer.c:264
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
 msgstr ""
-"Skriv navnet pÂ en fil og jeg vil vise den til deg. Tryk pÂ Tab for Â fylle "
+"Skriv navnet p√• en fil og jeg vil vise den til deg. Tryk p√• Tab for √• fylle "
 "ut den lengste lignende filen. Escape-tasten lukker minibufferet."
 
-#: minibuffer.c:270
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
-"Skriv en skallkommando som skal utf¯res. Klikk pÂ en fil for Â f¯ye den til "
+"Skriv en skallkommando som skal utf√∏res. Klikk p√• en fil for √• f√∏ye den til "
 "bufferen."
 
-#: minibuffer.c:275
+#: minibuffer.c:331
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2477,49 +2837,60 @@ msgid ""
 "*.png means any name ending in '.png'"
 msgstr ""
 
-#: minibuffer.c:287
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
 msgstr ""
 
-#: minibuffer.c:895
-msgid "Invalid Find condition"
-msgstr "Ugyldige s¯keparametere"
+#: minibuffer.c:358
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
 
-#: mount.c:374
+#: minibuffer.c:1045
+msgid "Invalid Find condition"
+msgstr "Ugyldige s√∏keparametere"
+
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr ""
 
-#: options.c:277
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr ""
 "ROX-Filer har kovertert din gamle Alternativ-fil til det nye XML-formatet."
 
-#: options.c:535 options.c:1258
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(bruk standard)"
 
-#: options.c:806
+#: options.c:844
 #, fuzzy, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Intern feil - inkorrekt infotype"
 
-#: options.c:917
+#: options.c:929
 msgid "Options"
 msgstr "Innstillinger..."
 
-#: options.c:962
+#: options.c:974
 msgid "_Revert"
 msgstr " Angre"
 
-#: options.c:968
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr ""
-"Tilbakestill alle endringer til det de var nÂr Innstillinger ble Âpnet."
+"Tilbakestill alle endringer til det de var n√•r Innstillinger ble √•pnet."
 
-#: options.c:983
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2528,125 +2899,124 @@ msgstr ""
 "Dine valg vil lagres som\n"
 "%s"
 
-#: options.c:991
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(lagring skrudd av pga. CHOICESPATH)"
 
-#: options.c:1164 usericons.c:450
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Feil under lagring av %s: %s"
 
-#: options.c:1794
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Mangler '='"
 
-#: panel.c:439
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "Din gamle panel-fil ble konvertert til det nye XML-formatet."
 
-#: panel.c:546
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
 msgstr ""
-"Du pr¯ver Â lukke et panel via vindushÂndtereren. Jeg oppfatter vanligvis "
+"Du pr√∏ver √• lukke et panel via vindush√•ndtereren. Jeg oppfatter vanligvis "
 "dette som et uhell... vil du virkelig lukke?"
 
-#: panel.c:639
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Mangler < eller > i panelkonfigurasjonsfilen"
 
-#: panel.c:1519
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Feil under lagring av panel %s: %s"
 
-#: panel.c:1835
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
-msgstr "Appleten avsluttet uten Â lage noen widget!"
+msgstr "Appleten avsluttet uten √• lage noen widget!"
 
-#: panel.c:1934
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
 "%s"
 msgstr ""
-"Fejl under kj¯ring av applet:\n"
+"Fejl under kj√∏ring av applet:\n"
 "%s"
 
-#: panel.c:2335
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "Er du sikker p√• at du vil √•pne %d vinduer?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Fjern"
+
+#: panel.c:2777
 #, fuzzy
 msgid "Panel Options..."
 msgstr "Innstillinger..."
 
-#: panel.c:2427
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr ""
 
-#: panel.c:2502
+#: panel.c:2897
+msgid "Top"
+msgstr ""
+
+#: panel.c:2899
+msgid "Bottom"
+msgstr ""
+
+#: panel.c:2901
+msgid "Left"
+msgstr ""
+
+#: panel.c:2903
+msgid "Right"
+msgstr ""
+
+#: panel.c:2905
 #, fuzzy
-msgid "Panel Options"
-msgstr "Innstillinger..."
+msgid "Default"
+msgstr "Standardinnstillinger"
 
-#: panel.c:2517
-#, fuzzy, c-format
-msgid "Panel: %s"
-msgstr "Paneler"
-
-#: panel.c:2525
-msgid "Select the panel's position:"
-msgstr ""
-
-#: panel.c:2531
+#: panel.c:2909
 #, fuzzy
-msgid "Top-edge panel"
-msgstr "Lukk panel?"
-
-#: panel.c:2532
-msgid "Top edge"
-msgstr ""
-
-#: panel.c:2533
-msgid "Bottom edge panel"
-msgstr ""
-
-#: panel.c:2534
-msgid "Bottom edge"
-msgstr ""
-
-#: panel.c:2535
-msgid "Left edge panel"
-msgstr ""
-
-#: panel.c:2536
-msgid "Left edge"
-msgstr ""
-
-#: panel.c:2537
-msgid "Right-edge panel"
-msgstr ""
-
-#: panel.c:2538
-msgid "Right edge"
-msgstr ""
+msgid "Unknown side"
+msgstr "Ukjent"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
 msgstr "Din gamle tavlefil ble konvertert til det nye XML-formatet."
 
-#: pinboard.c:635
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
 "the SOAP SetBackdropApp method."
 msgstr ""
-"Bakgrunnsbehandleren mÂ vÊre en programmappe. Dra en programmappe til Velg "
+"Bakgrunnsbehandleren m√• v√¶re en programmappe. Dra en programmappe til Velg "
 "Backdrop-dialogboksen, eller (for programmerere) send den til SOAPs "
 "SetBackdropApp-metode."
 
-#: pinboard.c:654
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2657,91 +3027,107 @@ msgstr ""
 "Du kan bare sette bakgrunnsbildet til et bilde eller et program som kan "
 "behandle ROX-Filers bakgrunnsbilde.\n"
 "\n"
-"Programmerere: Applikasjonens AppInfo.xml mÂ inneholde CanSetBackdrop-"
+"Programmerere: Applikasjonens AppInfo.xml m√• inneholde CanSetBackdrop-"
 "elementet, som beskrevet i ROX-Filers manual."
 
-#: pinboard.c:674
+#: pinboard.c:750
 msgid "Set backdrop"
 msgstr "Velg bakgrunn"
 
-#: pinboard.c:685
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
 msgstr ""
 
-#: pinboard.c:698
+#: pinboard.c:774
 #, fuzzy
 msgid "Centre the image without scaling it"
-msgstr "Slett filer uten Â sp¯rre f¯rst."
+msgstr "Slett filer uten √• sp√∏rre f√∏rst."
 
-#: pinboard.c:699
+#: pinboard.c:775
 #, fuzzy
 msgid "Centre"
 msgstr "Midtstilt"
 
-#: pinboard.c:700
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr ""
 
-#: pinboard.c:702
+#: pinboard.c:778
 #, fuzzy
 msgid "Scale"
 msgstr "Strukket"
 
-#: pinboard.c:703
+#: pinboard.c:779
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr ""
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Fil"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
 msgstr ""
 
-#: pinboard.c:704
+#: pinboard.c:783
 #, fuzzy
 msgid "Stretch"
 msgstr "Fransk"
 
-#: pinboard.c:705
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr ""
 
-#: pinboard.c:706
+#: pinboard.c:785
 #, fuzzy
 msgid "Tile"
 msgstr "Side ved side"
 
-#: pinboard.c:711
+#: pinboard.c:790
 msgid "Drop an image here"
 msgstr "Dra et bilde hit"
 
-#: pinboard.c:772
+#: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
 msgstr ""
 "Ingen tavle var i bruk... 'Standard'-tavla ble valgt. Bruk 'rox -p=Default' "
-"for Â skru den pÂ i framtida."
+"for √• skru den p√• i framtida."
 
-#: pinboard.c:866
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
 msgstr ""
-"Bare filer (og bestemte programmer) kan brukes til Â sette bakgrunnsbildet."
+"Bare filer (og bestemte programmer) kan brukes til √• sette bakgrunnsbildet."
 
-#: pinboard.c:1471
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Mangler '>' i ikontittelen"
 
-#: pinboard.c:1480
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Mangler ',' etter ikontittelen"
 
-#: pinboard.c:1565
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Feil under lagring av tavlen %s: %s"
 
-#: pinboard.c:2109
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr ""
 
-#: pinboard.c:2202
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Paneler"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2752,106 +3138,58 @@ msgstr ""
 "%s\n"
 "Bakgrunnsbildet fjernet."
 
-#: pixmaps.c:991
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
 "%s"
 msgstr ""
 
-#: pixmaps.c:1012
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr ""
 
-#: pixmaps.c:1025
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr ""
 
-#: remote.c:624
+#: remote.c:764
 #, fuzzy, c-format
 msgid "Unknown style '%s'"
 msgstr "Ukjent type"
 
-#: remote.c:646
+#: remote.c:786
 #, fuzzy, c-format
 msgid "Unknown details type '%s'"
 msgstr "Ukjent type"
 
-#: remote.c:674
+#: remote.c:815
 #, fuzzy, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Ukjent type"
 
-#: remote.c:1117
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
-msgstr "Fors¯k pÂ Â starte ukjent SOAP-metode '%s'"
+msgstr "Fors√∏k p√• √• starte ukjent SOAP-metode '%s'"
 
-#: rox_gettext.c:95
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Ugyldig .gmo oversettelses-fil (for kort): %s"
-
-#: rox_gettext.c:108
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Ugyldig .gmo oversettelses-fil (GNU magic number ikke funnet): %s"
-
-#: run.c:96 run.c:141
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "Programmet %s ikke funnet - slettet?"
 
-#: run.c:287
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "Filen eksisterer ikke, eller jeg har ikke tilgang til den: %s"
-
-#: run.c:292
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "Jeg vet ikke hvordan man Âpner '%s'"
-
-#: run.c:323
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"Program:\n"
-"Dette er en programmappe - du kan kj¯re den som et program, eller Âpne den "
-"(hold Shift nede mens du Âpner den). De fleste programmer har sin egen hjelp "
-"her, men denne har det ikke."
-
-#: run.c:407
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "Kunne ikke sende data til programmet %s"
-
-#: run.c:437
-#, c-format
-msgid "Could not read link: %s"
-msgstr "Kunne ikke lese lenken: %s"
-
-#: run.c:465
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr ""
-"Brutt symbolsk lenge (eller du har ikke tillatelse til Â f¯lge den): %s"
-
-#: run.c:502
+#: run.c:359
 #, fuzzy, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
 "action by choosing `Set Run Action' from the File menu, or you can just drag "
 "the file to an application.%s"
 msgstr ""
-"Ingen kj¯r-handling er satt for filer av denne typen(%s/%s). Du kan sette en "
-"kj¯r-handling ved Â velge `Velg Kj¯r-handling' fra Fil-menyen, eller du kan "
+"Ingen kj√∏r-handling er satt for filer av denne typen(%s/%s). Du kan sette en "
+"kj√∏r-handling ved √• velge `Velg Kj√∏r-handling' fra Fil-menyen, eller du kan "
 "dra filen rett til et prorgam"
 
-#: run.c:508
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -2859,196 +3197,65 @@ msgid ""
 "the execute bit by choosing Permissions from the File menu."
 msgstr ""
 
-#: support.c:272
-msgid "B"
-msgstr ""
-
-#: support.c:351
-msgid "byte"
-msgstr "byte"
-
-#: toolbar.c:115
-msgid "Close"
-msgstr "Lukk"
-
-#: toolbar.c:115
-msgid "Close filer window"
-msgstr "Lukk 'Filer'-vinduet"
-
-#: toolbar.c:119
-msgid "Up"
-msgstr "Opp"
-
-#: toolbar.c:119
-msgid "Change to parent directory"
-msgstr "GÂ til overmappen"
-
-#: toolbar.c:123
-msgid "Home"
-msgstr "Hjem"
-
-#: toolbar.c:123
-msgid "Change to home directory"
-msgstr "GÂ til hjemme-mappen"
-
-#: toolbar.c:127
-msgid "Bookmarks"
-msgstr ""
-
-#: toolbar.c:127
-msgid "Bookmarks menu"
-msgstr ""
-
-#: toolbar.c:131
-msgid "Scan"
-msgstr "Oppdater"
-
-#: toolbar.c:131
-msgid "Rescan directory contents"
-msgstr "Oppdater mappens innhold"
-
-#: toolbar.c:135
-msgid "Change icon size"
-msgstr "Endre ikonst¯rrelsen"
-
-#: toolbar.c:139
-msgid "Automatic size mode"
-msgstr ""
-
-#: toolbar.c:143
-msgid "Show extra details"
-msgstr "Vis ekstra detaljer"
-
-#: toolbar.c:147
-#, fuzzy
-msgid "Sort"
-msgstr "Sortering"
-
-#: toolbar.c:147
-#, fuzzy
-msgid "Change sort criteria"
-msgstr "Endre tid:"
-
-#: toolbar.c:151
-msgid "Hidden"
-msgstr "Skjult"
-
-#: toolbar.c:151
-msgid "Show/hide hidden files"
-msgstr "Vis/Skjul skjulte filer"
-
-#: toolbar.c:155
-#, fuzzy
-msgid "Select all/invert selection"
-msgstr "Velg motsatt"
-
-#: toolbar.c:159
-msgid "Show ROX-Filer help"
-msgstr "Vis ROX-Filers hjelp"
-
-#: toolbar.c:220
+#: run.c:373
 #, c-format
-msgid " (%u hidden)"
-msgstr " (%u skjulte)"
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "Filen eksisterer ikke, eller jeg har ikke tilgang til den: %s"
 
-#: toolbar.c:228 tips:80
-msgid "items"
-msgstr "objekter"
-
-#: toolbar.c:228
-msgid "item"
-msgstr "objekt"
-
-#: toolbar.c:231
+#: run.c:378
 #, c-format
-msgid "No items%s"
-msgstr "Ingen objekter%s"
+msgid "I don't know how to open '%s'"
+msgstr "Jeg vet ikke hvordan man √•pner '%s'"
 
-#: toolbar.c:250
-#, c-format
-msgid "%u selected (%s)"
-msgstr "%u valgt (%s)"
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "!'%s' er en symbolsk lenke\n"
 
-#: toolbar.c:422
-#, fuzzy
-msgid "Sort by name"
-msgstr "SortÈr etter Navn"
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "Mappen '%s' er ikke tilgjengelig"
 
-#: toolbar.c:422
-#, fuzzy
-msgid "Sort by type"
-msgstr "SortÈr etter Type"
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "Ikke-kj√∏rbar fil %s"
 
-#: toolbar.c:422
-#, fuzzy
-msgid "Sort by date"
-msgstr "SortÈr etter Dato"
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Feil i behandler %s: %s"
 
-#: toolbar.c:423
-#, fuzzy
-msgid "Sort by size"
-msgstr "SortÈr etter St¯rrelse"
-
-#: toolbar.c:423
-#, fuzzy
-msgid "Sort by owner"
-msgstr "SortÈr etter St¯rrelse"
-
-#: toolbar.c:423
-#, fuzzy
-msgid "Sort by group"
-msgstr "SortÈr etter Type"
-
-#: toolbar.c:457
-#, fuzzy
-msgid "ascending"
-msgstr "Muse-funktioner"
-
-#: toolbar.c:457
-msgid "descending"
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
 msgstr ""
+"Program:\n"
+"Dette er en programmappe - du kan kj√∏re den som et program, eller √•pne den "
+"(hold Shift nede mens du √•pner den). De fleste programmer har sin egen hjelp "
+"her, men denne har det ikke."
 
-#: type.c:203
-msgid "Sym link"
-msgstr "Symbolsk lenke"
+#: run.c:549
+#, c-format
+msgid "Could not send data to program: %s"
+msgstr "Kunne ikke sende data til programmet %s"
 
-#: type.c:205
-msgid "Mount point"
-msgstr "Monteringspunkt"
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "Kunne ikke lese lenken: %s"
 
-#: type.c:207
-msgid "App dir"
-msgstr "Programmappe"
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
+msgstr ""
+"Brutt symbolsk lenge (eller du har ikke tillatelse til √• f√∏lge den): %s"
 
-#: type.c:214
-msgid "Dir"
-msgstr "Mappe"
-
-#: type.c:216
-msgid "Char dev"
-msgstr "Char-enhet"
-
-#: type.c:218
-msgid "Block dev"
-msgstr "Block-enhet"
-
-#: type.c:220
-msgid "Pipe"
-msgstr "Pipe (r¯r)"
-
-#: type.c:222
-msgid "Socket"
-msgstr "Socket"
-
-#: type.c:224
-msgid "Door"
-msgstr "D¯r"
-
-#: type.c:227
-msgid "Unknown"
-msgstr "Ukjent"
-
-#: type.c:355
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3062,152 +3269,419 @@ msgid ""
 "Otherwise, you should check, or even just delete, all the existing run "
 "actions."
 msgstr ""
-"Kj¯rbar fil '%s' er offentlig skrivbar! Nekter Â kj¯re. Vennligst endre "
-"tillatelsene nÂ (dette problemet kan komme av en feil i tidligere versjoner "
+"Kj√∏rbar fil '%s' er offentlig skrivbar! Nekter √• kj√∏re. Vennligst endre "
+"tillatelsene n√• (dette problemet kan komme av en feil i tidligere versjoner "
 "av ROX-Filer).\n"
 "\n"
-"≈ ha (ikke-lenke) kj¯rehandlinger som er offentlig skrivbare betyr at andre "
-"som bruker din datamaskin kan erstatte dine kj¯rehandlinger med farlige "
+"√Ö ha (ikke-lenke) kj√∏rehandlinger som er offentlig skrivbare betyr at andre "
+"som bruker din datamaskin kan erstatte dine kj√∏rehandlinger med farlige "
 "erstatninger.\n"
 "\n"
-"Hvis du stoler pÂ alle som har tilgang til disse filene trenger du ikke "
-"bekymre deg. Hvis ikke b¯r du sjekke, eller slette, alle eksisterende "
-"kj¯rehandlinger."
+"Hvis du stoler p√• alle som har tilgang til disse filene trenger du ikke "
+"bekymre deg. Hvis ikke b√∏r du sjekke, eller slette, alle eksisterende "
+"kj√∏rehandlinger."
 
-#: type.c:368
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Fiks sikkerhetsproblem)"
 
-#: type.c:498
+#: support.c:288
+msgid " "
+msgstr ""
+
+#: support.c:381
+msgid "byte"
+msgstr "byte"
+
+#: support.c:1531 support.c:1585
+#, fuzzy, c-format
+msgid "Failed to open and stat file '%s': %s"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
+
+#: support.c:1542 support.c:1596
+#, fuzzy, c-format
+msgid "Failed to mmap file '%s': %s"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
+
+#: toolbar.c:116
+msgid "Close"
+msgstr "Lukk"
+
+#: toolbar.c:116
+msgid "Close filer window"
+msgstr "Lukk 'Filer'-vinduet"
+
+#: toolbar.c:120
+msgid "Up"
+msgstr "Opp"
+
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
+
+#: toolbar.c:126
+msgid "Home"
+msgstr "Hjem"
+
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
+
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
+
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
+
+#: toolbar.c:138
+msgid "Scan"
+msgstr "Oppdater"
+
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
+
+#: toolbar.c:143
+#, fuzzy
+msgid "Size‚îº"
+msgstr "St√∏rrelse"
+
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ‚îò : Huge\n"
+"  ‚î§ : Large\n"
+"  ‚îê : Small\n"
+"  ‚îå, ‚îú : Auto"
+msgstr ""
+
+#: toolbar.c:155
+msgid "Auto"
+msgstr ""
+
+#: toolbar.c:155
+msgid "Automatic size mode"
+msgstr ""
+
+#: toolbar.c:159
+msgid "List"
+msgstr ""
+
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
+#, fuzzy
+msgid "Sort"
+msgstr "Sortering"
+
+#: toolbar.c:165
+#, fuzzy
+msgid "Change sort criteria"
+msgstr "Endre tid:"
+
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
+
+#: toolbar.c:169
+msgid ""
+"Left: Show/hide hidden files\n"
+"Right: Show/hide thumbnails"
+msgstr ""
+
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "Velg motsatt"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "‚óã"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ‚ñΩ: No settings\n"
+"  ‚ñº: Own settings\n"
+"  ‚ñ∂: Parent settings\n"
+"  ‚ñ∑: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
+msgid "Show ROX-Filer help"
+msgstr "Vis ROX-Filers hjelp"
+
+#: toolbar.c:270
+#, c-format
+msgid " (%u hidden)"
+msgstr " (%u skjulte)"
+
+#: toolbar.c:276 tips:79
+msgid "items"
+msgstr "objekter"
+
+#: toolbar.c:276
+msgid "item"
+msgstr "objekt"
+
+#: toolbar.c:279
+#, c-format
+msgid "No items%s"
+msgstr "Ingen objekter%s"
+
+#: toolbar.c:298
+#, c-format
+msgid "%u selected (%s)"
+msgstr "%u valgt (%s)"
+
+#: toolbar.c:535
+#, fuzzy
+msgid "Sort by name"
+msgstr "Sort√©r etter Navn"
+
+#: toolbar.c:535
+#, fuzzy
+msgid "Sort by type"
+msgstr "Sort√©r etter Type"
+
+#: toolbar.c:535
+#, fuzzy
+msgid "Sort by date"
+msgstr "Sort√©r etter Dato"
+
+#: toolbar.c:535
+#, fuzzy
+msgid "Sort by size"
+msgstr "Sort√©r etter St√∏rrelse"
+
+#: toolbar.c:536
+#, fuzzy
+msgid "Sort by owner"
+msgstr "Sort√©r etter St√∏rrelse"
+
+#: toolbar.c:536
+#, fuzzy
+msgid "Sort by group"
+msgstr "Sort√©r etter Type"
+
+#: toolbar.c:568
+#, fuzzy
+msgid "ascending"
+msgstr "Muse-funktioner"
+
+#: toolbar.c:568
+msgid "descending"
+msgstr ""
+
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
+msgid "Sym link"
+msgstr "Symbolsk lenke"
+
+#: type.c:223
+msgid "Mount point"
+msgstr "Monteringspunkt"
+
+#: type.c:225
+msgid "App dir"
+msgstr "Programmappe"
+
+#: type.c:232
+msgid "Dir"
+msgstr "Mappe"
+
+#: type.c:234
+msgid "Char dev"
+msgstr "Char-enhet"
+
+#: type.c:236
+msgid "Block dev"
+msgstr "Block-enhet"
+
+#: type.c:238
+msgid "Pipe"
+msgstr "Pipe (r√∏r)"
+
+#: type.c:240
+msgid "Socket"
+msgstr "Socket"
+
+#: type.c:242
+msgid "Door"
+msgstr "D√∏r"
+
+#: type.c:245
+msgid "Unknown"
+msgstr "Ukjent"
+
+#: type.c:583
 #, fuzzy
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
 "gimp \"$@\""
 msgstr ""
-"Skriv en skallkommando som Âpner \"$1\" inn i et program. F.eks.:\n"
+"Skriv en skallkommando som √•pner \"$1\" inn i et program. F.eks.:\n"
 "\n"
 "gimp \"$1\""
 
-#: type.c:679
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Dette er ikke et program! Gi meg et program i stedet!"
 
-#: type.c:740
+#: type.c:839
 msgid "No run action defined"
-msgstr "Ingen kj¯r-handling er valgt"
+msgstr "Ingen kj√∏r-handling er valgt"
 
-#: type.c:766
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Feil i behandler %s: %s"
 
-#: type.c:781
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Ugyldig program %s (feil i AppRun)"
 
-#: type.c:792
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
-msgstr "Ikke-kj¯rbar fil %s"
+msgstr "Ikke-kj√∏rbar fil %s"
 
-#: type.c:825
+#: type.c:902
 msgid "Set run action"
-msgstr "Velg kj¯r-handling"
+msgstr "Velg kj√∏r-handling"
 
-#: type.c:831
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 
-#: type.c:833
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Sett som standard for alle `%s/<hva som helst>'"
 
-#: type.c:837
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr ""
 
-#: type.c:839
+#: type.c:916
 #, fuzzy, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Bare for typen `%s/%s'"
 
-#: type.c:845
+#: type.c:922
 #, fuzzy
 msgid "Drop a suitable application here"
 msgstr ""
 "Dra et passende\n"
 "program hit"
 
-#: type.c:860
+#: type.c:963
 msgid "OR"
 msgstr "ELLER"
 
-#: type.c:867
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Skriv en skallkommando:"
 
-#: type.c:896
+#: type.c:1000
 #, fuzzy
 msgid "_Use Command"
 msgstr "Kommando:"
 
-#: type.c:926
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
 msgstr ""
-"Det finnes allerede en kj¯r-handling og den er et ganske stort program - "
-"sikker pÂ at du vil slette den?"
+"Det finnes allerede en kj√∏r-handling og den er et ganske stort program - "
+"sikker p√• at du vil slette den?"
 
-#: type.c:937
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Kan ikke fjerne %s: %s"
 
-#: type.c:974
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
-msgstr "Lagring av Choices er slÂtt av vha. CHOICESPATH-variablen"
+msgstr "Lagring av Choices er sl√•tt av vha. CHOICESPATH-variablen"
 
-#: type.c:1249
-#, c-format
-msgid ""
-"Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr ""
-
-#: type.c:1263
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason)"
-msgstr ""
+"%s"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
 
-#: usericons.c:181
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "Sti-navnet du ga finnes ikke. Ikonet ble ikke endret."
 
-#: usericons.c:191 usericons.c:616
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
 "The icon has not been changed."
 msgstr ""
-"Kunne ikke lese bilde-filen -- kanskje den er i et format jeg ikke forstÂr,  "
+"Kunne ikke lese bilde-filen -- kanskje den er i et format jeg ikke forst√•r,  "
 "eller at tillatelsene ikke er i orden?\n"
 "Ikonet ble i alle fall ikke endret."
 
-#: usericons.c:238
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr ""
 
-#: usericons.c:242
+#: usericons.c:248
 #, fuzzy, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3216,43 +3690,43 @@ msgstr ""
 "Ingen tilgang til %s:\n"
 "%s"
 
-#: usericons.c:270
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Velg ikon"
 
-#: usericons.c:279
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr ""
 
-#: usericons.c:281
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Sett som ikon for alle `%s/<hva som helst>'"
 
-#: usericons.c:286
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr ""
 
-#: usericons.c:288
+#: usericons.c:299
 #, fuzzy, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Bare for typen `%s/%s'"
 
-#: usericons.c:294
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
 msgstr ""
 "Legg til filens og bildets filnavn til din personlige liste. Disse "
-"innstillingene vil gÂ tapt hvis bildet eller filen flyttes"
+"innstillingene vil g√• tapt hvis bildet eller filen flyttes"
 
-#: usericons.c:297
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Kun for filen `%s'"
 
-#: usericons.c:305
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
@@ -3262,226 +3736,166 @@ msgstr ""
 "kan da se ikonet, og du kan trygt flytte mappen rundt. Dette er vanligvis "
 "det beste valget hvis du har skriverettigheter til mappen."
 
-#: usericons.c:311
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Kopier bilde til mappen"
 
-#: usericons.c:317
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Dra en ikon-fil hit"
 
-#: usericons.c:587
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
-msgstr "Lagring av Choices er slÂtt av fra CHOICESPATH-variablen"
+msgstr "Lagring av Choices er sl√•tt av fra CHOICESPATH-variablen"
 
-#: usericons.c:631
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
 "%s"
 msgstr "Feil under laging av bildet '%s': %s"
 
-#: view_details.c:1009
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
+msgid "Mono font"
+msgstr ""
+
+#: view_details.c:1019
+msgid "Font for displaying mono-spaced text"
+msgstr ""
+
+#: view_details.c:1233
 #, fuzzy
 msgid "_Name"
 msgstr "Navn"
 
-#: view_details.c:1012
+#: view_details.c:1236
 #, fuzzy
 msgid "_Type"
 msgstr "Type"
 
-#: view_details.c:1015
+#: view_details.c:1238
+#, fuzzy
+msgid "_Size"
+msgstr "St√∏rrelse"
+
+#: view_details.c:1244
 #, fuzzy
 msgid "_Permissions"
 msgstr "Tillatelser"
 
-#: view_details.c:1016
+#: view_details.c:1250
 msgid "_Owner"
 msgstr ""
 
-#: view_details.c:1018
+#: view_details.c:1252
 msgid "_Group"
 msgstr ""
 
-#: view_details.c:1020
-#, fuzzy
-msgid "_Size"
-msgstr "St¯rrelse"
-
-#: view_details.c:1022
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr ""
 
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr ""
+
 #: tips:1
-msgid "Translation"
-msgstr "Oversettelse"
-
-#: tips:2
-msgid "Language"
-msgstr "SprÂk"
-
-#: tips:3
-msgid "Use the LANG environment variable"
-msgstr "Bruk milj¯variabelen LANG"
-
-#: tips:4
-msgid "Basque"
-msgstr ""
-
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Kinesisk (tradisjonell)"
-
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Kinesisk (forenklet)"
-
-#: tips:7
-msgid "Czech"
-msgstr ""
-
-# tips=x
-#: tips:8
-msgid "Danish"
-msgstr "Dansk"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Hollandsk"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Engelsk (ingen oversettelse)"
-
-#: tips:11
-msgid "Estonian"
-msgstr ""
-
-# tips=x
-#: tips:12
-#, fuzzy
-msgid "Finnish"
-msgstr "Dansk"
-
-#: tips:13
-msgid "French"
-msgstr "Fransk"
-
-#: tips:14
-msgid "German"
-msgstr "Tysk"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Ungarsk"
-
-#: tips:16
-msgid "Japanese"
-msgstr ""
-
-#: tips:17
-msgid "Norwegian"
-msgstr ""
-
-#: tips:18
-msgid "Italian"
-msgstr "Italiensk"
-
-#: tips:19
-msgid "Polish"
-msgstr "Polsk"
-
-#: tips:20
-msgid "Portuguese (Brasil)"
-msgstr ""
-
-#: tips:21
-msgid "Romanian"
-msgstr ""
-
-#: tips:22
-msgid "Russian"
-msgstr "Russisk"
-
-#: tips:23
-msgid "Spanish"
-msgstr "Spansk"
-
-#: tips:24
-msgid "Swedish"
-msgstr ""
-
-#: tips:25
 msgid "Filer windows"
 msgstr "'Filer'-vinduer"
 
-#: tips:26
+#: tips:2
 msgid "Auto-resize filer windows"
-msgstr "Automatisk st¯rrelse pÂ Filer-vindu"
+msgstr "Automatisk st√∏rrelse p√• Filer-vindu"
 
-#: tips:27
+#: tips:3
 msgid "Never automatically resize"
 msgstr "Tilpass aldri automatisk"
 
-#: tips:28
+#: tips:4
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
 msgstr ""
-"Du blir n¯dt til Â tilpasses st¯rrelsen manuelt, ved hjelp av "
-"vindushÂndtereren, `Tilpass st¯rrelse'-menykommandoen eller ved Â "
+"Du blir n√∏dt til √• tilpasses st√∏rrelsen manuelt, ved hjelp av "
+"vindush√•ndtereren, `Tilpass st√∏rrelse'-menykommandoen eller ved √• "
 "dobbeltklikke vindusbakgrunnen"
 
-#: tips:29
+#: tips:5
 msgid "Resize when changing the display style"
-msgstr "Tilpass st¯rrelse ved endring av visningsstil"
+msgstr "Tilpass st√∏rrelse ved endring av visningsstil"
 
-#: tips:30
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
 msgstr ""
-"NÂr du endrer st¯rrelsen pÂ ikonene eller detaljnivÂet vil vinduet "
-"automatisk endre st¯rrelse for deg."
+"N√•r du endrer st√∏rrelsen p√• ikonene eller detaljniv√•et vil vinduet "
+"automatisk endre st√∏rrelse for deg."
 
-#: tips:31
+#: tips:7
 msgid "Always resize"
-msgstr "Tilpass alltid st¯rrelsen"
+msgstr "Tilpass alltid st√∏rrelsen"
 
-#: tips:32
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
 msgstr ""
-"Vinduet vil tilpasse st¯rrelsen hver gang det virker nyttig (mao. ved skifte "
+"Vinduet vil tilpasse st√∏rrelsen hver gang det virker nyttig (mao. ved skifte "
 "av mappe- eller visningsstil)."
 
-#: tips:33
+#: tips:9
 msgid "Largest window size:"
-msgstr "St¯rste vindusst¯rrelse:"
+msgstr "St√∏rste vindusst√∏rrelse:"
 
-#: tips:34
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr ""
 
-#: tips:35
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
 msgstr ""
-"Den st¯rste st¯rrelsen, som en prosentdel av skjermst¯rrelsen, som vinduet "
+"Den st√∏rste st√∏rrelsen, som en prosentdel av skjermst√∏rrelsen, som vinduet "
 "vil tilpasse seg til."
 
-#: tips:36
-msgid "Window behaviour"
-msgstr "Vindusoppf¯rsel"
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "St√∏rste vindusst√∏rrelse:"
 
-#: tips:37
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Den st√∏rste st√∏rrelsen, som en prosentdel av skjermst√∏rrelsen, som vinduet "
+"vil tilpasse seg til."
+
+#: tips:15
+msgid "Window behaviour"
+msgstr "Vindusoppf√∏rsel"
+
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Korte tittellinjeflagg"
 
-#: tips:38
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
@@ -3489,135 +3903,237 @@ msgstr ""
 "Bruk enkeltbokstaver i stedet for ord for Oppdaterer, Alle og "
 "Miniatyrindikatorene i tittellinjen."
 
-#: tips:39
+#: tips:18
 msgid "Unique windows"
 msgstr "Unike vinduer"
 
-#: tips:40
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
 msgstr ""
-"Hvis du Âpner en mappe og denne mappen allerede vises i et annet vindu, "
-"f¯rer dette valget til at det andre vinduet lukkes."
+"Hvis du √•pner en mappe og denne mappen allerede vises i et annet vindu, "
+"f√∏rer dette valget til at det andre vinduet lukkes."
 
-#: tips:41
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Vindu"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 #, fuzzy
 msgid "New window on button 1"
-msgstr "Nytt vindu pÂ knapp 1 (RISC OS-stil)"
+msgstr "Nytt vindu p√• knapp 1 (RISC OS-stil)"
 
-#: tips:42
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
 "reuse the current window."
 msgstr ""
-"Ett klikk med museknapp 1 (venstre) Âpner en mappe i et nytt vindu dersom du "
+"Ett klikk med museknapp 1 (venstre) √•pner en mappe i et nytt vindu dersom du "
 "tar i bruk dette alternativet. Museknapp 2 (midt) vil gjenbruke det "
 "gjeldende vinduet."
 
-#: tips:43
+#: tips:26
 #, fuzzy
 msgid "Single-click navigation"
-msgstr "Enkelklikk for Â Âpne"
+msgstr "Enkelklikk for √• √•pne"
 
-#: tips:44 tips:137
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
 "things."
 msgstr ""
-"Med dette alternativet Âpnes et objekt med ett klikk. Hold nede CTRL for Â "
+"Med dette alternativet √•pnes et objekt med ett klikk. Hold nede CTRL for √• "
 "velge objektet i stedet. Uten dette alternativet velges objektet med et "
-"klikk; dobbeltklikk for Â Âpne."
+"klikk; dobbeltklikk for √• √•pne."
 
-#: tips:45
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr ""
 
-#: tips:46
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
 msgstr ""
 
-#: tips:47
+#: tips:30
 msgid "Sorting"
 msgstr "Sortering"
 
-#: tips:48
+#: tips:31
 #, fuzzy
 msgid "Directories come first (for sort by name)"
-msgstr "Mapper kommer alltid f¯rst"
+msgstr "Mapper kommer alltid f√∏rst"
 
-#: tips:49
+#: tips:32
 #, fuzzy
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
 msgstr ""
-"Hvis dette er slÂtt pÂ vil mapper alltid vises f¯rst i listen, uansett "
+"Hvis dette er sl√•tt p√• vil mapper alltid vises f√∏rst i listen, uansett "
 "sorteringsmekanisme."
 
-#: tips:50
+#: tips:33
 #, fuzzy
 msgid "Capitalised names first (for sort by name)"
-msgstr "Mapper kommer alltid f¯rst"
+msgstr "Mapper kommer alltid f√∏rst"
 
-#: tips:51
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
 msgstr ""
 
-#: tips:53
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Mapper kommer alltid f√∏rst"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sek"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "Ikke bruk vertsnavn"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "Standardinnstilling for nye vinduer"
 
-#: tips:54
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "Arv innstillinger fra kildevinduet"
 
-#: tips:55
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
 msgstr ""
-"Hvis dette er pÂ blir visningsinnstillingene kopiert fra kildevinduet "
-"sÂfremt det er mulig, hvis ikke settes de til standardene under."
+"Hvis dette er p√• blir visningsinnstillingene kopiert fra kildevinduet "
+"s√•fremt det er mulig, hvis ikke settes de til standardene under."
 
-#: tips:56
+#: tips:48
 #, fuzzy
 msgid "View type:"
 msgstr "Ukjent type"
 
-#: tips:59
+#: tips:51
 #, fuzzy
 msgid "Sort by:"
-msgstr "SortÈr etter"
+msgstr "Sort√©r etter"
 
-#: tips:61 tips:76
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Type"
 
-#: tips:62
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Dato"
 
-#: tips:64
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Dato"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Dato"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Vis skjulte filer"
 
-#: tips:65
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
-msgstr "Hvis dette er pÂ vises filer som begynner med ., ellers er de skjulte."
+msgstr "Hvis dette er p√• vises filer som begynner med ., ellers er de skjulte."
 
-#: tips:66
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Vis skjulte filer"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr "Hvis dette er p√• vises filer som begynner med ., ellers er de skjulte."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Kjempeikoner"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "piksler"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 #, fuzzy
 msgid "Icon View"
-msgstr "Ikonst¯rrelse:"
+msgstr "Ikonst√∏rrelse:"
 
 #: tips:67
 #, fuzzy
@@ -3628,13 +4144,13 @@ msgstr "Standardinnstillinger"
 msgid "Huge Icons"
 msgstr "Kjempeikoner"
 
-#: tips:69 tips:245
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Store Ikoner"
 
-#: tips:70 tips:244
+#: tips:70 tips:295
 msgid "Small Icons"
-msgstr "SmÂ Ikoner"
+msgstr "Sm√• Ikoner"
 
 #: tips:72
 #, fuzzy
@@ -3645,390 +4161,589 @@ msgstr "Standardinnstillinger"
 msgid "No details"
 msgstr "Ingen detaljer"
 
+#: tips:74
+msgid "Sizes"
+msgstr "St√∏rrelser"
+
+#: tips:77
+msgid "Times"
+msgstr "Tider"
+
 #: tips:78
-msgid "Automatic small icons:"
+msgid "Automatic small icons: Change at:"
 msgstr ""
 
-#: tips:79
-#, fuzzy
-msgid "Change at:"
-msgstr "Endre tid:"
-
-#: tips:81
+#: tips:80
 #, fuzzy
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
 "used."
 msgstr ""
-"Hvis mappen inneholder minst sÂ mange objekter vil den bli vist med smÂ "
+"Hvis mappen inneholder minst s√• mange objekter vil den bli vist med sm√• "
 "ikoner, ellers vil store ikoner bli brukt."
 
-#: tips:82
-msgid "Max width (Large icons):"
-msgstr ""
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Brytningsbredde for store"
 
-#: tips:83 tips:86
-msgid "pixels"
-msgstr "piksler"
-
-#: tips:84
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "Tekst som er bredere enn dette blir brutt i to linjer med Store ikoner-"
-"visning. Med Kjempe-visning blir teksten brutt hvis den er st¯rre enn 50% av "
+"visning. Med Kjempe-visning blir teksten brutt hvis den er st√∏rre enn 50% av "
 "dette"
 
-#: tips:85
-#, fuzzy
-msgid "(Small Icons):"
-msgstr "SmÂ Ikoner"
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
 
 #: tips:87
-msgid "Maximum width for the text beside a Small Icon."
-msgstr "Maksimal bredde for tekst ved siden av et lite ikon."
+msgid "Wrap by characters"
+msgstr ""
 
 #: tips:88
-msgid "Order small icons vertically"
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
 msgstr ""
 
 #: tips:89
-msgid ""
-"If this option is on, then small icons are ordered vertically, not "
-"horizontally."
-msgstr ""
-
-#: tips:90
-msgid "Order large icons vertically"
-msgstr ""
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "Maks bredde, sm√• ikoner:"
 
 #: tips:91
-msgid ""
-"If this option is on, then large icons are sorted vertically, not "
-"horizontally."
+msgid "Maximum width for the text beside a Small Icon."
+msgstr "Maksimal bredde for tekst ved siden av et lite ikon."
+
+#: tips:92
+msgid "Order small icons vertically"
 msgstr ""
 
 #: tips:93
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
+msgstr ""
+
+#: tips:94
+msgid "Order large icons vertically"
+msgstr ""
+
+#: tips:95
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
+msgstr ""
+
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 #, fuzzy
 msgid "Show column headings"
 msgstr "Vis Miniatyrer"
 
-#: tips:94
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr ""
 
-#: tips:95
+#: tips:102
 #, fuzzy
 msgid "Show full type"
-msgstr "SortÈr etter Type"
+msgstr "Sort√©r etter Type"
 
-#: tips:96
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr ""
 
-#: tips:97
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Maksimal bredde for tekst ved siden av et lite ikon."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Vis Miniatyrer"
+
+#: tips:113
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+
+#: tips:115
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+
+#: tips:117
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+
+#: tips:119
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+
+#: tips:121
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+
+#: tips:123
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+
+#: tips:124
+msgid "Last Modified"
+msgstr ""
+
+#: tips:125
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+
+#: tips:130
 #, fuzzy
 msgid "Tools/Minibuffer"
 msgstr "Minibuffere"
 
-#: tips:98
+#: tips:131
 msgid "Toolbar"
-msgstr "Verkt¯ylinje"
+msgstr "Verkt√∏ylinje"
 
-#: tips:99
+#: tips:132
 msgid "Toolbar type:"
-msgstr "Verkt¯ylinjetype"
+msgstr "Verkt√∏ylinjetype"
 
-#: tips:100
+#: tips:133
 #, fuzzy
 msgid "No toolbar"
-msgstr "Verkt¯ylinje"
+msgstr "Verkt√∏ylinje"
 
-#: tips:101
+#: tips:134
 msgid "Icons only"
 msgstr "Kun ikoner"
 
-#: tips:102
+#: tips:135
 msgid "Text under icons"
 msgstr "Tekst under ikoner"
 
-#: tips:103
+#: tips:136
 msgid "Text beside icons"
 msgstr "Tekst ved siden av ikoner"
 
-#: tips:104
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Kun bilde"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Vis totaler av objekter"
 
-#: tips:105
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
 "selected items and their combined size."
 msgstr ""
 "Vis antallet objekter vist i 'Filer'-vindeuet, sammen med antallet skjulte "
-"objekter. NÂr noe er valgt vises antallet valgte objekter og deres samlede "
-"st¯rrelse."
+"objekter. N√•r noe er valgt vises antallet valgte objekter og deres samlede "
+"st√∏rrelse."
 
-#: tips:106
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr ""
 
-#: tips:107
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr ""
 
-#: tips:108
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
 msgstr ""
 
-#: tips:109
+#: tips:143
 #, fuzzy
 msgid "Minibuffer"
 msgstr "Minibuffere"
 
-#: tips:110
+#: tips:144
 msgid "Beep if Tab-completion fails"
-msgstr "Tut hvis Tab-fullf¯ring slÂr feil"
+msgstr "Tut hvis Tab-fullf√∏ring sl√•r feil"
 
-#: tips:111
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
 "letter varies)."
 msgstr ""
-"NÂr man bruker `Skiv sti...'-minibufferen og Tab blir trykket tuter ROX hvis "
+"N√•r man bruker `Skiv sti...'-minibufferen og Tab blir trykket tuter ROX hvis "
 "ingenting skjer (f.eks. fordi det er flere muligheter og det neste tegnet "
 "varierer)."
 
-#: tips:112
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Tut hvis det er flere muligheter"
 
-#: tips:113
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
 msgstr ""
-"NÂr man bruker `Skiv sti...'-minibufferen og Tab blir trykket tuter ROX hvis "
+"N√•r man bruker `Skiv sti...'-minibufferen og Tab blir trykket tuter ROX hvis "
 "mer enn en fil passer, selv om noen tegn ble lagt til."
 
-#: tips:116
+#: tips:148
+msgid "Stdout handler"
+msgstr ""
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Feil i behandler %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
 msgstr ""
 
-#: tips:117
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Vis miniatyrer av bilder"
 
-#: tips:118
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
 msgstr ""
 
-#: tips:119
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Vis miniatyrer av bilder"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 #, fuzzy
 msgid "Video thumbnails"
 msgstr "Gem thumbnails"
 
-#: tips:120
+#: tips:160
 #, fuzzy
 msgid "Thumbnails cache"
 msgstr "Vis Miniatyrer"
 
-#: tips:121
+#: tips:161
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 
-#: tips:122 tips:195
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
+#, fuzzy
+msgid "Manage thumbnails"
+msgstr "Vis miniatyrer av bilder"
+
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Gem thumbnails"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sek"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Tavle"
 
-#: tips:123
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
 msgstr ""
-"NÂr du bruker ei tavle, kan du dra filer og programmer til "
-"skrivebordsbakgrunnen for Â lage snarveier til dem."
+"N√•r du bruker ei tavle, kan du dra filer og programmer til "
+"skrivebordsbakgrunnen for √• lage snarveier til dem."
 
-#: tips:124 tips:241
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Utseende"
 
-#: tips:125
+#: tips:179
 msgid "Foreground:"
 msgstr "Forgrunnsfarge:"
 
-#: tips:126
+#: tips:180
 msgid "Text shadow:"
 msgstr ""
 
-#: tips:127
+#: tips:181
 msgid "Background:"
 msgstr "Bakgrunnsfarge:"
 
-#: tips:128
+#: tips:182
 msgid "No shadow"
 msgstr ""
 
-#: tips:129
+#: tips:183
 msgid "Thin"
 msgstr ""
 
-#: tips:130
+#: tips:184
 msgid "Thick"
 msgstr ""
 
-#: tips:131
+#: tips:185
 msgid "Use custom font:"
 msgstr "Bruk egen skrift:"
 
-#: tips:132
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Skrifttypen for teksten som vises under ikonene"
 
-#: tips:133
+#: tips:187
 msgid "Fast scaling of images"
 msgstr ""
 
-#: tips:134
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
 msgstr ""
 
-#: tips:135
+#: tips:189
 msgid "Pinboard behaviour"
-msgstr "Tavlas oppf¯rsel"
+msgstr "Tavlas oppf√∏rsel"
 
-#: tips:136
+#: tips:190
 msgid "Single-click to open"
-msgstr "Enkelklikk for Â Âpne"
+msgstr "Enkelklikk for √• √•pne"
 
-#: tips:138
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Hold ikoner innenfor skjerm-arealet"
 
-#: tips:139
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
 msgstr ""
-"Hvis dette er pÂ holdes ikoner pÂ tavla alltid fullstendig innenfor "
-"skjermens areal - ogsÂ tittelen."
+"Hvis dette er p√• holdes ikoner p√• tavla alltid fullstendig innenfor "
+"skjermens areal - ogs√• tittelen."
 
-#: tips:140
+#: tips:194
 msgid "Icon grid step:"
-msgstr "Ikongitterst¯rrelse:"
+msgstr "Ikongitterst√∏rrelse:"
 
-#: tips:141
+#: tips:195
 msgid "Fine"
 msgstr "Liten"
 
-#: tips:142
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
-msgstr "Bruker et 2-piksels gitter til Â plassere ikoner pÂ skrivebordet."
+msgstr "Bruker et 2-piksels gitter til √• plassere ikoner p√• skrivebordet."
 
-#: tips:143
+#: tips:197
 msgid "Medium"
 msgstr "Middels"
 
-#: tips:144
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
-msgstr "Bruker et 16-piksels gitter til Â plassere ikoner pÂ skrivebordet."
+msgstr "Bruker et 16-piksels gitter til √• plassere ikoner p√• skrivebordet."
 
-#: tips:145
+#: tips:199
 msgid "Coarse"
 msgstr "Stor"
 
-#: tips:146
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
-msgstr "Bruker et 32-piksels gitter til Â plassere ikoner pÂ skrivebordet."
+msgstr "Bruker et 32-piksels gitter til √• plassere ikoner p√• skrivebordet."
 
-#: tips:147 tips:149
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Minimerte vinduer"
 
-#: tips:148
+#: tips:202
 #, fuzzy
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
 "windows."
 msgstr ""
-"De fleste vindushÂndterere har en mÂte Â minimere vinduer pÂ, og "
-"forskjellige programmer, f.eks. ROX-Filer, kan brukes til Â vise de "
-"minimerte vinduene. Hvis dette alternativet er pÂ, vil Filer vise alle "
-"minimerte vinduer som en liten knapp pÂ skjermen. Krever en kompatibel "
-"vindushÂndterer."
+"De fleste vindush√•ndterere har en m√•te √• minimere vinduer p√•, og "
+"forskjellige programmer, f.eks. ROX-Filer, kan brukes til √• vise de "
+"minimerte vinduene. Hvis dette alternativet er p√•, vil Filer vise alle "
+"minimerte vinduer som en liten knapp p√• skjermen. Krever en kompatibel "
+"vindush√•ndterer."
 
-#: tips:150
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Vis minimerte vinduer"
 
-#: tips:151
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
 "pinboard must be in use."
 msgstr ""
 
-#: tips:152
+#: tips:206
 msgid "Show per workspace"
 msgstr ""
 
-#: tips:153
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
 msgstr ""
 
-#: tips:154
+#: tips:208
 msgid "Iconify to the"
 msgstr "Minimer til"
 
-#: tips:155
+#: tips:209
 msgid "top-left"
-msgstr "¯vre venstre hj¯rne"
+msgstr "√∏vre venstre hj√∏rne"
 
-#: tips:156
+#: tips:210
 msgid "top-right"
-msgstr "¯vre h¯yre hj¯rne"
+msgstr "√∏vre h√∏yre hj√∏rne"
 
-#: tips:157
+#: tips:211
 msgid "bottom-left"
-msgstr "nedre venstre hj¯rne"
+msgstr "nedre venstre hj√∏rne"
 
-#: tips:158
+#: tips:212
 msgid "bottom-right"
-msgstr "nedre h¯yre hj¯rne"
+msgstr "nedre h√∏yre hj√∏rne"
 
-#: tips:159
+#: tips:213
 msgid ", going"
-msgstr ", og sÂ"
+msgstr ", og s√•"
 
-#: tips:160
+#: tips:214
 msgid "horizontally"
 msgstr "horisontalt"
 
-#: tips:161
+#: tips:215
 msgid "vertically"
 msgstr "vertikalt"
 
-#: tips:162
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4036,327 +4751,297 @@ msgid ""
 "about its own panel."
 msgstr ""
 
-#: tips:163
+#: tips:217
 msgid "Top margin"
 msgstr ""
 
-#: tips:164
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr ""
 
-#: tips:165
+#: tips:219
 msgid "Bottom margin"
 msgstr ""
 
-#: tips:166
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr ""
 
-#: tips:167
-msgid "Panels"
-msgstr "Paneler"
-
-#: tips:168
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr ""
-"Paneler er rekker av ikoner som l¯per langs siden av skjermen.\n"
-"Se manualen for mer informasjon om paneler."
-
-#: tips:169
-msgid "Panel style"
-msgstr "Panelstil"
-
-#: tips:170
-msgid "Image and text"
-msgstr "Bilder og tekst"
-
-#: tips:171
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Alle panel-ikoner blir vist med bilde og tekst."
-
-#: tips:172
-msgid "Image only for applications"
-msgstr "Kun bilder for programmer"
-
-#: tips:173
-msgid ""
-"Applications have just an image, everything else has both an image and text."
-msgstr "Programmer har bare bilde, alt annet har bilde og tekst."
-
-#: tips:174
-msgid "Image only"
-msgstr "Kun bilde"
-
-#: tips:175
-msgid "Only the image is shown."
-msgstr "Bare bilde vises"
-
-#: tips:176
-msgid "Panel width (thin)"
+#: tips:221
+msgid "Left margin"
 msgstr ""
 
-#: tips:177
-msgid "(thick)"
+#: tips:222
+msgid "Width of no-go area at left of screen."
 msgstr ""
 
-#: tips:178
-msgid "The size of the panels."
+#: tips:223
+msgid "Right margin"
 msgstr ""
 
-#: tips:179
-msgid "Do not cover panel"
+#: tips:224
+msgid "Width of no-go area at right of screen."
 msgstr ""
 
-#: tips:180
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
-msgstr ""
-
-#: tips:181
-msgid "Xinerama"
-msgstr ""
-
-#: tips:182
-msgid "Confine to Xinerama monitor"
-msgstr ""
-
-#: tips:183
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
-msgstr ""
-
-#: tips:184
-msgid ""
-"The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr ""
-
-#: tips:185
+#: tips:225
 msgid "Desktop"
 msgstr ""
 
-#: tips:186
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
 msgstr ""
 
-#: tips:187
+#: tips:227
 #, fuzzy
 msgid "Panel only"
 msgstr "Kun bilde"
 
-#: tips:188
+#: tips:228
 #, fuzzy
 msgid "Only a panel is shown."
 msgstr "Bare bilde vises"
 
-#: tips:189
+#: tips:229
 #, fuzzy
 msgid "Pinboard only"
 msgstr "Tavle"
 
-#: tips:190
+#: tips:230
 #, fuzzy
 msgid "Only the pinboard is shown."
 msgstr "Bare bilde vises"
 
-#: tips:191
+#: tips:231
 #, fuzzy
 msgid "Panel and pinboard"
 msgstr "Tavle"
 
-#: tips:192
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr ""
 
-#: tips:193
-#, fuzzy
-msgid "Panel"
-msgstr "Paneler"
-
-#: tips:194
-msgid "Enter the name of the panel to show here."
-msgstr ""
-
-#: tips:196
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr ""
 
-#: tips:197
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr ""
 
-#: tips:198
+#: tips:236
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 
-#: tips:199
+#: tips:237
 msgid "Action windows"
 msgstr "Handlingsvinduer"
 
-#: tips:200
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
 msgstr ""
-"Handlingsvinduer dukker opp nÂr du starter en bakgrunns-\n"
-"operasjon, f.eks. Â kopiere eller slette filer."
+"Handlingsvinduer dukker opp n√•r du starter en bakgrunns-\n"
+"operasjon, f.eks. √• kopiere eller slette filer."
 
-#: tips:201
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Auto-start (Stille) disse handlingene"
 
-#: tips:203
+#: tips:241
 msgid "Copy files without confirming first."
-msgstr "KopiÈr filer uten Â sp¯rre f¯rst."
+msgstr "Kopi√©r filer uten √• sp√∏rre f√∏rst."
 
-#: tips:205
+#: tips:243
 msgid "Move files without confirming first."
-msgstr "Flytt filer uten Â sp¯rre f¯rst."
+msgstr "Flytt filer uten √• sp√∏rre f√∏rst."
 
-#: tips:207
+#: tips:245
 msgid "Create links to files without confirming first."
-msgstr "Lag lenker til filer uten Â sp¯rre f¯rst."
+msgstr "Lag lenker til filer uten √• sp√∏rre f√∏rst."
 
-#: tips:209
+#: tips:247
 msgid "Delete files without confirming first."
-msgstr "Slett filer uten Â sp¯rre f¯rst."
+msgstr "Slett filer uten √• sp√∏rre f√∏rst."
 
-#: tips:210
+#: tips:248
 msgid "Mount"
 msgstr "Monter"
 
-#: tips:211
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
-msgstr "Monter og demonter filsystemer uten Â sp¯rre f¯rst."
+msgstr "Monter og demonter filsystemer uten √• sp√∏rre f√∏rst."
 
-#: tips:212
+#: tips:250
 msgid "Default settings"
 msgstr "Standardinnstillinger"
 
-#: tips:214
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Tving"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
-msgstr "Sp¯rr ikke om sletting av ikke-skrivbare objekter."
+msgstr "Sp√∏rr ikke om sletting av ikke-skrivbare objekter."
 
-#: tips:216
+#: tips:254
 msgid "Don't display so much information in the message area."
-msgstr "Ikke vis sÂ mye informasjon i beskjedomrÂdet."
+msgstr "Ikke vis s√• mye informasjon i beskjedomr√•det."
 
-#: tips:218
+#: tips:256
 msgid "Also change contents of subdirectories."
-msgstr "Innholdet i undermapper skal ogsÂ endres."
+msgstr "Innholdet i undermapper skal ogs√• endres."
 
-#: tips:221
+#: tips:263
+#, fuzzy
+msgid "Mount commands"
+msgstr "Monteringspunkt"
+
+#: tips:264
+#, fuzzy
+msgid "Mount command"
+msgstr "Monteringspunkt"
+
+#: tips:265
+msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
+msgstr ""
+
+#: tips:266
+#, fuzzy
+msgid "Unmount command"
+msgstr "Demonter"
+
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "Kommando:"
+
+#: tips:269
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Dra og Slipp"
 
-#: tips:222
+#: tips:273
 #, fuzzy
 msgid "Dragging to icons"
 msgstr "Gemmer indstillinger"
 
-#: tips:223
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Tillat draing til ikoner i 'Filer'-vinduer"
 
-#: tips:224
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
 "will put it into that directory, or load it into the program."
 msgstr ""
-"NÂr dette er slÂtt pÂ kan du dra en fil til en undermappe eller program i et "
+"N√•r dette er sl√•tt p√• kan du dra en fil til en undermappe eller program i et "
 "vindu. Objektet blir da markert, og hvis du slipper filen puttes den i "
 "mappen eller lastes i programmet"
 
-#: tips:225
+#: tips:276
 msgid "Directories spring open"
-msgstr "≈pne mapper ved draing"
+msgstr "√Öpne mapper ved draing"
 
-#: tips:226
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
 "short while."
 msgstr ""
-"Dette alternativet, som krever alternativet ovenfor ogsÂ, gj¯r at mappen "
-"under musepekeren Âpnes av seg selv etter at en fil holdes over den en liten "
+"Dette alternativet, som krever alternativet ovenfor ogs√•, gj√∏r at mappen "
+"under musepekeren √•pnes av seg selv etter at en fil holdes over den en liten "
 "stund."
 
-#: tips:227
+#: tips:278
 msgid "Spring delay:"
-msgstr "MappeÂpningsventetid"
+msgstr "Mappe√•pningsventetid"
 
-#: tips:228
+#: tips:279
 msgid "ms"
 msgstr ""
 
-#: tips:229
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
 "have any effect."
 msgstr ""
-"Innstillingen regulerer hvor lenge ROX skal vente f¯r den Âpner en mappe nÂr "
-"du drar en fil over den. Innstillingen ovenfor mÂ slÂs pÂ for at denne skal "
+"Innstillingen regulerer hvor lenge ROX skal vente f√∏r den √•pner en mappe n√•r "
+"du drar en fil over den. Innstillingen ovenfor m√• sl√•s p√• for at denne skal "
 "ha effekt."
 
-#: tips:230
+#: tips:281
 #, fuzzy
 msgid "When dragging files with the left mouse button"
 msgstr "Midtknapp-draing"
 
-#: tips:231 tips:235
+#: tips:282 tips:286
 #, fuzzy
 msgid "Show a menu of possible actions"
 msgstr "Viser en meny med mulige handlinger"
 
-#: tips:232
+#: tips:283
 #, fuzzy
 msgid "Copy the files"
 msgstr "Flytter filene"
 
-#: tips:233
+#: tips:284
 #, fuzzy
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
 msgstr ""
-"Merk at du stadig kan fÂ opp menyen hvis du drar med venstre museknapp og "
+"Merk at du stadig kan f√• opp menyen hvis du drar med venstre museknapp og "
 "holder nede Alt"
 
-#: tips:234
+#: tips:285
 #, fuzzy
 msgid "When dragging files with the middle mouse button"
 msgstr "Midtknapp-draing"
 
-#: tips:236
+#: tips:287
 #, fuzzy
 msgid "Move the files"
 msgstr "Flytter filene"
 
-#: tips:237
+#: tips:288
 #, fuzzy
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
 msgstr ""
-"Merk at du stadig kan fÂ opp menyen hvis du drar med venstre museknapp og "
+"Merk at du stadig kan f√• opp menyen hvis du drar med venstre museknapp og "
 "holder nede Alt"
 
-#: tips:238
+#: tips:289
 msgid "Download handler"
 msgstr ""
 
-#: tips:239
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4364,177 +5049,211 @@ msgid ""
 "xterm -e wget $1"
 msgstr ""
 
-#: tips:240
+#: tips:291
 msgid "Menus"
 msgstr "Menyer"
 
-#: tips:242
+#: tips:293
 msgid "Size of icons in menus:"
-msgstr "St¯rrelse pÂ ikoner i menyer:"
+msgstr "St√∏rrelse p√• ikoner i menyer:"
 
-#: tips:243
+#: tips:294
 msgid "No Icons"
 msgstr "Ingen ikoner"
 
-#: tips:246
+#: tips:297
 msgid "Same as current window"
-msgstr "Det samme som det nÂvÊrende vindu"
+msgstr "Det samme som det n√•v√¶rende vindu"
 
-#: tips:247
+#: tips:298
 msgid "Same as default"
 msgstr "Det samme som standard"
 
-#: tips:248
+#: tips:299
 #, fuzzy
 msgid "Behaviour"
-msgstr "Vindusoppf¯rsel"
+msgstr "Vindusoppf√∏rsel"
 
-#: tips:249
+#: tips:300
 msgid "File menu on right-click"
 msgstr ""
 
-#: tips:250
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
 msgstr ""
 
-#: tips:251
-msgid "`Xterm Here' program"
+#: tips:302
+#, fuzzy
+msgid "Terminal emulator program"
 msgstr "'Xterm Her'-program"
 
-#: tips:252
-msgid "The program to launch when you choose `Xterm Here' from the menu."
-msgstr "Programmet som brukes nÂr du velger `Xterm her' fra menyen."
+#: tips:303
+#, fuzzy
+msgid "The program to launch when you choose `Terminal Here' from the menu."
+msgstr "Programmet som brukes n√•r du velger `Xterm her' fra menyen."
 
-#: tips:253
+#: tips:304
 #, fuzzy
 msgid "Keyboard shortcuts"
 msgstr "Innstill tastatursnarveier"
 
-#: tips:255
+#: tips:305
+msgid "Types"
+msgstr "Typer"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME-typer"
 
-#: tips:256
+#: tips:307
 #, fuzzy
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
 msgstr ""
-"ROX Filer bruker et sett med regler til Â bestemme den korrekte MIME-typen "
-"for hver fil, og velger sÂ et passende ikon. Etter Â ha endret disse filene, "
-"mÂ du kj¯re 'update-mime-database'-kommandoen. Bruk 'Oppdater' pÂ "
-"verkt¯ylinjen for Â laste de nye typene."
+"ROX Filer bruker et sett med regler til √• bestemme den korrekte MIME-typen "
+"for hver fil, og velger s√• et passende ikon. Etter √• ha endret disse filene, "
+"m√• du kj√∏re 'update-mime-database'-kommandoen. Bruk 'Oppdater' p√• "
+"verkt√∏ylinjen for √• laste de nye typene."
 
-#: tips:257
+#: tips:308
 msgid "Edit MIME rules"
 msgstr ""
 
-#: tips:258
+#: tips:309
 #, fuzzy
 msgid "Themes"
 msgstr "Tider"
 
-#: tips:259
+#: tips:310
 #, fuzzy
 msgid "Icon theme"
 msgstr "Minimer til"
 
-#: tips:260
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr ""
 
-#: tips:261
+#: tips:312
 #, fuzzy
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
-msgstr "Bruk 'Velg Ikon...'-dialogboksen til Â definere ikonet for hver type."
+msgstr "Bruk 'Velg Ikon...'-dialogboksen til √• definere ikonet for hver type."
 
-#: tips:262
+#: tips:313
 msgid "Colours"
 msgstr "Farger"
 
-#: tips:263
+#: tips:314
 msgid "File type colours"
 msgstr "Filtypefarger"
 
-#: tips:264
+#: tips:315
 msgid "Colour files based on their types"
-msgstr "Farg filer basert pÂ deres type"
+msgstr "Farg filer basert p√• deres type"
 
-#: tips:265
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr "Filnavn (og detaljer) skal farges etter deres filtype."
 
-#: tips:266
+#: tips:317
 msgid "Directory:"
 msgstr "Mappe:"
 
-#: tips:267
+#: tips:318
 msgid "Regular file:"
 msgstr "Vanlig fil:"
 
-#: tips:268
+#: tips:319
 msgid "Pipe:"
-msgstr "Pipe (r¯r):"
+msgstr "Pipe (r√∏r):"
 
-#: tips:269
+#: tips:320
 msgid "Socket:"
 msgstr "Socket:"
 
-#: tips:271
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
 msgstr ""
 "Feil, som f.eks. en symbolsk lenke som peker mot en ikke-eksisterende fil, "
-"eller en fil som ikke kan unders¯kes."
+"eller en fil som ikke kan unders√∏kes."
 
-#: tips:272
+#: tips:323
 msgid "Character device:"
 msgstr "Character-enhet:"
 
-#: tips:273
+#: tips:324
 msgid "Block device:"
 msgstr "Blokkenhet:"
 
-#: tips:274
+#: tips:325
 msgid "Door:"
-msgstr "D¯r:"
+msgstr "D√∏r:"
 
-#: tips:275
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
-msgstr "D¯rfiler er omtrent som socketer og r¯r, og finnes bare pÂ Solaris"
+msgstr "D√∏rfiler er omtrent som socketer og r√∏r, og finnes bare p√• Solaris"
 
-#: tips:276
+#: tips:327
 msgid "Executable file:"
-msgstr "Kj¯rbar fil"
+msgstr "Kj√∏rbar fil"
 
-#: tips:277
+#: tips:328
 msgid "Application directory:"
 msgstr "Programmappe"
 
-#: tips:278
+#: tips:329
 msgid "Unknown type:"
 msgstr "Ukjent type"
 
-#: tips:279
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Bakgrunnsfarge:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Bakgrunnsfarge:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr ""
 
-#: tips:280
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr ""
 
-#: tips:281
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr ""
 
-#: tips:282
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4543,26 +5262,26 @@ msgid ""
 "them appear in window-select lists."
 msgstr ""
 
-#: tips:283
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "Send alle bakgrunnsmuseklikk til vindusbehandleren"
 
-#: tips:284
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
 "events to your window manager instead. Clicks on icons will not be forwarded."
 msgstr ""
-"NÂr du h¯yreklikker bakgrunnen Âpnes vanligvis tavlemenyen, og venstreklikk "
-"fjerner vanligvis gjeldende valg. Hvis du skrur dette alternativet pÂ, "
-"sendes museklikkene videre til vindusbehandleren i stedet. Klikk pÂ ikoner "
+"N√•r du h√∏yreklikker bakgrunnen √•pnes vanligvis tavlemenyen, og venstreklikk "
+"fjerner vanligvis gjeldende valg. Hvis du skrur dette alternativet p√•, "
+"sendes museklikkene videre til vindusbehandleren i stedet. Klikk p√• ikoner "
 "sendes ikke videre."
 
-#: tips:285
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr ""
 
-#: tips:286
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4570,45 +5289,64 @@ msgid ""
 "isn't necessary."
 msgstr ""
 
-#: tips:287
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr ""
 
-#: tips:288
+#: tips:346
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 
-#: tips:289
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Panelstil"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 #, fuzzy
 msgid "Drag and drop"
 msgstr "Dra og Slipp"
 
-#: tips:290
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Ikke bruk vertsnavn"
 
-#: tips:291
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
 "sign on the pointer but the drop doesn't work."
 msgstr ""
-"Noen gamle programmer st¯tter ikke XDND helt og kan ha behov for dette "
-"alternativet. Bruk det hvis fil-draing til et program viser et +-tegn pÂ "
+"Noen gamle programmer st√∏tter ikke XDND helt og kan ha behov for dette "
+"alternativet. Bruk det hvis fil-draing til et program viser et +-tegn p√• "
 "mysepekeren men slipping ikke virker"
 
-#: tips:292
-msgid "Extended attributes"
-msgstr ""
-
-#: tips:293
+#: tips:355
 #, fuzzy
 msgid "Don't use extended attributes"
 msgstr "Ikke bruk vertsnavn"
 
-#: tips:294
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4616,11 +5354,332 @@ msgid ""
 "the properties window does not report extended attributes."
 msgstr ""
 
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+msgid "Bottom gap:"
+msgstr ""
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+msgid "Right gap:"
+msgstr ""
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "Ny Mappe"
+
+#: ../Templates.ui.h:4
+#, fuzzy
+msgid "Panel Options"
+msgstr "Innstillinger..."
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Bilder og tekst"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Alle panel-ikoner blir vist med bilde og tekst."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Kun bilder for programmer"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr "Programmer har bare bilde, alt annet har bilde og tekst."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Kun bilde"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Bare bilde vises"
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Panelstil"
+
+#: ../Templates.ui.h:12
+msgid "The size of this panel."
+msgstr ""
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Oversettelse"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr ""
+
+#: ../Templates.ui.h:19
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Panelstil"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr ""
+
+#: ../Templates.ui.h:22
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+
+#: ../Templates.ui.h:23
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "Tillatelser"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr ""
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr ""
+
+#: ../Templates.ui.h:27
+msgid "Bottom edge"
+msgstr ""
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr ""
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "Tillatelser"
+
+#~ msgid "<dir>"
+#~ msgstr "<mappe>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' finnes allerede - skriv over?"
+
+#, fuzzy
+#~ msgid "Choices migration"
+#~ msgstr "Kinesisk (tradisjonell)"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Feil under oppdatering av '%s:\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Mappe mangler/er slettet"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Mappen '%s' ble ikke funnet."
+
+#~ msgid "Cancel"
+#~ msgstr "Avbryt"
+
+#~ msgid "GNOME-VFS library"
+#~ msgstr "GNOME-VFS-bibliotek"
+
+#~ msgid "Open AVFS"
+#~ msgstr "√Öpne med AVFS"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr "Du burde Shift+Meny-klikke over en fil for √• sende den et sted"
+
+#~ msgid "Look inside ... ?"
+#~ msgstr "Se i ... ?"
+
+#, fuzzy
+#~ msgid "Panel: %s"
+#~ msgstr "Paneler"
+
+#, fuzzy
+#~ msgid "Top-edge panel"
+#~ msgstr "Lukk panel?"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Ugyldig .gmo oversettelses-fil (for kort): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr "Ugyldig .gmo oversettelses-fil (GNU magic number ikke funnet): %s"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "G√• til overmappen"
+
+#~ msgid "Change to home directory"
+#~ msgstr "G√• til hjemme-mappen"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Oppdater mappens innhold"
+
+#~ msgid "Change icon size"
+#~ msgstr "Endre ikonst√∏rrelsen"
+
+#~ msgid "Show extra details"
+#~ msgstr "Vis ekstra detaljer"
+
+#~ msgid "Hidden"
+#~ msgstr "Skjult"
+
+#~ msgid "Show/hide hidden files"
+#~ msgstr "Vis/Skjul skjulte filer"
+
+#~ msgid "Language"
+#~ msgstr "Spr√•k"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "Bruk milj√∏variabelen LANG"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Kinesisk (tradisjonell)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Kinesisk (forenklet)"
+
+# tips=x
+#~ msgid "Danish"
+#~ msgstr "Dansk"
+
+#~ msgid "Dutch"
+#~ msgstr "Hollandsk"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Engelsk (ingen oversettelse)"
+
+# tips=x
+#, fuzzy
+#~ msgid "Finnish"
+#~ msgstr "Dansk"
+
+#~ msgid "French"
+#~ msgstr "Fransk"
+
+#~ msgid "German"
+#~ msgstr "Tysk"
+
+#~ msgid "Hungarian"
+#~ msgstr "Ungarsk"
+
+#~ msgid "Italian"
+#~ msgstr "Italiensk"
+
+#~ msgid "Polish"
+#~ msgstr "Polsk"
+
+#~ msgid "Russian"
+#~ msgstr "Russisk"
+
+#~ msgid "Spanish"
+#~ msgstr "Spansk"
+
+#, fuzzy
+#~ msgid "Change at:"
+#~ msgstr "Endre tid:"
+
+#, fuzzy
+#~ msgid "(Small Icons):"
+#~ msgstr "Sm√• Ikoner"
+
+#~ msgid "Panels"
+#~ msgstr "Paneler"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Paneler er rekker av ikoner som l√∏per langs siden av skjermen.\n"
+#~ "Se manualen for mer informasjon om paneler."
+
 #, fuzzy
 #~ msgid ""
 #~ "Error loading MIME database:\n"
 #~ "%s"
-#~ msgstr "Fejl under lÊsning af fil: %s: %s"
+#~ msgstr "Fejl under l√¶sning af fil: %s: %s"
 
 #~ msgid "File '%s' corrupted!"
 #~ msgstr "Filen '%s' inneholder en feil"
@@ -4644,26 +5703,23 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Executable files"
-#~ msgstr "Kj¯rbar fil"
+#~ msgstr "Kj√∏rbar fil"
 
 #~ msgid "Ignore eXecutable bit for known extensions"
-#~ msgstr "Overse Kj¯rbar-flagg (x) for kjente filetternavn"
+#~ msgstr "Overse Kj√∏rbar-flagg (x) for kjente filetternavn"
 
 #~ msgid ""
 #~ "If a file has a known extension (eg '.gif') then ignore the executable "
 #~ "bit. This is useful if you have files on a Windows-type filesystem which "
 #~ "are being shown as executable programs."
 #~ msgstr ""
-#~ "Hvis en fil har en kjent fil-type (f.eks. '.png') overses kj¯rbar-"
+#~ "Hvis en fil har en kjent fil-type (f.eks. '.png') overses kj√∏rbar-"
 #~ "flagget. Dette er nyttig hvis du har et Windows-aktig filsystem hvor alle "
-#~ "filer vises som kj¯rbare."
+#~ "filer vises som kj√∏rbare."
 
 #, fuzzy
 #~ msgid "Umount"
 #~ msgstr "Demonter"
-
-#~ msgid "A"
-#~ msgstr "A"
 
 #~ msgid "All, "
 #~ msgstr "Alle, "
@@ -4678,7 +5734,7 @@ msgstr ""
 #~ msgstr "Nei (gnome-vfs-config ikke funnet)"
 
 #~ msgid "Examine ... ?"
-#~ msgstr "Unders¯k ... ?"
+#~ msgstr "Unders√∏k ... ?"
 
 #~ msgid "Permissions:"
 #~ msgstr "Tillatelser:"
@@ -4693,15 +5749,15 @@ msgstr ""
 #~ "Executable file:\n"
 #~ "This is a file with an eXecute bit set - it can be run as a program."
 #~ msgstr ""
-#~ "Kj¯rbar fil:\n"
-#~ "Dette er en fil som er satt til 'kj¯rbar' - den kan kj¯res som et program."
+#~ "Kj√∏rbar fil:\n"
+#~ "Dette er en fil som er satt til 'kj√∏rbar' - den kan kj√∏res som et program."
 
 #~ msgid ""
 #~ "File:\n"
 #~ "This is a data file. Try using the Info menu item to find out more..."
 #~ msgstr ""
 #~ "Fil:\n"
-#~ "Dette er en datafil. Pr¯v Â bruke 'Info' i menyen for Â finne ut mere..."
+#~ "Dette er en datafil. Pr√∏v √• bruke 'Info' i menyen for √• finne ut mere..."
 
 #~ msgid ""
 #~ "Mount point:\n"
@@ -4710,8 +5766,8 @@ msgstr ""
 #~ "directory."
 #~ msgstr ""
 #~ "Monteringspunkt:\n"
-#~ "Et monteringspunkt er en mappe hvor et annet filsystem kan settes pÂ. Alt "
-#~ "pÂ det monterte filsystemet finnes deretter inne i mappen."
+#~ "Et monteringspunkt er en mappe hvor et annet filsystem kan settes p√•. Alt "
+#~ "p√• det monterte filsystemet finnes deretter inne i mappen."
 
 #~ msgid ""
 #~ "Device file:\n"
@@ -4719,7 +5775,7 @@ msgstr ""
 #~ "it was an ordinary file."
 #~ msgstr ""
 #~ "Device-fil (enhetsfil):\n"
-#~ "Devicefiler gj¯r at du kan skrive til eller fra en enhetsdriver akkurat "
+#~ "Devicefiler gj√∏r at du kan skrive til eller fra en enhetsdriver akkurat "
 #~ "som om det var det en normal fil."
 
 #~ msgid ""
@@ -4727,8 +5783,8 @@ msgstr ""
 #~ "Pipes allow different programs to communicate. One program writes data to "
 #~ "the pipe while another one reads it out again."
 #~ msgstr ""
-#~ "Navngitt pipe (r¯r):\n"
-#~ "Pipes (r¯r) gj¯r at forsjkellige programmer kan kommunisere. Et program "
+#~ "Navngitt pipe (r√∏r):\n"
+#~ "Pipes (r√∏r) gj√∏r at forsjkellige programmer kan kommunisere. Et program "
 #~ "skriver data til pipen mens et annet program leser fra den."
 
 #~ msgid ""
@@ -4736,14 +5792,14 @@ msgstr ""
 #~ "Sockets allow processes to communicate."
 #~ msgstr ""
 #~ "Socket:\n"
-#~ "Sockets s¯rger for at prosesser kan kommunisere."
+#~ "Sockets s√∏rger for at prosesser kan kommunisere."
 
 #~ msgid ""
 #~ "Door:\n"
 #~ "Doors are a little-used Solaris method for processes to communicate."
 #~ msgstr ""
-#~ "D¯r:\n"
-#~ "D¯rer er en lite brukt Solaris-metode for Â interprosesskommunikasjon."
+#~ "D√∏r:\n"
+#~ "D√∏rer er en lite brukt Solaris-metode for √• interprosesskommunikasjon."
 
 #~ msgid ""
 #~ "Unknown type:\n"
@@ -4752,7 +5808,7 @@ msgstr ""
 #~ msgstr ""
 #~ "Ukjent type:\n"
 #~ "Jeg kunne ikke finne ut hvilken type fil dette er. Kanskje finnes den "
-#~ "ikke lenger eller kanskje du ikke har s¯ketillatelse i mappen den ligger "
+#~ "ikke lenger eller kanskje du ikke har s√∏ketillatelse i mappen den ligger "
 #~ "i?"
 
 #~ msgid ""
@@ -4761,29 +5817,21 @@ msgstr ""
 #~ "the list."
 #~ msgstr ""
 #~ "Mappe:\n"
-#~ "Dette er en mappe. Den inneholder en oversikt over andre objekter - Âpne "
-#~ "den for Â se listen."
+#~ "Dette er en mappe. Den inneholder en oversikt over andre objekter - √•pne "
+#~ "den for √• se listen."
 
 #~ msgid "Menu on button 2 (RISC OS style)"
-#~ msgstr "Meny pÂ knapp 2 (RISC OS-stil)"
+#~ msgstr "Meny p√• knapp 2 (RISC OS-stil)"
 
 #~ msgid ""
 #~ "Use button 2, the middle button (click both buttons at once on two button "
 #~ "mice), to pop up the menu. If off, use button 3 (right) instead."
 #~ msgstr ""
-#~ "Bruk knapp 2 (den midterste knappen, eller begge samtidig pÂ toknappsmus) "
-#~ "for Â Âpne menyen. Hvis av, brukes knapp 3 (h¯yre)."
+#~ "Bruk knapp 2 (den midterste knappen, eller begge samtidig p√• toknappsmus) "
+#~ "for √• √•pne menyen. Hvis av, brukes knapp 3 (h√∏yre)."
 
 #~ msgid "Show name-to-type rules"
 #~ msgstr "Vis navn-til-type-regler"
-
-#, fuzzy
-#~ msgid "DirItem"
-#~ msgstr "objekt"
-
-#, fuzzy
-#~ msgid "Background color"
-#~ msgstr "Bakgrunnsfarge:"
 
 #~ msgid "Vertical Adjustment"
 #~ msgstr "Vertikal justering"
@@ -4815,7 +5863,7 @@ msgstr ""
 #~ "applications onto this box."
 #~ msgstr ""
 #~ "Du burde trekke en enkelt (lokal) bildefil til dropp-boksen - dette "
-#~ "bildet vil brukes som skrivebordsbakgrunn. Du kan ogsÂ dra bestemte "
+#~ "bildet vil brukes som skrivebordsbakgrunn. Du kan ogs√• dra bestemte "
 #~ "programmer til denne boksen."
 
 #~ msgid "Large"
@@ -4829,10 +5877,10 @@ msgstr ""
 #~ "application will be used to load files of this type in future"
 #~ msgstr ""
 #~ "Du kan dra et enkelt (lokalt) pogram til dropp-boksen - programmet vil "
-#~ "deretter bli brukt til Â laste filer av denne typen"
+#~ "deretter bli brukt til √• laste filer av denne typen"
 
 #~ msgid "Currently %s"
-#~ msgstr "NÂ: %s"
+#~ msgstr "N√•: %s"
 
 #~ msgid "Menu of directories previously used for icons"
 #~ msgstr "Meny av mapper tidligere brukt til ikoner"
@@ -4848,8 +5896,8 @@ msgstr ""
 #~ "You should drop a single local icon file onto the drop box - that icon "
 #~ "will be used for this file from now on."
 #~ msgstr ""
-#~ "Du kan dra en enkelt lokal ikon-fil til dropp-boksen - det ikonet vil sÂ "
-#~ "bli brukt til denne filen fra nÂ av"
+#~ "Du kan dra en enkelt lokal ikon-fil til dropp-boksen - det ikonet vil s√• "
+#~ "bli brukt til denne filen fra n√• av"
 
 #~ msgid ""
 #~ "Enter the full path of a file that contains a valid image to be used as "
@@ -4865,20 +5913,14 @@ msgstr ""
 #~ "Du har ikke defineret nogle specielle ikoner; derfor har jeg ingen mapper "
 #~ "vise dig"
 
-#~ msgid "Large wrap width:"
-#~ msgstr "Brytningsbredde for store"
-
-#~ msgid "Max Small Icons width:"
-#~ msgstr "Maks bredde, smÂ ikoner:"
-
 #, fuzzy
 #~ msgid ""
 #~ "<u>Quick Start</u>\n"
 #~ "Just put the name of the file you're looking for in single quotes:\n"
 #~ "<b>'index.html'</b> (to find a file called 'index.html')\n"
 #~ msgstr ""
-#~ "Bare skriv navnet pÂ filen du leter etter i anf¯rselstegn:\n"
-#~ "'index.html' (for Â finne en fil som heter 'index.html')"
+#~ "Bare skriv navnet p√• filen du leter etter i anf√∏rselstegn:\n"
+#~ "'index.html' (for √• finne en fil som heter 'index.html')"
 
 #~ msgid "Summary"
 #~ msgstr "Oversikt"
@@ -4887,7 +5929,7 @@ msgstr ""
 #~ msgstr "Store, med..."
 
 #~ msgid "Small, With..."
-#~ msgstr "SmÂ, med..."
+#~ msgstr "Sm√•, med..."
 
 #~ msgid "fork: %s"
 #~ msgstr "fork: %s"
@@ -4902,17 +5944,17 @@ msgstr ""
 #~ msgstr "Bruker:"
 
 #~ msgid "Change from Large icons to Small automatically:"
-#~ msgstr "Endre fra store til smÂ ikoner automatisk:"
+#~ msgstr "Endre fra store til sm√• ikoner automatisk:"
 
 #~ msgid ""
 #~ "If this is on then filer windows will change from Large icons to Small "
 #~ "when showing a new directory with lots of files."
 #~ msgstr ""
-#~ "Hvis dette er pÂ vil vinduene automatisk endre fra store til smÂ ikoner "
-#~ "nÂr de viser en mappe med mange filer."
+#~ "Hvis dette er p√• vil vinduene automatisk endre fra store til sm√• ikoner "
+#~ "n√•r de viser en mappe med mange filer."
 
 #~ msgid "Small Icons if at least:"
-#~ msgstr "SmÂ ikoner ved minst:"
+#~ msgstr "Sm√• ikoner ved minst:"
 
 #~ msgid "Single-click navigation in filer windows"
 #~ msgstr "Ettklikks navigasjon i 'Filer'-vinduer"
@@ -4931,21 +5973,21 @@ msgstr ""
 #~ "for et ikon"
 
 #~ msgid "Toolbar buttons"
-#~ msgstr "Verkt¯ylinjeknapper"
+#~ msgstr "Verkt√∏ylinjeknapper"
 
 #~ msgid "Unshade the tools you want."
-#~ msgstr "Velg de verkt¯y du ¯nsker."
+#~ msgstr "Velg de verkt√∏y du √∏nsker."
 
 #~ msgid "Toolbar appearance"
-#~ msgstr "Verkt¯ylinjeutseende"
+#~ msgstr "Verkt√∏ylinjeutseende"
 
 #~ msgid ""
 #~ "The minibuffers are text entry fields that appear along the bottom of a "
 #~ "filer window. They are used to enter pathnames, search conditions and "
 #~ "shell commands."
 #~ msgstr ""
-#~ "Minibufferne er tekstinnskrivingsfelt som vises nÊr bunnen av vinduet. De "
-#~ "brukes til Â skrive inn stier, s¯keparametre og skallkommandoer."
+#~ "Minibufferne er tekstinnskrivingsfelt som vises n√¶r bunnen av vinduet. De "
+#~ "brukes til √• skrive inn stier, s√∏keparametre og skallkommandoer."
 
 #~ msgid "Beeping"
 #~ msgstr "Tuting"
@@ -4993,13 +6035,13 @@ msgstr ""
 #~ "against the leafname only."
 #~ msgstr ""
 #~ "ErNormal, ErLenke, ErMappe, ErChar, ErBlokk, ErDev, ErPipe, ErSocket, "
-#~ "ErD¯r (typer)\n"
-#~ "ErSUID, ErSGID, ErKlebrig, ErLesbar, ErSkrivbar, ErUtf¯rbar "
+#~ "ErD√∏r (typer)\n"
+#~ "ErSUID, ErSGID, ErKlebrig, ErLesbar, ErSkrivbar, ErUtf√∏rbar "
 #~ "(tillatelser)\n"
 #~ "ErTom, ErMin\n"
 #~ "\n"
-#~ "Et m¯nster i enkle anf¯rselstegn s¯kes som et vanlig jokertegn-s¯k.\n"
-#~ "Hvis det inneholder en skrÂstrek sÂ sammenlignes det mot hele stien;\n"
+#~ "Et m√∏nster i enkle anf√∏rselstegn s√∏kes som et vanlig jokertegn-s√∏k.\n"
+#~ "Hvis det inneholder en skr√•strek s√• sammenlignes det mot hele stien;\n"
 #~ "hvis ikke sammenlignes det bare mot filnavnet."
 
 #~ msgid "Comparisons"
@@ -5011,10 +6053,10 @@ msgstr ""
 #~ "2 secs|mins|hours|days|weeks|years  ago|hence (times)\n"
 #~ "atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks (values)"
 #~ msgstr ""
-#~ "<, <=, =, !=, >, >=, Etter, F¯r (sammenlign to verdier)\n"
-#~ "5 byte, 1Kb, 2Mb, 3Gb (filst¯rrelser)\n"
-#~ "2 sekunder|minutter|timer|dager|uker|Âr  siden|om (tider)\n"
-#~ "atid, ctid, mtid, nÂ, str, inode, nlenke, uid, gid, blokker (verdier)"
+#~ "<, <=, =, !=, >, >=, Etter, F√∏r (sammenlign to verdier)\n"
+#~ "5 byte, 1Kb, 2Mb, 3Gb (filst√∏rrelser)\n"
+#~ "2 sekunder|minutter|timer|dager|uker|√•r  siden|om (tider)\n"
+#~ "atid, ctid, mtid, n√•, str, inode, nlenke, uid, gid, blokker (verdier)"
 
 #~ msgid "Specials"
 #~ msgstr "Spesielle"
@@ -5024,10 +6066,10 @@ msgstr ""
 #~ "in 'command' is replaced with the path of the current file)\n"
 #~ "prune (false, and prevents searching the contents of a directory)."
 #~ msgstr ""
-#~ "system(kommando) (sant hvis 'kommando' returnerer med en sluttstatus pÂ "
+#~ "system(kommando) (sant hvis 'kommando' returnerer med en sluttstatus p√• "
 #~ "0; en % \n"
 #~ "i 'kommando' blir erstattet med stien til den valgte fila)\n"
-#~ "utelukket (usant, og utelukker s¯king i en mappe)."
+#~ "utelukket (usant, og utelukker s√∏king i en mappe)."
 
 #~ msgid "Permissions command reference"
 #~ msgstr "Kommandoreferanse: Tillatelser"
@@ -5035,9 +6077,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "File Information"
 #~ msgstr "ROX-Filer innstillinger"
-
-#~ msgid "Remove"
-#~ msgstr "Fjern"
 
 #~ msgid "Intelligent sorting"
 #~ msgstr "Intelligent sortering"
@@ -5048,14 +6087,14 @@ msgstr ""
 #~ "File9, File10"
 #~ msgstr ""
 #~ "Hvis av: ASCII-sortering: Fil10, Fil9, fil8.\n"
-#~ "Hvis pÂ: overser store/smÂ, tegnsetting og behandler nummer korrekt: "
+#~ "Hvis p√•: overser store/sm√•, tegnsetting og behandler nummer korrekt: "
 #~ "fil8, Fil9, Fil10"
 
 #~ msgid "Unknown error"
 #~ msgstr "Ukjent feil"
 
 #~ msgid "Show ROX-Filer Help"
-#~ msgstr "Vis ROX-Filer HjÊlp"
+#~ msgstr "Vis ROX-Filer Hj√¶lp"
 
 #~ msgid "The label must contain at least one character!"
 #~ msgstr "Title skal indeholde i hvertfald et tegn!"
@@ -5071,7 +6110,7 @@ msgstr ""
 #~ msgstr "Mangler MIME-type"
 
 #~ msgid "Trailing chars after MIME-type"
-#~ msgstr "Eftef¯lgende tegn efter MIME-typen"
+#~ msgstr "Eftef√∏lgende tegn efter MIME-typen"
 
 #~ msgid ""
 #~ "The pinboard is the desktop background.\n"
@@ -5080,10 +6119,10 @@ msgstr ""
 #~ "See the manual for information about using the pinboard."
 #~ msgstr ""
 #~ "Opslagstavlen er desktoppens baggrund.\n"
-#~ "NÂr opslagstavlen er slÂet til kan du trÊkke filer\n"
-#~ "og programmer ind pÂ den for at oprette genveje til dem.\n"
-#~ "Opslagstavlen er ogsÂ kendt fra andre systemer under navne som Skrivebord "
-#~ "og ArbejdsbÊnk\n"
+#~ "N√•r opslagstavlen er sl√•et til kan du tr√¶kke filer\n"
+#~ "og programmer ind p√• den for at oprette genveje til dem.\n"
+#~ "Opslagstavlen er ogs√• kendt fra andre systemer under navne som Skrivebord "
+#~ "og Arbejdsb√¶nk\n"
 #~ "Se manualen for mere information om brug af opslagstavlen."
 
 #, fuzzy
@@ -5094,13 +6133,13 @@ msgstr ""
 #~ msgstr "Afbryd"
 
 #~ msgid "Can't allocate memory for buffer to load this file"
-#~ msgstr "Kan ikke allokere hukommelse til bufferen til at lÊse denne fil"
+#~ msgstr "Kan ikke allokere hukommelse til bufferen til at l√¶se denne fil"
 
 #~ msgid "Old VFS support"
-#~ msgstr "Gammel VFS underst¯ttelse"
+#~ msgstr "Gammel VFS underst√∏ttelse"
 
 #~ msgid "No (incompatible with Large File Support)"
-#~ msgstr "Nej (inkompatibel med Underst¯ttelse af Store Filer)"
+#~ msgstr "Nej (inkompatibel med Underst√∏ttelse af Store Filer)"
 
 #~ msgid "No (couldn't find a valid libvfs)"
 #~ msgstr "Nej (kunne ikke finde en gyldig libvfs)"
@@ -5115,16 +6154,16 @@ msgstr ""
 #~ msgstr "Ja (bruger libpng)"
 
 #~ msgid "No (needs libpng or Gtk+-2.0)"
-#~ msgstr "Nej (krÊver libpng eller Gtk+-2.0)"
+#~ msgstr "Nej (kr√¶ver libpng eller Gtk+-2.0)"
 
 #~ msgid "Character set translations"
-#~ msgstr "TegnsÊt oversÊttelser"
+#~ msgstr "Tegns√¶t overs√¶ttelser"
 
 #~ msgid "No (needs libiconv or Gtk+-2.0)"
-#~ msgstr "Nej (jrÊver libiconv eller Gtk+-2.0)"
+#~ msgstr "Nej (jr√¶ver libiconv eller Gtk+-2.0)"
 
 #~ msgid "Open VFS"
-#~ msgstr "≈ben med VFS"
+#~ msgstr "√Öben med VFS"
 
 #~ msgid "Unzip"
 #~ msgstr "Unzip"
@@ -5138,9 +6177,6 @@ msgstr ""
 #~ msgid "RPM"
 #~ msgstr "RPM"
 
-#~ msgid "New Directory"
-#~ msgstr "Ny Mappe"
-
 #~ msgid "New File"
 #~ msgstr "Ny Fil"
 
@@ -5151,14 +6187,14 @@ msgstr ""
 #~ "If off: Ben, animal, zoo.\n"
 #~ "If on: animal, Ben, zoo."
 #~ msgstr ""
-#~ "Hvis fra: B¯ffel, and, zebra.\n"
-#~ "Hvis til: and, B¯ffel, zebra."
+#~ "Hvis fra: B√∏ffel, and, zebra.\n"
+#~ "Hvis til: and, B√∏ffel, zebra."
 
 #~ msgid "No background"
 #~ msgstr "Ingen baggrund"
 
 #~ msgid "The text is drawn directly on the desktop background."
-#~ msgstr "Teksten bliver tegnet direkte pÂ desktoppens baggrund."
+#~ msgstr "Teksten bliver tegnet direkte p√• desktoppens baggrund."
 
 #~ msgid "Outlined text"
 #~ msgstr "Omridset tekst"
@@ -5170,16 +6206,13 @@ msgstr ""
 #~ msgstr "Firkantet baggrunds box"
 
 #~ msgid "The text is drawn on a solid rectangle."
-#~ msgstr "Teksten bliver tegnet pÂ en firkant"
+#~ msgstr "Teksten bliver tegnet p√• en firkant"
 
 #~ msgid "...never"
 #~ msgstr "... aldrig"
 
 #~ msgid "...always"
 #~ msgstr "...altid"
-
-#~ msgid "Window size limit"
-#~ msgstr "Vindues-st¯rrelse grÊnse"
 
 #~ msgid "Error"
 #~ msgstr "Fejl"
@@ -5188,25 +6221,25 @@ msgstr ""
 #~ msgstr "!FEJL: %s\n"
 
 #~ msgid "Force - don't confirm deletion of non-writeable items"
-#~ msgstr "Tving - bekrÊft ikke sletning af ikke-skrivbare objekter"
+#~ msgstr "Tving - bekr√¶ft ikke sletning af ikke-skrivbare objekter"
 
 #~ msgid "Recurse - also change contents of subdirectories"
-#~ msgstr "Recursivt - under-mappers indhold Êndres ogsÂ"
+#~ msgstr "Recursivt - under-mappers indhold √¶ndres ogs√•"
 
 #~ msgid "fork() failed"
 #~ msgstr "fork() mislykkedes"
 
 #~ msgid "Sorry, but the name must not contain < or >"
-#~ msgstr "DesvÊrre, men navnet mÂ hverken indeholde < eller >"
+#~ msgstr "Desv√¶rre, men navnet m√• hverken indeholde < eller >"
 
 #~ msgid "You must select a single file to open as a Virtual File System"
-#~ msgstr "Du mÂ kun vÊlge en fil som skal Âbnes som et Virtuelt Fil System"
+#~ msgstr "Du m√• kun v√¶lge en fil som skal √•bnes som et Virtuelt Fil System"
 
 #~ msgid "Failed to fork() child process"
-#~ msgstr "fork() af b¯rne-process mislykkedes"
+#~ msgstr "fork() af b√∏rne-process mislykkedes"
 
 #~ msgid "Notice"
-#~ msgstr "BemÊrk"
+#~ msgstr "Bem√¶rk"
 
 #~ msgid ""
 #~ "Restart\n"
@@ -5220,9 +6253,6 @@ msgstr ""
 
 #~ msgid "Named pipe"
 #~ msgstr "Navngivet pipe"
-
-#~ msgid "Application"
-#~ msgstr "Program"
 
 #~ msgid "Copy failed"
 #~ msgstr "Kopiering mislykkedes"

--- a/ROX-Filer/src/po/pl.po
+++ b/ROX-Filer/src/po/pl.po
@@ -2,59 +2,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rox 2.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-08-11 12:02+0200\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2003-02-23 16:34--100\n"
 "Last-Translator: Wit Wiliński <madman@berlios.de>\n"
 "Language-Team: Polish <pl@li.org>\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: abox.c:127
-msgid "<dir>"
-msgstr "<katalog>"
+msgid "<src>"
+msgstr ""
 
-#: abox.c:219
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Cicho"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Quiet"
 msgstr "Cicho"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Bez potwierdzania każdej operacji"
 
-#: abox.c:455 tips:60
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Nazwa"
 
-#: abox.c:461 menu.c:232
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Katalog"
 
-#: abox.c:550
+#: abox.c:546
 msgid "Expression:"
 msgstr "Wyrażenie:"
 
-#: action.c:58
+#: action.c:57
 msgid "See the attr(5) man page for full details."
 msgstr ""
 
-#: action.c:60
+#: action.c:59
 msgid "See the fsattr(5) man page for full details."
 msgstr ""
 
-#: action.c:62
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr ""
 
-#: action.c:188
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Opis możliwych wyrażeń"
 
-#: action.c:199
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -131,12 +136,12 @@ msgstr ""
 "pliku\n"
 "pomiń (fałsz, zapobiega przeszukiwaniu zawartości katalogu)."
 
-#: action.c:246
+#: action.c:256
 #, fuzzy
 msgid "Change permissions reference"
 msgstr "Opis możliwych wyrażeń"
 
-#: action.c:257
+#: action.c:267
 #, fuzzy
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
@@ -197,12 +202,12 @@ msgstr ""
 "\n"
 "Pełny opis znajduje się w dokumentacji chmod(1)."
 
-#: action.c:298
+#: action.c:308
 #, fuzzy
 msgid "Set type reference"
 msgstr "Opis możliwych wyrażeń"
 
-#: action.c:309
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -218,48 +223,55 @@ msgid ""
 "on certain file systems and where the OS implements them.\n"
 msgstr ""
 
-#: action.c:416
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Zadanie przerwane.\n"
 
-#: action.c:432
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Wystąpił błąd.\n"
 
-#: action.c:434
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Wystąpiło %d błędów.\n"
 
-#: action.c:458
+#: action.c:516
 msgid "ERROR reading"
 msgstr "błąd przy odczycie"
 
-#: action.c:501
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Zrobione\n"
 
-#: action.c:557 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "BŁĄD"
 
-#: action.c:711 main.c:674 main.c:681 main.c:688
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Tak"
 
-#: action.c:714 main.c:676 main.c:690
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Nie"
 
-#: action.c:732
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -267,7 +279,7 @@ msgstr ""
 "\n"
 "Próba przerwania procesu potomnego..\n"
 
-#: action.c:739
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -275,41 +287,41 @@ msgstr ""
 "\n"
 "Staram się ZABIĆ działający proces..\n"
 
-#: action.c:892
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Zliczyć zawartość %s?"
 
-#: action.c:928
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Usunąć %s\"%s\"?"
 
-#: action.c:929
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "ZABEZPIECZONY PRZED ZAPISEM "
 
-#: action.c:936
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "\"Usuwanie \"%s\"\n"
 
-#: action.c:949
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "\"Katalog \"%s\" usunięty\n"
 
-#: action.c:982
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?Wysunąć '%s'?"
 
-#: action.c:989
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Wysuń '%s'\n"
 
-#: action.c:1008
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -318,81 +330,96 @@ msgstr ""
 "!%s\n"
 "Wysunięcie nie powiodło się\n"
 
-#: action.c:1027 action.c:1046
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Sprawdzić \"%s\"?"
 
-#: action.c:1043
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Niewłaściwe wyrażenie wyszukiwania - zmień je i spróbuj ponownie\n"
 
-#: action.c:1053
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "\"(podczas sprawdzania \"%s\")\n"
 
-#: action.c:1127 action.c:1152
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Zmienić uprawnienia do \"%s\"?"
 
-#: action.c:1133
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "\"Zmiana uprawnień \"%s\"\n"
 
-#: action.c:1150
+#: action.c:1274
 #, fuzzy
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Niewłaściwe polecenie (tryb) - zmień i spróbuj ponownie\n"
 
-#: action.c:1207 action.c:1227
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?Zmienić typ '%s'?"
+
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Zmienić typ '%s'?"
 
-#: action.c:1224
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Niewłaściwy typ - zmień i spróbuj ponownie\n"
 
-#: action.c:1246
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Zmiana typu pliku '%s' na '%s'\n"
 
-#: action.c:1325
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'Zmiana typu pliku '%s' na '%s'\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' już istnieje - %s?"
 
-#: action.c:1327
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "połącz zawartość"
 
-#: action.c:1328
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "nadpisać"
 
-#: action.c:1344
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "\"Wymuszona próba kopiowania...\n"
 
-#: action.c:1353
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Skopiować %s jako %s?"
 
-#: action.c:1357
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Kopiowanie %s jako %s\n"
 
-#: action.c:1372
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!BŁĄD: Docelowy plik już istnieje, lecz nie jest katalogiem\n"
 
-#: action.c:1444
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -401,26 +428,7 @@ msgstr ""
 "!%s\n"
 "Kopiowanie \"%s\" nie powiodło się\n"
 
-#: action.c:1488
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?\"%s\" już istnieje - nadpisać?"
-
-#: action.c:1503
-msgid "'Trying move anyway...\n"
-msgstr "'Wymuszona próba przenoszenia...\n"
-
-#: action.c:1511
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Przenieść %s jako %s?"
-
-#: action.c:1515
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Przeniesienie %s jako %s\n"
-
-#: action.c:1523
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -429,45 +437,59 @@ msgstr ""
 "!%s\n"
 "Nie można przenieść %s do %s\n"
 
-#: action.c:1544
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Wymuszona próba przenoszenia...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Przenieść %s jako %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Przeniesienie %s jako %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!BŁĄD: Nie można skopiować pliku na siebie samego\n"
 
-#: action.c:1559
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!BŁĄD: Nie można przenieść pliku na siebie samego\n"
 
-#: action.c:1571
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Tworzenie dowiązania %s jako %s\n"
 
-#: action.c:1576
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Utworzyć dowiązanie %s jako %s?"
 
-#: action.c:1618
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Montowanie %s\n"
 
-#: action.c:1619
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Odmontowywanie %s\n"
 
-#: action.c:1622
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?Zamontować %s?"
 
-#: action.c:1623
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?Odmontować %s?"
 
-#: action.c:1643
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -476,7 +498,7 @@ msgstr ""
 "!%s\n"
 "Montowanie nie powiodło się\n"
 
-#: action.c:1644
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -485,11 +507,11 @@ msgstr ""
 "!%s\n"
 "Odmontowanie nie powiodło się\n"
 
-#: action.c:1652
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr ""
 
-#: action.c:1698
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -498,290 +520,314 @@ msgstr ""
 "'\n"
 "Razem: %s ("
 
-#: action.c:1704
+#: action.c:2108
 msgid "file"
 msgstr "plik"
 
-#: action.c:1704
+#: action.c:2108
 msgid "files"
 msgstr "plików"
 
-#: action.c:1708
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "brak katalogów)\n"
 
-#: action.c:1712
+#: action.c:2116
 msgid "directory"
 msgstr "katalog"
 
-#: action.c:1713
+#: action.c:2117
 msgid "directories"
 msgstr "katalogów"
 
 # ##
-#: action.c:1754
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Nie wybrano punktu montowania!\n"
 
-#: action.c:1839
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Następne wyszukiwanie?"
 
-#: action.c:1869 action.c:1900
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' jest dowiązaniem symbolicznym\n"
 
-#: action.c:1940
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "Należy wybrać elementy, wśród których wyszukiwać"
 
-#: action.c:1950 menu.c:223
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Znajdź"
 
-#: action.c:1983
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Należy wybrać elementy do zliczenia"
 
-#: action.c:1987
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Zajętość dysku"
 
-#: action.c:2021
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Zamontuj / Odmontuj"
 
-#: action.c:2034
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr "ROX-Filer nie obsługuje punktów montowania w tym systemie."
 
-#: action.c:2048 menu.c:210 tips:208
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Usuń"
 
-#: action.c:2058 tips:213
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Wymuś"
 
-#: action.c:2058
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Brak potwierdzania przy kasowaniu niezapisywalnych elementów"
 
-#: action.c:2061 action.c:2116 action.c:2175 action.c:2228 action.c:2264
-#: tips:215
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Zwięźle"
 
-#: action.c:2061
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Wyświetlanie jedynie usuwanych katalogów"
 
-#: action.c:2078
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "Należy wybrać elementy, których uprawnienia mają zostać zmienione"
 
-#: action.c:2086
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (wykonywalne/do przeglądania)"
 
-#: action.c:2088
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (niewykonywalne/nie do przeglądania)"
 
-#: action.c:2090
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (prawo odczytu i zapisu dla właściciela)"
 
-#: action.c:2092
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (prywatne - tylko dla właściciela)"
 
-#: action.c:2094
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (publiczne bez prawa zapisu)"
 
-#: action.c:2105 menu.c:184 menu.c:221 tips:75
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Uprawnienia"
 
-#: action.c:2116 action.c:2175
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Przetwarzane pliki nie są wypisywane"
 
-#: action.c:2119 action.c:2178 tips:217
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Rekursywnie"
 
-#: action.c:2119
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Zmienia również zawartość w podkatalogach"
 
-#: action.c:2123
+#: action.c:2547
 msgid "Command:"
 msgstr "Polecenie:"
 
-#: action.c:2151
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Należy wybrać elementy, których typ ma zostać zmieniony"
 
-#: action.c:2164
+#: action.c:2590
 msgid "Set type"
 msgstr "Zmień typ"
 
-#: action.c:2178
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Zmień zawartość podkatalogów"
 
-#: action.c:2185 infobox.c:615
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Typ:"
 
-#: action.c:2214 dnd.c:124 menu.c:1999 tips:202
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Skopiuj"
 
-#: action.c:2224 action.c:2260 tips:219
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Bez potwierdzania każdej operacji"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Nadpisywanie tylko gdy obiekt źródłowy jest nowszy niż docelowy."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Nowsze"
 
-#: action.c:2225 action.c:2261 tips:220
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Nadpisywanie tylko gdy obiekt źródłowy jest nowszy niż docelowy."
 
-#: action.c:2228
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "katalogów"
+
+#: action.c:2695
 #, fuzzy
 msgid "Only log directories as they are copied"
 msgstr "Wyświetlanie jedynie usuwanych katalogów"
 
-#: action.c:2250 dnd.c:125 tips:204
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Przenieś"
 
-#: action.c:2264
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr ""
 
-#: action.c:2284 tips:206
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Dowiązanie"
 
-#: action.c:2303 appmenu.c:113
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr ""
 
-#: action.c:2360
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Kasowanie elementów takich jak"
 
-#: action.c:2364
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Kasowanie elementu "
 
-#: action.c:2366
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Kasowanie elementów "
 
-#: action.c:2385
+#: action.c:2900
 msgid " and "
 msgstr " oraz "
 
-#: action.c:2394
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr " wpłynie na elementy na pulpicie lub panelu - na pewno kasować?"
 
-#: action.c:2401
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr " wpłynie na elementy na pulpicie lub panelu - na pewno je kasować?"
 
-#: appmenu.c:198
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<brakująca etykieta>"
 
-#: appmenu.c:295
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
 "menu for all items of this type (%s/%s)."
 msgstr ""
 
-#: appmenu.c:339 menu.c:234
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Dostosuj menu..."
 
-#: appmenu.c:396 menu.c:251 toolbar.c:159
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Pomoc"
 
-#: bookmarks.c:147
-msgid "Path"
-msgstr "Ścieżka"
-
-#: bookmarks.c:155
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Tytuł"
 
-#: bookmarks.c:304
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Ścieżka"
+
+#: bookmarks.c:466
 #, fuzzy, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Nie można dodać zdalnej lokacji \"%s\"\n"
 
-#: bookmarks.c:312 bookmarks.c:630
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "\"%s\" nie jest katalogiem"
 
-#: bookmarks.c:518
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Należy najpierw zaznaczyć elementy do usunięcia"
 
-#: bookmarks.c:542
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Wybierz pozycję do przesunięcia."
 
-#: bookmarks.c:562
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Wybrana pozycja jest już na końcu listy."
 
-#: bookmarks.c:636
+#: bookmarks.c:829
 #, fuzzy, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Nie można dodać zdalnego katalogu \"%s\"\n"
 
-#: bookmarks.c:778
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Dodaj zakładkę"
 
-#: bookmarks.c:785
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Edycja zakładek"
 
-#: bookmarks.c:790
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Ostatnio odwiedzone"
 
-#: bulk_rename.c:68
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr ""
 
-#: bulk_rename.c:71
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Przywróć"
 
-#: bulk_rename.c:76
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr ""
 
-#: bulk_rename.c:81
+#: bulk_rename.c:82
 #, fuzzy
 msgid "_Rename"
 msgstr "Przenieś"
 
-#: bulk_rename.c:94
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Zamień:"
 
-#: bulk_rename.c:101
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -796,57 +842,58 @@ msgstr "Na:"
 
 #: bulk_rename.c:116
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
 msgstr ""
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Stara nazwa"
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Nowa nazwa"
 
-#: bulk_rename.c:259
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr ""
 
-#: bulk_rename.c:264
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr ""
 
-#: bulk_rename.c:267
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr ""
 
-#: bulk_rename.c:293
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr ""
 
-#: bulk_rename.c:310
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr ""
 
-#: bulk_rename.c:343
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr ""
 
-#: bulk_rename.c:348
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -854,69 +901,86 @@ msgid ""
 "Aborting bulk rename."
 msgstr ""
 
-#: bulk_rename.c:410
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "Plik o nazwie '%s' już istnieje"
 
-#: bulk_rename.c:421
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
 "files to end up in different directories. Continue?"
 msgstr ""
 
-#: bulk_rename.c:436
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr ""
 
-#: choices.c:428
-msgid "Choices migration"
-msgstr "Migracja Choices"
+#: choices.c:434
+#, c-format
+msgid "%d directories could not be migrated"
+msgstr "%d katalogi nie mogły zostać przeniesione"
 
 #: choices.c:436
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Choices have been moved from \n"
-"<b>%s</b>\n"
+"%s\n"
 " to the new location \n"
-"<b>%s</b>\n"
+"%s\n"
+"%s"
 msgstr ""
 "Katalog Choices został przeniesiony z \n"
 "<b>%s</b>\n"
 " do nowego położenia \n"
 "<b>%s</b>\n"
 
-#: choices.c:447
-#, c-format
-msgid "%d directories could not be migrated"
-msgstr "%d katalogi nie mogły zostać przeniesione"
-
-#: dir.c:982
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Nie można znaleźć katalogu: %s"
 
-#: dir.c:991
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Nie można otworzyć katalogu: %s"
 
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Rozmiar"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
 # ##, c-format
-#: display.c:588
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "błąd lstat(2): %s"
 
-#: dnd.c:126
-msgid "Link (relative)"
-msgstr "Dowiązanie (względne)"
-
-#: dnd.c:127
-msgid "Link (absolute)"
-msgstr "Dowiązanie (absolutne)"
-
-#: dnd.c:426
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Wewnętrzny błąd - niewłaściwy typ informacji"
 
@@ -993,14 +1057,14 @@ msgstr ""
 "Nie można otrzymać danych ze zdalnego komputera (nie podano application/"
 "octet-stream)"
 
-#: dnd.c:1016
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
 "Niektóre z tych plików znajdują się na innym komputerze - zostaną one "
 "zignorowane"
 
-#: dnd.c:1023
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
@@ -1008,43 +1072,61 @@ msgstr ""
 "Żaden z podanych plików nie znajduje się na lokalnej maszynie - nie można "
 "operować na wielu zdalnych plikach."
 
-#: dnd.c:1036
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Zażądano nieznanej akcji"
 
-#: dnd.c:1044
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Błąd pobierania listy plików: %s"
 
-#: dropbox.c:114
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Dowiązanie (względne)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Dowiązanie (absolutne)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Dowiązanie (względne)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Dowiązanie (absolutne)"
+
+#: dropbox.c:112
 msgid "Show"
 msgstr "Wyświetl"
 
-#: dropbox.c:120
+#: dropbox.c:118
 msgid "Show the current choice in a filer window"
 msgstr "Wyświetl aktualny wybór w oknie programu"
 
-#: dropbox.c:174
+#: dropbox.c:172
 msgid "<nothing>"
 msgstr "<brak>"
 
-#: dropbox.c:239
+#: dropbox.c:237
 msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
 msgstr ""
 
-#: dropbox.c:263
+#: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
 msgstr "Niestety, musisz przeciągnąć dokładnie jeden plik do tego obszaru."
 
-#: dropbox.c:273
+#: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr "Niestety, nie mogę użyć '%s', ponieważ nie jest to lokalny plik."
 
-#: dropbox.c:280 pinboard.c:853
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1053,7 +1135,7 @@ msgstr ""
 "Nie mogę użyć \"%s\":\n"
 "%s"
 
-#: filer.c:453
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1062,16 +1144,7 @@ msgstr ""
 "Błąd przy skanowaniu \"%s\":\n"
 "%s\n"
 
-#: filer.c:457
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Błąd przy skanowaniu \"%s\":\n"
-"%s"
-
-#: filer.c:562
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1081,342 +1154,401 @@ msgstr ""
 "\n"
 "Odmontowanie pozwala bezpiecznie usunąć dysk."
 
-#: filer.c:566
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 #, fuzzy
 msgid "No change"
 msgstr "Nic"
 
-#: filer.c:572 menu.c:862
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Odmontuj"
 
-#: filer.c:669
-msgid "Directory missing/deleted"
-msgstr "Brakujący/skasowany katalog"
-
 # ##, c-format
-#: filer.c:1031
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
 "Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"Grupa %s nie jest ustawiona. Zaznacz kilka plików, następnie naciśnij Ctrl+%"
-"s aby ustawić grupę. Wciśnij samo %s aby wybrać pliki później."
+"Grupa %s nie jest ustawiona. Zaznacz kilka plików, następnie naciśnij Ctrl+"
+"%s aby ustawić grupę. Wciśnij samo %s aby wybrać pliki później."
 
-#: filer.c:1267
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Katalog \"%s\" nie jest dostępny"
+#: filer.c:2655
+msgid "A"
+msgstr ""
 
-#: filer.c:1419
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Nie znaleziono katalogu \"%s\""
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
 
-#: filer.c:1713
-msgid "Cancel"
-msgstr "Anuluj"
+#: filer.c:2659 find.c:923
+msgid "G"
+msgstr ""
 
 # Skanowanie
-#: filer.c:2002
+#: filer.c:2664
 msgid "S"
 msgstr "S"
 
 # Thumbnails
-#: filer.c:2004
+#: filer.c:2669
 msgid "T"
 msgstr "M"
 
-#: filer.c:2026
+#: filer.c:2670
+msgid "D"
+msgstr ""
+
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
+#, c-format
+msgid "Glob (%s), "
+msgstr ""
+
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Skanowanie, "
 
-#: filer.c:2028
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Miniaturki, "
 
-#: filer.c:2304
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Miniaturki, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "dowiązanie symboliczne do "
 
-#: filer.c:2335
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "Nazwa elementu nie jest w formacie UTF-8. Należy ją zmienić.\n"
 
 # ##
-#: filer.c:2643 menu.c:1989
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "Element już nie istnieje!"
 
-#: filer.c:3327
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Wybierz elementy widoku do zapisania"
 
-#: filer.c:3334
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Wybierz elementy widoku do zapisania"
+
+#: filer.c:4727
 msgid "Position"
 msgstr "Położenie"
 
-#: filer.c:3339 toolbar.c:135 toolbar.c:139 tips:63
-msgid "Size"
-msgstr "Rozmiar"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Okno"
 
-#: filer.c:3344
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Pokaż ukryte"
 
-#: filer.c:3350
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Styl widoku"
 
-#: filer.c:3356
+#: filer.c:4749
 #, fuzzy
 msgid "Sort type and order"
 msgstr "Posortowane wg właściciela"
 
-#: filer.c:3361 toolbar.c:143
+#: filer.c:4754
 msgid "Details"
 msgstr "Szczegóły"
 
-#: filer.c:3366 tips:114 tips:115
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Miniaturki"
 
-#: filer.c:3372
+#: filer.c:4765
 msgid "Filter"
 msgstr "Filtr"
 
-#: find.c:487
+#: find.c:485
 msgid "And"
 msgstr "i"
 
-#: find.c:511
+#: find.c:509
 msgid "Not"
 msgstr "nie"
 
-#: find.c:554
+#: find.c:552
 msgid "system"
 msgstr "system"
 
-#: find.c:562
+#: find.c:560
 msgid "prune"
 msgstr "pomiń"
 
-#: find.c:650
+#: find.c:648
 msgid "After"
 msgstr "po"
 
-#: find.c:652
+#: find.c:650
 msgid "Before"
 msgstr "przed"
 
-#: find.c:746
+#: find.c:744
 msgid "IsReg"
 msgstr "Plik?"
 
-#: find.c:748
+#: find.c:746
 msgid "IsLink"
 msgstr "Dowiązanie?"
 
-#: find.c:750
+#: find.c:748
 msgid "IsDir"
 msgstr "Katalog?"
 
-#: find.c:752
+#: find.c:750
 msgid "IsChar"
 msgstr "Znakowe?"
 
-#: find.c:754
+#: find.c:752
 msgid "IsBlock"
 msgstr "Blokowe?"
 
-#: find.c:756
+#: find.c:754
 msgid "IsDev"
 msgstr "Urządzenie?"
 
-#: find.c:758
+#: find.c:756
 msgid "IsPipe"
 msgstr "Potok?"
 
-#: find.c:760
+#: find.c:758
 msgid "IsSocket"
 msgstr "Gniazdo?"
 
-#: find.c:762
+#: find.c:760
 msgid "IsDoor"
 msgstr "Drzwi?"
 
-#: find.c:764
+#: find.c:762
 msgid "IsSUID"
 msgstr "SUID?"
 
-#: find.c:766
+#: find.c:764
 msgid "IsSGID"
 msgstr "SGID?"
 
-#: find.c:768
+#: find.c:766
 msgid "IsSticky"
 msgstr "Sticky?"
 
-#: find.c:770
+#: find.c:768
 msgid "IsReadable"
 msgstr "R?"
 
-#: find.c:772
+#: find.c:770
 msgid "IsWriteable"
 msgstr "W?"
 
-#: find.c:774
+#: find.c:772
 msgid "IsExecutable"
 msgstr "X?"
 
-#: find.c:776
+#: find.c:774
 msgid "IsEmpty"
 msgstr "Pusty?"
 
-#: find.c:778
+#: find.c:776
 msgid "IsMine"
 msgstr "Mój?"
 
-#: find.c:906
+#: find.c:904
 msgid "Now"
 msgstr "teraz"
 
-#: find.c:919
+#: find.c:917
 msgid "Byte"
 msgstr "bajt"
 
-#: find.c:919
+#: find.c:917
 msgid "Bytes"
 msgstr "bajty"
 
-#: find.c:921
+#: find.c:919
 msgid "Kb"
 msgstr ""
 
-#: find.c:921
+#: find.c:919
 msgid "K"
 msgstr ""
 
-#: find.c:923
+#: find.c:921
 msgid "Mb"
 msgstr ""
 
-#: find.c:923
+#: find.c:921
 msgid "M"
 msgstr ""
 
-#: find.c:925
+#: find.c:923
 msgid "Gb"
 msgstr ""
 
 #: find.c:925
-msgid "G"
-msgstr ""
-
-#: find.c:927
 msgid "Sec"
 msgstr "sekunda"
 
-#: find.c:927
+#: find.c:925
 msgid "Secs"
 msgstr "sekund"
 
-#: find.c:929
+#: find.c:927
 msgid "Min"
 msgstr "minuta"
 
-#: find.c:929
+#: find.c:927
 msgid "Mins"
 msgstr "minut"
 
-#: find.c:931
+#: find.c:929
 msgid "Hour"
 msgstr "godzina"
 
-#: find.c:931
+#: find.c:929
 msgid "Hours"
 msgstr "godzin"
 
-#: find.c:933
+#: find.c:931
 msgid "Day"
 msgstr "dzień"
 
-#: find.c:933
+#: find.c:931
 msgid "Days"
 msgstr "dni"
 
-#: find.c:935
+#: find.c:933
 msgid "Week"
 msgstr "tydzień"
 
-#: find.c:935
+#: find.c:933
 msgid "Weeks"
 msgstr "tygodni"
 
-#: find.c:937
+#: find.c:935
 msgid "Year"
 msgstr "rok"
 
-#: find.c:937
+#: find.c:935
 msgid "Years"
 msgstr "lata"
 
-#: find.c:946
+#: find.c:944
 msgid "Ago"
 msgstr "temu"
 
-#: find.c:948
+#: find.c:946
 msgid "Hence"
 msgstr "odtąd"
 
-#: find.c:963
+#: find.c:961
 msgid "atime"
 msgstr "dostęp"
 
-#: find.c:965
+#: find.c:963
 msgid "ctime"
 msgstr "utworzenie"
 
-#: find.c:967
+#: find.c:965
 msgid "mtime"
 msgstr "modyfikacja"
 
-#: find.c:969
+#: find.c:967
 msgid "size"
 msgstr "rozmiar"
 
-#: find.c:971
+#: find.c:969
 msgid "inode"
 msgstr "i-węzeł"
 
-#: find.c:973
+#: find.c:971
 msgid "nlinks"
 msgstr "dowiązania"
 
-#: find.c:975
+#: find.c:973
 msgid "uid"
 msgstr "uid"
 
-#: find.c:977
+#: find.c:975
 msgid "gid"
 msgstr "gid"
 
-#: find.c:979
+#: find.c:977
 msgid "blocks"
 msgstr "bloki"
 
-#: gtksavebox.c:251
+#: gtksavebox.c:249
 msgid "Save As:"
 msgstr "Zapisz jako:"
 
-#: gtksavebox.c:397
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "BezNazwy"
 
 # ##
-#: gtksavebox.c:473
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
@@ -1424,7 +1556,7 @@ msgstr ""
 "Zdalna aplikacja chce użyć funkcji bezpośredniego zapisu, ale nie mogę "
 "odczytać właściwości XdndDirectSave0 (typ text/plain).\n"
 
-#: gtksavebox.c:598
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1432,7 +1564,7 @@ msgstr ""
 "Przeciągnij ikonę do katalogu\n"
 "(lub wpisz pełną ścieżkę dostępu)"
 
-#: gui_support.c:331
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1440,20 +1572,21 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:400
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr ""
 "Próba odczytania pliku w formacie XML jako pliku tekstowego. Plik \"%s\" "
 "może być uszkodzony."
 
-#: gui_support.c:417
-#, c-format
+#: gui_support.c:542
+#, fuzzy, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
 "This may be due to upgrading from a previous version of ROX-Filer. Open the "
-"Options window and click on Save.\n"
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
 "Błąd w pliku \"%s\" w linii %d: \n"
@@ -1462,36 +1595,37 @@ msgstr ""
 "Otwórz okno opcji i kliknij Zapisz.\n"
 "Następne błędy zostaną zignorowane."
 
-#: gui_support.c:1000
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Niewłaściwy lub brakujący znak końca linii w danych text/uri-list"
 
-#: gui_support.c:1332
+#: gui_support.c:1473
 #, fuzzy, c-format
 msgid "Failed to open file '%s': %s"
 msgstr ""
 "!%s\n"
 "Kopiowanie \"%s\" nie powiodło się\n"
 
-#: gui_support.c:1376
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
 msgstr ""
 
-#: gui_support.c:1427
+#: gui_support.c:1583
+#, fuzzy, c-format
 msgid ""
-"This program cannot be run, as the 0launch command is not available. It can "
-"be downloaded from here:\n"
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
-"Program nie mógł zostać uruchomiony, ponieważ polecenie 0launch nie jest dostępne. Może być pobrane "
-"z tąd:\n"
+"Program nie mógł zostać uruchomiony, ponieważ polecenie 0launch nie jest "
+"dostępne. Może być pobrane z tąd:\n"
 "\n"
 "http://0install.net/injector.html"
 
-#: i18n.c:38
+#: i18n.c:39
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
@@ -1499,157 +1633,180 @@ msgstr ""
 "Po ustawieniu opcji programu należy zapisać zmiany i zrestartować program by "
 "ustawienia zaczęły w pełni działać."
 
-#: icon.c:78
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(kliknij by ustawić)"
 
-#: icon.c:133
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:134 menu.c:252
-msgid "About ROX-Filer..."
-msgstr "O ROX-Filerze..."
-
-#: icon.c:135 menu.c:253
-msgid "Show Help Files"
-msgstr "Wyświetl pliki z dokumentacją"
-
-#: icon.c:136 menu.c:254
-msgid "Manual"
-msgstr "Dokumentacja"
-
-#: icon.c:138 menu.c:230
-msgid "Options..."
-msgstr "Ustawienia..."
-
-#: icon.c:139 menu.c:239
-msgid "Home Directory"
-msgstr "Katalog domowy"
-
-#: icon.c:140 icon.c:1340 menu.c:206 type.c:212
-msgid "File"
-msgstr "Plik"
-
-#: icon.c:141 menu.c:212 menu.c:875
-msgid "Shift Open"
-msgstr "Otwórz (shift)"
-
-#: icon.c:142 menu.c:218
-msgid "Properties"
-msgstr "Właściwości"
-
-#: icon.c:143 menu.c:216
-msgid "Set Run Action..."
-msgstr "Określ akcję..."
-
-#: icon.c:144 menu.c:217
-msgid "Set Icon..."
-msgstr "Określ ikonę..."
-
-#: icon.c:145 icon.c:806
-msgid "Edit Item"
-msgstr "Modyfikacja elementu"
-
-#: icon.c:146
-msgid "Show Location"
-msgstr "Pokaż lokalizację"
-
-#: icon.c:147
-msgid "Remove Item(s)"
-msgstr "Usuń element(y)"
-
-#: icon.c:278 menu.c:764
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:291
+#: icon.c:311
 msgid "Nothing"
 msgstr "Nic"
 
-#: icon.c:547
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "Lokalizacja musi zawierać przynajmniej jeden znak!"
 
-#: icon.c:613
+#: icon.c:641
+#, c-format
+msgid "You must unlock '%s' before removing it"
+msgstr ""
+
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Należy najpierw zaznaczyć elementy do usunięcia"
 
-#: icon.c:627
+#: icon.c:657
+msgid "An item must be unlocked before it can be removed."
+msgstr ""
+
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Należy otworzyć menu nad elementem"
 
-#: icon.c:652 menu.c:1260
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "Można określić akcję jedynie dla zwykłego pliku"
 
-#: icon.c:738
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Naciśnij wybraną kombinację klawiszy (np. Control+F1)"
 
-#: icon.c:760
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Nie udało się przechwycić kombinacji klawiszy!"
 
-#: icon.c:809
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Modyfikacja elementu"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Kliknięcie na ikonę otwiera:"
 
-#: icon.c:819
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Parametry do przekazania poleceniu:"
 
-#: icon.c:833
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "Tekst wyświetlany pod ikoną:"
 
-#: icon.c:846
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "Kombinacja klawiszy:"
 
-#: infobox.c:112
+#: icon.c:910
+#, fuzzy
+msgid "Locked"
+msgstr "Gniazdo"
+
+#: icon.c:915
+msgid "Locking an item prevents it from being accidentally removed"
+msgstr ""
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "O ROX-Filerze..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Wyświetl pliki z dokumentacją"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Dokumentacja"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Ustawienia..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Katalog domowy"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Plik"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Otwórz (shift)"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Właściwości"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Określ akcję..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Określ ikonę..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Pokaż lokalizację"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Usuń element(y)"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
 msgstr "Czy na pewno chcesz otworzyć %d okien?"
 
-#: infobox.c:113
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Informacje"
 
-#: infobox.c:135 menu.c:769
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(zły UTF-8)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Pokaż pliki pomocy"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Uprawnienia</b>"
 
-#: infobox.c:286
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>Plik zawiera...</b>"
 
-#: infobox.c:423 infobox.c:560 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Wyświetlanie jedynie usuwanych katalogów"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "bajty"
 
-#: infobox.c:446
+#: infobox.c:480
 #, fuzzy
 msgid "Failed to read size"
 msgstr ""
 "!%s\n"
 "Kopiowanie \"%s\" nie powiodło się\n"
 
-#: infobox.c:504
+#: infobox.c:543
 #, fuzzy, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "!\"%s\" jest dowiązaniem symbolicznym \n"
 
-#: infobox.c:511
+#: infobox.c:550
 #, fuzzy, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1658,7 +1815,7 @@ msgstr ""
 "!%s\n"
 "Kopiowanie \"%s\" nie powiodło się\n"
 
-#: infobox.c:516
+#: infobox.c:555
 #, fuzzy, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1668,145 +1825,194 @@ msgstr ""
 "!%s\n"
 "Kopiowanie \"%s\" nie powiodło się\n"
 
-#: infobox.c:539 tips:270
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Błąd:"
 
-#: infobox.c:546
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Katalog:"
 
-#: infobox.c:549
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Właściciel, Grupa:"
 
-#: infobox.c:556 infobox.c:571 infobox.c:580
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Rozmiar:"
 
-#: infobox.c:581
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Skanowanie"
 
-#: infobox.c:602
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Błąd skanowania"
 
-#: infobox.c:609
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Data zmiany:"
 
-#: infobox.c:611
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Data modyfikacji:"
 
-#: infobox.c:613
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Data dostępu:"
 
-#: infobox.c:621
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Rozszerzone atrybuty:"
 
-#: infobox.c:623
+#: infobox.c:667
 msgid "Present"
 msgstr ""
 
-#: infobox.c:624
+#: infobox.c:668
 msgid "None"
 msgstr "brak"
 
-#: infobox.c:625
+#: infobox.c:669
 msgid "Not supported"
 msgstr "nie obsługiwane"
 
-#: infobox.c:637
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Cel dowiązania:"
 
-#: infobox.c:649 infobox.c:652
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Akcja:"
 
-#: infobox.c:649
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Uruchom plik"
 
-#: infobox.c:744
+#: infobox.c:805
+#, fuzzy
+msgid "Comment"
+msgstr "Polecenie:"
+
+#: infobox.c:807
+#, fuzzy
+msgid "Execute"
+msgstr "Uruchom plik"
+
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<jeszcze nic>"
 
-#: infobox.c:814
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "Informacja z file(1)... %s"
 
-#: infobox.c:871
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Nie można zmienić uprawnień do %s"
 
-#: infobox.c:889
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Właściciel"
 
-#: infobox.c:891
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Grupa"
 
-#: infobox.c:893
+#: infobox.c:974
 msgid "World"
 msgstr "Inni"
 
-#: infobox.c:896
+#: infobox.c:977
 msgid "Read"
 msgstr "Odczyt"
 
-#: infobox.c:898
+#: infobox.c:980
 msgid "Write"
 msgstr "Zapis"
 
-#: infobox.c:900
+#: infobox.c:983
 msgid "Exec"
 msgstr "Wykonanie"
 
-#: infobox.c:917
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:924
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:931
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky"
 
-#: infobox.c:953
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<brak>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Dowiązanie symboliczne"
 
-#: infobox.c:956
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "Aplikacja ROXa"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "mounted"
 msgstr "zamontowany"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "odmontowany"
 
-#: infobox.c:968
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Punkt zamontowania dla %s (%s)"
 
-#: infobox.c:971
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Punkt zamontowania (%s)"
+
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d plików"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Kopiuj..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "Modyfikacja elementu"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Czas"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Ustawienia"
 
 #: main.c:95
 msgid ""
@@ -1844,7 +2050,7 @@ msgstr ""
 "\n"
 
 #: main.c:115
-#, fuzzy
+#, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Open each directory or file listed, or the current working\n"
@@ -1866,10 +2072,12 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
-"Report bugs to "
+"Report bugs to %s.\n"
+"Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
 "Użycie: rox [OPCJA]... [PLIK]...\n"
 "Otwiera podany katalog lub plik.\n"
@@ -1899,13 +2107,7 @@ msgstr ""
 "języku angielskim).\n"
 " \n"
 
-#: main.c:136
-msgid ""
-".\n"
-"Home page (including updated versions): http://rox.sourceforge.net/\n"
-msgstr ""
-
-#: main.c:234
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1913,287 +2115,386 @@ msgid ""
 "Trying to continue..."
 msgstr ""
 
-#: main.c:382
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
 msgstr ""
 "Parametr -o nie jest już używany. Opcja została przeniesiona do ustawień."
 
-#: main.c:489
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Uruchomiony jsko użytkownik '%s'"
 
-#: main.c:666
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Skompilowane z GTK w wersji %s\n"
 
-#: main.c:667
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Uruchomione z GTK w wersji %d.%d.%d\n"
 
-#: main.c:671
+#: main.c:693
 msgid "features set at compile time"
 msgstr "właściwości włączone podczas kompilacji"
 
-#: main.c:672
+#: main.c:694
 msgid "Large File Support"
 msgstr "Obsługa dużych plików"
 
-#: main.c:679
-msgid "GNOME-VFS library"
-msgstr "Biblioteka GNOME-VFS"
-
-#: main.c:683
-msgid "No (need 2.8.0 or later)"
-msgstr ""
-
-#: main.c:686
-msgid "Dnotify support"
-msgstr ""
-
-#: main.c:693
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Zgodność binarna"
 
-#: main.c:695
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr ""
 
-#: main.c:697
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr ""
 
-#: menu.c:180 tips:52
+#: main.c:709
+#, fuzzy
+msgid "Extended attribute support"
+msgstr "Rozszerzone atrybuty"
+
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr ""
+"!%s\n"
+"Kopiowanie \"%s\" nie powiodło się\n"
+
+#: main.c:895
+#, c-format
+msgid ""
+"Left-click to run %s.\n"
+"Right-click for a list of versions."
+msgstr ""
+
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Błąd przy tworzeniu \"%s\": %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Zapisz jako:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Wyświetlanie"
 
-#: menu.c:181 tips:57
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "Widok ikon"
 
-#: menu.c:182
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "Ikony oraz..."
 
-#: menu.c:183 tips:74
-msgid "Sizes"
-msgstr "Rozmiar"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Styl "
 
-#: menu.c:185 tips:254
-msgid "Types"
-msgstr "Typy"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Uprawnienia"
 
-#: menu.c:186 tips:77
-msgid "Times"
-msgstr "Czas"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Ikony oraz..."
 
-#: menu.c:187 tips:58 tips:92
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "Widok listy"
 
-#: menu.c:189
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "Większe ikony"
 
-#: menu.c:190
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "Mniejsze ikony"
 
-#: menu.c:191 tips:71
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Automatycznie"
 
-#: menu.c:193
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Posortowane wg nazw"
 
-#: menu.c:194
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Posortowane wg typów"
 
-#: menu.c:195
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Posortowane wg dat"
 
-#: menu.c:196
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Posortowane wg dat"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Posortowane wg dat"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Posortowane wg rozmiaru"
 
-#: menu.c:197
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Uprawnienia"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "Posortowane wg właściciela"
 
-#: menu.c:198
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "Posortowane wg grup"
 
-#: menu.c:199
+#: menu.c:671
 msgid "Reversed"
 msgstr "Odwrotnie"
 
-#: menu.c:201
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "Pokaż ukryte"
 
-#: menu.c:202
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Wyświetl pliki z dokumentacją"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "brak katalogów)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "Filtruj pliki..."
 
-#: menu.c:203
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Filtruj pliki..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "Pokaż miniaturki"
 
-#: menu.c:204
+#: menu.c:683
 msgid "Refresh"
 msgstr "Odśwież"
 
-#: menu.c:205
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Odśwież"
+
+#: menu.c:686
 msgid "Save Display Settings..."
 msgstr "Zapisz ustawienia..."
 
-#: menu.c:207
-msgid "Copy..."
-msgstr "Kopiuj..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Zapisz ustawienia..."
 
-#: menu.c:208
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Zlicz"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "Zmień nazwę..."
 
-#: menu.c:209
+#: menu.c:700
 msgid "Link..."
 msgstr "Dowiąż..."
 
-#: menu.c:213
-msgid "Open AVFS"
-msgstr "Otwórz AVFS"
-
-#: menu.c:214
+#: menu.c:708
 msgid "Send To..."
 msgstr "Wyślij do..."
 
-#: menu.c:219
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Rozszerzone atrybuty"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Zlicz"
 
-#: menu.c:220
+#: menu.c:723
 msgid "Set Type..."
 msgstr "Ustaw typ..."
 
-#: menu.c:224 toolbar.c:155
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Wybierz"
 
-#: menu.c:225
+#: menu.c:733
 msgid "Select All"
 msgstr "Wybierz wszystkie"
 
-#: menu.c:226
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "Wyczyść wybór"
 
-#: menu.c:227
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "Odwróć wybór"
 
-#: menu.c:228
+#: menu.c:737
 #, fuzzy
 msgid "Select by Name..."
 msgstr "Posortowane wg nazw"
 
-#: menu.c:229
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Zaznacz gdy..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Zaznacz gdy..."
 
-#: menu.c:231
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Nowy"
 
-#: menu.c:233
+#: menu.c:752
 msgid "Blank file"
 msgstr "Pusty plik"
 
-#: menu.c:235 tasklist.c:308
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Okno"
 
-#: menu.c:236
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "Katalog nadrzędny w nowym oknie"
 
-#: menu.c:237
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "Katalog nadrzędny w tym oknie"
 
-#: menu.c:238
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "Nowe okno"
 
-#: menu.c:240
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "Pokaż zakładki"
 
-#: menu.c:241
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Informacje"
+
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "Podąż za dowiązaniem symbolicznym"
 
-#: menu.c:242
+#: menu.c:769
 msgid "Resize Window"
 msgstr "Zmień rozmiar okna"
 
-#: menu.c:245
+#: menu.c:771
 msgid "Close Window"
 msgstr "Zamknij okno"
 
-#: menu.c:247
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Podaj Scieżkę..."
 
-#: menu.c:248
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Polecenie..."
 
-#: menu.c:249
-msgid "Xterm Here"
+#: menu.c:780
+#, fuzzy
+msgid "Terminal Here"
 msgstr "Terminal w tym katalogu"
 
-#: menu.c:250
-msgid "Switch to xterm"
+#: menu.c:782
+#, fuzzy
+msgid "Switch to Terminal"
 msgstr "Przełącz do terminala"
 
-#: menu.c:718
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "Aby wysłać gdziekolwiek plik, należy użyć Shift+Menu nad plikiem"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Dostosuj menu..."
 
-#: menu.c:754
+#: menu.c:976
 msgid "Next Click"
 msgstr "Następne kliknięcie"
 
-#: menu.c:776
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d plików"
 
-#: menu.c:864
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "Otwórz bez montowania"
 
-#: menu.c:867
+#: menu.c:1097
 msgid "Show Target"
 msgstr "Pokaż cel"
 
-#: menu.c:869
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "Zajrzyj do środka"
 
-#: menu.c:871
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "Otwórz jako tekst"
 
-#: menu.c:1031
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2202,15 +2503,15 @@ msgid ""
 "mount option ('user_xattr' on Linux)."
 msgstr ""
 
-#: menu.c:1037
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr ""
 
-#: menu.c:1072
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "dowiązanie _relatywne"
 
-#: menu.c:1078
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2224,43 +2525,53 @@ msgstr ""
 "Użyj tego, jeśli dowiązanie symboliczne może być przeniesione, ale plik "
 "dowiązany ma zostać na miejscu."
 
-#: menu.c:1148
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "Nowa ścieżka nie jest absolutna"
 
-#: menu.c:1214
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr "Dowiązanie z \"%s\" już istnieje. Zamienić je dowiązaniem do \"%s\"?"
 
-#: menu.c:1220
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Zamień"
 
-#: menu.c:1351 menu.c:1392 menu.c:1452
-msgid "Create"
-msgstr "Utwórz"
-
-#: menu.c:1352
+#: menu.c:1704
 msgid "NewDir"
 msgstr "NowyKatalog"
 
-#: menu.c:1366 menu.c:1372
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Błąd przy tworzeniu \"%s\": %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Utwórz"
 
-#: menu.c:1393
+#: menu.c:1755
 msgid "NewFile"
 msgstr "NowyPlik"
 
-#: menu.c:1411
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "Błąd tworzenia pliku: nie można znaleźć szablonu dla %s"
 
-#: menu.c:1482
-#, c-format
+#: menu.c:1847
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2272,8 +2583,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "Menu \"Wyślij do\" zapewnia szybki sposób wysyłania wybranych plików do "
 "aplikacji. Aplikacje wymienione są w następujących katalogach:\n"
@@ -2288,7 +2600,7 @@ msgstr ""
 "które zostaną użyte tylko dla plików tego typu. \".grupa\" będzie "
 "wyświetlona tylko jeśli zaznaczonych będzie kilka plików."
 
-#: menu.c:1493
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
@@ -2296,12 +2608,12 @@ msgstr ""
 "Zostanie otwarty katalog SendTo. Można w nim tworzyć odnośniki (np. "
 "przezprzeciąganie z jednoczesnym wciśnięciem Ctrl+Shift)."
 
-#: menu.c:1496 menu.c:1536
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr ""
 "Ustawienie zmiennej CHOICESPATH wyłącza możliwość dostosowywania ustawień."
 
-#: menu.c:1529
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2313,7 +2625,7 @@ msgid ""
 "%s\n"
 msgstr ""
 
-#: menu.c:1534
+#: menu.c:1936
 #, fuzzy
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
@@ -2322,15 +2634,21 @@ msgstr ""
 "Zostanie otwarty katalog SendTo. Można w nim tworzyć odnośniki (np. "
 "przezprzeciąganie z jednoczesnym wciśnięciem Ctrl+Shift)."
 
-#: menu.c:1651
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Dostosuj"
 
-#: menu.c:1717
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Dostosuj menu..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "To już jest nazwa kanoniczna dla tego katalogu."
 
-#: menu.c:1748
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2338,76 +2656,104 @@ msgstr ""
 "Nie można otworzyć drugiego okna dla tego katalogu, ponieważ jest włączona "
 "opcja \"unikalnych okien\" w konfiguracji."
 
-#: menu.c:1869
-msgid "Copy ... ?"
-msgstr "Skopiować ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1872
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Skopiować %s jako %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Skopiować %s jako %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Przenieść ... ?"
 
-#: menu.c:1875
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Dowiązać ... ?"
 
-#: menu.c:1878
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Otwórz (shift) .. ?"
 
-#: menu.c:1881
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Właściwości ... ?"
 
-#: menu.c:1884
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Rozszerzone atrybuty"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Określ typ dla ... ?"
 
-#: menu.c:1887
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Określ akcję dla ... ?"
 
-#: menu.c:1890
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Określ ikonę dla ... ?"
 
-#: menu.c:1893
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Wyślij do ... ?"
 
-#: menu.c:1896
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "SKASOWAĆ ... ?"
 
-#: menu.c:1899
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Zlicz rozmiar ... ?"
 
-#: menu.c:1902
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Ustaw uprawnienia ... ?"
 
-#: menu.c:1905
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Szukać wewnątrz ... ?"
 
-#: menu.c:1908
-msgid "Look inside ... ?"
-msgstr "Zajrzeć do środka ... ?"
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Skopiować ... ?"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
 
 # ##
-#: menu.c:1972
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Nie można tego zrobić dla więcej niż jednego elementu"
 
-#: menu.c:2004
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Przenieś"
 
-#: menu.c:2009
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Dowiąż"
 
-#: menu.c:2041
+#: menu.c:2654
 #, fuzzy
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
@@ -2427,7 +2773,7 @@ msgstr ""
 "2) dodając następującą linię do ~/.gtkrc-2.0:\n"
 "\tgtk-can-change-accels = 1"
 
-#: menu.c:2052
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2447,31 +2793,40 @@ msgstr ""
 "Zdefiniowana kombinacja pokaże się w menu. Od tej chwili wystarczy nacisnąć "
 "tę kombinacje, aby wybrać funkcję bez korzystania z menu."
 
-#: menu.c:2067
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Ustaw skróty klawiszowe"
 
-#: minibuffer.c:131
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Idź do:"
 
-#: minibuffer.c:132
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Polecenie:"
 
-#: minibuffer.c:133
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Zaznacz gdy:"
 
-#: minibuffer.c:134
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr ""
 
-#: minibuffer.c:135
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Zaznacz gdy:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Wzór:"
 
-#: minibuffer.c:264
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
@@ -2479,14 +2834,26 @@ msgstr ""
 "Wprowadź nazwę pliku do wyświetlenia. \"Tab\" uzupełnia do najdłuższej "
 "zgadzającej się nazwy. \"Escape\" zamyka minibufor."
 
-#: minibuffer.c:270
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
 "Wprowadź polecenie do wykonania. Kliknij na plik, aby dodać jego nazwę do "
 "bufora."
 
-#: minibuffer.c:275
+#: minibuffer.c:331
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2497,49 +2864,60 @@ msgid ""
 "*.png means any name ending in '.png'"
 msgstr ""
 
-#: minibuffer.c:287
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
 msgstr ""
 
-#: minibuffer.c:895
+#: minibuffer.c:358
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Nieprawidłowe wyrażenie"
 
-#: mount.c:374
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr ""
 
-#: options.c:277
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr ""
 "Stary plik z konfiguracją został przekonwertowany na nowy w formacie XML."
 
-#: options.c:535 options.c:1258
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(użyj domyślnej)"
 
-#: options.c:806
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Wewnętrzny błąd - %s nie jest odczytywalny"
 
-#: options.c:917
+#: options.c:929
 msgid "Options"
 msgstr "Ustawienia"
 
-#: options.c:962
+#: options.c:974
 msgid "_Revert"
 msgstr "_Przywróć"
 
-#: options.c:968
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr ""
 "Przywraca ustawienia do takich jakie były przed otwarciem okna \"Opcje\""
 
-#: options.c:983
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2548,26 +2926,38 @@ msgstr ""
 "Wybór zostanie zapisany jako:\n"
 "%s"
 
-#: options.c:991
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(zapis wyłączony przez zmienną CHOICESPATH)"
 
-#: options.c:1164 usericons.c:450
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Błąd przy zapisywaniu %s: %s"
 
-#: options.c:1794
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Brakuje \"=\""
 
-#: panel.c:439
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr ""
+"!%s\n"
+"Kopiowanie \"%s\" nie powiodło się\n"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr ""
 "Stary plik z konfiguracją panelu został przekonwertowany na nowy w formacie "
 "XML."
 
-#: panel.c:546
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
@@ -2575,20 +2965,20 @@ msgstr ""
 "Zamykanie panelu z poziomu managera okien zazwyczaj jest wynikiem "
 "przypadkowego działania."
 
-#: panel.c:639
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Brakujące < lub > w pliku konfiguracyjnym panelu"
 
-#: panel.c:1519
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Błąd zapisu konfiguracji panelu %s: %s"
 
-#: panel.c:1835
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "Aplet zakończył działanie bez utworzenia widżeta."
 
-#: panel.c:1934
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2597,59 +2987,50 @@ msgstr ""
 "Błąd przy uruchamianiu apletu:\n"
 "%s"
 
-#: panel.c:2335
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "Czy na pewno chcesz otworzyć %d okien?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Usuń element(y)"
+
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Ustawienia panelu..."
 
-#: panel.c:2427
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr ""
 
-#: panel.c:2502
-msgid "Panel Options"
-msgstr "Ustawienia panelu"
-
-#: panel.c:2517
-#, c-format
-msgid "Panel: %s"
-msgstr "Panel: %s"
-
-#: panel.c:2525
-msgid "Select the panel's position:"
+#: panel.c:2897
+msgid "Top"
 msgstr ""
 
-#: panel.c:2531
-msgid "Top-edge panel"
+#: panel.c:2899
+msgid "Bottom"
 msgstr ""
 
-#: panel.c:2532
-msgid "Top edge"
+#: panel.c:2901
+msgid "Left"
 msgstr ""
 
-#: panel.c:2533
-msgid "Bottom edge panel"
+#: panel.c:2903
+msgid "Right"
 msgstr ""
 
-#: panel.c:2534
-msgid "Bottom edge"
-msgstr ""
+#: panel.c:2905
+#, fuzzy
+msgid "Default"
+msgstr "Domyślny rozmiar:"
 
-#: panel.c:2535
-msgid "Left edge panel"
-msgstr ""
-
-#: panel.c:2536
-msgid "Left edge"
-msgstr ""
-
-#: panel.c:2537
-msgid "Right-edge panel"
-msgstr ""
-
-#: panel.c:2538
-msgid "Right edge"
-msgstr ""
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "Nieznane"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
@@ -2657,7 +3038,7 @@ msgstr ""
 "Stary plik z konfiguracją biurka został przekonwertowany na nowy w formacie "
 "XML."
 
-#: pinboard.c:635
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
@@ -2667,7 +3048,7 @@ msgstr ""
 "katalog takiej aplikacji na okno dialogowe Ustaw Tło, lub (dla programistów) "
 "przekaż używając metody SOAP SetBackdropApp."
 
-#: pinboard.c:654
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2680,52 +3061,64 @@ msgstr ""
 "Dla programistów: AppInfo.xml musi zawierać element \"CanSetBackdrop\" tak "
 "jak jest to opisane w dokumentacji ROX-Filera."
 
-#: pinboard.c:674
+#: pinboard.c:750
 msgid "Set backdrop"
 msgstr "Ustaw tło"
 
-#: pinboard.c:685
+#: pinboard.c:761
 #, fuzzy
 msgid "Choose a style and drag an image in:"
 msgstr "Wybierz styl i przeciągnij obraz."
 
-#: pinboard.c:698
+#: pinboard.c:774
 msgid "Centre the image without scaling it"
 msgstr "Umieść obraz na środku ekranu"
 
-#: pinboard.c:699
+#: pinboard.c:775
 msgid "Centre"
 msgstr "Wyśrodkowany"
 
-#: pinboard.c:700
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr "Przeskaluj obraz z zachowaniem proporcji"
 
-#: pinboard.c:702
+#: pinboard.c:778
 msgid "Scale"
 msgstr "Przeskalowany"
 
-#: pinboard.c:703
+#: pinboard.c:779
+#, fuzzy
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr "Przeskaluj obraz z zachowaniem proporcji"
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Filtr"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
 msgstr "Rozciągnij obraz na całą powierzchnię biurka"
 
-#: pinboard.c:704
+#: pinboard.c:783
 msgid "Stretch"
 msgstr "Rozciągnięty"
 
-#: pinboard.c:705
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr "Ułóż obraz sąsiadująco"
 
-#: pinboard.c:706
+#: pinboard.c:785
 msgid "Tile"
 msgstr "Sąsiadująco"
 
-#: pinboard.c:711
+#: pinboard.c:790
 msgid "Drop an image here"
 msgstr "Przeciągnij tutaj obrazek"
 
-#: pinboard.c:772
+#: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
@@ -2733,31 +3126,36 @@ msgstr ""
 "Nie był użyty żaden pulpit... został wybrany 'Default'. Użyj \"rox -p=Default"
 "\" by włączyć go w przyszłości."
 
-#: pinboard.c:866
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
 msgstr ""
 "Tylko pliki (i odpowiednie aplikacje) mogą być użyte do ustawienia tła biurka"
 
-#: pinboard.c:1471
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Brakujący znak \">\" w etykiecie ikony"
 
-#: pinboard.c:1480
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Brakujący przecinek za etykietą ikony"
 
-#: pinboard.c:1565
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Błąd przy zapisywaniu konfiguracji pulpitu %s: %s"
 
-#: pinboard.c:2109
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Tło..."
 
-#: pinboard.c:2202
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Panel"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2768,7 +3166,7 @@ msgstr ""
 "%s\n"
 "Tło usunięte."
 
-#: pixmaps.c:991
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2777,61 +3175,90 @@ msgstr ""
 "Nie można usunąć miniaturek w %s:\n"
 "%s"
 
-#: pixmaps.c:1012
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Nie ma żadnych miniaturek do skasowania."
 
-#: pixmaps.c:1025
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Wyczyszczenie bufora miniaturek"
 
-#: remote.c:624
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Nieznany styl '%s'"
 
-#: remote.c:646
+#: remote.c:786
 #, fuzzy, c-format
 msgid "Unknown details type '%s'"
 msgstr "Nieznany typ:"
 
-#: remote.c:674
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Nieznany typ sortowania '%s'"
 
-#: remote.c:1117
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Wywołanie nieznanej metody SOAP \"%s\""
 
-#: rox_gettext.c:95
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Niewłaściwy (zbyt krótki) plik z tłumaczeniem: %s"
-
-#: rox_gettext.c:108
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Niewłaściwy (brak magicznego numeru GNU) plik z tłumaczeniem: %s"
-
 # ##, c-format
-#: run.c:96 run.c:141
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "Nie znaleziono programu %s - skasowany?"
 
-#: run.c:287
+#: run.c:359
+#, fuzzy, c-format
+msgid ""
+"No run action specified for files of this type (%s/%s) - you can set a run "
+"action by choosing `Set Run Action' from the File menu, or you can just drag "
+"the file to an application.%s"
+msgstr ""
+"Nie wiadomo w jaki sposób uaktywnić plik tego typu (%s/%s) - można określić "
+"domyślną akcję wybierając polecenie \"Określ akcję\" z menu lub przeciągnąć "
+"ikonę tego pliku na odpowiedni program"
+
+#: run.c:365
+msgid ""
+"\n"
+"\n"
+"Note: If this is a computer program which you want to run, you need to set "
+"the execute bit by choosing Permissions from the File menu."
+msgstr ""
+
+#: run.c:373
 #, c-format
 msgid "File doesn't exist, or I can't access it: %s"
 msgstr "Plik nie istnieje lub nie można go otworzyć: %s"
 
-#: run.c:292
+#: run.c:378
 #, c-format
 msgid "I don't know how to open '%s'"
 msgstr "Nie wiadomo jak otworzyć \"%s\""
 
-#: run.c:323
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "!\"%s\" jest dowiązaniem symbolicznym \n"
+
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "Katalog \"%s\" nie jest dostępny"
+
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "Niewykonywalny %s"
+
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Błąd w obsłudze %s: %s"
+
+#: run.c:465
 msgid ""
 "Application:\n"
 "This is an application directory - you can run it as a program, or open it "
@@ -2843,222 +3270,23 @@ msgstr ""
 "katalog (przytrzymując Shift). Większość aplikacji udostępnia własną pomoc, "
 "ale nie ten."
 
-#: run.c:407
+#: run.c:549
 #, c-format
 msgid "Could not send data to program: %s"
 msgstr "Nie można wysłać danych do programu: %s"
 
-#: run.c:437
+#: run.c:578
 #, c-format
 msgid "Could not read link: %s"
 msgstr "Nie można odczytać dowiązania: %s"
 
 # ##, c-format
-#: run.c:465
+#: run.c:606
 #, c-format
 msgid "Broken symlink (or you don't have permission to follow it): %s"
 msgstr "Zerwane dowiązanie (lub nie brak uprawnień by nim podążać): %s"
 
-#: run.c:502
-#, fuzzy, c-format
-msgid ""
-"No run action specified for files of this type (%s/%s) - you can set a run "
-"action by choosing `Set Run Action' from the File menu, or you can just drag "
-"the file to an application.%s"
-msgstr ""
-"Nie wiadomo w jaki sposób uaktywnić plik tego typu (%s/%s) - można określić "
-"domyślną akcję wybierając polecenie \"Określ akcję\" z menu lub przeciągnąć "
-"ikonę tego pliku na odpowiedni program"
-
-#: run.c:508
-msgid ""
-"\n"
-"\n"
-"Note: If this is a computer program which you want to run, you need to set "
-"the execute bit by choosing Permissions from the File menu."
-msgstr ""
-
-#: support.c:272
-msgid "B"
-msgstr "B"
-
-#: support.c:351
-msgid "byte"
-msgstr "bajt"
-
-#: toolbar.c:115
-msgid "Close"
-msgstr "Zamknij"
-
-#: toolbar.c:115
-msgid "Close filer window"
-msgstr "Zamknij okno"
-
-#: toolbar.c:119
-msgid "Up"
-msgstr "W górę"
-
-#: toolbar.c:119
-msgid "Change to parent directory"
-msgstr "Przejdź do katalogu nadrzędnego"
-
-#: toolbar.c:123
-msgid "Home"
-msgstr "Dom"
-
-#: toolbar.c:123
-msgid "Change to home directory"
-msgstr "Przejdź do katalogu domowego"
-
-#: toolbar.c:127
-msgid "Bookmarks"
-msgstr "Zakładki"
-
-#: toolbar.c:127
-msgid "Bookmarks menu"
-msgstr "Menu zakładek"
-
-#: toolbar.c:131
-msgid "Scan"
-msgstr "Odśwież"
-
-#: toolbar.c:131
-msgid "Rescan directory contents"
-msgstr "Odczytaj ponownie zawartość katalogu"
-
-#: toolbar.c:135
-msgid "Change icon size"
-msgstr "Zmień rozmiar ikon"
-
-#: toolbar.c:139
-msgid "Automatic size mode"
-msgstr "Automatyczna zmiana rozmiaru okna"
-
-#: toolbar.c:143
-msgid "Show extra details"
-msgstr "Pokaż szczegóły"
-
-#: toolbar.c:147
-msgid "Sort"
-msgstr "Sortowanie"
-
-#: toolbar.c:147
-msgid "Change sort criteria"
-msgstr "Zmienia tryb sortowania"
-
-#: toolbar.c:151
-msgid "Hidden"
-msgstr "Ukryte"
-
-#: toolbar.c:151
-msgid "Show/hide hidden files"
-msgstr "Pokaż/ukryj ukryte pliki"
-
-#: toolbar.c:155
-#, fuzzy
-msgid "Select all/invert selection"
-msgstr "Odwróć wybór"
-
-#: toolbar.c:159
-msgid "Show ROX-Filer help"
-msgstr "Pokaż pomoc ROX-Filer-a"
-
-#: toolbar.c:220
-#, c-format
-msgid " (%u hidden)"
-msgstr " (%u ukrytych)"
-
-#: toolbar.c:228 tips:80
-msgid "items"
-msgstr "elementów"
-
-#: toolbar.c:228
-msgid "item"
-msgstr "element"
-
-#: toolbar.c:231
-#, c-format
-msgid "No items%s"
-msgstr "Brak elementów %s"
-
-#: toolbar.c:250
-#, c-format
-msgid "%u selected (%s)"
-msgstr "%u zaznaczonych (%s)"
-
-#: toolbar.c:422
-msgid "Sort by name"
-msgstr "Posortowane wg nazw"
-
-#: toolbar.c:422
-msgid "Sort by type"
-msgstr "Posortowane wg typów"
-
-#: toolbar.c:422
-msgid "Sort by date"
-msgstr "Posortowane wg dat"
-
-#: toolbar.c:423
-msgid "Sort by size"
-msgstr "Posortowane wg rozmiaru"
-
-#: toolbar.c:423
-msgid "Sort by owner"
-msgstr "Posortowane wg właściciela"
-
-#: toolbar.c:423
-msgid "Sort by group"
-msgstr "Posortowane wg grup"
-
-#: toolbar.c:457
-msgid "ascending"
-msgstr "rosnąco"
-
-#: toolbar.c:457
-msgid "descending"
-msgstr "malejąco"
-
-#: type.c:203
-msgid "Sym link"
-msgstr "Dowiązanie symboliczne"
-
-#: type.c:205
-msgid "Mount point"
-msgstr "Punkt montowania"
-
-#: type.c:207
-msgid "App dir"
-msgstr "Katalog aplikacji"
-
-#: type.c:214
-msgid "Dir"
-msgstr "Katalog"
-
-#: type.c:216
-msgid "Char dev"
-msgstr "Urządzenie znakowe"
-
-#: type.c:218
-msgid "Block dev"
-msgstr "Urządzenie blokowe"
-
-#: type.c:220
-msgid "Pipe"
-msgstr "Potok"
-
-#: type.c:222
-msgid "Socket"
-msgstr "Gniazdo"
-
-#: type.c:224
-msgid "Door"
-msgstr "Drzwi"
-
-#: type.c:227
-msgid "Unknown"
-msgstr "Nieznane"
-
-#: type.c:355
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3082,11 +3310,284 @@ msgstr ""
 "przeciwnym wypadku należy sprawdzić (a najlepiej skasować) wszystkie pliki "
 "od akcji."
 
-#: type.c:368
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Naprawia problem z bezpieczeństwem)"
 
-#: type.c:498
+#: support.c:288
+msgid " "
+msgstr ""
+
+#: support.c:381
+msgid "byte"
+msgstr "bajt"
+
+#: support.c:1531 support.c:1585
+#, fuzzy, c-format
+msgid "Failed to open and stat file '%s': %s"
+msgstr ""
+"!%s\n"
+"Kopiowanie \"%s\" nie powiodło się\n"
+
+#: support.c:1542 support.c:1596
+#, fuzzy, c-format
+msgid "Failed to mmap file '%s': %s"
+msgstr ""
+"!%s\n"
+"Kopiowanie \"%s\" nie powiodło się\n"
+
+#: toolbar.c:116
+msgid "Close"
+msgstr "Zamknij"
+
+#: toolbar.c:116
+msgid "Close filer window"
+msgstr "Zamknij okno"
+
+#: toolbar.c:120
+msgid "Up"
+msgstr "W górę"
+
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
+
+#: toolbar.c:126
+msgid "Home"
+msgstr "Dom"
+
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
+
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
+
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
+
+#: toolbar.c:138
+msgid "Scan"
+msgstr "Odśwież"
+
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
+
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Rozmiar"
+
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automatycznie"
+
+#: toolbar.c:155
+msgid "Automatic size mode"
+msgstr "Automatyczna zmiana rozmiaru okna"
+
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Widok listy"
+
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
+msgid "Sort"
+msgstr "Sortowanie"
+
+#: toolbar.c:165
+msgid "Change sort criteria"
+msgstr "Zmienia tryb sortowania"
+
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
+
+#: toolbar.c:169
+msgid ""
+"Left: Show/hide hidden files\n"
+"Right: Show/hide thumbnails"
+msgstr ""
+
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "Odwróć wybór"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
+msgid "Show ROX-Filer help"
+msgstr "Pokaż pomoc ROX-Filer-a"
+
+#: toolbar.c:270
+#, c-format
+msgid " (%u hidden)"
+msgstr " (%u ukrytych)"
+
+#: toolbar.c:276 tips:79
+msgid "items"
+msgstr "elementów"
+
+#: toolbar.c:276
+msgid "item"
+msgstr "element"
+
+#: toolbar.c:279
+#, c-format
+msgid "No items%s"
+msgstr "Brak elementów %s"
+
+#: toolbar.c:298
+#, c-format
+msgid "%u selected (%s)"
+msgstr "%u zaznaczonych (%s)"
+
+#: toolbar.c:535
+msgid "Sort by name"
+msgstr "Posortowane wg nazw"
+
+#: toolbar.c:535
+msgid "Sort by type"
+msgstr "Posortowane wg typów"
+
+#: toolbar.c:535
+msgid "Sort by date"
+msgstr "Posortowane wg dat"
+
+#: toolbar.c:535
+msgid "Sort by size"
+msgstr "Posortowane wg rozmiaru"
+
+#: toolbar.c:536
+msgid "Sort by owner"
+msgstr "Posortowane wg właściciela"
+
+#: toolbar.c:536
+msgid "Sort by group"
+msgstr "Posortowane wg grup"
+
+#: toolbar.c:568
+msgid "ascending"
+msgstr "rosnąco"
+
+#: toolbar.c:568
+msgid "descending"
+msgstr "malejąco"
+
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
+msgid "Sym link"
+msgstr "Dowiązanie symboliczne"
+
+#: type.c:223
+msgid "Mount point"
+msgstr "Punkt montowania"
+
+#: type.c:225
+msgid "App dir"
+msgstr "Katalog aplikacji"
+
+#: type.c:232
+msgid "Dir"
+msgstr "Katalog"
+
+#: type.c:234
+msgid "Char dev"
+msgstr "Urządzenie znakowe"
+
+#: type.c:236
+msgid "Block dev"
+msgstr "Urządzenie blokowe"
+
+#: type.c:238
+msgid "Pipe"
+msgstr "Potok"
+
+#: type.c:240
+msgid "Socket"
+msgstr "Gniazdo"
+
+#: type.c:242
+msgid "Door"
+msgstr "Drzwi"
+
+#: type.c:245
+msgid "Unknown"
+msgstr "Nieznane"
+
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3096,72 +3597,72 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:679
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "To nie jest program."
 
-#: type.c:740
+#: type.c:839
 msgid "No run action defined"
 msgstr "Brak określonej akcji"
 
-#: type.c:766
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Błąd w obsłudze %s: %s"
 
-#: type.c:781
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Niewłaściwa aplikacja %s (niewłaściwy AppRun)"
 
-#: type.c:792
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "Niewykonywalny %s"
 
-#: type.c:825
+#: type.c:902
 msgid "Set run action"
 msgstr "Określ akcję"
 
-#: type.c:831
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 "Jeżeli nie została zdefiniowana obsługa danego typu pliku, użyj tego jako "
 "domyślnego programu."
 
-#: type.c:833
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Ustaw domyślnie dla wszystkich \"%s/<cokolwiek>\""
 
-#: type.c:837
+#: type.c:914
 #, fuzzy
 msgid "Use this application for all files with this MIME type."
 msgstr "Użyj kopii obrazka dla wszystkich plików tego typu."
 
-#: type.c:839
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Tylko dla typu \"%s\" (\"%s/%s\")"
 
-#: type.c:845
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Upuść tutaj właściwą aplikację"
 
-#: type.c:860
+#: type.c:963
 msgid "OR"
 msgstr "LUB"
 
-#: type.c:867
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Wprowadź polecenie:"
 
-#: type.c:896
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Użyj polecenia"
 
-#: type.c:926
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
@@ -3169,36 +3670,29 @@ msgstr ""
 "Akcja już istnieje i jest całkiem sporym programem - czy na pewno chcesz ją "
 "usunąć?"
 
-#: type.c:937
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Nie można usunąć %s: %s"
 
-#: type.c:974
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "Zapis opcji wyłączony przez zmienną CHOICESPATH"
 
-#: type.c:1249
-#, c-format
-msgid ""
-"Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr ""
-
-#: type.c:1263
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason)"
+"%s"
 msgstr ""
+"!%s\n"
+"Kopiowanie \"%s\" nie powiodło się\n"
 
-#: usericons.c:181
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "Podana ścieżka nie istnieje. Ikona nie została zmieniona."
 
-#: usericons.c:191 usericons.c:616
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3208,12 +3702,12 @@ msgstr ""
 "uprawnień do odczytu.\n"
 "Ikona nie została zmieniona."
 
-#: usericons.c:238
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Czy na pewno usunąć ikonę \"%s\"?"
 
-#: usericons.c:242
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3222,30 +3716,30 @@ msgstr ""
 "Nie mogę usunąć \"%s\":\n"
 "%s"
 
-#: usericons.c:270
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Ustaw ikonę"
 
-#: usericons.c:279
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr "Użyj kopii obrazka jako domyślnego dla wszystkich plików tych typów."
 
-#: usericons.c:281
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Ustaw ikonę dla wszystkich \"%s/<cokolwiek>\""
 
-#: usericons.c:286
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "Użyj kopii obrazka dla wszystkich plików tego typu."
 
-#: usericons.c:288
+#: usericons.c:299
 #, fuzzy, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Tylko dla typu \"%s\" (\"%s/%s\")"
 
-#: usericons.c:294
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
@@ -3253,12 +3747,12 @@ msgstr ""
 "Dodaj plik oraz nazwy plików z obrazami do osobistej listy. Ustawienia będą "
 "stracone jeśli obraz lub plik zostaną usunięte."
 
-#: usericons.c:297
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Tylko dla pliku \"%s\""
 
-#: usericons.c:305
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
@@ -3269,19 +3763,19 @@ msgstr ""
 "przenosić katalog z miejsca na miejsce. Wybór tej opcji jest zazwyczaj "
 "najlepszy w przypadku posiadania uprawnienia do zapisu w katalogu."
 
-#: usericons.c:311
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Skopiuj do katalogu"
 
-#: usericons.c:317
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Przeciągnij tutaj plik z ikoną"
 
-#: usericons.c:587
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "Ustawianie ikon wyłączone przez zmienną CHOICESPATH"
 
-#: usericons.c:631
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3290,143 +3784,71 @@ msgstr ""
 "Błąd przy tworzenia obrazka \"%s\":\n"
 "%s"
 
-#: view_details.c:1009
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
+msgid "Mono font"
+msgstr ""
+
+#: view_details.c:1019
+msgid "Font for displaying mono-spaced text"
+msgstr ""
+
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Nazwa"
 
-#: view_details.c:1012
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Typ"
 
-#: view_details.c:1015
-msgid "_Permissions"
-msgstr "_Uprawnienia"
-
-#: view_details.c:1016
-msgid "_Owner"
-msgstr "_Właściciel"
-
-#: view_details.c:1018
-msgid "_Group"
-msgstr "_Grupa"
-
-#: view_details.c:1020
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Rozmiar"
 
-#: view_details.c:1022
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Uprawnienia"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_Właściciel"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Grupa"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "_Modyfikacja"
 
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Rozszerzone atrybuty"
+
 #: tips:1
-msgid "Translation"
-msgstr "Tłumaczenie"
-
-#: tips:2
-msgid "Language"
-msgstr "Język"
-
-#: tips:3
-msgid "Use the LANG environment variable"
-msgstr "Użyj zmiennej środowiskowej LANG"
-
-#: tips:4
-msgid "Basque"
-msgstr ""
-
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Chiński (tradycyjny)"
-
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Chiński (uproszczony)"
-
-#: tips:7
-msgid "Czech"
-msgstr "Czeski"
-
-#: tips:8
-msgid "Danish"
-msgstr "Duński"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Holenderski"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Angielski (brak tłumaczenia)"
-
-#: tips:11
-msgid "Estonian"
-msgstr "Estoński"
-
-#: tips:12
-msgid "Finnish"
-msgstr "Fiński"
-
-#: tips:13
-msgid "French"
-msgstr "Francuski"
-
-#: tips:14
-msgid "German"
-msgstr "Niemiecki"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Węgierski"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Japoński"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "Norweski"
-
-#: tips:18
-msgid "Italian"
-msgstr "Włoski"
-
-#: tips:19
-msgid "Polish"
-msgstr "Polski"
-
-#: tips:20
-msgid "Portuguese (Brasil)"
-msgstr ""
-
-#: tips:21
-msgid "Romanian"
-msgstr "Rumuński"
-
-#: tips:22
-msgid "Russian"
-msgstr "Rosyjski"
-
-#: tips:23
-msgid "Spanish"
-msgstr "Hiszpański"
-
-#: tips:24
-msgid "Swedish"
-msgstr "Szwedzki"
-
-#: tips:25
 msgid "Filer windows"
 msgstr "Okna plików"
 
-#: tips:26
+#: tips:2
 msgid "Auto-resize filer windows"
 msgstr "Automatyczna zmiana rozmiaru okien"
 
-#: tips:27
+#: tips:3
 msgid "Never automatically resize"
 msgstr "Brak automatycznych zmian rozmiaru okien"
 
-#: tips:28
+#: tips:4
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
@@ -3435,11 +3857,11 @@ msgstr ""
 "okien, opcji menu \"Zmień rozmiar okna\" lub przez podwójne kliknięcie na "
 "tło okna."
 
-#: tips:29
+#: tips:5
 msgid "Resize when changing the display style"
 msgstr "Zmieniaj wielkość przy zmianie stylu wyświetlania"
 
-#: tips:30
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
@@ -3447,11 +3869,11 @@ msgstr ""
 "Zmiana rozmiaru ikon oraz oraz ilości wyświetlanych szczegółów powoduje "
 "automatyczną zmianę wielkości okna."
 
-#: tips:31
+#: tips:7
 msgid "Always resize"
 msgstr "Zawsze zmieniaj"
 
-#: tips:32
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
@@ -3459,15 +3881,16 @@ msgstr ""
 "Okno z plikami będzie zmieniać rozmiar wtedy kiedy program uzna to za "
 "stosowne (np. przy zmianie katalogu lub zmianie stylu wyświetlania)."
 
-#: tips:33
+#: tips:9
 msgid "Largest window size:"
 msgstr "Największy rozmiar okna:"
 
-#: tips:34
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:35
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
@@ -3475,15 +3898,29 @@ msgstr ""
 "Największy (w procentach wielkości ekranu) rozmiar jaki może osiągnąć okno "
 "przy automatycznej zmianie rozmiaru."
 
-#: tips:36
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Największy rozmiar okna:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Największy (w procentach wielkości ekranu) rozmiar jaki może osiągnąć okno "
+"przy automatycznej zmianie rozmiaru."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Zachowanie okien"
 
-#: tips:37
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Flagi belki tytułowej"
 
-#: tips:38
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
@@ -3491,11 +3928,11 @@ msgstr ""
 "Użycie pojedynczych liter zamiast słów Skanowanie, Wszystkie oraz Miniaturki "
 "w nazwie okna."
 
-#: tips:39
+#: tips:18
 msgid "Unique windows"
 msgstr "Unikalne okna"
 
-#: tips:40
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3503,11 +3940,34 @@ msgstr ""
 "Otwarcie katalogu już wyświetlanego przez inne okno spowoduje zamknięcie "
 "tego okna"
 
-#: tips:41
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Okno"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Nowe okno na przycisku 1"
 
-#: tips:42
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3517,11 +3977,11 @@ msgstr ""
 "nowym oknie. Kliknięcie drugim przyciskiem (środkowym) spowoduje otwarcie w "
 "tym samym oknie"
 
-#: tips:43
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Otwieranie za pomocą pojedyńczego kliknięcia"
 
-#: tips:44 tips:137
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
@@ -3531,25 +3991,25 @@ msgstr ""
 "\"Control\". Jeżeli opcja ta pozostanie wyłączona pojedyńcze kliknięcie "
 "zaznaczy element, natomiast podwójne otworzy."
 
-#: tips:45
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr ""
 
-#: tips:46
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
 msgstr ""
 
-#: tips:47
+#: tips:30
 msgid "Sorting"
 msgstr "Sortowanie"
 
-#: tips:48
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Umieść katalogi na górze"
 
-#: tips:49
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
@@ -3557,12 +4017,12 @@ msgstr ""
 "Przy tej opcji katalogi będą umieszczane przed wszystkimi plikami, "
 "niezależnie od wybranego typu sortowania."
 
-#: tips:50
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr ""
 "Umieść nazwy pisane Dużymi literami na górze (przy sortowaniu po nazwach)"
 
-#: tips:51
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
@@ -3570,15 +4030,58 @@ msgstr ""
 "Jeśli ta opcja jest włączona, wszystkie nazwy zaczynające się od dużej "
 "litery będą umieszczone przed nazwami pisanymi z małej litery."
 
-#: tips:53
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Umieść katalogi na górze"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "sekunda"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "Rozszerzone atrybuty"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "Domyślne ustawienia dla nowych okien"
 
-#: tips:54
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "Odziedzicz opcje z okna źródłowego"
 
-#: tips:55
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
@@ -3587,27 +4090,38 @@ msgstr ""
 "jeśli to możliwe, z okna źródłowego. W przeciwnym przypadku są ustawiane "
 "według poniższych opcji."
 
-#: tips:56
+#: tips:48
 msgid "View type:"
 msgstr "Typ widoku:"
 
-#: tips:59
+#: tips:51
 msgid "Sort by:"
 msgstr "Sortowanie wg:"
 
-#: tips:61 tips:76
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Typ"
 
-#: tips:62
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Data"
 
-#: tips:64
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Data"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Data"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Pokaż ukryte pliki"
 
-#: tips:65
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
@@ -3615,7 +4129,34 @@ msgstr ""
 "Przy włączonej opcji, pliki których nazwy zaczynają się od kropki są również "
 "pokazywane. W przeciwnym wypadku zostaną ukryte."
 
-#: tips:66
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Pokaż ukryte pliki"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Przy włączonej opcji, pliki których nazwy zaczynają się od kropki są również "
+"pokazywane. W przeciwnym wypadku zostaną ukryte."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Wielkie ikony"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "pikseli"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "Widok ikon"
 
@@ -3627,11 +4168,11 @@ msgstr "Domyślny rozmiar:"
 msgid "Huge Icons"
 msgstr "Wielkie ikony"
 
-#: tips:69 tips:245
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Duże ikony"
 
-#: tips:70 tips:244
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "Małe ikony"
 
@@ -3643,15 +4184,20 @@ msgstr "Domyślne szczegóły:"
 msgid "No details"
 msgstr "bez szczegółów"
 
+#: tips:74
+msgid "Sizes"
+msgstr "Rozmiar"
+
+#: tips:77
+msgid "Times"
+msgstr "Czas"
+
 #: tips:78
-msgid "Automatic small icons:"
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "Automatycznie do małych ikon:"
 
-#: tips:79
-msgid "Change at:"
-msgstr "Powyżej:"
-
-#: tips:81
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3661,104 +4207,237 @@ msgstr ""
 "elementów to będzie pokazany przy użyciu Małych ikon. W przeciwnym wypadku "
 "użyte będą Duże ikony."
 
-#: tips:82
-msgid "Max width (Large icons):"
-msgstr "Maks. szerokość: (Duże ikony)"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Duże ikony"
 
-#: tips:83 tips:86
-msgid "pixels"
-msgstr "pikseli"
-
-#: tips:84
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "Tekst o większej szerokości zostanie złamany na dwie linie w trybie Dużych "
 "Ikon. W trybie Wielkich Ikon, tekst będzie zawinięty kiedy będzie o 50% "
 "szerszy."
 
-#: tips:85
-msgid "(Small Icons):"
-msgstr "(Małe ikony):"
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
 
 #: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
+#: tips:88
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr ""
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "(Małe ikony):"
+
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "Maksymalny rozmiar podpisu małej ikony."
 
-#: tips:88
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "Uporządkuj małe ikony pionowo"
 
-#: tips:89
+#: tips:93
 msgid ""
-"If this option is on, then small icons are ordered vertically, not "
-"horizontally."
+"If this option is on, then small icons are arranged in columns, not rows."
 msgstr ""
 
-#: tips:90
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "Uporządkuj duże ikony pionowo"
 
-#: tips:91
+#: tips:95
 msgid ""
-"If this option is on, then large icons are sorted vertically, not "
-"horizontally."
+"If this option is on, then large icons are arranged in columns, not rows."
 msgstr ""
 
-#: tips:93
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Wyświetl nagłówki kolumn"
 
-#: tips:94
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr ""
 "Jeśli ta opcja jest włączona, nagłówki kolumn będą wyświetlane w widoku "
 "listy."
 
-#: tips:95
+#: tips:102
 msgid "Show full type"
 msgstr "Pokaż pełny typ"
 
-#: tips:96
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr ""
 
-#: tips:97
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Maksymalny rozmiar podpisu małej ikony."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Wyświetl nagłówki kolumn"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Jeśli ta opcja jest włączona, nagłówki kolumn będą wyświetlane w widoku "
+"listy."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Jeśli ta opcja jest włączona, nagłówki kolumn będą wyświetlane w widoku "
+"listy."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Jeśli ta opcja jest włączona, nagłówki kolumn będą wyświetlane w widoku "
+"listy."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Jeśli ta opcja jest włączona, nagłówki kolumn będą wyświetlane w widoku "
+"listy."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Jeśli ta opcja jest włączona, nagłówki kolumn będą wyświetlane w widoku "
+"listy."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Jeśli ta opcja jest włączona, nagłówki kolumn będą wyświetlane w widoku "
+"listy."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "_Modyfikacja"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Jeśli ta opcja jest włączona, nagłówki kolumn będą wyświetlane w widoku "
+"listy."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Jeśli ta opcja jest włączona, nagłówki kolumn będą wyświetlane w widoku "
+"listy."
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Jeśli ta opcja jest włączona, nagłówki kolumn będą wyświetlane w widoku "
+"listy."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Narzędzia/Minibufor"
 
-#: tips:98
+#: tips:131
 msgid "Toolbar"
 msgstr "Pasek narzędziowy"
 
-#: tips:99
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Typ paska narzędzi:"
 
-#: tips:100
+#: tips:133
 msgid "No toolbar"
 msgstr "wyłączony"
 
-#: tips:101
+#: tips:134
 msgid "Icons only"
 msgstr "tylko ikony"
 
-#: tips:102
+#: tips:135
 msgid "Text under icons"
 msgstr "tekst pod ikoną"
 
-#: tips:103
+#: tips:136
 msgid "Text beside icons"
 msgstr "tekst obok ikon"
 
-#: tips:104
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Tylko ikony"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Pokaż liczbę elementów"
 
-#: tips:105
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3768,29 +4447,29 @@ msgstr ""
 "(o ile takie istnieją). Po zaznaczeniu wyświetla liczbę zaznaczonych "
 "elementów oraz ich łączny rozmiar."
 
-#: tips:106
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Wybierz przyciski które mają być w pasku narzędzi:"
 
-#: tips:107
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "Szerokość paska narzędzi określa minimalną szerokość okna"
 
-#: tips:108
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
 msgstr ""
 
-#: tips:109
+#: tips:143
 msgid "Minibuffer"
 msgstr "Minibufor"
 
-#: tips:110
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Użyj sygnału dźwiękowego gdy zawiedzie dopełnianie"
 
-#: tips:111
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
@@ -3800,11 +4479,11 @@ msgstr ""
 "\" nic nie zostanie dopasowane (np. jest kilka możliwości do wyboru) "
 "zostanie wygenerowany sygnał dźwiękowy."
 
-#: tips:112
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Użyj sygnału dźwiękowego przy wieloznacznym dopasowaniu"
 
-#: tips:113
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
@@ -3813,7 +4492,27 @@ msgstr ""
 "\" istnieje więcej dopasowań niż jedno, zostanie wygenerowany sygnał "
 "dźwiękowy, nawet po dodaniu kilku następnych liter."
 
-#: tips:116
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Obsługa pobierania"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Błąd w obsłudze %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
@@ -3821,11 +4520,11 @@ msgstr ""
 "Gdy miniaturki są włączone każdy obrazek w katalogu jest wczytywany i "
 "pokazywana jest jego miniaturka."
 
-#: tips:117
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Pokazuj miniaturki"
 
-#: tips:118
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
@@ -3833,29 +4532,103 @@ msgstr ""
 "To jest domyślne ustawienie dla nowych okien. Użyj menu Wyświetlanie by "
 "przełączać pokazywanie miniaturek dla poszczególnych okien."
 
-#: tips:119
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Pokazuj miniaturki"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "Miniaturki filmów"
 
-#: tips:120
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Bufor miniaturek"
 
-#: tips:121
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "By przyśpieszyć pracę programu miniaturki są przechowywane w ukrytym "
 "katalogu ~/.thumbnails. Naciśnij tutaj by usunąć wszystkie miniaturki. "
 "Zostaną one ponownie utworzone w razie potrzeby."
 
-#: tips:122 tips:195
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
+#, fuzzy
+msgid "Manage thumbnails"
+msgstr "Pokazuj miniaturki"
+
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Miniaturki filmów"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "sekunda"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Biurko"
 
-#: tips:123
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
@@ -3863,65 +4636,65 @@ msgstr ""
 "Przy używaniu biurka można przenosić pliki i aplikacje na biurko by tworzyć "
 "skróty do nich."
 
-#: tips:124 tips:241
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Wygląd"
 
-#: tips:125
+#: tips:179
 msgid "Foreground:"
 msgstr "Kolor znaków:"
 
-#: tips:126
+#: tips:180
 msgid "Text shadow:"
 msgstr "Cień tesktu:"
 
-#: tips:127
+#: tips:181
 msgid "Background:"
 msgstr "Kolor tła:"
 
-#: tips:128
+#: tips:182
 msgid "No shadow"
 msgstr "Bez cienia"
 
-#: tips:129
+#: tips:183
 msgid "Thin"
 msgstr "Cienkie"
 
-#: tips:130
+#: tips:184
 msgid "Thick"
 msgstr "Grube"
 
-#: tips:131
+#: tips:185
 msgid "Use custom font:"
 msgstr "Użyj innej czcionki:"
 
-#: tips:132
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Czcionka używana do wyświetlania tekstu pod ikonami"
 
-#: tips:133
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Szybkie skalowanie grafiki"
 
-#: tips:134
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
 msgstr ""
 
-#: tips:135
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Zachowanie biurka"
 
-#: tips:136
+#: tips:190
 msgid "Single-click to open"
 msgstr "Otwieranie za pomocą pojedyńczego kliknięcia"
 
-#: tips:138
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Trzymaj ikony w obrębie ekranu"
 
-#: tips:139
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
@@ -3929,39 +4702,39 @@ msgstr ""
 "Po włączeniu tej opcji, ikony na pulpicie będą zawsze trzymane całkowicie w "
 "ramach ekranu, włączając etykietę."
 
-#: tips:140
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Rozmiar siatki dla ikon: "
 
-#: tips:141
+#: tips:195
 msgid "Fine"
 msgstr "Mały"
 
-#: tips:142
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "Użyj siatki o rozmiarze 2 pikseli do rozmieszczenia ikon na biurku"
 
-#: tips:143
+#: tips:197
 msgid "Medium"
 msgstr "Średni"
 
-#: tips:144
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "Użyj siatki o rozmiarze 16 pikseli do rozmieszczenia ikon na biurku"
 
-#: tips:145
+#: tips:199
 msgid "Coarse"
 msgstr "Duży"
 
-#: tips:146
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "Użyj siatki o rozmiarze 32 pikseli do rozmieszczenia ikon na biurku"
 
-#: tips:147 tips:149
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Zminimalizowane okna"
 
-#: tips:148
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
@@ -3970,11 +4743,11 @@ msgstr ""
 "Większość menedżerów okien pozwala zminimalizować okna do ikony, a różne "
 "programy (w tym ROX-Filer) mogą być użyte do ich wyświetlenia."
 
-#: tips:150
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Pokaż zminimalizowane okna"
 
-#: tips:151
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
@@ -3984,11 +4757,11 @@ msgstr ""
 "przycisk na biurku. Wymaga to kompatybilnego menedżera okien i włączonego "
 "biurka."
 
-#: tips:152
+#: tips:206
 msgid "Show per workspace"
 msgstr ""
 
-#: tips:153
+#: tips:207
 #, fuzzy
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
@@ -3998,39 +4771,39 @@ msgstr ""
 "przycisk na biurku. Wymaga to kompatybilnego menedżera okien i włączonego "
 "biurka."
 
-#: tips:154
+#: tips:208
 msgid "Iconify to the"
 msgstr "Minimalizuj do"
 
-#: tips:155
+#: tips:209
 msgid "top-left"
 msgstr "górnego-lewego"
 
-#: tips:156
+#: tips:210
 msgid "top-right"
 msgstr "górnego-prawego"
 
-#: tips:157
+#: tips:211
 msgid "bottom-left"
 msgstr "dolnego-lewego"
 
-#: tips:158
+#: tips:212
 msgid "bottom-right"
 msgstr "dolny-prawego"
 
-#: tips:159
+#: tips:213
 msgid ", going"
 msgstr " rogu w "
 
-#: tips:160
+#: tips:214
 msgid "horizontally"
 msgstr "poziomie"
 
-#: tips:161
+#: tips:215
 msgid "vertically"
 msgstr "pionie"
 
-#: tips:162
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4038,169 +4811,91 @@ msgid ""
 "about its own panel."
 msgstr ""
 
-#: tips:163
+#: tips:217
 msgid "Top margin"
 msgstr ""
 
-#: tips:164
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr ""
 
-#: tips:165
+#: tips:219
 msgid "Bottom margin"
 msgstr ""
 
-#: tips:166
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr ""
 
-#: tips:167
-msgid "Panels"
-msgstr "Panele"
-
-#: tips:168
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr ""
-"Panele są belkami ikon wyświetlanymi wzdłuż boków ekranu. W dokumentacji "
-"można znaleźć więcej informacji na temat używania paneli."
-
-#: tips:169
-msgid "Panel style"
-msgstr "Styl panelu"
-
-#: tips:170
-msgid "Image and text"
-msgstr "Ikony i tekst"
-
-#: tips:171
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Każdy panel jest wyświetlany jako ikony z podpisami."
-
-#: tips:172
-msgid "Image only for applications"
-msgstr "Ikony tylko przy aplikacjach"
-
-#: tips:173
-msgid ""
-"Applications have just an image, everything else has both an image and text."
-msgstr ""
-"Aplikacje są przedstawione tylko za pomocą ikon, wszystko inne jako ikona i "
-"podpis."
-
-#: tips:174
-msgid "Image only"
-msgstr "Tylko ikony"
-
-#: tips:175
-msgid "Only the image is shown."
-msgstr "Pokazywane są tylko ikony"
-
-#: tips:176
-msgid "Panel width (thin)"
-msgstr "Szerokość panelu (wąski)"
-
-#: tips:177
-msgid "(thick)"
-msgstr "(szeroki)"
-
-#: tips:178
-msgid "The size of the panels."
-msgstr "Rozmiar paneli."
-
-#: tips:179
-msgid "Do not cover panel"
-msgstr "Nie zakrywaj panelu"
-
-#: tips:180
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
+#: tips:221
+msgid "Left margin"
 msgstr ""
 
-#: tips:181
-msgid "Xinerama"
+#: tips:222
+msgid "Width of no-go area at left of screen."
 msgstr ""
 
-#: tips:182
-msgid "Confine to Xinerama monitor"
+#: tips:223
+msgid "Right margin"
 msgstr ""
 
-#: tips:183
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
+#: tips:224
+msgid "Width of no-go area at right of screen."
 msgstr ""
 
-#: tips:184
-msgid ""
-"The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr ""
-
-#: tips:185
+#: tips:225
 msgid "Desktop"
 msgstr "Biurko"
 
-#: tips:186
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
 msgstr ""
 
-#: tips:187
+#: tips:227
 msgid "Panel only"
 msgstr "Tylko panel"
 
-#: tips:188
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Widoczny jest tylko panel."
 
-#: tips:189
+#: tips:229
 msgid "Pinboard only"
 msgstr "Tylko biurko"
 
-#: tips:190
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "Widoczne jest tylko biurko."
 
-#: tips:191
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "Panel i biurko"
 
-#: tips:192
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "Widoczny jest panel i biurko."
 
-#: tips:193
-msgid "Panel"
-msgstr "Panel"
-
-#: tips:194
-msgid "Enter the name of the panel to show here."
-msgstr ""
-
-#: tips:196
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr ""
 
-#: tips:197
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr ""
 
-#: tips:198
+#: tips:236
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 
-#: tips:199
+#: tips:237
 msgid "Action windows"
 msgstr "Okna akcji"
 
-#: tips:200
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4208,63 +4903,110 @@ msgstr ""
 "Okno z akcjami wyświetla się kiedy uruchomiane są operacje w tle\n"
 " (np. kopiowanie lub kasowanie plików)"
 
-#: tips:201
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Automatyczne (ciche) uruchamianie następujących akcji"
 
-#: tips:203
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Kopiowanie plików bez uprzedniego potwierdzania."
 
-#: tips:205
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Przenoszenie plików bez uprzedniego potwierdzania."
 
-#: tips:207
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Tworzenie dowiązań bez uprzedniego potwierdzania."
 
-#: tips:209
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Kasowanie plików bez poprzedniego potwierdzania."
 
-#: tips:210
+#: tips:248
 msgid "Mount"
 msgstr "Zamontuj"
 
-#: tips:211
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Zamontuj i odmontuj bez uprzedniego potwierdzania"
 
-#: tips:212
+#: tips:250
 msgid "Default settings"
 msgstr "Domyślne ustawienia"
 
-#: tips:214
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Wymuś"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "Bez potwierdzania usuwania obiektów w trybie tylko do odczytu"
 
-#: tips:216
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Bez wyświetlania zbyt wielu informacji w obszarze wiadomości."
 
-#: tips:218
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Zmiana zawartości także w podkatalogach"
 
-#: tips:221
+#: tips:263
+#, fuzzy
+msgid "Mount commands"
+msgstr "Punkt montowania"
+
+#: tips:264
+#, fuzzy
+msgid "Mount command"
+msgstr "Punkt montowania"
+
+#: tips:265
+msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
+msgstr ""
+
+#: tips:266
+#, fuzzy
+msgid "Unmount command"
+msgstr "Odmontuj"
+
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "_Użyj polecenia"
+
+#: tips:269
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Mechanizm przeciągania i upuszczania"
 
-#: tips:222
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Przeciąganie na ikony"
 
-#: tips:223
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Ikony w obrębie tego samego okna mogą być przenoszone"
 
-#: tips:224
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
@@ -4275,11 +5017,11 @@ msgstr ""
 "kursorem. Puszczenie przycisku myszy spowoduje skopiowanie pliku do katalogu "
 "lub uruchomienie aplikacji."
 
-#: tips:225
+#: tips:276
 msgid "Directories spring open"
 msgstr "Otwieranie wybranych katalogów"
 
-#: tips:226
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
@@ -4289,15 +5031,15 @@ msgstr ""
 "okna. Jeżeli w trakcie przeciągania pliku myszką zatrzymamy kursor nad "
 "katalogiem na pewien czas, zostanie on otwarty w nowym oknie."
 
-#: tips:227
+#: tips:278
 msgid "Spring delay:"
 msgstr "Opóźnienie otwarcia:"
 
-#: tips:228
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:229
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
@@ -4306,19 +5048,19 @@ msgstr ""
 "Ta opcja określa jak długo czekać (w ms), aby podświetlony katalog został "
 "otwarty. Aby odniosło to jakiś efekt musi być włączona opcja wyżej."
 
-#: tips:230
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Przeciąganie plików lewym przyciskiem myszy"
 
-#: tips:231 tips:235
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Pokazuje menu możliwych akcji"
 
-#: tips:232
+#: tips:283
 msgid "Copy the files"
 msgstr "Kopiuje pliki"
 
-#: tips:233
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
@@ -4326,15 +5068,15 @@ msgstr ""
 "Nalezy zauważyć, że cały czas jest dostęp do menu, przez przeciąganie z "
 "przytrzymanym klawiszem Alt."
 
-#: tips:234
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Przeciąganie plików środkowym przyciskiem myszy"
 
-#: tips:236
+#: tips:287
 msgid "Move the files"
 msgstr "Przenosi pliki"
 
-#: tips:237
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
@@ -4342,11 +5084,11 @@ msgstr ""
 "Zauważ, że cały czas masz dostęp do menu, przez przeciąganie lewym "
 "przyciskiem myszy z przytrzymanym klawiszem Alt."
 
-#: tips:238
+#: tips:289
 msgid "Download handler"
 msgstr "Obsługa pobierania"
 
-#: tips:239
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4354,58 +5096,64 @@ msgid ""
 "xterm -e wget $1"
 msgstr ""
 
-#: tips:240
+#: tips:291
 msgid "Menus"
 msgstr "Menu"
 
-#: tips:242
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Rozmiar ikon w menu:"
 
-#: tips:243
+#: tips:294
 msgid "No Icons"
 msgstr "brak ikon"
 
-#: tips:246
+#: tips:297
 msgid "Same as current window"
 msgstr "takie jak w bieżącym oknie"
 
-#: tips:247
+#: tips:298
 msgid "Same as default"
 msgstr "domyślne"
 
-#: tips:248
+#: tips:299
 msgid "Behaviour"
 msgstr "Zachowanie okien"
 
-#: tips:249
+#: tips:300
 msgid "File menu on right-click"
 msgstr ""
 
-#: tips:250
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
 msgstr ""
 
-#: tips:251
-msgid "`Xterm Here' program"
+#: tips:302
+#, fuzzy
+msgid "Terminal emulator program"
 msgstr "Program terminala"
 
-#: tips:252
-msgid "The program to launch when you choose `Xterm Here' from the menu."
+#: tips:303
+#, fuzzy
+msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr ""
 "Program który ma zostać uruchomiony po wybraniu z menu polecenia \"Terminal\""
 
-#: tips:253
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Skróty klawiszowe"
 
-#: tips:255
+#: tips:305
+msgid "Types"
+msgstr "Typy"
+
+#: tips:306
 msgid "MIME types"
 msgstr "Typy MIME"
 
-#: tips:256
+#: tips:307
 #, fuzzy
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
@@ -4416,23 +5164,23 @@ msgstr ""
 "należy uruchomić \"update-mime-database\". Naciśnięcie przycisku \"Odśwież\" "
 "przeładuje już nowe typy."
 
-#: tips:257
+#: tips:308
 msgid "Edit MIME rules"
 msgstr ""
 
-#: tips:258
+#: tips:309
 msgid "Themes"
 msgstr "Style"
 
-#: tips:259
+#: tips:310
 msgid "Icon theme"
 msgstr "Styl "
 
-#: tips:260
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr ""
 
-#: tips:261
+#: tips:312
 #, fuzzy
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
@@ -4441,39 +5189,39 @@ msgstr ""
 "Użyj okna dialogowego \"Ustaw ikonę...\" aby określić ikonę dla każdego typu "
 "MIME."
 
-#: tips:262
+#: tips:313
 msgid "Colours"
 msgstr "Kolory"
 
-#: tips:263
+#: tips:314
 msgid "File type colours"
 msgstr "Kolory typów"
 
-#: tips:264
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Kolory elementów bazują na ich typach"
 
-#: tips:265
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr "Nazwy elementów (oraz szczegółów) są kolorowane według ich typów."
 
-#: tips:266
+#: tips:317
 msgid "Directory:"
 msgstr "Katalog:"
 
-#: tips:267
+#: tips:318
 msgid "Regular file:"
 msgstr "Zwykły plik:"
 
-#: tips:268
+#: tips:319
 msgid "Pipe:"
 msgstr "Potok:"
 
-#: tips:269
+#: tips:320
 msgid "Socket:"
 msgstr "Gniazdo:"
 
-#: tips:271
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
@@ -4481,19 +5229,19 @@ msgstr ""
 "Dowiązanie symboliczne prowadzące do nieistniejącego pliku lub element do "
 "którego nie posiadamy uprawnień."
 
-#: tips:272
+#: tips:323
 msgid "Character device:"
 msgstr "Urządzenie znakowe:"
 
-#: tips:273
+#: tips:324
 msgid "Block device:"
 msgstr "Urządzenie blokowe:"
 
-#: tips:274
+#: tips:325
 msgid "Door:"
 msgstr "Drzwi:"
 
-#: tips:275
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
@@ -4501,31 +5249,59 @@ msgstr ""
 "Drzwi przypominają w działaniu Gniazdka lub Potoki, występują one wyłącznie "
 "w systemie Solaris"
 
-#: tips:276
+#: tips:327
 msgid "Executable file:"
 msgstr "Plik wykonywalny:"
 
-#: tips:277
+#: tips:328
 msgid "Application directory:"
 msgstr "Katalog aplikacji:"
 
-#: tips:278
+#: tips:329
 msgid "Unknown type:"
 msgstr "Nieznany typ:"
 
-#: tips:279
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Kolor tła:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Użyj innej czcionki:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Zgodność"
 
-#: tips:280
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Problemy z menedżerem okien"
 
-#: tips:281
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "Przejmij kontrolę nad biurkiem i panelami"
 
-#: tips:282
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4540,11 +5316,11 @@ msgstr ""
 "biurko i panele pojawiają się na liście okien lub mają dodane dekoracje od "
 "od menedżera okien."
 
-#: tips:283
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "Przekaż wszystkie kliknięcia myszki do menedżera okien."
 
-#: tips:284
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
@@ -4554,11 +5330,11 @@ msgstr ""
 "wyłącza zaznaczenie. Włączenie tej opcji przekazuje te zdarzenia do "
 "menedżera okien. Kliknięcia na ikony nie są przekazywane."
 
-#: tips:285
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr ""
 
-#: tips:286
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4566,25 +5342,48 @@ msgid ""
 "isn't necessary."
 msgstr ""
 
-#: tips:287
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "Panel jest warstwą 'dock'"
 
-#: tips:288
+#: tips:346
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 
-#: tips:289
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Styl panelu"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Przeciągnij i Upuść"
 
-#: tips:290
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Nie używaj nazwy hosta"
 
-#: tips:291
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4595,18 +5394,356 @@ msgstr ""
 "wskaźniku myszy pokazuje znak '+' lecz funkcja \"przeciągnij i upuść\" nie "
 "działa poprawnie."
 
-#: tips:292
-msgid "Extended attributes"
-msgstr "Rozszerzone atrybuty"
-
-#: tips:293
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Nie używaj rozszerzonych atrybutów"
 
-#: tips:294
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
 "disabled, the MIME type of the file is only derived from the file name and "
 "the properties window does not report extended attributes."
 msgstr ""
+
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+msgid "Bottom gap:"
+msgstr ""
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+msgid "Right gap:"
+msgstr ""
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "Katalog domowy"
+
+#: ../Templates.ui.h:4
+msgid "Panel Options"
+msgstr "Ustawienia panelu"
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Ikony i tekst"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Każdy panel jest wyświetlany jako ikony z podpisami."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Ikony tylko przy aplikacjach"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"Aplikacje są przedstawione tylko za pomocą ikon, wszystko inne jako ikona i "
+"podpis."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Tylko ikony"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Pokazywane są tylko ikony"
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Szerokość panelu (wąski)"
+
+#: ../Templates.ui.h:12
+#, fuzzy
+msgid "The size of this panel."
+msgstr "Rozmiar paneli."
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Tłumaczenie"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "Nie zakrywaj panelu"
+
+#: ../Templates.ui.h:19
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Styl panelu"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr ""
+
+#: ../Templates.ui.h:22
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+
+#: ../Templates.ui.h:23
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "<b>Uprawnienia</b>"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr ""
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr ""
+
+#: ../Templates.ui.h:27
+msgid "Bottom edge"
+msgstr ""
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr ""
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "<b>Uprawnienia</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<katalog>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?\"%s\" już istnieje - nadpisać?"
+
+#~ msgid "Choices migration"
+#~ msgstr "Migracja Choices"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Błąd przy skanowaniu \"%s\":\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Brakujący/skasowany katalog"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Nie znaleziono katalogu \"%s\""
+
+#~ msgid "Cancel"
+#~ msgstr "Anuluj"
+
+#~ msgid "GNOME-VFS library"
+#~ msgstr "Biblioteka GNOME-VFS"
+
+#~ msgid "Open AVFS"
+#~ msgstr "Otwórz AVFS"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr "Aby wysłać gdziekolwiek plik, należy użyć Shift+Menu nad plikiem"
+
+#~ msgid "Look inside ... ?"
+#~ msgstr "Zajrzeć do środka ... ?"
+
+#~ msgid "Panel: %s"
+#~ msgstr "Panel: %s"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Niewłaściwy (zbyt krótki) plik z tłumaczeniem: %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr "Niewłaściwy (brak magicznego numeru GNU) plik z tłumaczeniem: %s"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Przejdź do katalogu nadrzędnego"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Przejdź do katalogu domowego"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Zakładki"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Menu zakładek"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Odczytaj ponownie zawartość katalogu"
+
+#~ msgid "Change icon size"
+#~ msgstr "Zmień rozmiar ikon"
+
+#~ msgid "Show extra details"
+#~ msgstr "Pokaż szczegóły"
+
+#~ msgid "Hidden"
+#~ msgstr "Ukryte"
+
+#~ msgid "Show/hide hidden files"
+#~ msgstr "Pokaż/ukryj ukryte pliki"
+
+#~ msgid "Language"
+#~ msgstr "Język"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "Użyj zmiennej środowiskowej LANG"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Chiński (tradycyjny)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Chiński (uproszczony)"
+
+#~ msgid "Czech"
+#~ msgstr "Czeski"
+
+#~ msgid "Danish"
+#~ msgstr "Duński"
+
+#~ msgid "Dutch"
+#~ msgstr "Holenderski"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Angielski (brak tłumaczenia)"
+
+#~ msgid "Estonian"
+#~ msgstr "Estoński"
+
+#~ msgid "Finnish"
+#~ msgstr "Fiński"
+
+#~ msgid "French"
+#~ msgstr "Francuski"
+
+#~ msgid "German"
+#~ msgstr "Niemiecki"
+
+#~ msgid "Hungarian"
+#~ msgstr "Węgierski"
+
+#~ msgid "Japanese"
+#~ msgstr "Japoński"
+
+#~ msgid "Norwegian"
+#~ msgstr "Norweski"
+
+#~ msgid "Italian"
+#~ msgstr "Włoski"
+
+#~ msgid "Polish"
+#~ msgstr "Polski"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumuński"
+
+#~ msgid "Russian"
+#~ msgstr "Rosyjski"
+
+#~ msgid "Spanish"
+#~ msgstr "Hiszpański"
+
+#~ msgid "Swedish"
+#~ msgstr "Szwedzki"
+
+#~ msgid "Change at:"
+#~ msgstr "Powyżej:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Maks. szerokość: (Duże ikony)"
+
+#~ msgid "Panels"
+#~ msgstr "Panele"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Panele są belkami ikon wyświetlanymi wzdłuż boków ekranu. W dokumentacji "
+#~ "można znaleźć więcej informacji na temat używania paneli."
+
+#~ msgid "(thick)"
+#~ msgstr "(szeroki)"

--- a/ROX-Filer/src/po/pt_BR.po
+++ b/ROX-Filer/src/po/pt_BR.po
@@ -4,42 +4,44 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rox\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-11-24 10:34-0200\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2009-11-27 18:58-0300\n"
 "Last-Translator: Sérgio Cipolla <secipolla@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: abox.c:125
-msgid "<dir>"
-msgstr "<dir>"
+#: abox.c:127
+msgid "<src>"
+msgstr ""
 
-#: abox.c:218
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "Silenci_oso"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Quiet"
 msgstr "Silencioso"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Não confirmar cada operação"
 
-#: abox.c:454
-#: infobox.c:782
-#: tips:36
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Nome"
 
-#: abox.c:460
-#: menu.c:237
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Diretório"
 
-#: abox.c:549
+#: abox.c:546
 msgid "Expression:"
 msgstr "Expressão:"
 
@@ -55,11 +57,11 @@ msgstr "Veja a página de manual do fsattr(5) para mais detalhes."
 msgid "You do not appear to have OS support."
 msgstr "Parece que não há suporte pelo sistema operacional."
 
-#: action.c:191
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Localizar a referência da expressão"
 
-#: action.c:202
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -75,10 +77,13 @@ msgid ""
 "<b>IsReg system(grep -q fred \"%\")</b> (contains the word 'fred')\n"
 "\n"
 "<u>Simple Tests</u>\n"
-"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</b> (types)\n"
-"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> (permissions)\n"
+"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
+"b> (types)\n"
+"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
+"(permissions)\n"
 "<b>IsEmpty, IsMine</b>\n"
-"A pattern in single quotes is a shell-style wildcard pattern to match. If it\n"
+"A pattern in single quotes is a shell-style wildcard pattern to match. If "
+"it\n"
 "contains a slash then the match is against the full path; otherwise it is\n"
 "against the leafname only.\n"
 "\n"
@@ -86,7 +91,8 @@ msgid ""
 "<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (compare two values)\n"
 "<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (file sizes)\n"
 "<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (times)\n"
-"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> (values)\n"
+"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
+"(values)\n"
 "\n"
 "<u>Specials</u>\n"
 "<b>system(command)</b> (true if 'command' returns with a zero exit status;\n"
@@ -94,7 +100,8 @@ msgid ""
 "<b>prune</b> (false, and prevents searching the contents of a directory)."
 msgstr ""
 "<u>Introdução Rápida</u>\n"
-"Apenas ponha o nome do arquivo que você esta procurando entre aspas simples:\n"
+"Apenas ponha o nome do arquivo que você esta procurando entre aspas "
+"simples:\n"
 "<b>'index.html'</b> (para localizar um arquivo de nome 'index.html')\n"
 "\n"
 "<u>Exemplos</u>\n"
@@ -102,43 +109,53 @@ msgstr ""
 "<b>IsDir 'lib'</b> (localiza diretórios de nome 'lib')\n"
 "<b>IsReg 'core'</b> (localiza um arquivo regular de nome 'core')\n"
 "<b>! (IsDir, IsReg)</b> (não é nem diretório nem arquivo regular)\n"
-"<b>mtime after 1 day ago and size > 1Mb</b> (grande e modificado recentemente)\n"
+"<b>mtime after 1 day ago and size > 1Mb</b> (grande e modificado "
+"recentemente)\n"
 "<b>'CVS' prune, isreg</b> (um arquivo regular não em CVS)\n"
 "<b>IsReg system(grep -q fred \"%\")</b> (contém a palavra 'fred')\n"
 "\n"
 "<u>Testes Simples</u>\n"
-"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</b> (tipos)\n"
-"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> (permissões)\n"
+"<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
+"b> (tipos)\n"
+"<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
+"(permissões)\n"
 "<b>IsEmpty, IsMine</b>\n"
-"Um padrão em aspas simples é um padrão curinga no estilo shell a ser correspondido.\n"
-"Se ele contém uma barra então deve ser correspondido o caminho completo; se não\n"
+"Um padrão em aspas simples é um padrão curinga no estilo shell a ser "
+"correspondido.\n"
+"Se ele contém uma barra então deve ser correspondido o caminho completo; se "
+"não\n"
 "ele é correspondido com o nome de face apenas.\n"
 "\n"
 "<u>Comparações</u>\n"
-"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (comparar dois valores)\n"
+"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (comparar dois "
+"valores)\n"
 "<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (tamanhos de arquivo)\n"
 "<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (data)\n"
-"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> (valores)\n"
+"<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
+"(valores)\n"
 "\n"
 "<u>Especiais</u>\n"
-"<b>system(comando)</b> (verdadeiro se 'comando' retorna um status de saída zero;\n"
+"<b>system(comando)</b> (verdadeiro se 'comando' retorna um status de saída "
+"zero;\n"
 "um % em 'comando' é substituído pelo caminho do arquivo atual)\n"
 "<b>prune</b> (falso, e impede a busca pelo conteúdo de um diretório)."
 
-#: action.c:249
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Modificar a referência das permissões"
 
-#: action.c:260
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
 "\n"
 "The format of a command is: <b>CHANGE, CHANGE, ...</b>\n"
 "Each <b>CHANGE</b> is: <b>WHO HOW PERMISSIONS</b>\n"
-"<b>WHO</b> is some combination of <b>u</b>, <b>g</b> and <b>o</b> which determines whether to\n"
+"<b>WHO</b> is some combination of <b>u</b>, <b>g</b> and <b>o</b> which "
+"determines whether to\n"
 "change the permissions for the User (owner), Group or Others.\n"
-"<b>HOW</b> is <b>+</b>, <b>-</b> or <b>=</b> to add, remove or set exactly the permissions.\n"
+"<b>HOW</b> is <b>+</b>, <b>-</b> or <b>=</b> to add, remove or set exactly "
+"the permissions.\n"
 "<b>PERMISSIONS</b> is some combination of the letters <b>rwxXstugo</b>\n"
 "\n"
 "Bracketed text and spaces are ignored.\n"
@@ -146,7 +163,8 @@ msgid ""
 "<u>Examples</u>\n"
 "<b>u+rw</b>: the file owner gains read and write permission\n"
 "<b>g=u</b>: the group permissions are set to be the same as the user's\n"
-"<b>o=u-w</b>: others get the same permissions as the owner, but without write permission\n"
+"<b>o=u-w</b>: others get the same permissions as the owner, but without "
+"write permission\n"
 "<b>a+x</b>: <b>a</b>ll get execute/access permission - same as <b>ugo+x</b>\n"
 "<b>a+X</b>: directories become accessable by everyone; files which were\n"
 "executable by anyone become executable by everyone\n"
@@ -161,9 +179,12 @@ msgstr ""
 "\n"
 "O formato de um comando é: <b>MODIFICAÇÃO, MODIFICAÇÃO,...</b>\n"
 "Cada <b>MODIFICAÇÃO</b> é: <b>QUEM COMO PERMISSÕES</b>\n"
-"<b>QUEM</b> é uma combinação de <b>u</b>, <b>g<b> e <b>o</b> que determina se\n"
-"se deve modificar as permissões para Usuário (proprietário), Grupo ou Outros.\n"
-"<b>COMO</b> é <b>+</b>, <b>-</b> ou <b>=</b> para adicionar, remover ou definir precisamente as permissões.\n"
+"<b>QUEM</b> é uma combinação de <b>u</b>, <b>g<b> e <b>o</b> que determina "
+"se\n"
+"se deve modificar as permissões para Usuário (proprietário), Grupo ou "
+"Outros.\n"
+"<b>COMO</b> é <b>+</b>, <b>-</b> ou <b>=</b> para adicionar, remover ou "
+"definir precisamente as permissões.\n"
 "<b>PERMISSÕES</b> é uma combinação das letras <b>rwxXstugo</b>\n"
 "\n"
 "Espaços e texto entre colchetes são ignorados.\n"
@@ -171,21 +192,25 @@ msgstr ""
 "<u>Exemplos</u>\n"
 "<b>u+rw</b>: o proprietário do arquivo ganha permissão de leitura e escrita\n"
 "<b>g=u</b>: as permissões do grupo são definidas como as mesmas do usuário\n"
-"<b>o=u-w</b>: outros herdam as mesmas permissões do proprietário exceto a de escrita\n"
-"<b>a+x</b>: todos (<b>a</b>) obtêm permissão de execução/acesso - o mesmo que <b>ugo+x</b>\n"
-"<b>a+X</b>: os diretórios tornam-se acessíveis para todos; os arquivos que fossem\n"
+"<b>o=u-w</b>: outros herdam as mesmas permissões do proprietário exceto a de "
+"escrita\n"
+"<b>a+x</b>: todos (<b>a</b>) obtêm permissão de execução/acesso - o mesmo "
+"que <b>ugo+x</b>\n"
+"<b>a+X</b>: os diretórios tornam-se acessíveis para todos; os arquivos que "
+"fossem\n"
 "executáveis por qualquer um tornam-se executáveis por todos\n"
 "<b>u+rw, go+r</b>: dois comandos ao mesmo tempo!\n"
-"<b>u+s</b>: definir o bit SetUID - geralmente não faz efeito em arquivos de script\n"
+"<b>u+s</b>: definir o bit SetUID - geralmente não faz efeito em arquivos de "
+"script\n"
 "<b>755</b>: definir as permissões diretamente\n"
 "\n"
 "Ver a página de manual chmod(1) para mais detalhes."
 
-#: action.c:301
+#: action.c:308
 msgid "Set type reference"
 msgstr "Definir a referência do tipo"
 
-#: action.c:312
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -214,57 +239,55 @@ msgstr ""
 "não diretórios, dispositivos, pipes ou sockets e apenas em alguns\n"
 "sistemas de arquivo e onde o s.o. os implementa.\n"
 
-#: action.c:419
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Processo terminado.\n"
 
-#: action.c:435
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Houve um erro.\n"
 
-#: action.c:437
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Houveram %d erros.\n"
 
-#: action.c:461
+#: action.c:516
 msgid "ERROR reading"
 msgstr "ERRO ao ler"
 
-#: action.c:504
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Pronto\n"
 
-#: action.c:560
-#: support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "ERRO"
 
-#: action.c:714
-#: main.c:698
-#: main.c:705
-#: main.c:712
-#: main.c:726
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Sim"
 
-#: action.c:717
-#: main.c:700
-#: main.c:707
-#: main.c:714
-#: main.c:726
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Não"
 
-#: action.c:735
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -272,7 +295,7 @@ msgstr ""
 "\n"
 "Requisitando ao processo filho que termine...\n"
 
-#: action.c:742
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -280,41 +303,41 @@ msgstr ""
 "\n"
 "Tentando INTERROMPER processos fugitivos...\n"
 
-#: action.c:895
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Contar o conteúdo de %s?"
 
-#: action.c:931
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Apagar %s'%s'?"
 
-#: action.c:932
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "PROTEGIDO CONTRA ESCRITA "
 
-#: action.c:939
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'Apagando '%s'\n"
 
-#: action.c:952
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'Diretório '%s' apagado\n"
 
-#: action.c:985
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?Ejetar '%s'?"
 
-#: action.c:992
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Ejetar '%s'\n"
 
-#: action.c:1011
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -323,98 +346,95 @@ msgstr ""
 "!%s\n"
 "falha ao ejetar\n"
 
-#: action.c:1030
-#: action.c:1049
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Conferir '%s'?"
 
-#: action.c:1046
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Condição de busca inválida - modifique-a e tente novamente\n"
 
-#: action.c:1056
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(enquanto confiro '%s')\n"
 
-#: action.c:1130
-#: action.c:1155
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Modificar as permissões de '%s'?"
 
-#: action.c:1136
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Modificando as permissões de '%s'\n"
 
-#: action.c:1153
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Comando de modo inválido - modifique-o e tente novamente\n"
 
-#: action.c:1211
+#: action.c:1332
 #, c-format
 msgid "?Change contents of '%s'?"
 msgstr "?Modificar o conteúdo de '%s'?"
 
-#: action.c:1214
-#: action.c:1234
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "Modificar o tipo de '%s'?"
 
-#: action.c:1231
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Tipo inválido - modifique-o e tente novamente\n"
 
-#: action.c:1253
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "Modificando o tipo de '%s' para '%s'\n"
 
-#: action.c:1276
+#: action.c:1397
 #, c-format
 msgid "'Not changing type of directory '%s'\n"
 msgstr "'Não modificando o tipo do diretório '%s'\n"
 
-#: action.c:1282
+#: action.c:1403
 #, c-format
 msgid "'Non-regular file '%s' not changed\n"
 msgstr "'O arquivo não-regular '%s' não foi modificado\n"
 
-#: action.c:1342
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' já existe - %s?"
 
-#: action.c:1344
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "mesclar os conteúdos"
 
-#: action.c:1345
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "sobrescrever"
 
-#: action.c:1361
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Tentando uma cópia de qualquer modo...\n"
 
-#: action.c:1370
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Copiar %s para %s?"
 
-#: action.c:1374
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Copiando %s como %s\n"
 
-#: action.c:1389
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!ERRO: o destino já existe mas não é um diretório\n"
 
-#: action.c:1461
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -423,26 +443,7 @@ msgstr ""
 "!%s\n"
 "Falha ao copiar '%s'\n"
 
-#: action.c:1505
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' já existe - sobrescrever?"
-
-#: action.c:1520
-msgid "'Trying move anyway...\n"
-msgstr "'Tentando mover de qualquer modo...\n"
-
-#: action.c:1528
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Mover %s como %s?"
-
-#: action.c:1532
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Movendo %s como %s\n"
-
-#: action.c:1540
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -451,45 +452,59 @@ msgstr ""
 "!%s\n"
 "Falha ao mover %s como %s\n"
 
-#: action.c:1561
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Tentando mover de qualquer modo...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Mover %s como %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Movendo %s como %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!ERRO: não posso copiar o objeto para ele mesmo\n"
 
-#: action.c:1576
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!ERRO: não posso mover/renomear o objeto para ele mesmo\n"
 
-#: action.c:1588
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Ligando %s como %s\n"
 
-#: action.c:1593
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Ligar %s como %s?"
 
-#: action.c:1636
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Montando %s\n"
 
-#: action.c:1637
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Desmontando %s\n"
 
-#: action.c:1640
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?Montar %s?"
 
-#: action.c:1641
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?Desmontar %s?"
 
-#: action.c:1662
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -498,7 +513,7 @@ msgstr ""
 "!%s\n"
 "Falha ao montar\n"
 
-#: action.c:1663
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -507,11 +522,11 @@ msgstr ""
 "!%s\n"
 "Falha ao desmontar\n"
 
-#: action.c:1671
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(de qualquer modo agora parece estar montado)\n"
 
-#: action.c:1717
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -520,320 +535,315 @@ msgstr ""
 "'\n"
 "Total: %s ("
 
-#: action.c:1723
+#: action.c:2108
 msgid "file"
 msgstr "arquivo"
 
-#: action.c:1723
+#: action.c:2108
 msgid "files"
 msgstr "arquivos"
 
-#: action.c:1727
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "sem diretórios)\n"
 
-#: action.c:1731
+#: action.c:2116
 msgid "directory"
 msgstr "diretório"
 
-#: action.c:1732
+#: action.c:2117
 msgid "directories"
 msgstr "diretórios"
 
 # ##
-#: action.c:1773
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Nenhum ponto de montagem selecionado!\n"
 
-#: action.c:1858
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Outra busca?"
 
-#: action.c:1888
-#: action.c:1919
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' é uma ligação simbólica\n"
 
-#: action.c:1959
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "Você precisa selecionar alguns itens por onde buscar"
 
-#: action.c:1969
-#: menu.c:228
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Localizar"
 
-#: action.c:2002
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Você precisa selecionar alguns itens para contar"
 
-#: action.c:2006
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Uso do Disco"
 
-#: action.c:2042
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Montar / Desmontar"
 
-#: action.c:2059
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
-msgstr "O ROX-Filer ainda não suporta pontos de montagem no seu sistema - desculpe."
+msgstr ""
+"O ROX-Filer ainda não suporta pontos de montagem no seu sistema - desculpe."
 
-#: action.c:2073
-#: menu.c:216
-#: tips:173
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Apagar"
 
-#: action.c:2085
-#: tips:178
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Forçar"
 
-#: action.c:2085
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Não confirmar o apagamento de itens somente-leitura"
 
-#: action.c:2088
-#: action.c:2147
-#: action.c:2210
-#: action.c:2283
-#: action.c:2323
-#: tips:180
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Breve"
 
-#: action.c:2088
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Apenas logar os diretórios a serem apagados"
 
-#: action.c:2107
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "Você precisa selecionar os itens cujas permissões quer alterar"
 
-#: action.c:2115
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (tornar executável/pesquisável)"
 
-#: action.c:2117
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (tornar não-executável/não-pesquisável)"
 
-#: action.c:2119
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (dar ao proprietário leitura+escrita)"
 
-#: action.c:2121
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (privado - acesso somente pelo proprietário)"
 
-#: action.c:2123
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (acesso público, somente leitura)"
 
-#: action.c:2134
-#: menu.c:189
-#: menu.c:226
-#: tips:53
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Permissões"
 
-#: action.c:2147
-#: action.c:2210
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Não listar os arquivos processados"
 
-#: action.c:2150
-#: action.c:2213
-#: tips:182
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Recursivo"
 
-#: action.c:2150
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Também modificar o conteúdo dos subdiretórios"
 
-#: action.c:2154
+#: action.c:2547
 msgid "Command:"
 msgstr "Comando:"
 
-#: action.c:2184
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Você precisa selecionar os itens cujo tipo modificar"
 
-#: action.c:2197
+#: action.c:2590
 msgid "Set type"
 msgstr "Definir o tipo"
 
-#: action.c:2213
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Modificar o conteúdo dos subdiretórios"
 
-#: action.c:2220
-#: infobox.c:638
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Tipo:"
 
-#: action.c:2267
-#: dnd.c:122
-#: menu.c:2024
-#: tips:167
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Copiar"
 
-#: action.c:2279
-#: action.c:2319
-#: tips:184
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Não confirmar cada operação"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Apenas sobrescrever se a origem é mais nova que o destino."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Mais recentes"
 
-#: action.c:2280
-#: action.c:2320
-#: tips:185
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Apenas sobrescrever se a origem é mais nova que o destino."
 
-#: action.c:2283
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "diretórios"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Apenas logar os diretórios enquanto são copiados"
 
-#: action.c:2307
-#: dnd.c:123
-#: tips:169
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Mover"
 
-#: action.c:2323
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Não logar cada arquivos ao ser movido"
 
-#: action.c:2346
-#: tips:171
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Ligar"
 
-#: action.c:2369
-#: appmenu.c:111
-#: filer.c:646
-#: infobox.c:1051
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Ejetar "
 
-#: action.c:2437
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Apagando itens como "
 
-#: action.c:2441
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Apagando o item "
 
-#: action.c:2443
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Apagando os itens "
 
-#: action.c:2462
+#: action.c:2900
 msgid " and "
 msgstr " e "
 
-#: action.c:2471
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr " afetará alguns itens no quadro ou painel - apagar realmente?"
 
-#: action.c:2478
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr " afetará alguns itens no quadro ou painel - apagar realmente?"
 
-#: appmenu.c:197
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<rótulo faltando>"
 
-#: appmenu.c:319
+#: appmenu.c:317
 #, c-format
-msgid "Symlink any programs you want into this directory. They will appear in the menu for all items of this type (%s/%s)."
-msgstr "Crie uma ligação simbólica de qualquer programa que você quiser para este diretório. Eles aparecerão no menu para todos os itens desse tipo (%s/%s)."
+msgid ""
+"Symlink any programs you want into this directory. They will appear in the "
+"menu for all items of this type (%s/%s)."
+msgstr ""
+"Crie uma ligação simbólica de qualquer programa que você quiser para este "
+"diretório. Eles aparecerão no menu para todos os itens desse tipo (%s/%s)."
 
-#: appmenu.c:363
-#: menu.c:239
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Personalizar o Menu..."
 
-#: appmenu.c:420
-#: menu.c:257
-#: toolbar.c:158
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Ajuda"
 
-#: bookmarks.c:148
-#: log.c:160
-msgid "Path"
-msgstr "Caminho"
-
-#: bookmarks.c:156
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Título"
 
-#: bookmarks.c:305
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Caminho"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Não posso marcar o recurso não-local '%s'\n"
 
-#: bookmarks.c:313
-#: bookmarks.c:631
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' não é um diretório"
 
-#: bookmarks.c:519
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Você deveria selecionar primeiro algumas linhas para apagar"
 
-#: bookmarks.c:543
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Ponha o cursor em uma entrada da lista para movê-la"
 
-#: bookmarks.c:563
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Este item já esta no final"
 
-#: bookmarks.c:637
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Não posso marcar diretórios não-locais como '%s'"
 
-#: bookmarks.c:779
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Adicionar Nova Marcação"
 
-#: bookmarks.c:786
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Editar Marcações"
 
-#: bookmarks.c:791
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Visitados Recentemente"
 
-#: bulk_rename.c:66
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Renomear arquivos em massa"
 
-#: bulk_rename.c:69
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Reconfigurar"
 
-#: bulk_rename.c:74
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "Fazer da coluna Nova uma cópia da Antiga"
 
-#: bulk_rename.c:79
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "_Renomear"
 
-#: bulk_rename.c:92
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Substituir:"
 
-#: bulk_rename.c:99
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -847,58 +857,71 @@ msgstr ""
 "\\. corresponde a um ponto\n"
 "\\.htm$ corresponde ao '.htm' em 'index.htm' etc."
 
-#: bulk_rename.c:107
+#: bulk_rename.c:109
 msgid "With:"
 msgstr "Com:"
 
-#: bulk_rename.c:114
-msgid "The first match in each filename will be replaced by this string. The only special characters are back-references from \\0 to \\9. To use them literally, they have to be escaped with a backslash."
-msgstr "A primeira correspondência em cada nome de arquivo será substituída por esta cadeia. Os únicos caracteres especiais são referências prévias de \\0 a \\9. Para usá-las literalmente, elas devem ser precedidas por uma barra invertida."
+#: bulk_rename.c:116
+msgid ""
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
+msgstr ""
+"A primeira correspondência em cada nome de arquivo será substituída por esta "
+"cadeia. Os únicos caracteres especiais são referências prévias de \\0 a \\9. "
+"Para usá-las literalmente, elas devem ser precedidas por uma barra invertida."
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Aplicar"
 
-#: bulk_rename.c:123
-msgid "Do a search-and-replace in the New column. The files are not actually renamed until you click on the Rename button below."
-msgstr "Efetuar um pesquisar-e-substituir na Nova coluna. Os arquivos não são efetivamente renomeados até que você clique no botão Renomear."
+#: bulk_rename.c:125
+msgid ""
+"Do a search-and-replace in the New column. The files are not actually "
+"renamed until you click on the Rename button below."
+msgstr ""
+"Efetuar um pesquisar-e-substituir na Nova coluna. Os arquivos não são "
+"efetivamente renomeados até que você clique no botão Renomear."
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Nome antigo"
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Nome novo"
 
-#: bulk_rename.c:293
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr "Nenhuma cadeia (na coluna Nova) corresponde à expressão fornecida"
 
-#: bulk_rename.c:298
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Um nome correspondeu mas o resultado foi o mesmo"
 
-#: bulk_rename.c:301
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d nomes corresponderam mas os resultados foram todos os mesmos"
 
-#: bulk_rename.c:327
-msgid "Specify a regular expression to match, and a string to replace matches with."
-msgstr "Especifique uma expressão a ser correspondida e uma cadeia com a qual substituir as correspondências."
+#: bulk_rename.c:330
+msgid ""
+"Specify a regular expression to match, and a string to replace matches with."
+msgstr ""
+"Especifique uma expressão a ser correspondida e uma cadeia com a qual "
+"substituir as correspondências."
 
-#: bulk_rename.c:344
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (para '%s')"
 
-#: bulk_rename.c:377
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr "Já existe um arquivo chamado '%s'. Abortando a renomeação em massa."
 
-#: bulk_rename.c:382
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -909,17 +932,21 @@ msgstr ""
 "%s\n"
 "Abortando a renomeação em massa."
 
-#: bulk_rename.c:444
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "Já existe um arquivo chamado '%s'"
 
-#: bulk_rename.c:455
+#: bulk_rename.c:458
 #, c-format
-msgid "Some of the New names contain / characters (eg '%s'). This will cause the files to end up in different directories. Continue?"
-msgstr "Alguns dos nomes de Novo contém o caractere / (p.ex. '%s'). Isso faz com que os arquivos terminem em diretórios diferentes. Continuar?"
+msgid ""
+"Some of the New names contain / characters (eg '%s'). This will cause the "
+"files to end up in different directories. Continue?"
+msgstr ""
+"Alguns dos nomes de Novo contém o caractere / (p.ex. '%s'). Isso faz com que "
+"os arquivos terminem em diretórios diferentes. Continuar?"
 
-#: bulk_rename.c:470
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Nenhum dos nomes foi modificado. Nada a fazer!"
 
@@ -943,116 +970,178 @@ msgstr ""
 "%s\n"
 "%s"
 
-#: dir.c:1041
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Não posso chamar stat no diretório: %s"
 
-#: dir.c:1050
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Não posso abrir o diretório: %s"
 
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Tamanho"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
 # ##, c-format
-#: display.c:659
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "Falha do lstat(2): %s"
 
-#: dnd.c:124
-msgid "Link (relative)"
-msgstr "Ligação (relativa)"
-
-#: dnd.c:125
-msgid "Link (absolute)"
-msgstr "Ligação (absoluta)"
-
-#: dnd.c:424
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Erro interno - tipo ruim de informação"
 
-#: dnd.c:563
+#: dnd.c:565
 msgid "Drag a directory here to bookmark it."
 msgstr "Arraste um diretório aqui para marcá-lo"
 
-#: dnd.c:578
+#: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
 msgstr "Erro no protocolo XDS: o nome de face não pode conter  '/'\n"
 
-#: dnd.c:603
-msgid "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/plain) did not contain a leafname\n"
-msgstr "O alvo XdndDirectSave0 foi fornecido mas o atom XdndDirectSave0 (type text/plain) não continha um nome de face\n"
+#: dnd.c:605
+msgid ""
+"XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
+"plain) did not contain a leafname\n"
+msgstr ""
+"O alvo XdndDirectSave0 foi fornecido mas o atom XdndDirectSave0 (type text/"
+"plain) não continha um nome de face\n"
 
-#: dnd.c:616
+#: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
-msgstr "Desculpe - eu requeiro um tipo alvo de text/uri-list ou XdndDirectSave0."
+msgstr ""
+"Desculpe - eu requeiro um tipo alvo de text/uri-list ou XdndDirectSave0."
 
-#: dnd.c:619
-msgid "Sorry - I require a target type of text/uri-list or application/octet-stream."
-msgstr "Desculpe - eu requeiro um tipo alvo de text/uri-list ou application/octet-stream."
+#: dnd.c:621
+msgid ""
+"Sorry - I require a target type of text/uri-list or application/octet-stream."
+msgstr ""
+"Desculpe - eu requeiro um tipo alvo de text/uri-list ou application/octet-"
+"stream."
 
-#: dnd.c:689
+#: dnd.c:691
 #, c-format
 msgid ""
-"Failed to add some items to the pinboard, because they are on a remote machine. For example:\n"
+"Failed to add some items to the pinboard, because they are on a remote "
+"machine. For example:\n"
 "\n"
 "%s"
 msgstr ""
-"Falha ao acrescentar alguns itens ao quadro pois estão em uma máquina remota. Por exemplo:\n"
+"Falha ao acrescentar alguns itens ao quadro pois estão em uma máquina "
+"remota. Por exemplo:\n"
 "\n"
 "%s"
 
-#: dnd.c:764
+#: dnd.c:766
 msgid "Unknown target"
 msgstr "Alvo desconhecido"
 
-#: dnd.c:797
+#: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
-msgstr "O aplicativo remoto não me pode enviar ou não me enviará os dados - desculpe"
+msgstr ""
+"O aplicativo remoto não me pode enviar ou não me enviará os dados - desculpe"
 
 # ##, fuzzy
-#: dnd.c:810
+#: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
-msgstr "Erro no protocolo XDS: o código de retorno deveria ser 'S', 'F' ou 'E'\n"
+msgstr ""
+"Erro no protocolo XDS: o código de retorno deveria ser 'S', 'F' ou 'E'\n"
 
-#: dnd.c:843
+#: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
-msgstr "Desculpe - não posso exibir um menu de ações para um arquivo remoto / dados brutos."
+msgstr ""
+"Desculpe - não posso exibir um menu de ações para um arquivo remoto / dados "
+"brutos."
 
-#: dnd.c:859
+#: dnd.c:861
 msgid "UntitledData"
 msgstr "DadosSemTítulo"
 
-#: dnd.c:886
+#: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
 msgstr "Erro ao salvar o arquivo: %s"
 
 # ##
-#: dnd.c:959
+#: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
 msgstr "Nenhuma URI em text/uri-list (nada a fazer!)"
 
-#: dnd.c:991
-msgid "Can't get data from remote machine (application/octet-stream not provided)"
-msgstr "Não posso obter dados da máquina remota (application/octet-stream  não fornecido)"
+#: dnd.c:993
+msgid ""
+"Can't get data from remote machine (application/octet-stream not provided)"
+msgstr ""
+"Não posso obter dados da máquina remota (application/octet-stream  não "
+"fornecido)"
 
-#: dnd.c:1014
-msgid "Some of these files are on a different machine - they will be ignored - sorry"
-msgstr "Alguns desses arquivos estão em outra máquina - eles serão ignorados - desculpe"
+#: dnd.c:1015 menu.c:2406
+msgid ""
+"Some of these files are on a different machine - they will be ignored - sorry"
+msgstr ""
+"Alguns desses arquivos estão em outra máquina - eles serão ignorados - "
+"desculpe"
 
-#: dnd.c:1021
-msgid "None of these files are on the local machine - I can't operate on multiple remote files - sorry."
-msgstr "Nenhum desses aquivos está na máquina local - não posso operar com múltiplos arquivos remotos - desculpe."
+#: dnd.c:1024 menu.c:2414
+msgid ""
+"None of these files are on the local machine - I can't operate on multiple "
+"remote files - sorry."
+msgstr ""
+"Nenhum desses aquivos está na máquina local - não posso operar com múltiplos "
+"arquivos remotos - desculpe."
 
-#: dnd.c:1034
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "A ação requisitada é desconhecida"
 
-#: dnd.c:1042
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Erro ao obter a lista de aquivos: %s"
+
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Ligação (relativa)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Ligação (absoluta)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Ligação (relativa)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Ligação (absoluta)"
 
 #: dropbox.c:112
 msgid "Show"
@@ -1067,20 +1156,24 @@ msgid "<nothing>"
 msgstr "<nada>"
 
 #: dropbox.c:237
-msgid "I can't show you the currently set item, because nothing is currently set. Drag something onto me!"
-msgstr "Não posso exibir o item atualmente selecionado pois não há nada selecionado. Arraste algo para mim!"
+msgid ""
+"I can't show you the currently set item, because nothing is currently set. "
+"Drag something onto me!"
+msgstr ""
+"Não posso exibir o item atualmente selecionado pois não há nada selecionado. "
+"Arraste algo para mim!"
 
 #: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
-msgstr "Desculpe - você precisa soltar o arquivo com exatidão na área de soltura."
+msgstr ""
+"Desculpe - você precisa soltar o arquivo com exatidão na área de soltura."
 
 #: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr "Desculpe - não posso usar '%s' pois não é um arquivo local."
 
-#: dropbox.c:278
-#: pinboard.c:932
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1089,7 +1182,7 @@ msgstr ""
 "Não posso acessar '%s':\n"
 "%s"
 
-#: filer.c:461
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1098,16 +1191,7 @@ msgstr ""
 "Erro ao escanear '%s':\n"
 "%s\n"
 
-#: filer.c:465
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Erro ao escanear '%s':\n"
-"%s"
-
-#: filer.c:621
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1117,145 +1201,172 @@ msgstr ""
 "\n"
 "Desmontar um dispositivo torna segura a retirada do disco"
 
-#: filer.c:626
+#: filer.c:889
 msgid "Perform the same action in future for this mount point"
 msgstr "Efetuar a mesma ação no futuro para este ponto de montagem"
 
-#: filer.c:633
+#: filer.c:896
 msgid "No change"
 msgstr "Sem modificação"
 
-#: filer.c:639
-#: infobox.c:1049
-#: menu.c:872
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Desmontar"
 
-#: filer.c:743
-msgid "Directory missing/deleted"
-msgstr "Diretório inexistente/apagado"
-
 # ##, c-format
-#: filer.c:1107
+#: filer.c:1490
 #, c-format
 msgid ""
-"Group %s is not set. Select some files and press Ctrl+%s to set the group. Press %s on its own to reselect the files later.\n"
+"Group %s is not set. Select some files and press Ctrl+%s to set the group. "
+"Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"O grupo %s não está definido. Selecione alguns arquivos e pressione Ctrl+%s para definir o grupo. Pressione %s sozinho para reselecionar os arquivos posteriormente.\n"
+"O grupo %s não está definido. Selecione alguns arquivos e pressione Ctrl+%s "
+"para definir o grupo. Pressione %s sozinho para reselecionar os arquivos "
+"posteriormente.\n"
 "Certifique-se de que o NumLock esteja ativado se você usa o teclado numérico."
 
-#: filer.c:1343
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "O diretório '%s' não esta acessível"
-
-#: filer.c:1495
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "O diretório '%s' não foi encontrado"
-
-#: filer.c:1795
-msgid "Cancel"
-msgstr "Cancelar"
-
 # Todos
-#: filer.c:2076
+#: filer.c:2655
 msgid "A"
 msgstr "T"
 
-#: filer.c:2078
-#: find.c:923
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr "F"
 
-#: filer.c:2083
+#: filer.c:2664
 msgid "S"
 msgstr "E"
 
 # Thumbnails
-#: filer.c:2085
+#: filer.c:2669
 msgid "T"
 msgstr "M"
 
-#: filer.c:2095
-msgid "All, "
-msgstr "Todos, "
+#: filer.c:2670
+msgid "D"
+msgstr ""
 
-#: filer.c:2098
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
 msgstr "Filtro (%s), "
 
-#: filer.c:2106
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Escaneando, "
 
-#: filer.c:2108
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Miniaturas, "
 
-#: filer.c:2384
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Miniaturas, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Ligação simbólica para "
 
-#: filer.c:2426
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "O nome deste arquivo não é UTF-8 válido. Você deveria renomeá-lo\n"
 
 # ##
-#: filer.c:2743
-#: menu.c:2014
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "O item não existe mais!"
 
-#: filer.c:3549
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Selecione as propriedades de visualização a serem salvas"
 
-#: filer.c:3553
+#: filer.c:4712
+#, fuzzy
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr "<b>Salvar a configuração de visualização para o diretório</b>"
+
+#: filer.c:4713
 msgid "<b>Save display settings for directory</b>"
 msgstr "<b>Salvar a configuração de visualização para o diretório</b>"
 
-#: filer.c:3560
+#: filer.c:4720
 msgid "Select settings to save"
 msgstr "Selecione as configurações a serem salvas"
 
-#: filer.c:3567
+#: filer.c:4727
 msgid "Position"
 msgstr "Posição"
 
-#: filer.c:3572
-#: toolbar.c:133
-#: toolbar.c:137
-#: tips:39
-msgid "Size"
-msgstr "Tamanho"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Janela"
 
-#: filer.c:3577
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Exibir ocultos"
 
-#: filer.c:3583
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Estilo de visualização"
 
-#: filer.c:3589
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Separar por tipo e ordenar"
 
-#: filer.c:3594
-#: toolbar.c:141
+#: filer.c:4754
 msgid "Details"
 msgstr "Detalhes"
 
-#: filer.c:3599
-#: tips:92
-#: tips:93
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Miniaturas"
 
-#: filer.c:3605
+#: filer.c:4765
 msgid "Filter"
 msgstr "Filtrar"
 
@@ -1479,16 +1590,20 @@ msgstr "blocos"
 msgid "Save As:"
 msgstr "Salvar Como:"
 
-#: gtksavebox.c:395
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Sem nome"
 
 # ##
-#: gtksavebox.c:471
-msgid "Remote application wants to use Direct Save, but I can't read the XdndDirectSave0 (type text/plain) property.\n"
-msgstr "A aplicação remota quer usar Direct Save mas não posso ler a propriedade XdndDirectSave0 (type text/plain).\n"
+#: gtksavebox.c:477
+msgid ""
+"Remote application wants to use Direct Save, but I can't read the "
+"XdndDirectSave0 (type text/plain) property.\n"
+msgstr ""
+"A aplicação remota quer usar Direct Save mas não posso ler a propriedade "
+"XdndDirectSave0 (type text/plain).\n"
 
-#: gtksavebox.c:596
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1496,7 +1611,7 @@ msgstr ""
 "Arraste o ícone para um visualizador de diretórios\n"
 "(ou informe um caminho completo)"
 
-#: gui_support.c:330
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1504,195 +1619,194 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:399
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
-msgstr "Tentar ler um arquivo XML como arquivo de texto. O arquivo '%s' pode estar corrompido."
+msgstr ""
+"Tentar ler um arquivo XML como arquivo de texto. O arquivo '%s' pode estar "
+"corrompido."
 
-#: gui_support.c:416
+#: gui_support.c:542
 #, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
-"This may be due to upgrading from a previous version of ROX-Filer. Open the Options window and try changing something and then changing it back (causing the file to be resaved).\n"
+"This may be due to upgrading from a previous version of ROX-Filer. Open the "
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
 "Erro no arquivo '%s' à linha %d: \n"
 "\"%s\"\n"
-"Isso pode ser devido a uma atualização a partir de uma versão anterior do ROX-Filer. Abra a janela de Opções, modifique algo e em seguida reverta a modificação (fazendo\n"
-"com que o arquivo seja salvo novamente). Os erros subsequentes serão ignorados."
+"Isso pode ser devido a uma atualização a partir de uma versão anterior do "
+"ROX-Filer. Abra a janela de Opções, modifique algo e em seguida reverta a "
+"modificação (fazendo\n"
+"com que o arquivo seja salvo novamente). Os erros subsequentes serão "
+"ignorados."
 
-#: gui_support.c:1008
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Quebra de linha inexistente ou incorreta nos dados de text/uri-list"
 
-#: gui_support.c:1341
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "Falha ao abrir o arquivo '%s': %s"
 
-#: gui_support.c:1385
-#, c-format
-msgid "Failed to load image '%s': reason not known, probably a corrupt image file"
-msgstr "Falha ao carregar a imagem '%s': razão desconhecida, provavelmente um arquivo de imagem corrompido"
-
-#: gui_support.c:1450
+#: gui_support.c:1517
 #, c-format
 msgid ""
-"This program (%s) cannot be run, as the 0launch command is not available. It can be downloaded from here:\n"
+"Failed to load image '%s': reason not known, probably a corrupt image file"
+msgstr ""
+"Falha ao carregar a imagem '%s': razão desconhecida, provavelmente um "
+"arquivo de imagem corrompido"
+
+#: gui_support.c:1583
+#, c-format
+msgid ""
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
-"Este programa (%s) não pode ser executado pois o comando 0launch não está disponível. Ele pode ser baixado daqui:\n"
+"Este programa (%s) não pode ser executado pois o comando 0launch não está "
+"disponível. Ele pode ser baixado daqui:\n"
 "\n"
 "http://0install.net/injector.html"
 
 #: i18n.c:39
-msgid "Note that you must save your choices and restart the filer for the new language setting to take full effect."
-msgstr "Note que você deve salvar as escolhas e reiniciar o gerente de arquivos para a nova configuração de idioma funcionar."
+msgid ""
+"Note that you must save your choices and restart the filer for the new "
+"language setting to take full effect."
+msgstr ""
+"Note que você deve salvar as escolhas e reiniciar o gerente de arquivos para "
+"a nova configuração de idioma funcionar."
 
-#: icon.c:76
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(clique para definir)"
 
-#: icon.c:131
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:132
-#: menu.c:258
-msgid "About ROX-Filer..."
-msgstr "Sobre o ROX-Filer..."
-
-#: icon.c:133
-#: menu.c:259
-msgid "Show Help Files"
-msgstr "Exibir Arquivos de Ajuda"
-
-#: icon.c:134
-#: menu.c:260
-msgid "Manual"
-msgstr "Manual"
-
-#: icon.c:136
-#: menu.c:235
-msgid "Options..."
-msgstr "Opções..."
-
-#: icon.c:137
-#: menu.c:244
-msgid "Home Directory"
-msgstr "Diretório Home"
-
-#: icon.c:138
-#: icon.c:1410
-#: menu.c:212
-#: type.c:223
-msgid "File"
-msgstr "Arquivo"
-
-#: icon.c:139
-#: menu.c:218
-#: menu.c:885
-msgid "Shift Open"
-msgstr "Abrir com Shift"
-
-#: icon.c:140
-#: menu.c:223
-msgid "Properties"
-msgstr "Propriedades"
-
-#: icon.c:141
-#: menu.c:221
-msgid "Set Run Action..."
-msgstr "Definir Ação Para Execução..."
-
-#: icon.c:142
-#: menu.c:222
-msgid "Set Icon..."
-msgstr "Definir o Ícone..."
-
-#: icon.c:143
-#: icon.c:867
-msgid "Edit Item"
-msgstr "Editar o Item"
-
-#: icon.c:144
-msgid "Show Location"
-msgstr "Exibir a Localização"
-
-#: icon.c:145
-msgid "Remove Item(s)"
-msgstr "Remover Itens"
-
-#: icon.c:318
-#: log.c:110
-#: menu.c:774
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:331
+#: icon.c:311
 msgid "Nothing"
 msgstr "Nada"
 
-#: icon.c:592
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "A localização deve conter pelo menos um caractere!"
 
-#: icon.c:657
+#: icon.c:641
 #, c-format
 msgid "You must unlock '%s' before removing it"
 msgstr "Você precisa desbloquear '%s' antes de removê-lo"
 
-#: icon.c:667
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Primeiro você deve selecionar algum item para remover"
 
-#: icon.c:673
+#: icon.c:657
 msgid "An item must be unlocked before it can be removed."
 msgstr "Um item necessita estar desbloqueado para ser removido."
 
-#: icon.c:687
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Você deve abrir o menu sobre o item"
 
-#: icon.c:712
-#: menu.c:1285
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "Você só pode definir a ação para execução para um arquivo regular"
 
-#: icon.c:798
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Pressione o atalho desejado (p.ex. Ctrl+F1)"
 
-#: icon.c:820
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Falha no acesso ao teclado!"
 
-#: icon.c:870
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Editar o Item"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Clicar no ícone abre:"
 
-#: icon.c:880
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Argumentos a serem transmitidos (para executáveis):"
 
-#: icon.c:894
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "O texto sob o ícone é:"
 
-#: icon.c:907
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "O atalho de teclado é:"
 
-#: icon.c:927
+#: icon.c:910
 msgid "Locked"
 msgstr "Bloqueado"
 
-#: icon.c:932
+#: icon.c:915
 msgid "Locking an item prevents it from being accidentally removed"
 msgstr "O bloqueio de um item previne que o mesmo seja removido acidentalmente"
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Sobre o ROX-Filer..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Exibir Arquivos de Ajuda"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Manual"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Opções..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Diretório Home"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Arquivo"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Abrir com Shift"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Propriedades"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Definir Ação Para Execução..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Definir o Ícone..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Exibir a Localização"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Remover Itens"
 
 #: infobox.c:113
 #, c-format
@@ -1703,43 +1817,40 @@ msgstr "Você tem certeza de que quer abrir %d janelas?"
 msgid "Show Info"
 msgstr "Exibir Informação"
 
-#: infobox.c:136
-#: menu.c:779
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(utf-8 ruim)"
 
-#: infobox.c:261
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Exibir Arquivos de _Ajuda"
 
-#: infobox.c:274
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Permissões</b>"
 
-#: infobox.c:292
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>O conteúdo indica...</b>"
 
-#: infobox.c:302
+#: infobox.c:319
 msgid "<b>When all directories are closed</b>"
 msgstr "<b>Quando todos os diretórios estão fechados</b>"
 
-#: infobox.c:438
-#: infobox.c:579
-#: support.c:349
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "bytes"
 
-#: infobox.c:461
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Falha ao ler o tamanho"
 
-#: infobox.c:522
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' não é mais uma ligação simbólica"
 
-#: infobox.c:529
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1748,7 +1859,7 @@ msgstr ""
 "Falha ao desligar '%s':\n"
 "%s"
 
-#: infobox.c:534
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1759,184 +1870,185 @@ msgstr ""
 "%s\n"
 "(nota: a ligação antiga foi apagada)"
 
-#: infobox.c:558
-#: tips:242
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Erro:"
 
-#: infobox.c:565
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Diretório real:"
 
-#: infobox.c:568
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Proprietário, Grupo:"
 
-#: infobox.c:575
-#: infobox.c:590
-#: infobox.c:599
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Tamanho:"
 
-#: infobox.c:600
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Escaneando"
 
-#: infobox.c:625
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Falha ao escanear"
 
-#: infobox.c:632
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Mudança de status:"
 
-#: infobox.c:634
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Modificação:"
 
-#: infobox.c:636
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Último acesso:"
 
-#: infobox.c:644
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Atributos estendidos:"
 
-#: infobox.c:646
+#: infobox.c:667
 msgid "Present"
 msgstr "Presente"
 
-#: infobox.c:647
+#: infobox.c:668
 msgid "None"
 msgstr "Nenhum"
 
-#: infobox.c:648
+#: infobox.c:669
 msgid "Not supported"
 msgstr "Não suportado"
 
-#: infobox.c:660
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Alvo da ligação:"
 
-#: infobox.c:672
-#: infobox.c:675
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Ação para execução:"
 
-#: infobox.c:672
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Executar o arquivo"
 
-#: infobox.c:784
+#: infobox.c:805
 msgid "Comment"
 msgstr "Comentar"
 
-#: infobox.c:786
+#: infobox.c:807
 msgid "Execute"
 msgstr "Executar"
 
-#: infobox.c:800
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<nada ainda>"
 
-#: infobox.c:871
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "file(1) diz... %s"
 
-#: infobox.c:928
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Não pude modificar as permissões: %s"
 
-#: infobox.c:946
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Proprietário"
 
-#: infobox.c:948
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Grupo"
 
-#: infobox.c:950
+#: infobox.c:974
 msgid "World"
 msgstr "Mundo"
 
-#: infobox.c:953
+#: infobox.c:977
 msgid "Read"
 msgstr "Leitura"
 
-#: infobox.c:956
+#: infobox.c:980
 msgid "Write"
 msgstr "Escrita"
 
-#: infobox.c:959
+#: infobox.c:983
 msgid "Exec"
 msgstr "Execução"
 
-#: infobox.c:977
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:984
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:991
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky"
 
-#: infobox.c:1047
+#: infobox.c:1071
 msgid "Do nothing"
 msgstr "Nada fazer"
 
-#: infobox.c:1053
+#: infobox.c:1077
 msgid "Ask"
 msgstr "Perguntar"
 
-#: infobox.c:1065
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Ligação simbólica"
 
-#: infobox.c:1068
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "Aplicação ROX"
 
-#: infobox.c:1076
+#: infobox.c:1100
 msgid "mounted"
 msgstr "montado"
 
-#: infobox.c:1076
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "desmontado"
 
-#: infobox.c:1080
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Ponto de montagem para %s (%s)"
 
-#: infobox.c:1083
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Ponto de montagem (%s)"
 
-#: log.c:55
+#: log.c:54
 msgid "ROX-Filer started"
 msgstr "O ROX-Filer iniciou"
 
-#: log.c:112
+#: log.c:115
 #, c-format
 msgid "%s on %d items"
 msgstr "%s em %d itens"
 
-#: log.c:125
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Copiar..."
+
+#: log.c:139
 msgid "Item"
 msgstr "Item"
 
-#: log.c:149
+#: log.c:165
 msgid "Time"
 msgstr "Data"
 
-#: log.c:154
+#: log.c:170
 msgid "Action"
 msgstr "Ação"
 
@@ -2032,71 +2144,69 @@ msgstr ""
 
 #: main.c:237
 msgid ""
-"We got a BadWindow error from the X server. This might be due to this GTK bug (during drag-and-drop?):\n"
+"We got a BadWindow error from the X server. This might be due to this GTK "
+"bug (during drag-and-drop?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Trying to continue..."
 msgstr ""
-"Recebemos do servidor X um erro BadWindow. Isso pode ser em razão deste bug do GTK (ao arrastar e soltar?):\n"
+"Recebemos do servidor X um erro BadWindow. Isso pode ser em razão deste bug "
+"do GTK (ao arrastar e soltar?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Tentando continuar..."
 
-#: main.c:400
-msgid "The -o argument is no longer used. You can turn on override redirect from the Options box instead."
-msgstr "O argumento -o não é mais usado. Em vez dele você pode habilitar sobrepujar redirecionamento na caixa de Opções."
+#: main.c:399
+msgid ""
+"The -o argument is no longer used. You can turn on override redirect from "
+"the Options box instead."
+msgstr ""
+"O argumento -o não é mais usado. Em vez dele você pode habilitar sobrepujar "
+"redirecionamento na caixa de Opções."
 
-#: main.c:529
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Executando como usuário '%s'"
 
-#: main.c:690
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Compilado com GTK versão %s\n"
 
-#: main.c:691
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Executando com GTK versão %d.%d.%d\n"
 
-#: main.c:695
+#: main.c:693
 msgid "features set at compile time"
 msgstr "recursos definidos durante a compilação"
 
-#: main.c:696
+#: main.c:694
 msgid "Large File Support"
 msgstr "Suporte a Arquivos Grandes"
 
-#: main.c:703
-msgid "Inotify support"
-msgstr "Suporte ao Inotify "
-
-#: main.c:710
-msgid "Dnotify support"
-msgstr "Suporte ao Dnotify "
-
-#: main.c:717
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Compatibilidade binária"
 
-#: main.c:719
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Sim (funciona com versões mais velhas da glibc)"
 
-#: main.c:721
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Não (apsymbols.h não foi encontrado)"
 
-#: main.c:725
+#: main.c:709
 msgid "Extended attribute support"
 msgstr "Suporte a arquivos estendidos"
 
-#: main.c:876
+#: main.c:856
 #, c-format
 msgid "Unable to read '%s': %s"
 msgstr "Incapaz de ler '%s': %s"
 
-#: main.c:918
+#: main.c:895
 #, c-format
 msgid ""
 "Left-click to run %s.\n"
@@ -2105,453 +2215,615 @@ msgstr ""
 "Botão-esquerdo para executar %s.\n"
 "Botão-direito para uma lista das versões."
 
-#: menu.c:185
-#: tips:28
-msgid "Display"
-msgstr "Visualização"
-
-#: menu.c:186
-#: tips:33
-msgid "Icons View"
-msgstr "Visão em Ícones"
-
-#: menu.c:187
-msgid "Icons, With..."
-msgstr "Ícones, com..."
-
-#: menu.c:188
-#: tips:52
-msgid "Sizes"
-msgstr "Tamanho"
-
-#: menu.c:190
-#: tips:226
-msgid "Types"
-msgstr "Tipo"
-
-#: menu.c:191
-#: tips:55
-msgid "Times"
-msgstr "Data"
-
-#: menu.c:192
-#: tips:34
-#: tips:70
-msgid "List View"
-msgstr "Visão em Lista"
-
-#: menu.c:194
-msgid "Bigger Icons"
-msgstr "Ícones Maiores"
-
-#: menu.c:195
-msgid "Smaller Icons"
-msgstr "Ícones Menores"
-
-#: menu.c:196
-#: tips:49
-msgid "Automatic"
-msgstr "Automático"
-
-#: menu.c:198
-msgid "Sort by Name"
-msgstr "Ordenar por Nome"
-
-#: menu.c:199
-msgid "Sort by Type"
-msgstr "Ordenar por Tipo"
-
-#: menu.c:200
-msgid "Sort by Date"
-msgstr "Ordenar por Data"
-
-#: menu.c:201
-msgid "Sort by Size"
-msgstr "Ordenar por Tamanho"
-
-#: menu.c:202
-msgid "Sort by Owner"
-msgstr "Ordenar por Proprietário"
-
-#: menu.c:203
-msgid "Sort by Group"
-msgstr "Ordenar por Grupo"
-
-#: menu.c:204
-msgid "Reversed"
-msgstr "Reversa"
-
-#: menu.c:206
-msgid "Show Hidden"
-msgstr "Exibir Ocultos"
-
-#: menu.c:207
-msgid "Filter Files..."
-msgstr "Filtrar Arquivos..."
-
-#: menu.c:208
-msgid "Filter Directories With Files"
-msgstr "Filtrar Diretórios com Arquivos"
-
-#: menu.c:209
-msgid "Show Thumbnails"
-msgstr "Exibir Miniaturas"
-
-#: menu.c:210
-msgid "Refresh"
-msgstr "Atualizar"
-
-#: menu.c:211
-msgid "Save Current Display Settings..."
-msgstr "Salvar a Configuração Atual de Visualização..."
-
-#: menu.c:213
-msgid "Copy..."
-msgstr "Copiar..."
-
-#: menu.c:214
-msgid "Rename..."
-msgstr "Renomear..."
-
-#: menu.c:215
-msgid "Link..."
-msgstr "Ligar..."
-
-#: menu.c:219
-msgid "Send To..."
-msgstr "Enviar Para..."
-
-#: menu.c:224
-msgid "Count"
-msgstr "Contar"
-
-#: menu.c:225
-msgid "Set Type..."
-msgstr "Definir o Tipo..."
-
-#: menu.c:229
-#: toolbar.c:154
-msgid "Select"
-msgstr "Selecionar"
-
-#: menu.c:230
-msgid "Select All"
-msgstr "Selecionar Todos"
-
-#: menu.c:231
-msgid "Clear Selection"
-msgstr "Limpar a Seleção"
-
-#: menu.c:232
-msgid "Invert Selection"
-msgstr "Inverter a Seleção"
-
-#: menu.c:233
-msgid "Select by Name..."
-msgstr "Selecionar por Nome..."
-
-#: menu.c:234
-msgid "Select If..."
-msgstr "Selecionar Se..."
-
-#: menu.c:236
-msgid "New"
-msgstr "Novo"
-
-#: menu.c:238
-msgid "Blank file"
-msgstr "Arquivo vazio"
-
-#: menu.c:240
-#: tasklist.c:309
-msgid "Window"
-msgstr "Janela"
-
-#: menu.c:241
-msgid "Parent, New Window"
-msgstr "Diretório Superior, Nova Janela"
-
-#: menu.c:242
-msgid "Parent, Same Window"
-msgstr "Diretório Superior, Mesma Janela"
-
-#: menu.c:243
-msgid "New Window"
-msgstr "Nova janela"
-
-#: menu.c:245
-msgid "Show Bookmarks"
-msgstr "Exibir as Marcações"
-
-#: menu.c:246
-msgid "Show Log"
-msgstr "Exibir o Log"
-
-#: menu.c:247
-msgid "Follow Symbolic Links"
-msgstr "Seguir as Ligações Simbólicas"
-
-#: menu.c:248
-msgid "Resize Window"
-msgstr "Redimensionar a Janela"
-
-#: menu.c:251
-msgid "Close Window"
-msgstr "Fechar a Janela"
-
-#: menu.c:253
-msgid "Enter Path..."
-msgstr "Informar o Caminho..."
-
-#: menu.c:254
-msgid "Shell Command..."
-msgstr "Comando Shell..."
-
-#: menu.c:255
-msgid "Terminal Here"
-msgstr "Terminal Aqui"
-
-#: menu.c:256
-msgid "Switch to Terminal"
-msgstr "Mudar para o Terminal"
-
-#: menu.c:725
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "Você deveria usar Shift+clique de menu (botão-direito por padrão) sobre um arquivo para enviá-lo para algum lugar"
-
-#: menu.c:764
-msgid "Next Click"
-msgstr "Próximo Clique"
-
-#: menu.c:786
-#, c-format
-msgid "%d items"
-msgstr "%d itens"
-
-#: menu.c:874
-msgid "Open unmounted"
-msgstr "Abrir desmontado"
-
-#: menu.c:877
-msgid "Show Target"
-msgstr "Exibir o Alvo"
-
-#: menu.c:879
-msgid "Look Inside"
-msgstr "Olhar Dentro"
-
-#: menu.c:881
-msgid "Open As Text"
-msgstr "Abrir Como Texto"
-
-#: menu.c:1052
-msgid ""
-"Extended attributes, used to store types, are not supported for this file or files.\n"
-"This may be due to lack of support from the filesystem or the C library, or it may simply be that the filesystem needs to be mounted with the right mount option ('user_xattr' on Linux)."
-msgstr ""
-"Atributos estendidos, usados para guardar tipos, não são suportados para este(s) arquivo(s).\n"
-"Isso pode se dever à falta de suporte da parte do sistema de arquivos ou da biblioteca C ou pode ser apenas que o sistema de arquivos deve ser montado com a opção correta ('user_xattr' no Linux)."
-
-#: menu.c:1058
-msgid "Setting type not supported for some of these files"
-msgstr "A definição do tipo não é suportada para alguns desses arquivos."
-
-#: menu.c:1095
-msgid "_Relative link"
-msgstr "Link _relativo"
-
-#: menu.c:1101
-msgid ""
-"If on, the symlink will store the path from the symlink to the target file. Use this if the symlink and the target will be moved together.\n"
-"If off, the path from the root directory is stored - use this if the symlink may move but the target will stay put."
-msgstr ""
-"Se habilitado, a ligação simbólica armazena o caminho da ligação ao arquivo alvo - use isto se a ligação e o alvo serão movidos juntos.\n"
-"Se desabilitado, o caminho a partir do diretório raiz é armazenado - use isto se a ligação pode ser movida mas o alvo permanecerá no lugar."
-
-#: menu.c:1171
-msgid "New pathname is not absolute"
-msgstr "O novo caminho não é absoluto"
-
-#: menu.c:1239
-#, c-format
-msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
-msgstr "A ligação de '%s' já existe. Substitui-la com uma ligação para '%s'?"
-
-#: menu.c:1245
-msgid "_Replace"
-msgstr "_Substituir"
-
-#: menu.c:1365
-#: menu.c:1406
-#: menu.c:1468
-msgid "Create"
-msgstr "Criar"
-
-#: menu.c:1366
-msgid "NewDir"
-msgstr "NovoDiretório"
-
-#: menu.c:1380
-#: menu.c:1386
+#: main.c:942 menu.c:1723 menu.c:1729
 #, c-format
 msgid "Error creating '%s': %s"
 msgstr "Erro ao criar '%s': %s"
 
-#: menu.c:1407
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Salvar Como:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
+msgid "Display"
+msgstr "Visualização"
+
+#: menu.c:641 tips:49
+msgid "Icons View"
+msgstr "Visão em Ícones"
+
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
+msgstr "Ícones, com..."
+
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Tema de ícones"
+
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Permissões"
+
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Ícones, com..."
+
+#: menu.c:647 tips:50 tips:98 tips:99
+msgid "List View"
+msgstr "Visão em Lista"
+
+#: menu.c:651
+msgid "Bigger Icons"
+msgstr "Ícones Maiores"
+
+#: menu.c:653
+msgid "Smaller Icons"
+msgstr "Ícones Menores"
+
+#: menu.c:655 tips:71
+msgid "Automatic"
+msgstr "Automático"
+
+#: menu.c:661
+msgid "Sort by Name"
+msgstr "Ordenar por Nome"
+
+#: menu.c:662
+msgid "Sort by Type"
+msgstr "Ordenar por Tipo"
+
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
+msgstr "Ordenar por Data"
+
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Ordenar por Data"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Ordenar por Data"
+
+#: menu.c:666
+msgid "Sort by Size"
+msgstr "Ordenar por Tamanho"
+
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Permissões"
+
+#: menu.c:668
+msgid "Sort by Owner"
+msgstr "Ordenar por Proprietário"
+
+#: menu.c:669
+msgid "Sort by Group"
+msgstr "Ordenar por Grupo"
+
+#: menu.c:671
+msgid "Reversed"
+msgstr "Reversa"
+
+#: menu.c:675
+msgid "Show Hidden"
+msgstr "Exibir Ocultos"
+
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Exibir Arquivos de Ajuda"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "sem diretórios)\n"
+
+#: menu.c:679
+msgid "Filter Files..."
+msgstr "Filtrar Arquivos..."
+
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Filtrar Arquivos..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr "Filtrar Diretórios com Arquivos"
+
+#: menu.c:682
+msgid "Show Thumbnails"
+msgstr "Exibir Miniaturas"
+
+#: menu.c:683
+msgid "Refresh"
+msgstr "Atualizar"
+
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Atualizar"
+
+#: menu.c:686
+#, fuzzy
+msgid "Save Display Settings..."
+msgstr "Salvar a Configuração Atual de Visualização..."
+
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Salvar a Configuração Atual de Visualização..."
+
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Contar"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
+msgid "Rename..."
+msgstr "Renomear..."
+
+#: menu.c:700
+msgid "Link..."
+msgstr "Ligar..."
+
+#: menu.c:708
+msgid "Send To..."
+msgstr "Enviar Para..."
+
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Atributos estendidos"
+
+#: menu.c:721
+msgid "Count"
+msgstr "Contar"
+
+#: menu.c:723
+msgid "Set Type..."
+msgstr "Definir o Tipo..."
+
+#: menu.c:731 toolbar.c:179
+msgid "Select"
+msgstr "Selecionar"
+
+#: menu.c:733
+msgid "Select All"
+msgstr "Selecionar Todos"
+
+#: menu.c:735
+msgid "Clear Selection"
+msgstr "Limpar a Seleção"
+
+#: menu.c:736
+msgid "Invert Selection"
+msgstr "Inverter a Seleção"
+
+#: menu.c:737
+msgid "Select by Name..."
+msgstr "Selecionar por Nome..."
+
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Selecionar Se..."
+
+#: menu.c:741
+msgid "Select If..."
+msgstr "Selecionar Se..."
+
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
+msgid "New"
+msgstr "Novo"
+
+#: menu.c:752
+msgid "Blank file"
+msgstr "Arquivo vazio"
+
+#: menu.c:756 tasklist.c:305
+msgid "Window"
+msgstr "Janela"
+
+#: menu.c:758
+msgid "Parent, New Window"
+msgstr "Diretório Superior, Nova Janela"
+
+#: menu.c:759
+msgid "Parent, Same Window"
+msgstr "Diretório Superior, Mesma Janela"
+
+#: menu.c:761 tips:44
+msgid "New Window"
+msgstr "Nova janela"
+
+#: menu.c:764
+msgid "Show Bookmarks"
+msgstr "Exibir as Marcações"
+
+#: menu.c:766
+msgid "Show Log"
+msgstr "Exibir o Log"
+
+#: menu.c:768
+msgid "Follow Symbolic Links"
+msgstr "Seguir as Ligações Simbólicas"
+
+#: menu.c:769
+msgid "Resize Window"
+msgstr "Redimensionar a Janela"
+
+#: menu.c:771
+msgid "Close Window"
+msgstr "Fechar a Janela"
+
+#: menu.c:776
+msgid "Enter Path..."
+msgstr "Informar o Caminho..."
+
+#: menu.c:778
+msgid "Shell Command..."
+msgstr "Comando Shell..."
+
+#: menu.c:780
+msgid "Terminal Here"
+msgstr "Terminal Aqui"
+
+#: menu.c:782
+msgid "Switch to Terminal"
+msgstr "Mudar para o Terminal"
+
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Personalizar o Menu..."
+
+#: menu.c:976
+msgid "Next Click"
+msgstr "Próximo Clique"
+
+#: menu.c:998
+#, c-format
+msgid "%d items"
+msgstr "%d itens"
+
+#: menu.c:1094
+msgid "Open unmounted"
+msgstr "Abrir desmontado"
+
+#: menu.c:1097
+msgid "Show Target"
+msgstr "Exibir o Alvo"
+
+#: menu.c:1099
+msgid "Look Inside"
+msgstr "Olhar Dentro"
+
+#: menu.c:1101
+msgid "Open As Text"
+msgstr "Abrir Como Texto"
+
+#: menu.c:1320
+msgid ""
+"Extended attributes, used to store types, are not supported for this file or "
+"files.\n"
+"This may be due to lack of support from the filesystem or the C library, or "
+"it may simply be that the filesystem needs to be mounted with the right "
+"mount option ('user_xattr' on Linux)."
+msgstr ""
+"Atributos estendidos, usados para guardar tipos, não são suportados para "
+"este(s) arquivo(s).\n"
+"Isso pode se dever à falta de suporte da parte do sistema de arquivos ou da "
+"biblioteca C ou pode ser apenas que o sistema de arquivos deve ser montado "
+"com a opção correta ('user_xattr' no Linux)."
+
+#: menu.c:1326
+msgid "Setting type not supported for some of these files"
+msgstr "A definição do tipo não é suportada para alguns desses arquivos."
+
+#: menu.c:1364
+msgid "_Relative link"
+msgstr "Link _relativo"
+
+#: menu.c:1370
+msgid ""
+"If on, the symlink will store the path from the symlink to the target file. "
+"Use this if the symlink and the target will be moved together.\n"
+"If off, the path from the root directory is stored - use this if the symlink "
+"may move but the target will stay put."
+msgstr ""
+"Se habilitado, a ligação simbólica armazena o caminho da ligação ao arquivo "
+"alvo - use isto se a ligação e o alvo serão movidos juntos.\n"
+"Se desabilitado, o caminho a partir do diretório raiz é armazenado - use "
+"isto se a ligação pode ser movida mas o alvo permanecerá no lugar."
+
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
+msgid "New pathname is not absolute"
+msgstr "O novo caminho não é absoluto"
+
+#: menu.c:1540
+#, c-format
+msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
+msgstr "A ligação de '%s' já existe. Substitui-la com uma ligação para '%s'?"
+
+#: menu.c:1546
+msgid "_Replace"
+msgstr "_Substituir"
+
+#: menu.c:1704
+msgid "NewDir"
+msgstr "NovoDiretório"
+
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Criar"
+
+#: menu.c:1755
 msgid "NewFile"
 msgstr "NovoArquivo"
 
-#: menu.c:1425
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "Erro ao criar arquivo: não pude encontrar o modelo para %s"
 
-#: menu.c:1498
-#, c-format
+#: menu.c:1847
+#, fuzzy
 msgid ""
-"The `Send To' menu provides a quick way to send some files to an application. The applications listed are those in the following directories:\n"
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Crie uma ligação simbólica de qualquer programa que você quiser para este "
+"diretório. Eles aparecerão no menu para todos os itens desse tipo (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
+msgid ""
+"The `Send To' menu provides a quick way to send some files to an "
+"application. The applications listed are those in the following "
+"directories:\n"
 "\n"
 "%s\n"
 "%s\n"
 "The `Send To' menu may be opened by Shift+Menu clicking over a file.\n"
 "\n"
 "Advanced use:\n"
-"You can also create subdirectories called `.text_html', `.text', etc which will only be shown for files of that type. `.group' is shown only when multiple files are selected."
+"You can also create subdirectories called `.text_html', `.text', etc which "
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
-"O Menu `Enviar Para' provê um modo rápido de enviar alguns arquivos para uma aplicação. As aplicações listadas estão nos seguintes diretórios:\n"
+"O Menu `Enviar Para' provê um modo rápido de enviar alguns arquivos para uma "
+"aplicação. As aplicações listadas estão nos seguintes diretórios:\n"
 "\n"
 "%s\n"
 "%s\n"
-"O menu  `Enviar Para'  é aberto por Shift+clique de menu (botão-direito por padrão) sobre um arquivo.\n"
+"O menu  `Enviar Para'  é aberto por Shift+clique de menu (botão-direito por "
+"padrão) sobre um arquivo.\n"
 "\n"
 "Uso avançado:\n"
-"Você também pode criar subdiretórios chamados `.text_html', `.text', etc. que só serão exibidos para arquivos daquele tipo. `.group' é exibido somente quando se seleciona arquivos múltiplos."
+"Você também pode criar subdiretórios chamados `.text_html', `.text', etc. "
+"que só serão exibidos para arquivos daquele tipo. `.group' é exibido somente "
+"quando se seleciona arquivos múltiplos."
 
-#: menu.c:1509
-msgid "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift drag) any applications you want into it."
-msgstr "Eu lhe mostrarei agora o seu diretório EnviarPara; você deveria criar ligações (Ctrl+Shift ao arrastar) para ele das aplicações desejadas."
+#: menu.c:1895
+msgid ""
+"I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
+"drag) any applications you want into it."
+msgstr ""
+"Eu lhe mostrarei agora o seu diretório EnviarPara; você deveria criar "
+"ligações (Ctrl+Shift ao arrastar) para ele das aplicações desejadas."
 
-#: menu.c:1512
-#: menu.c:1552
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
-msgstr "A sua configuração da variável CHOICESPATH impede personalizações - desculpe."
+msgstr ""
+"A sua configuração da variável CHOICESPATH impede personalizações - desculpe."
 
-#: menu.c:1545
+#: menu.c:1931
 #, c-format
 msgid ""
-"Any files placed in your Templates directories will appear on the `New' menu. Choosing one of them will make a copy of it as the new file.\n"
+"Any files placed in your Templates directories will appear on the `New' "
+"menu. Choosing one of them will make a copy of it as the new file.\n"
 "\n"
 "The following directories contain templates:\n"
 "\n"
 "%s\n"
 "%s\n"
 msgstr ""
-"Quaisquer arquivos no seu diretório Templates (Modelos) aparecerão no menu `Novo'. Ao escolher um deles uma cópia do mesmo será gerada como o novo arquivo.\n"
+"Quaisquer arquivos no seu diretório Templates (Modelos) aparecerão no menu "
+"`Novo'. Ao escolher um deles uma cópia do mesmo será gerada como o novo "
+"arquivo.\n"
 "\n"
 "Os seguintes diretórios contém modelos:\n"
 "\n"
 "%s\n"
 "%s\n"
 
-#: menu.c:1550
-msgid "I'll show you your Templates directory now; you should place any template files you want inside it."
-msgstr "Eu lhe mostrarei o seu diretório Templates; você deve colocar nele os arquivos de modelo (template) que desejar."
+#: menu.c:1936
+msgid ""
+"I'll show you your Templates directory now; you should place any template "
+"files you want inside it."
+msgstr ""
+"Eu lhe mostrarei o seu diretório Templates; você deve colocar nele os "
+"arquivos de modelo (template) que desejar."
 
-#: menu.c:1667
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Personalizar"
 
-#: menu.c:1740
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Personalizar o Menu..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Esse já é o nome canônico deste diretório."
 
-#: menu.c:1771
-msgid "You can't open a second view onto this directory because the `Unique Windows' option is turned on in the Options window."
-msgstr "Você não pode abrir uma segunda visualização neste diretório pois a opção `Janela Única' está ativada na janela de Opções."
+#: menu.c:2200
+msgid ""
+"You can't open a second view onto this directory because the `Unique "
+"Windows' option is turned on in the Options window."
+msgstr ""
+"Você não pode abrir uma segunda visualização neste diretório pois a opção "
+"`Janela Única' está ativada na janela de Opções."
 
-#: menu.c:1897
-msgid "Copy ... ?"
-msgstr "Copiar ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1900
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Copiar %s para %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Copiar %s para %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Renomear ... ?"
 
-#: menu.c:1903
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Ligar ... ?"
 
-#: menu.c:1906
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Abrir com Shift ... ?"
 
-#: menu.c:1909
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Propriedades de ...?"
 
-#: menu.c:1912
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Atributos estendidos"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Definir o tipo de ... ?"
 
-#: menu.c:1915
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Definir ação para execução para ... ?"
 
-#: menu.c:1918
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Definir o ícone para ... ?"
 
-#: menu.c:1921
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Enviar ... para ... ?"
 
-#: menu.c:1924
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "APAGAR ... ?"
 
-#: menu.c:1927
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Contar o tamanho ... ?"
 
-#: menu.c:1930
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Definir as permissões sobre ... ?"
 
-#: menu.c:1933
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Procurar dentro ... ?"
 
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Copiar ... ?"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
 # ##
-#: menu.c:1997
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Você não pode fazer isto com mais de um item ao mesmo tempo"
 
-#: menu.c:2029
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Renomear"
 
-#: menu.c:2034
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Ligar"
 
-#: menu.c:2063
+#: menu.c:2654
 msgid ""
-"User-definable shortcuts are disabled by default in Gtk2, and you have not enabled them. You can turn this feature on by:\n"
+"User-definable shortcuts are disabled by default in Gtk2, and you have not "
+"enabled them. You can turn this feature on by:\n"
 "\n"
-"1) using an XSettings manager, such as ROX-Session or gnome-settings-daemon, or\n"
+"1) using an XSettings manager, such as ROX-Session or gnome-settings-daemon, "
+"or\n"
 "\n"
 "2) adding this line to ~/.gtkrc-2.0:\n"
 "\tgtk-can-change-accels = 1\n"
 "\t(this only works if NOT using XSETTINGS)"
 msgstr ""
-"Atalhos definíveis pelo usuário são desabilitados por padrão no Gtk2 e você não os habilitou. Você pode habilitar esse recurso:\n"
-"1) usando um gerenciador de XSettings como o ROX-Session ou o gnome-settings-daemon, ou\n"
+"Atalhos definíveis pelo usuário são desabilitados por padrão no Gtk2 e você "
+"não os habilitou. Você pode habilitar esse recurso:\n"
+"1) usando um gerenciador de XSettings como o ROX-Session ou o gnome-settings-"
+"daemon, ou\n"
 "\n"
 "2) adicionando esta linha a ~/.gtkrc-2.0:\n"
 "\tgtk-can-change-accels = 1\n"
 "\t(isto só funciona se NÃO estiver usando XSETTINGS)"
 
-#: menu.c:2074
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2559,7 +2831,8 @@ msgid ""
 "- Move the pointer over the item you want to use,\n"
 "- Press the key you want attached to it.\n"
 "\n"
-"The key will appear next to the menu item and you can just press that key without opening the menu in future."
+"The key will appear next to the menu item and you can just press that key "
+"without opening the menu in future."
 msgstr ""
 "Para definir um atalho de teclado pra um item do menu:\n"
 "\n"
@@ -2567,41 +2840,79 @@ msgstr ""
 "- Mova o cursor sobre o item que quer usar,\n"
 "- Pressione a tecla que deseja vincular com ele.\n"
 "\n"
-"A tecla aparecerá junto do item do menu e no futuro você poderá apenas pressionar aquela tecla sem precisar abrir o menu."
+"A tecla aparecerá junto do item do menu e no futuro você poderá apenas "
+"pressionar aquela tecla sem precisar abrir o menu."
 
-#: menu.c:2089
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Definir atalhos de teclado"
 
-#: minibuffer.c:129
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Ir Para:"
 
-#: minibuffer.c:130
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Shell:"
 
-#: minibuffer.c:131
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Selecionar Se:"
 
-#: minibuffer.c:132
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Selecionar Nomeado:"
 
-#: minibuffer.c:133
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Selecionar Se:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Padrão:"
 
-#: minibuffer.c:265
-msgid "Enter the name of a file and I'll display it for you. Press Tab to fill in the longest match. Escape to close the minibuffer."
-msgstr "Informe o nome de um aquivo e eu o exibirei. Pressione Tab para preencher com a correspondência mais longa. Esc para fechar o minibuffer."
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
 
-#: minibuffer.c:271
-msgid "Enter a shell command to execute. Click on a file to add it to the buffer."
-msgstr "Informe um comando shell para ser executado. Clique num arquivo para adicioná-lo ao buffer."
+#: minibuffer.c:320
+msgid ""
+"Enter the name of a file and I'll display it for you. Press Tab to fill in "
+"the longest match. Escape to close the minibuffer."
+msgstr ""
+"Informe o nome de um aquivo e eu o exibirei. Pressione Tab para preencher "
+"com a correspondência mais longa. Esc para fechar o minibuffer."
 
-#: minibuffer.c:276
+#: minibuffer.c:326
+msgid ""
+"Enter a shell command to execute. Click on a file to add it to the buffer."
+msgstr ""
+"Informe um comando shell para ser executado. Clique num arquivo para "
+"adicioná-lo ao buffer."
+
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Informe um padrão de nome de arquivo para selecionar todos os arquivos "
+"correspondentes:\n"
+"\n"
+"? significa qualquer caractere\n"
+"* significa zero ou mais caracteres\n"
+"[aA] significa 'a' ou 'A'\n"
+"[a-z] significa qualquer caractere de 'a' a 'z' (minúsculo)\n"
+"*.png significa qualquer nome terminando em '.png'"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2611,7 +2922,8 @@ msgid ""
 "[a-z] means any character from a to z (lowercase)\n"
 "*.png means any name ending in '.png'"
 msgstr ""
-"Informe um padrão de nome de arquivo para selecionar todos os arquivos correspondentes:\n"
+"Informe um padrão de nome de arquivo para selecionar todos os arquivos "
+"correspondentes:\n"
 "\n"
 "? significa qualquer caractere\n"
 "* significa zero ou mais caracteres\n"
@@ -2619,51 +2931,66 @@ msgstr ""
 "[a-z] significa qualquer caractere de 'a' a 'z' (minúsculo)\n"
 "*.png significa qualquer nome terminando em '.png'"
 
-#: minibuffer.c:288
-msgid "Enter a pattern to match for files to be shown.  An empty filter turns the filter off."
-msgstr "Informe um padrão para os arquivos correspondentes serem exibidos. Um filtro vazio desliga a filtragem."
+#: minibuffer.c:352
+msgid ""
+"Enter a pattern to match for files to be shown.  An empty filter turns the "
+"filter off."
+msgstr ""
+"Informe um padrão para os arquivos correspondentes serem exibidos. Um filtro "
+"vazio desliga a filtragem."
 
-#: minibuffer.c:908
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Informe um padrão para os arquivos correspondentes serem exibidos. Um filtro "
+"vazio desliga a filtragem."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Condição do Localizar inválida"
 
 #: mount.c:103
 #, c-format
 msgid "File system table \"%s\" not found, cannot monitor system mounts"
-msgstr "A tabela do sistema de arquivos \"%s\"  não foi encontrada. Não posso monitorar as montagens do sistema"
+msgstr ""
+"A tabela do sistema de arquivos \"%s\"  não foi encontrada. Não posso "
+"monitorar as montagens do sistema"
 
 #: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s total, %s usado, %s livre (%.1f%%)"
 
-#: options.c:275
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "O ROX-Filer converteu o seu arquivo de Opções para o novo formato XML"
 
-#: options.c:535
-#: options.c:1256
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(usar padrão)"
 
-#: options.c:805
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Erro interno: %s ilegível"
 
-#: options.c:914
+#: options.c:929
 msgid "Options"
 msgstr "Opções"
 
-#: options.c:959
+#: options.c:974
 msgid "_Revert"
 msgstr "_Reverter"
 
-#: options.c:965
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
-msgstr "Restaurar as escolhas para como elas estavam ao abrir a janela de Opções."
+msgstr ""
+"Restaurar as escolhas para como elas estavam ao abrir a janela de Opções."
 
-#: options.c:980
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2672,52 +2999,55 @@ msgstr ""
 "As escolhas serão salvas como:\n"
 "%s"
 
-#: options.c:988
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(gravação desabilitada por CHOICESPATH)"
 
-#: options.c:1161
-#: usericons.c:452
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Erro ao salvar %s: %s"
 
-#: options.c:1793
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Faltando '='"
 
-#: panel.c:322
+#: panel.c:326
 #, c-format
 msgid "Unable to replace '%s'"
 msgstr "Incapaz de substituir '%s'"
 
-#: panel.c:326
+#: panel.c:330
 #, c-format
 msgid "Unable to save '%s'"
 msgstr "Incapaz de salvar '%s'"
 
-#: panel.c:529
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "O seu arquivo antigo do painel foi convertido para o novo formato XML."
 
-#: panel.c:637
-msgid "You have tried to close a panel via the window manager - I usually find that this is accidental... really close?"
-msgstr "Você tentou fechar um painel a partir do gerenciador de janelas - eu normalmente penso que isso é acidental... realmente fechar?"
+#: panel.c:670
+msgid ""
+"You have tried to close a panel via the window manager - I usually find that "
+"this is accidental... really close?"
+msgstr ""
+"Você tentou fechar um painel a partir do gerenciador de janelas - eu "
+"normalmente penso que isso é acidental... realmente fechar?"
 
-#: panel.c:738
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Faltando < ou > no arquivo de configuração do painel"
 
-#: panel.c:1610
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Erro ao salvar o painel %s: %s"
 
-#: panel.c:1925
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "O mini-aplicativo fechou sem jamais criar um widget!"
 
-#: panel.c:2021
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2726,45 +3056,44 @@ msgstr ""
 "Erro ao executar o mini-aplicativo:\n"
 "%s"
 
-#: panel.c:2646
+#: panel.c:2751
 msgid "Are you sure you want to remove this panel from the desktop?"
 msgstr "Você tem certeza de que quer remover este painel da área de trabalho?"
 
-#: panel.c:2649
-#: panel.c:2676
+#: panel.c:2754 panel.c:2781
 msgid "Remove Panel"
 msgstr "Remover Painel"
 
-#: panel.c:2672
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Opções do Painel..."
 
-#: panel.c:2757
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Monitor Xinerama %d indisponível"
 
-#: panel.c:2787
+#: panel.c:2897
 msgid "Top"
 msgstr "No alto"
 
-#: panel.c:2789
+#: panel.c:2899
 msgid "Bottom"
 msgstr "Embaixo"
 
-#: panel.c:2791
+#: panel.c:2901
 msgid "Left"
 msgstr "À esquerda"
 
-#: panel.c:2793
+#: panel.c:2903
 msgid "Right"
 msgstr "À direita"
 
-#: panel.c:2795
+#: panel.c:2905
 msgid "Default"
 msgstr "Padrão"
 
-#: panel.c:2799
+#: panel.c:2909
 msgid "Unknown side"
 msgstr "Lado desconhecido"
 
@@ -2773,18 +3102,28 @@ msgid "Your old pinboard file has been converted to the new XML format."
 msgstr "O seu arquivo antigo do quadro foi convertido para o novo formato XML."
 
 #: pinboard.c:711
-msgid "The backdrop handler must be an application directory. Drag an application directory into the Set Backdrop dialog box, or (for programmers) pass it to the SOAP SetBackdropApp method."
-msgstr "O manipulador do fundo precisa ser um diretório-aplicação. Arraste um diretório-aplicação para a caixa de diálogo Definir o Fundo ou (para programadores) passe-o para o método SOAP SetBackdropApp."
+msgid ""
+"The backdrop handler must be an application directory. Drag an application "
+"directory into the Set Backdrop dialog box, or (for programmers) pass it to "
+"the SOAP SetBackdropApp method."
+msgstr ""
+"O manipulador do fundo precisa ser um diretório-aplicação. Arraste um "
+"diretório-aplicação para a caixa de diálogo Definir o Fundo ou (para "
+"programadores) passe-o para o método SOAP SetBackdropApp."
 
 #: pinboard.c:730
 msgid ""
-"You can only set the backdrop to an image or to a program which knows how to manage ROX-Filer's backdrop.\n"
+"You can only set the backdrop to an image or to a program which knows how to "
+"manage ROX-Filer's backdrop.\n"
 "\n"
-"Programmers: the application's AppInfo.xml must contain the CanSetBackdrop element, as described in ROX-Filer's manual."
+"Programmers: the application's AppInfo.xml must contain the CanSetBackdrop "
+"element, as described in ROX-Filer's manual."
 msgstr ""
-"Você só pode definir o fundo com uma imagem ou programa que saiba como lidar com o fundo do ROX-Filer.\n"
+"Você só pode definir o fundo com uma imagem ou programa que saiba como lidar "
+"com o fundo do ROX-Filer.\n"
 "\n"
-"Programadores: o AppInfo.xml da aplicação necessita conter o elemento CanSetBackdrop como descrito no manual do ROX-Filer."
+"Programadores: o AppInfo.xml da aplicação necessita conter o elemento "
+"CanSetBackdrop como descrito no manual do ROX-Filer."
 
 #: pinboard.c:750
 msgid "Set backdrop"
@@ -2811,8 +3150,12 @@ msgid "Scale"
 msgstr "Escalonar"
 
 #: pinboard.c:779
-msgid "Scale the image to fit the backdrop area, regardless of image dimensions - overscale"
-msgstr "Escalonar a imagem para que caiba no fundo, independentemente do seu tamanho - superdimensionar"
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr ""
+"Escalonar a imagem para que caiba no fundo, independentemente do seu tamanho "
+"- superdimensionar"
 
 #: pinboard.c:781
 msgid "Fit"
@@ -2839,35 +3182,43 @@ msgid "Drop an image here"
 msgstr "Arraste uma imagem para cá"
 
 #: pinboard.c:851
-msgid "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox -p=Default' to turn it on in future."
-msgstr "Nenhum quadro estava em uso... o quadro 'Padrão' foi selecionado. Use 'rox -p=Default' para habilitá-lo no futuro."
+msgid ""
+"No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
+"-p=Default' to turn it on in future."
+msgstr ""
+"Nenhum quadro estava em uso... o quadro 'Padrão' foi selecionado. Use 'rox -"
+"p=Default' para habilitá-lo no futuro."
 
 #: pinboard.c:945
-msgid "Only files (and certain applications) can be used to set the background image."
-msgstr "Apenas arquivos (e certas aplicações) podem ser usados para definir a imagem de fundo."
+msgid ""
+"Only files (and certain applications) can be used to set the background "
+"image."
+msgstr ""
+"Apenas arquivos (e certas aplicações) podem ser usados para definir a imagem "
+"de fundo."
 
-#: pinboard.c:1602
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Faltando '>' no rótulo do ícone"
 
-#: pinboard.c:1611
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Faltando ',' após o rótulo do ícone"
 
-#: pinboard.c:1699
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Erro ao salvar o quadro %s: %s"
 
-#: pinboard.c:2244
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Fundo..."
 
-#: pinboard.c:2247
+#: pinboard.c:2250
 msgid "Add Panel"
 msgstr "Adicionar Painel"
 
-#: pinboard.c:2341
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2878,7 +3229,7 @@ msgstr ""
 "%s\n"
 "O fundo foi removido."
 
-#: pixmaps.c:969
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2887,214 +3238,272 @@ msgstr ""
 "Não posso apagar as miniaturas em %s:\n"
 "%s"
 
-#: pixmaps.c:990
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Não há miniaturas para apagar"
 
-#: pixmaps.c:1003
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Eliminar o cache do disco de miniaturas"
 
-#: remote.c:722
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Estilo desconhecido '%s'"
 
-#: remote.c:744
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Tipo de detalhes desconhecido '%s'"
 
-#: remote.c:772
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Tipo de ordenação desconhecido '%s'"
 
-#: remote.c:1247
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Tentativa de invocar um método SOAP desconhecido '%s'"
 
 # ##, c-format
-#: run.c:99
-#: run.c:152
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "O programa %s não foi encontrado - apagado?"
 
-#: run.c:302
+#: run.c:359
+#, c-format
+msgid ""
+"No run action specified for files of this type (%s/%s) - you can set a run "
+"action by choosing `Set Run Action' from the File menu, or you can just drag "
+"the file to an application.%s"
+msgstr ""
+"Nenhuma ação para execução especificada para o tipo (%s/%s) - você pode "
+"definir uma ação para execução através de `Definir Ação Para Execução' no "
+"menu Arquivo ou arrastando o arquivo para um aplicativo.%s"
+
+#: run.c:365
+msgid ""
+"\n"
+"\n"
+"Note: If this is a computer program which you want to run, you need to set "
+"the execute bit by choosing Permissions from the File menu."
+msgstr ""
+"\n"
+"\n"
+"Nota: se este é um programa que você quer executar, é preciso definir o bit "
+"executável através de Permissões no menu Arquivo."
+
+#: run.c:373
 #, c-format
 msgid "File doesn't exist, or I can't access it: %s"
 msgstr "O arquivo não existe ou eu não posso acessá-lo: %s"
 
-#: run.c:307
+#: run.c:378
 #, c-format
 msgid "I don't know how to open '%s'"
 msgstr "Não sei como abrir  '%s'"
 
-#: run.c:338
+#: run.c:409
 #, c-format
 msgid "'%s' is not a valid URI"
 msgstr "'%s' não é uma URI válida"
 
-#: run.c:349
+#: run.c:420
 #, c-format
 msgid "%s not accessable"
 msgstr "%s não está acessível"
 
-#: run.c:357
+#: run.c:428
 #, c-format
 msgid "Non-local URL %s"
 msgstr "URL não-local %s"
 
-#: run.c:374
+#: run.c:445
 #, c-format
 msgid "%s: no handler for %s"
 msgstr "%s: no manipulador para %s"
 
-#: run.c:394
+#: run.c:465
 msgid ""
 "Application:\n"
-"This is an application directory - you can run it as a program, or open it (hold down Shift while you open it). Most applications provide their own help here, but this one doesn't."
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
 msgstr ""
 "Aplicação:\n"
-"Este é um diretório-aplicação - você pode executá-lo como um programa ou abri-lo (pressione Shift enquanto o abre). A maioria das aplicações provê ajuda mas esta não."
+"Este é um diretório-aplicação - você pode executá-lo como um programa ou "
+"abri-lo (pressione Shift enquanto o abre). A maioria das aplicações provê "
+"ajuda mas esta não."
 
-#: run.c:478
+#: run.c:549
 #, c-format
 msgid "Could not send data to program: %s"
 msgstr "Não pude enviar os dados para o programa: %s"
 
-#: run.c:508
+#: run.c:578
 #, c-format
 msgid "Could not read link: %s"
 msgstr "Não pude ler a ligação: %s"
 
 # ##, c-format
-#: run.c:536
+#: run.c:606
 #, c-format
 msgid "Broken symlink (or you don't have permission to follow it): %s"
 msgstr "Ligação quebrada (ou você não tem autorização para segui-la): %s"
 
-#: run.c:573
-#, c-format
-msgid "No run action specified for files of this type (%s/%s) - you can set a run action by choosing `Set Run Action' from the File menu, or you can just drag the file to an application.%s"
-msgstr "Nenhuma ação para execução especificada para o tipo (%s/%s) - você pode definir uma ação para execução através de `Definir Ação Para Execução' no menu Arquivo ou arrastando o arquivo para um aplicativo.%s"
-
-#: run.c:579
-msgid ""
-"\n"
-"\n"
-"Note: If this is a computer program which you want to run, you need to set the execute bit by choosing Permissions from the File menu."
-msgstr ""
-"\n"
-"\n"
-"Nota: se este é um programa que você quer executar, é preciso definir o bit executável através de Permissões no menu Arquivo."
-
-#: run.c:753
+#: run.c:785
 #, c-format
 msgid ""
-"Executable '%s' is world-writeable! Refusing to run. Please change the permissions now (this problem may have been caused by a bug in earlier versions of the filer).\n"
+"Executable '%s' is world-writeable! Refusing to run. Please change the "
+"permissions now (this problem may have been caused by a bug in earlier "
+"versions of the filer).\n"
 "\n"
-"Having (non-symlink) run actions world-writeable means that other people who use your computer can replace your run actions with malicious versions.\n"
+"Having (non-symlink) run actions world-writeable means that other people who "
+"use your computer can replace your run actions with malicious versions.\n"
 "\n"
-"If you trust everyone who could write to these files then you needn't worry. Otherwise, you should check, or even just delete, all the existing run actions."
+"If you trust everyone who could write to these files then you needn't worry. "
+"Otherwise, you should check, or even just delete, all the existing run "
+"actions."
 msgstr ""
-"O executável '%s' é escrevível por todo o mundo! Recusando-me a executar. Por favor, modifique as permissões agora (este problema pode ter sido causado por um bug em versões anteriores do gerente de arquivos).\n"
+"O executável '%s' é escrevível por todo o mundo! Recusando-me a executar. "
+"Por favor, modifique as permissões agora (este problema pode ter sido "
+"causado por um bug em versões anteriores do gerente de arquivos).\n"
 "\n"
-"Ter ações para execução (não-ligadas) escrevíveis por todo o mundo significa que outras pessoas que usam o seu computador podem substituir as suas ações para execução por versões maliciosas.\n"
+"Ter ações para execução (não-ligadas) escrevíveis por todo o mundo significa "
+"que outras pessoas que usam o seu computador podem substituir as suas ações "
+"para execução por versões maliciosas.\n"
 "\n"
-"Se você confia em todos que podem escrever nesses arquivos então não precisa preocupar-se. Se não, você precisa verificar ou mesmo simplesmente apagar todas as ações para execução existentes."
+"Se você confia em todos que podem escrever nesses arquivos então não precisa "
+"preocupar-se. Se não, você precisa verificar ou mesmo simplesmente apagar "
+"todas as ações para execução existentes."
 
-#: run.c:766
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (reparar problema de segurança)"
 
-#: support.c:272
-msgid "B"
-msgstr "B"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:351
+#: support.c:381
 msgid "byte"
 msgstr "byte"
 
-#: support.c:1596
-#: support.c:1650
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
 msgstr "Falha ao abrir e stat o arquivo '%s': %s"
 
-#: support.c:1607
-#: support.c:1661
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
 msgstr "Falha ao mmap o arquivo '%s': %s"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close"
 msgstr "Fechar"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close filer window"
 msgstr "Fechar a janela do gerente de arquivos"
 
-#: toolbar.c:117
+#: toolbar.c:120
 msgid "Up"
 msgstr "Para cima"
 
-#: toolbar.c:117
-msgid "Change to parent directory"
-msgstr "Mudar para o diretório superior"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:121
+#: toolbar.c:126
 msgid "Home"
 msgstr "Home"
 
-#: toolbar.c:121
-msgid "Change to home directory"
-msgstr "Mudar para o diretório home"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks"
-msgstr "Marcações"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks menu"
-msgstr "Menu de marcações"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:129
+#: toolbar.c:138
 msgid "Scan"
 msgstr "Escanear"
 
-#: toolbar.c:129
-msgid "Rescan directory contents"
-msgstr "Reescanear o conteúdo do diretório"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:133
-msgid "Change icon size"
-msgstr "Modificar o tamanho dos ícones"
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Tamanho"
 
-#: toolbar.c:137
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automático"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
 msgstr "Modo de tamanho automático"
 
-#: toolbar.c:141
-msgid "Show extra details"
-msgstr "Exibir detalhes extras"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Visão em Lista"
 
-#: toolbar.c:145
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
 msgstr "Ordenar"
 
-#: toolbar.c:145
+#: toolbar.c:165
 msgid "Change sort criteria"
 msgstr "Modificar o critério de ordenação"
 
-#: toolbar.c:149
-msgid "Hidden"
-msgstr "Ocultos"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:149
+#: toolbar.c:169
 msgid ""
 "Left: Show/hide hidden files\n"
 "Right: Show/hide thumbnails"
@@ -3102,195 +3511,246 @@ msgstr ""
 "Esquerdo: exibir/ocultar arquivos ocultos\n"
 "Direito: exibir/ocultar miniaturas"
 
-#: toolbar.c:154
-msgid "Select all/invert selection"
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+#, fuzzy
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+"Esquerdo: exibir/ocultar arquivos ocultos\n"
+"Direito: exibir/ocultar miniaturas"
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
 msgstr "Selecionar todos/inverter seleção"
 
-#: toolbar.c:158
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
 msgstr "Exibir a ajuda do ROX-Filer"
 
-#: toolbar.c:221
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
 msgstr " (%u ocultos)"
 
-#: toolbar.c:229
-#: tips:58
+#: toolbar.c:276 tips:79
 msgid "items"
 msgstr "itens"
 
-#: toolbar.c:229
+#: toolbar.c:276
 msgid "item"
 msgstr "item"
 
-#: toolbar.c:232
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
 msgstr "Sem itens%s"
 
-#: toolbar.c:251
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
 msgstr "%u selecionado (%s)"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by name"
 msgstr "Ordenar por nome"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by type"
 msgstr "Ordenar por tipo"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by date"
 msgstr "Ordenar por data"
 
-#: toolbar.c:446
+#: toolbar.c:535
 msgid "Sort by size"
 msgstr "Ordenar por tamanho"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by owner"
 msgstr "Ordenar por proprietário"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by group"
 msgstr "Ordenar por grupo"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "ascending"
 msgstr "ascendente"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "descending"
 msgstr "descendente"
 
-#: type.c:214
+#: toolbar.c:891
+#, fuzzy
+msgid "_N_Items_"
+msgstr "Item"
+
+#: type.c:221
 msgid "Sym link"
 msgstr "Ligação simbólica"
 
-#: type.c:216
+#: type.c:223
 msgid "Mount point"
 msgstr "Ponto de montagem"
 
-#: type.c:218
+#: type.c:225
 msgid "App dir"
 msgstr "Dir-apl"
 
-#: type.c:225
+#: type.c:232
 msgid "Dir"
 msgstr "Dir"
 
-#: type.c:227
+#: type.c:234
 msgid "Char dev"
 msgstr "Char dev"
 
-#: type.c:229
+#: type.c:236
 msgid "Block dev"
 msgstr "Block dev"
 
-#: type.c:231
+#: type.c:238
 msgid "Pipe"
 msgstr "Pipe"
 
-#: type.c:233
+#: type.c:240
 msgid "Socket"
 msgstr "Socket"
 
-#: type.c:235
+#: type.c:242
 msgid "Door"
 msgstr "Door"
 
-#: type.c:238
+#: type.c:245
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: type.c:554
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
 "gimp \"$@\""
 msgstr ""
-"Informe um comando shell que carregará \"$@\" num programa apropriado. P.ex:\n"
+"Informe um comando shell que carregará \"$@\" num programa apropriado. P."
+"ex:\n"
 "\n"
 "gimp \"$@\""
 
-#: type.c:735
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Isto não é um programa! Ao invés disso, me dê uma aplicação!"
 
-#: type.c:795
+#: type.c:839
 msgid "No run action defined"
 msgstr "Nenhuma ação para execução definida"
 
-#: type.c:799
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Erro no manipulador %s: %s"
 
-#: type.c:814
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Aplicação inválida %s (AppRun ruim)"
 
-#: type.c:825
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "Não-executável %s"
 
-#: type.c:858
+#: type.c:902
 msgid "Set run action"
 msgstr "Definir ação para execução"
 
-#: type.c:864
-msgid "If a handler for the specific type isn't set up, use this as the default."
-msgstr "Se nenhum manipulador estiver definido para o tipo específico, usar este por padrão."
+#: type.c:908
+msgid ""
+"If a handler for the specific type isn't set up, use this as the default."
+msgstr ""
+"Se nenhum manipulador estiver definido para o tipo específico, usar este por "
+"padrão."
 
-#: type.c:866
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Definir o padrão para todos `%s/<anything>'"
 
-#: type.c:870
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Usar esta aplicação para todos os arquivos com esse tipo MIME"
 
-#: type.c:872
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Apenas para o tipo  `%s' (%s/%s)"
 
-#: type.c:878
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Solte uma aplicação apropriada aqui"
 
-#: type.c:893
+#: type.c:963
 msgid "OR"
 msgstr "OU"
 
-#: type.c:900
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Informe um comando shell:"
 
-#: type.c:929
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Usar o Comando"
 
-#: type.c:959
-msgid "A run action already exists and is quite a big program - are you sure you want to delete it?"
-msgstr "Uma ação para execução já existe e é um programa relativamente grande - tem certeza que deseja apagá-la?"
+#: type.c:1030
+msgid ""
+"A run action already exists and is quite a big program - are you sure you "
+"want to delete it?"
+msgstr ""
+"Uma ação para execução já existe e é um programa relativamente grande - tem "
+"certeza que deseja apagá-la?"
 
-#: type.c:970
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Não posso remover %s: %s"
 
-#: type.c:1007
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "A gravação das escolhas está desabilitada pela variável CHOICESPATH"
 
-#: type.c:1309
+#: type.c:1395
 #, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
@@ -3299,25 +3759,26 @@ msgstr ""
 "Falha ao criar a ligação simbólica '%s':\n"
 "%s"
 
-#: usericons.c:179
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "O caminho que você forneceu não existe. O ícone não foi modificado."
 
-#: usericons.c:189
-#: usericons.c:618
+#: usericons.c:198 usericons.c:644
 msgid ""
-"Unable to load image file -- maybe it's not in a format I understand, or maybe the permissions are wrong?\n"
+"Unable to load image file -- maybe it's not in a format I understand, or "
+"maybe the permissions are wrong?\n"
 "The icon has not been changed."
 msgstr ""
-"Incapaz de carregar o arquivo de imagem - talvez ele esteja em um formato que eu não entenda ou talvez as permissões estejam erradas?\n"
+"Incapaz de carregar o arquivo de imagem - talvez ele esteja em um formato "
+"que eu não entenda ou talvez as permissões estejam erradas?\n"
 "O ícone não foi modificado."
 
-#: usericons.c:235
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Realmente apagar o ícone '%s'?"
 
-#: usericons.c:239
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3326,54 +3787,67 @@ msgstr ""
 "Não posso apagar '%s':\n"
 "%s"
 
-#: usericons.c:272
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Definir o ícone"
 
-#: usericons.c:281
-msgid "Use a copy of the image as the default for all files of these MIME types."
-msgstr "Usar uma cópia da imagem como padrão para todos os arquivos deste tipo MIME."
+#: usericons.c:290
+msgid ""
+"Use a copy of the image as the default for all files of these MIME types."
+msgstr ""
+"Usar uma cópia da imagem como padrão para todos os arquivos deste tipo MIME."
 
-#: usericons.c:283
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Definir o ícone para todos `%s/<anything>'"
 
-#: usericons.c:288
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "Usar uma cópia da imagem para todos os arquivos deste tipo MIME."
 
-#: usericons.c:290
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Para todos os arquivos do tipo `%s'(%s/%s)"
 
-#: usericons.c:296
-msgid "Add the file and image filenames to your personal list. The setting will be lost if the image or the file is moved."
-msgstr "Adicionar os nomes do arquivo e da imagem para a sua lista pessoal. A configuração será perdida se a imagem ou o arquivo forem movidos."
+#: usericons.c:305
+msgid ""
+"Add the file and image filenames to your personal list. The setting will be "
+"lost if the image or the file is moved."
+msgstr ""
+"Adicionar os nomes do arquivo e da imagem para a sua lista pessoal. A "
+"configuração será perdida se a imagem ou o arquivo forem movidos."
 
-#: usericons.c:299
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Apenas para o arquivo `%s'"
 
-#: usericons.c:307
-msgid "Copy the image inside the directory, as a hidden file called '.DirIcon'. All users will then see the icon, and you can move the directory around safely. This is usually the best option if you can write to the directory."
-msgstr "Copiar a imagem para dentro do diretório como um arquivo oculto de nome '.DirIcon'. Todos os usuários verão o ícone e você pode mover o diretório com segurança. Esta normalmente é a melhor opção se você pode escrever no diretório."
+#: usericons.c:316
+msgid ""
+"Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
+"users will then see the icon, and you can move the directory around safely. "
+"This is usually the best option if you can write to the directory."
+msgstr ""
+"Copiar a imagem para dentro do diretório como um arquivo oculto de nome '."
+"DirIcon'. Todos os usuários verão o ícone e você pode mover o diretório com "
+"segurança. Esta normalmente é a melhor opção se você pode escrever no "
+"diretório."
 
-#: usericons.c:313
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Copiar a imagem para o diretório"
 
-#: usericons.c:319
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Solte um arquivo de ícone aqui"
 
-#: usericons.c:589
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "A definição de ícones está desabilitada por CHOICESPATH"
 
-#: usericons.c:633
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3382,41 +3856,57 @@ msgstr ""
 "Erro ao criar imagem '%s':\n"
 "%s"
 
-#: view_details.c:957
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
 msgid "Mono font"
 msgstr "Fonte mono"
 
-#: view_details.c:958
+#: view_details.c:1019
 msgid "Font for displaying mono-spaced text"
 msgstr "Fonte para visualizar texto monoespaçado"
 
-#: view_details.c:1059
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Nome"
 
-#: view_details.c:1062
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Tipo"
 
-#: view_details.c:1065
-msgid "_Permissions"
-msgstr "_Permissões"
-
-#: view_details.c:1070
-msgid "_Owner"
-msgstr "Pr_oprietário"
-
-#: view_details.c:1072
-msgid "_Group"
-msgstr "_Grupo"
-
-#: view_details.c:1074
+#: view_details.c:1238
 msgid "_Size"
 msgstr "T_amanho"
 
-#: view_details.c:1080
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Permissões"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "Pr_oprietário"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Grupo"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "Última_Modificação"
+
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Atributos estendidos"
 
 #: tips:1
 msgid "Filer windows"
@@ -3431,586 +3921,1082 @@ msgid "Never automatically resize"
 msgstr "Nunca redimensionar automaticamente"
 
 #: tips:4
-msgid "You'll have to resize windows manually, using the window manager, the `Resize Window' menu entry or by double-clicking on the window background."
-msgstr "Você terá de redimensionar as janelas manualmente usando o gerenciador de janelas, a entrada `Redimensionar a Janela' no menu ou com um clique-duplo no fundo da janela."
+msgid ""
+"You'll have to resize windows manually, using the window manager, the "
+"`Resize Window' menu entry or by double-clicking on the window background."
+msgstr ""
+"Você terá de redimensionar as janelas manualmente usando o gerenciador de "
+"janelas, a entrada `Redimensionar a Janela' no menu ou com um clique-duplo "
+"no fundo da janela."
 
 #: tips:5
 msgid "Resize when changing the display style"
 msgstr "Redimensionar ao modificar o estilo de visualização"
 
 #: tips:6
-msgid "Changing the size of the icons or which details are displayed will resize the window for you."
-msgstr "Modificar o tamanho dos ícones ou os detalhes exibidos redimensionará a janela para você."
+msgid ""
+"Changing the size of the icons or which details are displayed will resize "
+"the window for you."
+msgstr ""
+"Modificar o tamanho dos ícones ou os detalhes exibidos redimensionará a "
+"janela para você."
 
 #: tips:7
 msgid "Always resize"
 msgstr "Redimensionar sempre"
 
 #: tips:8
-msgid "The filer will resize windows whenever it seems useful (that is, when changing directory or display style)."
-msgstr "O gerente de arquivos redimensionará a janela quando parecer útil (ou seja, ao mudar de diretório ou de estilo de visualização)."
+msgid ""
+"The filer will resize windows whenever it seems useful (that is, when "
+"changing directory or display style)."
+msgstr ""
+"O gerente de arquivos redimensionará a janela quando parecer útil (ou seja, "
+"ao mudar de diretório ou de estilo de visualização)."
 
 #: tips:9
 msgid "Largest window size:"
 msgstr "Tamanho máximo da janela:"
 
-#: tips:10
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
 #: tips:11
-msgid "The largest size, as a percentage of the screen size, that the auto-resizer will resize a window to."
-msgstr "O maior tamanho, como porcentagem do tamanho da tela, para o qual o auto-redimensionador redimensionará uma janela."
+msgid ""
+"The largest size, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"O maior tamanho, como porcentagem do tamanho da tela, para o qual o auto-"
+"redimensionador redimensionará uma janela."
 
 #: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Tamanho máximo da janela:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"O maior tamanho, como porcentagem do tamanho da tela, para o qual o auto-"
+"redimensionador redimensionará uma janela."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Comportamento da janela"
 
-#: tips:13
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Emblemas da barra de título curtos"
 
-#: tips:14
-msgid "Use single letters instead of words for Scanning, All and Thumbs indicators in the titlebar."
-msgstr "Usa uma só letra ao invés de palavras para os indicadores Escaneando, Todos e Miniaturas na barra de título."
+#: tips:17
+msgid ""
+"Use single letters instead of words for Scanning, All and Thumbs indicators "
+"in the titlebar."
+msgstr ""
+"Usa uma só letra ao invés de palavras para os indicadores Escaneando, Todos "
+"e Miniaturas na barra de título."
 
-#: tips:15
+#: tips:18
 msgid "Unique windows"
 msgstr "Janela única"
 
-#: tips:16
-msgid "If you open a directory and that directory is already displayed in another window, then this option causes the other window to be closed."
-msgstr "Se você abrir um diretório e o mesmo já está sendo exibido em outra janela, então esta opção faz com que a outra janela seja fechada."
+#: tips:19
+msgid ""
+"If you open a directory and that directory is already displayed in another "
+"window, then this option causes the other window to be closed."
+msgstr ""
+"Se você abrir um diretório e o mesmo já está sendo exibido em outra janela, "
+"então esta opção faz com que a outra janela seja fechada."
 
-#: tips:17
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Janela"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Nova janela no botão 1"
 
-#: tips:18
-msgid "Clicking with mouse button 1 (usually the left button) opens a directory in a new window with this turned on. Clicking with the button-2 (middle) will reuse the current window."
-msgstr "Clicar com o botão 1 do mouse (normalmente o botão-esquerdo) abre um diretório em uma nova janela com isto habilitado. Clicar com o botão 2 (do meio) reusa a janela atual."
+#: tips:25
+msgid ""
+"Clicking with mouse button 1 (usually the left button) opens a directory in "
+"a new window with this turned on. Clicking with the button-2 (middle) will "
+"reuse the current window."
+msgstr ""
+"Clicar com o botão 1 do mouse (normalmente o botão-esquerdo) abre um "
+"diretório em uma nova janela com isto habilitado. Clicar com o botão 2 (do "
+"meio) reusa a janela atual."
 
-#: tips:19
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Navegação por clique-único"
 
-#: tips:20
-#: tips:116
-msgid "Clicking on an item opens it with this on. Hold down Control to select the item instead. If off, clicking once selects an item; double click to open things."
-msgstr "Clicar num item abre-o com isto habilitado. Pressione Ctrl ao clicar para selecionar. Se desabilitado, clicar uma vez seleciona um item; clique-duplo abre-o."
+#: tips:27 tips:191
+msgid ""
+"Clicking on an item opens it with this on. Hold down Control to select the "
+"item instead. If off, clicking once selects an item; double click to open "
+"things."
+msgstr ""
+"Clicar num item abre-o com isto habilitado. Pressione Ctrl ao clicar para "
+"selecionar. Se desabilitado, clicar uma vez seleciona um item; clique-duplo "
+"abre-o."
 
-#: tips:21
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Clique-duplo no fundo redimensiona"
 
-#: tips:22
-msgid "If on then double clicking on the window background resizes the window, just like clicking on the Automatic size mode button in the toolbar."
-msgstr "Se habilitado, ao clicar duas vezes no fundo da janela esta é redimensionada como ao clicar no botão do Modo de tamanho automático na barra de utilitários."
+#: tips:29
+msgid ""
+"If on then double clicking on the window background resizes the window, just "
+"like clicking on the Automatic size mode button in the toolbar."
+msgstr ""
+"Se habilitado, ao clicar duas vezes no fundo da janela esta é redimensionada "
+"como ao clicar no botão do Modo de tamanho automático na barra de "
+"utilitários."
 
-#: tips:23
+#: tips:30
 msgid "Sorting"
 msgstr "Ordenação"
 
-#: tips:24
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Diretórios primeiro (ordenação por nome)"
 
-#: tips:25
-msgid "If this is on then directories will always appear before anything else when sorting by name."
-msgstr "Se isto estiver habilitado os diretórios sempre aparecerão antes de tudo o mais numa ordenação por nome."
+#: tips:32
+msgid ""
+"If this is on then directories will always appear before anything else when "
+"sorting by name."
+msgstr ""
+"Se isto estiver habilitado os diretórios sempre aparecerão antes de tudo o "
+"mais numa ordenação por nome."
 
-#: tips:26
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Nomes em maiúsculas primeiro (para a ordenação por nome)"
 
-#: tips:27
-msgid "If on, all filenames starting with a capital letter come before filenames starting with lowercase ones."
-msgstr "Se habilitado, todos os nomes de arquivo começando com uma letra maiúscula vêm antes daqueles começando com minúscula."
-
-#: tips:29
-msgid "Default settings for new windows"
-msgstr "Configuração padrão para novas janelas"
-
-#: tips:30
-msgid "Inherit options from source window"
-msgstr "Herdar as opções da janela fonte"
-
-#: tips:31
-msgid "If this is on then display options for a new window are inherited from the source window if possible, otherwise they are set to the defaults below."
-msgstr "Se isto estiver habilitado as opções de visualização para a nova janela são herdadas da janela fonte se possível, se não elas são definidas pelo padrão abaixo."
-
-#: tips:32
-msgid "View type:"
-msgstr "Tipo de visualização:"
+#: tips:34
+msgid ""
+"If on, all filenames starting with a capital letter come before filenames "
+"starting with lowercase ones."
+msgstr ""
+"Se habilitado, todos os nomes de arquivo começando com uma letra maiúscula "
+"vêm antes daqueles começando com minúscula."
 
 #: tips:35
-msgid "Sort by:"
-msgstr "Ordenar por:"
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Diretórios primeiro (ordenação por nome)"
 
-#: tips:37
-#: tips:54
-msgid "Type"
-msgstr "Tipo"
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Segundo"
 
 #: tips:38
-msgid "Date"
-msgstr "Data"
-
-#: tips:40
-msgid "Show hidden files"
-msgstr "Exibir arquivos ocultos"
-
-#: tips:41
-msgid "If this is on then files whose names start with a dot are shown too, otherwise they are hidden."
-msgstr "Se isto estiver habilitado, arquivos cujos nomes comecem por um ponto também são exibidos, se não, são ocultados."
-
-#: tips:42
 msgid "Show extended attribute indicator"
 msgstr "Exibir o indicador de atributo estendido"
 
-#: tips:43
-msgid "If this is on then files which have one or more extended attributes set will have an emblem added to indicate this."
-msgstr "Se isto estiver habilitado, arquivos que possuírem um ou mais atributos estendidos terão um emblema para indicar isso."
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+"Se isto estiver habilitado, arquivos que possuírem um ou mais atributos "
+"estendidos terão um emblema para indicar isso."
 
-#: tips:44
-msgid "Icon View"
-msgstr "Visão em Ícones"
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
 
 #: tips:45
-msgid "Default size:"
-msgstr "Tamanho padrão:"
+msgid "Default settings for new windows"
+msgstr "Configuração padrão para novas janelas"
 
 #: tips:46
-msgid "Huge Icons"
-msgstr "Ícones Enormes"
+msgid "Inherit options from source window"
+msgstr "Herdar as opções da janela fonte"
 
 #: tips:47
-#: tips:217
-msgid "Large Icons"
-msgstr "Ícones Grandes"
+msgid ""
+"If this is on then display options for a new window are inherited from the "
+"source window if possible, otherwise they are set to the defaults below."
+msgstr ""
+"Se isto estiver habilitado as opções de visualização para a nova janela são "
+"herdadas da janela fonte se possível, se não elas são definidas pelo padrão "
+"abaixo."
 
 #: tips:48
-#: tips:216
-msgid "Small Icons"
-msgstr "Ícones Pequenos"
-
-#: tips:50
-msgid "Default details:"
-msgstr "Detalhes padrão:"
+msgid "View type:"
+msgstr "Tipo de visualização:"
 
 #: tips:51
-msgid "No details"
-msgstr "Sem detalhes"
+msgid "Sort by:"
+msgstr "Ordenar por:"
+
+#: tips:53 tips:76 tips:114
+msgid "Type"
+msgstr "Tipo"
+
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
+msgstr "Data"
+
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Data"
 
 #: tips:56
-msgid "Automatic small icons:"
-msgstr "Ícones pequenos automáticos:"
+#, fuzzy
+msgid "Date (a)"
+msgstr "Data"
 
-#: tips:57
-msgid "Change at:"
-msgstr "modificar a partir de:"
+#: tips:58
+msgid "Show hidden files"
+msgstr "Exibir arquivos ocultos"
 
 #: tips:59
-msgid "When automatic icon sizing is selected: If the directory contains this many items then it will be shown using Small Icons, otherwise Large Icons will be used."
-msgstr "Ao habilitar o tamanho automático dos ícones, se o diretório contém este tanto ou mais itens ele usa Ícones Pequenos, se não, são usados Ícones Grandes."
+msgid ""
+"If this is on then files whose names start with a dot are shown too, "
+"otherwise they are hidden."
+msgstr ""
+"Se isto estiver habilitado, arquivos cujos nomes comecem por um ponto também "
+"são exibidos, se não, são ocultados."
 
 #: tips:60
-msgid "Max width (Large icons):"
-msgstr "Largura máxima (Ícones Grandes):"
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Exibir arquivos ocultos"
 
 #: tips:61
-#: tips:64
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Se isto estiver habilitado, arquivos cujos nomes comecem por um ponto também "
+"são exibidos, se não, são ocultados."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Ícones Enormes"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
 msgid "pixels"
 msgstr "pixel"
 
-#: tips:62
-msgid "Text wider than this is broken onto two lines in Large Icons mode. In Huge Icons mode, text is wrapped when 50% wider than this."
-msgstr "Texto mais largo que isto é quebrado em duas linhas no modo de Ícones Grandes. No modo de Ícones Enormes o texto é quebrado com a metade desta largura."
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
 
-#: tips:63
-msgid "(Small Icons):"
+#: tips:65 tips:66
+msgid "Icon View"
+msgstr "Visão em Ícones"
+
+#: tips:67
+msgid "Default size:"
+msgstr "Tamanho padrão:"
+
+#: tips:68
+msgid "Huge Icons"
+msgstr "Ícones Enormes"
+
+#: tips:69 tips:296
+msgid "Large Icons"
+msgstr "Ícones Grandes"
+
+#: tips:70 tips:295
+msgid "Small Icons"
+msgstr "Ícones Pequenos"
+
+#: tips:72
+msgid "Default details:"
+msgstr "Detalhes padrão:"
+
+#: tips:73
+msgid "No details"
+msgstr "Sem detalhes"
+
+#: tips:74
+msgid "Sizes"
+msgstr "Tamanho"
+
+#: tips:77
+msgid "Times"
+msgstr "Data"
+
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
+msgstr "Ícones pequenos automáticos:"
+
+#: tips:80
+msgid ""
+"When automatic icon sizing is selected: If the directory contains this many "
+"items then it will be shown using Small Icons, otherwise Large Icons will be "
+"used."
+msgstr ""
+"Ao habilitar o tamanho automático dos ícones, se o diretório contém este "
+"tanto ou mais itens ele usa Ícones Pequenos, se não, são usados Ícones "
+"Grandes."
+
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Ícones Grandes"
+
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
+msgstr ""
+"Texto mais largo que isto é quebrado em duas linhas no modo de Ícones "
+"Grandes. No modo de Ícones Enormes o texto é quebrado com a metade desta "
+"largura."
+
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
+
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
+#: tips:88
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr ""
+"Se esta opção estiver habilitada, ícones grandes são arranjados em colunas, "
+"não linhas."
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
 msgstr "(Ícones Pequenos):"
 
-#: tips:65
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "Largura máxima para um texto ao lado de um Ícone Pequeno."
 
-#: tips:66
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "Ordenar ícones pequenos verticalmente"
 
-#: tips:67
-msgid "If this option is on, then small icons are arranged in columns, not rows."
-msgstr "Se esta opção estiver habilitada, ícones pequenos são arranjados em colunas, não linhas."
+#: tips:93
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
+msgstr ""
+"Se esta opção estiver habilitada, ícones pequenos são arranjados em colunas, "
+"não linhas."
 
-#: tips:68
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "Ordenar ícones grandes verticalmente"
 
-#: tips:69
-msgid "If this option is on, then large icons are arranged in columns, not rows."
-msgstr "Se esta opção estiver habilitada, ícones grandes são arranjados em colunas, não linhas."
+#: tips:95
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
+msgstr ""
+"Se esta opção estiver habilitada, ícones grandes são arranjados em colunas, "
+"não linhas."
 
-#: tips:71
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Exibir o cabeçalho das colunas"
 
-#: tips:72
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
-msgstr "Se isto estiver habilitado, os cabeçalhos das colunas são exibidos na visão em lista."
+msgstr ""
+"Se isto estiver habilitado, os cabeçalhos das colunas são exibidos na visão "
+"em lista."
 
-#: tips:73
+#: tips:102
 msgid "Show full type"
 msgstr "Exibir o tipo completo"
 
-#: tips:74
-msgid "If this is on then the full description of each object's type will be show rather than a short summary of its basic type."
-msgstr "Se isto estiver habilitado, é exibida uma descrição completa do tipo de cada objeto ao invés de um resumo curto do seu tipo básico."
+#: tips:103
+msgid ""
+"If this is on then the full description of each object's type will be show "
+"rather than a short summary of its basic type."
+msgstr ""
+"Se isto estiver habilitado, é exibida uma descrição completa do tipo de cada "
+"objeto ao invés de um resumo curto do seu tipo básico."
 
-#: tips:75
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Largura máxima para um texto ao lado de um Ícone Pequeno."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Exibir o cabeçalho das colunas"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Se isto estiver habilitado, os cabeçalhos das colunas são exibidos na visão "
+"em lista."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Se isto estiver habilitado, os cabeçalhos das colunas são exibidos na visão "
+"em lista."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Se isto estiver habilitado, os cabeçalhos das colunas são exibidos na visão "
+"em lista."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Se isto estiver habilitado, os cabeçalhos das colunas são exibidos na visão "
+"em lista."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Se isto estiver habilitado, os cabeçalhos das colunas são exibidos na visão "
+"em lista."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Se isto estiver habilitado, os cabeçalhos das colunas são exibidos na visão "
+"em lista."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "Última_Modificação"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Se isto estiver habilitado, os cabeçalhos das colunas são exibidos na visão "
+"em lista."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Se isto estiver habilitado, os cabeçalhos das colunas são exibidos na visão "
+"em lista."
+
+#: tips:128
+#, fuzzy
+msgid "Last Accessed"
+msgstr "%s não está acessível"
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Se isto estiver habilitado, os cabeçalhos das colunas são exibidos na visão "
+"em lista."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Utilitários/Minibuffer"
 
-#: tips:76
+#: tips:131
 msgid "Toolbar"
 msgstr "Barra de utilitários"
 
-#: tips:77
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Tipo da barra de utilitários:"
 
-#: tips:78
+#: tips:133
 msgid "No toolbar"
 msgstr "Sem barra de utilitários"
 
-#: tips:79
+#: tips:134
 msgid "Icons only"
 msgstr "Somente ícones"
 
-#: tips:80
+#: tips:135
 msgid "Text under icons"
 msgstr "Texto sob os ícones"
 
-#: tips:81
+#: tips:136
 msgid "Text beside icons"
 msgstr "Texto ao lado dos ícones"
 
-#: tips:82
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Somente o painel"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Exibir o total de itens"
 
-#: tips:83
-msgid "Show the number of items displayed in a filer window, as well as the number of hidden items (if any). When there's a selection, show the number of selected items and their combined size."
-msgstr "Exibir o número de itens exibidos numa janela do gerente de arquivos assim como o número de itens ocultos (se houver). Se houver uma seleção, exibir o número de itens selecionados e seu tamanho combinado."
+#: tips:139
+msgid ""
+"Show the number of items displayed in a filer window, as well as the number "
+"of hidden items (if any). When there's a selection, show the number of "
+"selected items and their combined size."
+msgstr ""
+"Exibir o número de itens exibidos numa janela do gerente de arquivos assim "
+"como o número de itens ocultos (se houver). Se houver uma seleção, exibir o "
+"número de itens selecionados e seu tamanho combinado."
 
-#: tips:84
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Escolha os botões que você deseja na barra:"
 
-#: tips:85
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "A largura da barra de utilitários define a largura mínima da janela"
 
-#: tips:86
-msgid "Each filer window is constrained to be wide enough to show the whole of the toolbar"
-msgstr "Cada janela do gerente de arquivos é obrigatoriamente larga o suficiente para exibir toda a barra de utilitários"
+#: tips:142
+msgid ""
+"Each filer window is constrained to be wide enough to show the whole of the "
+"toolbar"
+msgstr ""
+"Cada janela do gerente de arquivos é obrigatoriamente larga o suficiente "
+"para exibir toda a barra de utilitários"
 
-#: tips:87
+#: tips:143
 msgid "Minibuffer"
 msgstr "Minibuffer"
 
-#: tips:88
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Bipar se uma complementação por Tab falhar"
 
-#: tips:89
-msgid "When using the `Enter Path...' minibuffer and Tab is pressed, beep if nothing happens (eg, because there are several possibilities and the next letter varies)."
-msgstr "Ao usar o minibuffer `Informar o Caminho...' e pressionar Tab, bipar se nada acontecer (p.ex. se houver várias possibilidades e a letra seguinte varia)."
+#: tips:145
+msgid ""
+"When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
+"nothing happens (eg, because there are several possibilities and the next "
+"letter varies)."
+msgstr ""
+"Ao usar o minibuffer `Informar o Caminho...' e pressionar Tab, bipar se nada "
+"acontecer (p.ex. se houver várias possibilidades e a letra seguinte varia)."
 
-#: tips:90
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Bipar se houver várias correspondências"
 
-#: tips:91
-msgid "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there is more than one matching file, even though some more letters were added."
-msgstr "Ao usar o minibuffer `Informar o Caminho...' e pressionar Tab, bipar se houver mais de um arquivo correspondente, ainda que algumas letras mais tiverem sido adicionadas."
+#: tips:147
+msgid ""
+"When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
+"is more than one matching file, even though some more letters were added."
+msgstr ""
+"Ao usar o minibuffer `Informar o Caminho...' e pressionar Tab, bipar se "
+"houver mais de um arquivo correspondente, ainda que algumas letras mais "
+"tiverem sido adicionadas."
 
-#: tips:94
-msgid "When thumbnails are turned on, each image file in a directory is loaded and a small thumbnail of it is shown."
-msgstr "Quando as miniaturas estão habilitadas cada arquivo de imagem num diretório é carregado e uma pequena miniatura dele é exibido."
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Manipulador de downloads"
 
-#: tips:95
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Erro no manipulador %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
+msgid ""
+"When thumbnails are turned on, each image file in a directory is loaded and "
+"a small thumbnail of it is shown."
+msgstr ""
+"Quando as miniaturas estão habilitadas cada arquivo de imagem num diretório "
+"é carregado e uma pequena miniatura dele é exibido."
+
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Exibir miniaturas de imagens"
 
-#: tips:96
-msgid "This is the default setting for new windows. Use the Display menu to turn thumbnails on and off for individual windows."
-msgstr "Esta é a configuração padrão para novas janelas. Use o menu Visualização para habilitar e desabilitar miniaturas para janelas específicas."
+#: tips:156
+msgid ""
+"This is the default setting for new windows. Use the Display menu to turn "
+"thumbnails on and off for individual windows."
+msgstr ""
+"Esta é a configuração padrão para novas janelas. Use o menu Visualização "
+"para habilitar e desabilitar miniaturas para janelas específicas."
 
-#: tips:97
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Exibir miniaturas de imagens"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "Miniaturas de vídeo"
 
-#: tips:98
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Cache de miniaturas"
 
-#: tips:99
-msgid "To speed things up, the generated thumbnails are stored in the hidden ~/.thumbnails directory. Click here to remove all the cached thumbnails. They will be created again as needed."
-msgstr "Para apressar as coisas, as miniaturas geradas são armazenadas no diretório oculto ~/.thumbnails. Clique aqui para remover todas as miniaturas guardadas. Elas serão criadas novamente quando necessário."
+#: tips:161
+#, fuzzy
+msgid ""
+"To speed things up, the generated thumbnails are stored in the hidden ~/."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
+msgstr ""
+"Para apressar as coisas, as miniaturas geradas são armazenadas no diretório "
+"oculto ~/.thumbnails. Clique aqui para remover todas as miniaturas "
+"guardadas. Elas serão criadas novamente quando necessário."
 
-#: tips:100
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
 msgid "Manage thumbnails"
 msgstr "Gerenciar miniaturas"
 
-#: tips:101
-#: tips:158
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Miniaturas de vídeo"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Segundo"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Quadro"
 
-#: tips:102
-msgid "When using a pinboard, you can drag files and applications onto the desktop background to create shortcuts to them."
-msgstr "Ao usar um quadro você pode arrastar arquivos e aplicações para o fundo da área de trabalho criando assim atalhos para eles."
+#: tips:177
+msgid ""
+"When using a pinboard, you can drag files and applications onto the desktop "
+"background to create shortcuts to them."
+msgstr ""
+"Ao usar um quadro você pode arrastar arquivos e aplicações para o fundo da "
+"área de trabalho criando assim atalhos para eles."
 
-#: tips:103
-#: tips:213
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Aparência"
 
-#: tips:104
+#: tips:179
 msgid "Foreground:"
 msgstr "Primeiro plano:"
 
-#: tips:105
+#: tips:180
 msgid "Text shadow:"
 msgstr "Sombra do texto:"
 
-#: tips:106
+#: tips:181
 msgid "Background:"
 msgstr "Plano de fundo:"
 
-#: tips:107
+#: tips:182
 msgid "No shadow"
 msgstr "Sem sombra"
 
-#: tips:108
+#: tips:183
 msgid "Thin"
 msgstr "Fino"
 
-#: tips:109
+#: tips:184
 msgid "Thick"
 msgstr "Grosso"
 
-#: tips:110
+#: tips:185
 msgid "Use custom font:"
 msgstr "Usar fonte personalizada:"
 
-#: tips:111
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "A fonte usada para o texto exibido sob os ícones"
 
-#: tips:112
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Escalonamento rápido de imagens"
 
-#: tips:113
-msgid "Choose between the fast or slow method of scaling backdrop images.  The slow method can give better results."
-msgstr "Escolha entre os métodos rápido ou lento de escalonamento das imagens de fundo. O método lento pode gerar melhores resultados."
+#: tips:188
+msgid ""
+"Choose between the fast or slow method of scaling backdrop images.  The slow "
+"method can give better results."
+msgstr ""
+"Escolha entre os métodos rápido ou lento de escalonamento das imagens de "
+"fundo. O método lento pode gerar melhores resultados."
 
-#: tips:114
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Comportamento do quadro"
 
-#: tips:115
+#: tips:190
 msgid "Single-click to open"
 msgstr "Abrir com clique-único"
 
-#: tips:117
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Manter os ícones dentro dos limites da tela"
 
-#: tips:118
-msgid "If this is set, pinboard icons are always kept completely within screen limits, including the label."
-msgstr "Se isto estiver habilitado os ícones do quadro são sempre mantidos completamente dentro dos limites da tela, incluindo o rótulo."
+#: tips:193
+msgid ""
+"If this is set, pinboard icons are always kept completely within screen "
+"limits, including the label."
+msgstr ""
+"Se isto estiver habilitado os ícones do quadro são sempre mantidos "
+"completamente dentro dos limites da tela, incluindo o rótulo."
 
-#: tips:119
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Resolução da grade de ícones:"
 
-#: tips:120
+#: tips:195
 msgid "Fine"
 msgstr "Fina"
 
-#: tips:121
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
-msgstr "Usar uma grade de 2 pixel para posicionar os ícones na área de trabalho."
+msgstr ""
+"Usar uma grade de 2 pixel para posicionar os ícones na área de trabalho."
 
-#: tips:122
+#: tips:197
 msgid "Medium"
 msgstr "Média"
 
-#: tips:123
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
-msgstr "Usar uma grade de 16 pixel para posicionar os ícones na área de trabalho."
+msgstr ""
+"Usar uma grade de 16 pixel para posicionar os ícones na área de trabalho."
 
-#: tips:124
+#: tips:199
 msgid "Coarse"
 msgstr "Grossa"
 
-#: tips:125
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
-msgstr "Usar uma grade de 32 pixel para posicionar os ícones na área de trabalho."
+msgstr ""
+"Usar uma grade de 32 pixel para posicionar os ícones na área de trabalho."
 
-#: tips:126
-#: tips:128
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Janelas iconificadas"
 
-#: tips:127
-msgid "Most window managers provide a way to iconify (or 'minimise') windows, and various programs, including ROX-Filer, can be used to display the iconified windows."
-msgstr "A maioria dos gerenciadores de janelas provê uma maneira de iconificar (ou 'minimizar') janelas e vários programas, incluindo o ROX-Filer, podem ser usados para exibir as janelas iconificadas."
+#: tips:202
+msgid ""
+"Most window managers provide a way to iconify (or 'minimise') windows, and "
+"various programs, including ROX-Filer, can be used to display the iconified "
+"windows."
+msgstr ""
+"A maioria dos gerenciadores de janelas provê uma maneira de iconificar (ou "
+"'minimizar') janelas e vários programas, incluindo o ROX-Filer, podem ser "
+"usados para exibir as janelas iconificadas."
 
-#: tips:129
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Exibir janelas iconificadas"
 
-#: tips:130
-msgid "If this option is on, the filer will show each iconified window as a small button on the pinboard. Requires a compatible window manager, and the pinboard must be in use."
-msgstr "Se esta opção estiver habilitada o gerente de arquivos exibirá cada janela iconificada como um pequeno botão no quadro. Requer um gerenciador de janelas compatível e o quadro deve estar em uso."
+#: tips:205
+msgid ""
+"If this option is on, the filer will show each iconified window as a small "
+"button on the pinboard. Requires a compatible window manager, and the "
+"pinboard must be in use."
+msgstr ""
+"Se esta opção estiver habilitada o gerente de arquivos exibirá cada janela "
+"iconificada como um pequeno botão no quadro. Requer um gerenciador de "
+"janelas compatível e o quadro deve estar em uso."
 
-#: tips:131
+#: tips:206
 msgid "Show per workspace"
 msgstr "Exibir por espaço de trabalho"
 
-#: tips:132
-msgid "If this option is on, the filer will only show iconified windows associated with the current workspace."
-msgstr "Se esta opção estiver habilitada o gerente de arquivos exibirá apenas as janelas iconificadas associadas ao espaço de trabalho atual."
+#: tips:207
+msgid ""
+"If this option is on, the filer will only show iconified windows associated "
+"with the current workspace."
+msgstr ""
+"Se esta opção estiver habilitada o gerente de arquivos exibirá apenas as "
+"janelas iconificadas associadas ao espaço de trabalho atual."
 
-#: tips:133
+#: tips:208
 msgid "Iconify to the"
 msgstr "Iconificar para"
 
-#: tips:134
+#: tips:209
 msgid "top-left"
 msgstr "alto, à esquerda"
 
-#: tips:135
+#: tips:210
 msgid "top-right"
 msgstr "alto, à direita"
 
-#: tips:136
+#: tips:211
 msgid "bottom-left"
 msgstr "baixo, à esquerda"
 
-#: tips:137
+#: tips:212
 msgid "bottom-right"
 msgstr "baixo, à direita"
 
-#: tips:138
+#: tips:213
 msgid ", going"
 msgstr ", indo"
 
-#: tips:139
+#: tips:214
 msgid "horizontally"
 msgstr "horizontalmente"
 
-#: tips:140
+#: tips:215
 msgid "vertically"
 msgstr "verticalmente"
 
-#: tips:141
-msgid "Sometimes the filer doesn't know about your desktop furniture and puts iconified windows under (for example) the Gnome panel. You can define a top or bottom margin to avoid placing the icons there. The filer already knows about its own panel."
-msgstr "Às vezes o gerente de arquivos não conhece os objetos da sua área de trabalho e coloca as janela iconificadas por baixo do painel do Gnome (por exemplo). Você pode definir uma margem superior ou inferior em que os ícones não serão colocados. O gerente de arquivos conhece e sabe lidar com o seu próprio painel."
+#: tips:216
+msgid ""
+"Sometimes the filer doesn't know about your desktop furniture and puts "
+"iconified windows under (for example) the Gnome panel. You can define a top "
+"or bottom margin to avoid placing the icons there. The filer already knows "
+"about its own panel."
+msgstr ""
+"Às vezes o gerente de arquivos não conhece os objetos da sua área de "
+"trabalho e coloca as janela iconificadas por baixo do painel do Gnome (por "
+"exemplo). Você pode definir uma margem superior ou inferior em que os ícones "
+"não serão colocados. O gerente de arquivos conhece e sabe lidar com o seu "
+"próprio painel."
 
-#: tips:142
+#: tips:217
 msgid "Top margin"
 msgstr "Margem superior"
 
-#: tips:143
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Altura da área proibida no topo da tela"
 
-#: tips:144
+#: tips:219
 msgid "Bottom margin"
 msgstr "Margem inferior"
 
-#: tips:145
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "Altura da área proibida na parte inferior da tela"
 
-#: tips:146
+#: tips:221
 msgid "Left margin"
 msgstr "Margem esquerda"
 
-#: tips:147
+#: tips:222
 msgid "Width of no-go area at left of screen."
 msgstr "Largura da área proibida da tela à esquerda"
 
-#: tips:148
+#: tips:223
 msgid "Right margin"
 msgstr "Margem direita"
 
-#: tips:149
+#: tips:224
 msgid "Width of no-go area at right of screen."
 msgstr "Largura da área proibida da tela à direita"
 
-#: tips:150
+#: tips:225
 msgid "Desktop"
 msgstr "Área de Trabalho"
 
-#: tips:151
-msgid "When run by a session manager program (such as ROX-Session) the filer can open up a panel and/or the pinboard.  Here you configure which."
-msgstr "Quando executado por um gerente de sessões (como o ROX-Session), o gerente de arquivos pode abrir um painel e/ou o quadro. Aqui você configura qual."
+#: tips:226
+msgid ""
+"When run by a session manager program (such as ROX-Session) the filer can "
+"open up a panel and/or the pinboard.  Here you configure which."
+msgstr ""
+"Quando executado por um gerente de sessões (como o ROX-Session), o gerente "
+"de arquivos pode abrir um painel e/ou o quadro. Aqui você configura qual."
 
-#: tips:152
+#: tips:227
 msgid "Panel only"
 msgstr "Somente o painel"
 
-#: tips:153
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Somente o painel é exibido"
 
-#: tips:154
+#: tips:229
 msgid "Pinboard only"
 msgstr "Somente o quadro"
 
-#: tips:155
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "Somente o quadro é exibido."
 
-#: tips:156
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "Painel e quadro"
 
-#: tips:157
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "Tanto um painel quanto um quadro são exibidos."
 
-#: tips:159
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "Informe o nome do quadro a ser exibido."
 
-#: tips:160
-msgid "Panel (obsolete)"
-msgstr "Painel (obsoleto)"
-
-#: tips:161
-msgid "Enter the name of the panel to show here. This option is now only used when upgrading from an old version."
-msgstr "Informe o nome do painel a ser exibido. Esta opção atualmente só é usada ao atualizar de uma versão antiga."
-
-#: tips:162
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
-msgstr "As modificações aqui têm efeito da próxima vez que o gerente de arquivos for executado."
+msgstr ""
+"As modificações aqui têm efeito da próxima vez que o gerente de arquivos for "
+"executado."
 
-#: tips:163
-msgid "The session manager activates these options by using the -S or --rox-session argument to rox."
-msgstr "O gerente de sessões ativa estas opções usando os argumentos -S ou --rox-session para o rox."
+#: tips:236
+#, fuzzy
+msgid ""
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
+msgstr ""
+"O gerente de sessões ativa estas opções usando os argumentos -S ou --rox-"
+"session para o rox."
 
-#: tips:164
+#: tips:237
 msgid "Action windows"
 msgstr "Janelas de ação"
 
-#: tips:165
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4018,550 +5004,907 @@ msgstr ""
 "Janelas de ação aparecem quando você inicia uma operação\n"
 "de fundo, como copiar ou apagar alguns arquivos."
 
-#: tips:166
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Auto-iniciar (Silencioso) estas ações"
 
-#: tips:168
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Copiar arquivos sem primeiro confirmar."
 
-#: tips:170
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Mover arquivos sem primeiro confirmar."
 
-#: tips:172
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Criar ligações sem primeiro confirmar."
 
-#: tips:174
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Apagar arquivos sem primeiro confirmar."
 
-#: tips:175
+#: tips:248
 msgid "Mount"
 msgstr "Montar"
 
-#: tips:176
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Montar e desmontar sistemas de arquivo sem primeiro confirmar."
 
-#: tips:177
+#: tips:250
 msgid "Default settings"
 msgstr "Configuração padrão"
 
-#: tips:179
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Forçar"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "Não confirmar o apagamento de itens somente-leitura."
 
-#: tips:181
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Não exibir tanta informação na área de mensagens."
 
-#: tips:183
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Também modificar o conteúdo dos subdiretórios."
 
-#: tips:186
+#: tips:263
 msgid "Mount commands"
 msgstr "Comandos de montagem"
 
-#: tips:187
+#: tips:264
 msgid "Mount command"
 msgstr "Comando para montar"
 
-#: tips:188
+#: tips:265
 msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
-msgstr "Comando usado para montar um sistema de arquivos. Na dúvida, use \"mount\"."
+msgstr ""
+"Comando usado para montar um sistema de arquivos. Na dúvida, use \"mount\"."
 
-#: tips:189
+#: tips:266
 msgid "Unmount command"
 msgstr "Comando para desmontar"
 
-#: tips:190
-msgid "The command used to unmount a filesystem. If unsure, use \"umount\" (yes, without the first \"n\")."
-msgstr "Comando usado para desmontar um sistema de arquivos. Na dúvida, use \"umount\" (sim, sem o primeiro \"n\")."
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+"Comando usado para desmontar um sistema de arquivos. Na dúvida, use \"umount"
+"\" (sim, sem o primeiro \"n\")."
 
-#: tips:191
+#: tips:268
 msgid "Eject command"
 msgstr "Comando para ejetar"
 
-#: tips:192
+#: tips:269
 msgid "The command used to eject removable media. If unsure, use \"eject\"."
-msgstr "Comando usado para ejetar uma mídia removível. Na dúvida, use \"eject\"."
+msgstr ""
+"Comando usado para ejetar uma mídia removível. Na dúvida, use \"eject\"."
 
-#: tips:193
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Arrastar e Soltar"
 
-#: tips:194
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Arrastar para ícones"
 
-#: tips:195
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Permite arrastar para ícones nas janelas do gerente de arquivos"
 
-#: tips:196
-msgid "When this is on you can drag a file over a sub-directory or program in a filer window. The item will highlight when you do this and dropping the file will put it into that directory, or load it into the program."
-msgstr "Quando isto está habilitado você pode arrastar um arquivo sobre um subdiretório ou programa numa janela do gerente de arquivos. O item será realçado quando você fizer isso e ao soltar o arquivo ele será posto dentro daquele diretório ou será carregado pelo programa."
+#: tips:275
+msgid ""
+"When this is on you can drag a file over a sub-directory or program in a "
+"filer window. The item will highlight when you do this and dropping the file "
+"will put it into that directory, or load it into the program."
+msgstr ""
+"Quando isto está habilitado você pode arrastar um arquivo sobre um "
+"subdiretório ou programa numa janela do gerente de arquivos. O item será "
+"realçado quando você fizer isso e ao soltar o arquivo ele será posto dentro "
+"daquele diretório ou será carregado pelo programa."
 
-#: tips:197
+#: tips:276
 msgid "Directories spring open"
 msgstr "Diretórios abrem num salto"
 
-#: tips:198
-msgid "This option, which requires the above option to be turned on too, causes the highlighted directory to 'spring open' after the file is held over it for a short while."
-msgstr "Esta opção, que requer que a opção acima também esteja habilitada, faz com que o diretório realçado 'abra num salto' após o arquivo ser seguro sobre ele por um pequeno espaço de tempo."
+#: tips:277
+msgid ""
+"This option, which requires the above option to be turned on too, causes the "
+"highlighted directory to 'spring open' after the file is held over it for a "
+"short while."
+msgstr ""
+"Esta opção, que requer que a opção acima também esteja habilitada, faz com "
+"que o diretório realçado 'abra num salto' após o arquivo ser seguro sobre "
+"ele por um pequeno espaço de tempo."
 
-#: tips:199
+#: tips:278
 msgid "Spring delay:"
 msgstr "Atraso do salto:"
 
-#: tips:200
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:201
-msgid "This option sets how long, in ms, you must hold a file over a directory before it will spring open. The above option must be turned on for this to have any effect."
-msgstr "Esta opção define por quanto tempo, em ms, você deve segurar um arquivo sobre um diretório antes que ele abra num salto. A opção acima precisa estar habilitada para esta ter efeito."
+#: tips:280
+msgid ""
+"This option sets how long, in ms, you must hold a file over a directory "
+"before it will spring open. The above option must be turned on for this to "
+"have any effect."
+msgstr ""
+"Esta opção define por quanto tempo, em ms, você deve segurar um arquivo "
+"sobre um diretório antes que ele abra num salto. A opção acima precisa estar "
+"habilitada para esta ter efeito."
 
-#: tips:202
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Ao arrastar arquivos com o botão-esquerdo"
 
-#: tips:203
-#: tips:207
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Mostrar um menu das ações possíveis"
 
-#: tips:204
+#: tips:283
 msgid "Copy the files"
 msgstr "Copiar os arquivos"
 
-#: tips:205
-msgid "Note that you can still get the menu to appear, by dragging with Alt held down."
-msgstr "Note que você ainda pode fazer o menu aparecer ao arrastar pressionando a tecla Alt."
+#: tips:284
+msgid ""
+"Note that you can still get the menu to appear, by dragging with Alt held "
+"down."
+msgstr ""
+"Note que você ainda pode fazer o menu aparecer ao arrastar pressionando a "
+"tecla Alt."
 
-#: tips:206
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Ao arrastar arquivos com o botão-do-meio"
 
-#: tips:208
+#: tips:287
 msgid "Move the files"
 msgstr "Mover os arquivos"
 
-#: tips:209
-msgid "Note that you can still get the menu to appear, by dragging with the left button and holding down the Alt key."
-msgstr "Note que você ainda pode fazer o menu aparecer ao arrastar com o botão-esquerdo e pressionando a tecla Alt."
+#: tips:288
+msgid ""
+"Note that you can still get the menu to appear, by dragging with the left "
+"button and holding down the Alt key."
+msgstr ""
+"Note que você ainda pode fazer o menu aparecer ao arrastar com o botão-"
+"esquerdo e pressionando a tecla Alt."
 
-#: tips:210
+#: tips:289
 msgid "Download handler"
 msgstr "Manipulador de downloads"
 
-#: tips:211
+#: tips:290
 msgid ""
-"When you drag a file from a web browser or other remote source, this program will be run to download it. $1 is the URI dragged to the filer, and the current directory is the destination. Eg:\n"
+"When you drag a file from a web browser or other remote source, this program "
+"will be run to download it. $1 is the URI dragged to the filer, and the "
+"current directory is the destination. Eg:\n"
 "xterm -e wget $1"
 msgstr ""
-"Ao arrastar um arquivo do navegador da Internet ou de outra fonte remota, esse programa será executado para baixá-lo. $1 é a URI arrastada para o gerente de arquivos e o diretório atual é o destino. P.ex.:\n"
+"Ao arrastar um arquivo do navegador da Internet ou de outra fonte remota, "
+"esse programa será executado para baixá-lo. $1 é a URI arrastada para o "
+"gerente de arquivos e o diretório atual é o destino. P.ex.:\n"
 "xterm -e wget $1"
 
-#: tips:212
+#: tips:291
 msgid "Menus"
 msgstr "Menus"
 
-#: tips:214
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Tamanho dos ícones nos menus:"
 
-#: tips:215
+#: tips:294
 msgid "No Icons"
 msgstr "Sem Ícones"
 
-#: tips:218
+#: tips:297
 msgid "Same as current window"
 msgstr "O mesmo que a janela atual"
 
-#: tips:219
+#: tips:298
 msgid "Same as default"
 msgstr "O mesmo que o padrão"
 
-#: tips:220
+#: tips:299
 msgid "Behaviour"
 msgstr "Comportamento"
 
-#: tips:221
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Menu do arquivo com o botão-direito"
 
-#: tips:222
-msgid "Show the File menu instead of the main menu when right-clicking with files selected (the main menu can be accessed by holding down Control)."
-msgstr "Exibir o menu Arquivo ao invés do menu principal ao clicar com o botão-direito com arquivos selecionados (o menu principal pode ser acessado mantendo pressionada a tecla Ctrl)."
+#: tips:301
+msgid ""
+"Show the File menu instead of the main menu when right-clicking with files "
+"selected (the main menu can be accessed by holding down Control)."
+msgstr ""
+"Exibir o menu Arquivo ao invés do menu principal ao clicar com o botão-"
+"direito com arquivos selecionados (o menu principal pode ser acessado "
+"mantendo pressionada a tecla Ctrl)."
 
-#: tips:223
+#: tips:302
 msgid "Terminal emulator program"
 msgstr "Programa emulador de terminal"
 
-#: tips:224
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
-msgstr "O programa a ser executado quando você escolher `Terminal Aqui' no menu."
+msgstr ""
+"O programa a ser executado quando você escolher `Terminal Aqui' no menu."
 
-#: tips:225
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Atalhos de teclado"
 
-#: tips:227
+#: tips:305
+msgid "Types"
+msgstr "Tipo"
+
+#: tips:306
 msgid "MIME types"
 msgstr "Tipos MIME"
 
-#: tips:228
-msgid "The filer uses a set of rules to work out the correct MIME type for each regular file, and then chooses a suitable icon for that type."
-msgstr "O gerente de arquivos usa um conjunto de regras para determinar o tipo MIME correto para cada aquivo regular e então escolhe o ícone apropriado para esse tipo."
+#: tips:307
+msgid ""
+"The filer uses a set of rules to work out the correct MIME type for each "
+"regular file, and then chooses a suitable icon for that type."
+msgstr ""
+"O gerente de arquivos usa um conjunto de regras para determinar o tipo MIME "
+"correto para cada aquivo regular e então escolhe o ícone apropriado para "
+"esse tipo."
 
-#: tips:229
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "Editar as regras MIME"
 
-#: tips:230
+#: tips:309
 msgid "Themes"
 msgstr "Temas"
 
-#: tips:231
+#: tips:310
 msgid "Icon theme"
 msgstr "Tema de ícones"
 
-#: tips:232
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "Os temas devem ser colocados no diretório ~/.icons"
 
-#: tips:233
-msgid "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note that icons set this way override those from the selected theme."
-msgstr "Use a caixa de diálogo 'Definir o Ícone...' para definir o ícone para cada tipo MIME. Note que ícones definidos desse modo prevalecem sobre os do tema selecionado."
+#: tips:312
+msgid ""
+"Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
+"that icons set this way override those from the selected theme."
+msgstr ""
+"Use a caixa de diálogo 'Definir o Ícone...' para definir o ícone para cada "
+"tipo MIME. Note que ícones definidos desse modo prevalecem sobre os do tema "
+"selecionado."
 
-#: tips:234
+#: tips:313
 msgid "Colours"
 msgstr "Cores"
 
-#: tips:235
+#: tips:314
 msgid "File type colours"
 msgstr "Cores dos tipos de arquivo"
 
-#: tips:236
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Colorir os arquivos conforme o seu tipo"
 
-#: tips:237
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
-msgstr "Os nomes (e detalhes) dos arquivos são coloridos de acordo com o tipo de arquivo."
+msgstr ""
+"Os nomes (e detalhes) dos arquivos são coloridos de acordo com o tipo de "
+"arquivo."
 
-#: tips:238
+#: tips:317
 msgid "Directory:"
 msgstr "Diretório:"
 
-#: tips:239
+#: tips:318
 msgid "Regular file:"
 msgstr "Arquivo regular:"
 
-#: tips:240
+#: tips:319
 msgid "Pipe:"
 msgstr "Pipe:"
 
-#: tips:241
+#: tips:320
 msgid "Socket:"
 msgstr "Socket:"
 
-#: tips:243
-msgid "Error, such as a symlink which points to a non-existant file, or a file which the filer does not have permission to examine."
-msgstr "Erro, como uma ligação simbólica que aponta para um arquivo inexistente ou um arquivo que o gerente de arquivos não tem permissão para examinar."
+#: tips:322
+msgid ""
+"Error, such as a symlink which points to a non-existant file, or a file "
+"which the filer does not have permission to examine."
+msgstr ""
+"Erro, como uma ligação simbólica que aponta para um arquivo inexistente ou "
+"um arquivo que o gerente de arquivos não tem permissão para examinar."
 
-#: tips:244
+#: tips:323
 msgid "Character device:"
 msgstr "Character device (dispositivo de caractere):"
 
-#: tips:245
+#: tips:324
 msgid "Block device:"
 msgstr "Block device (dispositivo de bloco):"
 
-#: tips:246
+#: tips:325
 msgid "Door:"
 msgstr "Door (porta):"
 
-#: tips:247
-msgid "Door files are a bit like sockets or pipes, and have only been seen on Solaris."
-msgstr "Arquivos de porta (door) são um pouco como sockets ou pipes e só tem estado presentes no Solaris."
+#: tips:326
+msgid ""
+"Door files are a bit like sockets or pipes, and have only been seen on "
+"Solaris."
+msgstr ""
+"Arquivos de porta (door) são um pouco como sockets ou pipes e só tem estado "
+"presentes no Solaris."
 
-#: tips:248
+#: tips:327
 msgid "Executable file:"
 msgstr "Arquivo executável:"
 
-#: tips:249
+#: tips:328
 msgid "Application directory:"
 msgstr "Diretório-aplicação:"
 
-#: tips:250
+#: tips:329
 msgid "Unknown type:"
 msgstr "Tipo desconhecido:"
 
-#: tips:251
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Plano de fundo:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Usar fonte personalizada:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
-#: tips:252
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Problemas com o gerenciador de janelas"
 
-#: tips:253
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
-msgstr "Sobrepujar o controle do gerenciador de janelas sobre o quadro e painéis"
+msgstr ""
+"Sobrepujar o controle do gerenciador de janelas sobre o quadro e painéis"
 
-#: tips:254
-msgid "Some window managers don't support the new Extended Window Manager Hints system, and so treat the pinboard and panels like normal windows. Turn this on to fix problems such as the pinboard coming to the front when you click on it, titlebars and other decorations appearing around windows, or having them appear in window-select lists."
-msgstr "Alguns gerenciadores de janelas não suportam o novo sistema Estendido de Otimização para Gerenciadores de Janelas e assim tratam o quadro e os painéis como janelas normais. Habilite isto para resolver problemas como o quadro vir para a frente quando você o clica, barra de títulos e outras decorações aparecendo em volta das janelas ou na lista de seleção de janelas."
+#: tips:340
+msgid ""
+"Some window managers don't support the new Extended Window Manager Hints "
+"system, and so treat the pinboard and panels like normal windows. Turn this "
+"on to fix problems such as the pinboard coming to the front when you click "
+"on it, titlebars and other decorations appearing around windows, or having "
+"them appear in window-select lists."
+msgstr ""
+"Alguns gerenciadores de janelas não suportam o novo sistema Estendido de "
+"Otimização para Gerenciadores de Janelas e assim tratam o quadro e os "
+"painéis como janelas normais. Habilite isto para resolver problemas como o "
+"quadro vir para a frente quando você o clica, barra de títulos e outras "
+"decorações aparecendo em volta das janelas ou na lista de seleção de janelas."
 
-#: tips:255
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
-msgstr "Transmitir todos os cliques do mouse sobre o fundo para o gerenciador de janelas"
+msgstr ""
+"Transmitir todos os cliques do mouse sobre o fundo para o gerenciador de "
+"janelas"
 
-#: tips:256
-msgid "Normally, right clicking on the desktop background will open the pinboard menu and left clicking will clear the selection. Turn this on to forward the events to your window manager instead. Clicks on icons will not be forwarded."
-msgstr "Normalmente, clicar com o botão-direito no fundo da área de trabalho abre o menu do quadro e com o botão-esquerdo limpa a seleção. Habilite esta opção para, em vez disso, encaminhar os eventos para o seu gerenciador de janelas. Os cliques nos ícones não serão encaminhados."
+#: tips:342
+msgid ""
+"Normally, right clicking on the desktop background will open the pinboard "
+"menu and left clicking will clear the selection. Turn this on to forward the "
+"events to your window manager instead. Clicks on icons will not be forwarded."
+msgstr ""
+"Normalmente, clicar com o botão-direito no fundo da área de trabalho abre o "
+"menu do quadro e com o botão-esquerdo limpa a seleção. Habilite esta opção "
+"para, em vez disso, encaminhar os eventos para o seu gerenciador de janelas. "
+"Os cliques nos ícones não serão encaminhados."
 
-#: tips:257
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Hack para o menu do Blackbox"
 
-#: tips:258
-msgid "Blackbox, Fluxbox and similar window managers do not yet work well with the ROX-Filer pinboard. This option enables some workarounds. These window managers are expected to change their behaviour in new versions so that this isn't necessary."
-msgstr "Blackbox, Fluxbox e outros gerenciadores de janela similares ainda não trabalham bem com o quadro do ROX-Filer. Esta opção habilita algumas correções. Esses gerenciadores de janela devem mudar nas novas versões, então isto não será mais necessário."
+#: tips:344
+msgid ""
+"Blackbox, Fluxbox and similar window managers do not yet work well with the "
+"ROX-Filer pinboard. This option enables some workarounds. These window "
+"managers are expected to change their behaviour in new versions so that this "
+"isn't necessary."
+msgstr ""
+"Blackbox, Fluxbox e outros gerenciadores de janela similares ainda não "
+"trabalham bem com o quadro do ROX-Filer. Esta opção habilita algumas "
+"correções. Esses gerenciadores de janela devem mudar nas novas versões, "
+"então isto não será mais necessário."
 
-#: tips:259
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "Painel é um 'dock'"
 
-#: tips:260
-msgid "Makes sure panels stay against screen edges. Disable this option if the panel stays above other windows against your wishes. Requires a restart to take effect."
+#: tips:346
+msgid ""
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
-"Certificar-se de que os painéis se posicionem nas beiradas da tela. Desabilite esta opção se o painel fica sobre outras janelas contra a sua vontade. Requer um\n"
+"Certificar-se de que os painéis se posicionem nas beiradas da tela. "
+"Desabilite esta opção se o painel fica sobre outras janelas contra a sua "
+"vontade. Requer um\n"
 "reinício para ter efeito."
 
-#: tips:261
+#: tips:347
 msgid "Panel stays on top"
 msgstr "Painel permanece por cima"
 
-#: tips:262
-msgid "Keeps the panel above other windows. Enable this option to make sure the dock option works correctly in some versions of compiz. May require a restart to take effect."
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
 msgstr ""
-"Mantém o painel sobre outras janelas. Habilite esta opção para para que a opção de 'dock' funcione corretamente em algumas versões do compiz.\n"
+"Mantém o painel sobre outras janelas. Habilite esta opção para para que a "
+"opção de 'dock' funcione corretamente em algumas versões do compiz.\n"
 "Pode requerer um reinício para ter efeito."
 
-#: tips:263
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Arrastar e soltar"
 
-#: tips:264
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Não usar hostnames"
 
-#: tips:265
-msgid "Some older applications don't support XDND fully and may need to have this option turned on. Use this if dragging files to an application shows a + sign on the pointer but the drop doesn't work."
-msgstr "Algumas aplicações antigas não suportam completamente XDND e podem precisar desta opção habilitada para funcionar. Use-a se ao arrastar um arquivo para uma aplicação um sinal + no cursor é exibido e soltar não funciona"
+#: tips:353
+msgid ""
+"Some older applications don't support XDND fully and may need to have this "
+"option turned on. Use this if dragging files to an application shows a + "
+"sign on the pointer but the drop doesn't work."
+msgstr ""
+"Algumas aplicações antigas não suportam completamente XDND e podem precisar "
+"desta opção habilitada para funcionar. Use-a se ao arrastar um arquivo para "
+"uma aplicação um sinal + no cursor é exibido e soltar não funciona"
 
-#: tips:266
-msgid "Extended attributes"
-msgstr "Atributos estendidos"
-
-#: tips:267
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Não usar atributos estendidos"
 
-#: tips:268
-msgid "This disables the use of extended attributes available in newer operating systems and file systems.  With this option set the 'Set Type' menu entry is disabled, the MIME type of the file is only derived from the file name and the properties window does not report extended attributes."
-msgstr "Isto desabilita o uso de atributos estendidos disponível em sistemas operacionais e de arquivos mais recentes. Ao escolher esta opção a entrada 'Definir o Tipo' no menu é desabilitada, o tipo MIME do arquivo é derivado apenas do seu nome e a janela de propriedades não exibe atributos estendidos."
+#: tips:356
+msgid ""
+"This disables the use of extended attributes available in newer operating "
+"systems and file systems.  With this option set the 'Set Type' menu entry is "
+"disabled, the MIME type of the file is only derived from the file name and "
+"the properties window does not report extended attributes."
+msgstr ""
+"Isto desabilita o uso de atributos estendidos disponível em sistemas "
+"operacionais e de arquivos mais recentes. Ao escolher esta opção a entrada "
+"'Definir o Tipo' no menu é desabilitada, o tipo MIME do arquivo é derivado "
+"apenas do seu nome e a janela de propriedades não exibe atributos estendidos."
 
-#: ../Templates.glade:7
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Extremidade inferior"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "Extremidade direita"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
 msgid "ROX-Filer log viewer"
 msgstr "Visualizador de logs do ROX-Filer"
 
-#: ../Templates.glade:22
+#: ../Templates.ui.h:2
 msgid "Recently performed actions..."
 msgstr "Ações efetuadas recentemente..."
 
-#: ../Templates.glade:77
+#: ../Templates.ui.h:3
 msgid "Open Directory"
 msgstr "Abrir o Diretório"
 
-#: ../Templates.glade:129
+#: ../Templates.ui.h:4
 msgid "Panel Options"
 msgstr "Opções do Painel"
 
-#: ../Templates.glade:169
-msgid "Every icon on this panel is shown with an image and some text."
-msgstr "Todo ícone neste painel é visto com uma imagem e algum texto."
-
-#: ../Templates.glade:170
+#: ../Templates.ui.h:5
 msgid "Image and Text"
 msgstr "Imagem e Texto"
 
-#: ../Templates.glade:186
-msgid "Applications in this panel have just an image, everything else has both an image and text."
-msgstr "Aplicações neste painel trazem apenas uma imagem, tudo o mais traz tanto uma imagem como texto."
+#: ../Templates.ui.h:6
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Todo ícone neste painel é visto com uma imagem e algum texto."
 
-#: ../Templates.glade:187
+#: ../Templates.ui.h:7
 msgid "Image only for applications"
 msgstr "Somente a imagem para aplicações"
 
-#: ../Templates.glade:205
-msgid "Only the image is shown for icons in this panel."
-msgstr "Somente a imagem é exibida para ícones neste painel."
+#: ../Templates.ui.h:8
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"Aplicações neste painel trazem apenas uma imagem, tudo o mais traz tanto uma "
+"imagem como texto."
 
-#: ../Templates.glade:206
+#: ../Templates.ui.h:9
 msgid "Image only"
 msgstr "Somente a imagem"
 
-#: ../Templates.glade:235
+#: ../Templates.ui.h:10
+msgid "Only the image is shown for icons in this panel."
+msgstr "Somente a imagem é exibida para ícones neste painel."
+
+#: ../Templates.ui.h:11
 msgid "Panel width"
 msgstr "Largura do painel"
 
-#: ../Templates.glade:247
+#: ../Templates.ui.h:12
 msgid "The size of this panel."
 msgstr "O tamanho deste painel."
 
-#: ../Templates.glade:259
+#: ../Templates.ui.h:13
 msgid "px"
 msgstr "px"
 
-#: ../Templates.glade:278
-msgid "Ask the window manager not to cover this panel when maximising windows, otherwise leave just 2 pixels at the edge of the screen to allow auto-raising. Some window managers may not honour this setting."
-msgstr "Solicitar ao gerenciador de janelas para não cobrir este painel ao maximizar janelas ou então deixar 2 pixel na beirada da tela para possibilitar auto-elevação. Alguns gerenciadores de janelas podem não honrar esta opção."
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Tradução"
 
-#: ../Templates.glade:279
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
 msgid "Do not cover panel"
 msgstr "Não cobrir o painel"
 
-#: ../Templates.glade:297
+#: ../Templates.ui.h:19
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Solicitar ao gerenciador de janelas para não cobrir este painel ao maximizar "
+"janelas ou então deixar 2 pixel na beirada da tela para possibilitar auto-"
+"elevação. Alguns gerenciadores de janelas podem não honrar esta opção."
+
+#: ../Templates.ui.h:20
 msgid "<b>Panel style</b>"
 msgstr "<b>Estilo do painel</b>"
 
-#: ../Templates.glade:331
-msgid "If you use multiple monitors with Xinerama, use this option to confine the panel to one monitor."
-msgstr "Se você usa mais de um monitor com o Xinerama, use esta opção para confinar o painel a um único monitor."
-
-#: ../Templates.glade:332
+#: ../Templates.ui.h:21
 msgid "Confine to Xinerama monitor"
 msgstr "Confinar ao monitor Xinerama"
 
-#: ../Templates.glade:347
-msgid "The monitor this panel is confined to when using Xinerama. The numbering starts from zero."
-msgstr "O monitor ao qual este painel é confinado ao usar o Xinerama. A numeração começa do zero."
+#: ../Templates.ui.h:22
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Se você usa mais de um monitor com o Xinerama, use esta opção para confinar "
+"o painel a um único monitor."
 
-#: ../Templates.glade:372
+#: ../Templates.ui.h:23
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+"O monitor ao qual este painel é confinado ao usar o Xinerama. A numeração "
+"começa do zero."
+
+#: ../Templates.ui.h:24
 msgid "<b>Xinerama</b>"
 msgstr "<b>Xinerama</b>"
 
-#: ../Templates.glade:407
+#: ../Templates.ui.h:25
 msgid "Right edge"
 msgstr "Extremidade direita"
 
-#: ../Templates.glade:426
+#: ../Templates.ui.h:26
 msgid "Left edge"
 msgstr "Extremidade esquerda"
 
-#: ../Templates.glade:443
+#: ../Templates.ui.h:27
 msgid "Bottom edge"
 msgstr "Extremidade inferior"
 
-#: ../Templates.glade:462
+#: ../Templates.ui.h:28
 msgid "Top edge"
 msgstr "Extremidade superior"
 
-#: ../Templates.glade:496
+#: ../Templates.ui.h:29
 msgid "<b>Position</b>"
 msgstr "<b>Posição</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<dir>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' já existe - sobrescrever?"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Erro ao escanear '%s':\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Diretório inexistente/apagado"
+
+#~ msgid "Directory '%s' is not accessible"
+#~ msgstr "O diretório '%s' não esta acessível"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "O diretório '%s' não foi encontrado"
+
+#~ msgid "Cancel"
+#~ msgstr "Cancelar"
+
+#~ msgid "All, "
+#~ msgstr "Todos, "
+
+#~ msgid "Inotify support"
+#~ msgstr "Suporte ao Inotify "
+
+#~ msgid "Dnotify support"
+#~ msgstr "Suporte ao Dnotify "
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Você deveria usar Shift+clique de menu (botão-direito por padrão) sobre "
+#~ "um arquivo para enviá-lo para algum lugar"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Mudar para o diretório superior"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Mudar para o diretório home"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Marcações"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Menu de marcações"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Reescanear o conteúdo do diretório"
+
+#~ msgid "Change icon size"
+#~ msgstr "Modificar o tamanho dos ícones"
+
+#~ msgid "Show extra details"
+#~ msgstr "Exibir detalhes extras"
+
+#~ msgid "Hidden"
+#~ msgstr "Ocultos"
+
+#~ msgid "Change at:"
+#~ msgstr "modificar a partir de:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Largura máxima (Ícones Grandes):"
+
+#~ msgid "Panel (obsolete)"
+#~ msgstr "Painel (obsoleto)"
+
+#~ msgid ""
+#~ "Enter the name of the panel to show here. This option is now only used "
+#~ "when upgrading from an old version."
+#~ msgstr ""
+#~ "Informe o nome do painel a ser exibido. Esta opção atualmente só é usada "
+#~ "ao atualizar de uma versão antiga."
 
 #, fuzzy
 #~ msgid "Choices migration"
 #~ msgstr "Chinese (traditional)"
+
 #~ msgid "GNOME-VFS library"
 #~ msgstr "Biblioteca GNOME-VFS"
+
 #~ msgid "Open AVFS"
 #~ msgstr "Open AVFS"
+
 #~ msgid "Look inside ... ?"
 #~ msgstr "Olhar dentro... ?"
 
 #, fuzzy
 #~ msgid "Panel: %s"
 #~ msgstr "Paineis"
+
 #~ msgid "Invalid .gmo translation file (too short): %s"
 #~ msgstr "Invalid .gmo translation file (too short): %s"
+
 #~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
 #~ msgstr "Invalid .gmo translation file (GNU magic number not found): %s"
+
 #~ msgid "Show/hide hidden files"
 #~ msgstr "Exibir/Esconder aquivos ocultos"
+
 #~ msgid ""
 #~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
 #~ "instead."
 #~ msgstr "Os ícones do tema '%s' não contêm ícones MIME,Utilizando..."
-#~ msgid "Translation"
-#~ msgstr "Tradução"
+
 #~ msgid "Language"
 #~ msgstr "Linguagem"
+
 #~ msgid "Use the LANG environment variable"
 #~ msgstr "Use the a variabel LANG"
+
 #~ msgid "Chinese (traditional)"
 #~ msgstr "Chinese (traditional)"
+
 #~ msgid "Chinese (simplified)"
 #~ msgstr "Chinese (simplified)"
+
 #~ msgid "Czech"
 #~ msgstr "Checo"
+
 #~ msgid "Danish"
 #~ msgstr "Duński"
+
 #~ msgid "Dutch"
 #~ msgstr "Holenderski"
+
 #~ msgid "English (no translation)"
 #~ msgstr "English (no translation)"
 
 #, fuzzy
 #~ msgid "Finnish"
 #~ msgstr "Duński"
+
 #~ msgid "French"
 #~ msgstr "French"
+
 #~ msgid "German"
 #~ msgstr "German"
+
 #~ msgid "Hungarian"
 #~ msgstr "Hungarian"
+
 #~ msgid "Japanese"
 #~ msgstr "Japanese"
+
 #~ msgid "Norwegian"
 #~ msgstr "Norwegian"
+
 #~ msgid "Italian"
 #~ msgstr "Italian"
+
 #~ msgid "Polish"
 #~ msgstr "Polish"
+
 #~ msgid "Russian"
 #~ msgstr "Russian"
+
 #~ msgid "Spanish"
 #~ msgstr "Spanish"
+
 #~ msgid "Swedish"
 #~ msgstr "Swedish"
+
 #~ msgid "Panels"
 #~ msgstr "Paineis"
+
 #~ msgid ""
 #~ "Panels are bars of icons that run along the side of the screen. See the "
 #~ "manual for information about using panels."
 #~ msgstr ""
 #~ "Panels are bars of icons that run along the side of the screen. See the "
 #~ "manual for information about using panels."
+
 #~ msgid "(thick)"
 #~ msgstr "(thick)"
+
 #~ msgid ""
 #~ "Error loading MIME database:\n"
 #~ "%s"
 #~ msgstr ""
 #~ "Erro carregando banco de dados MIME:\n"
 #~ "%s"
+
 #~ msgid "File '%s' corrupted!"
 #~ msgstr "O arquivo  \"%s\" esta corrompido"
+
 #~ msgid ""
 #~ "The ~/.mime directory has moved. It should now be ~/.local/share/mime. "
 #~ "You should move it there (and make a symlink from ~/.mime to it for older "
@@ -4570,6 +5913,7 @@ msgstr "<b>Posição</b>"
 #~ "O diretório ~/.mime foi movido.Agora deveria ser: ~/.local/share/mime."
 #~ "Você deveria move-lo para la(e fazer um link simbolico para seus "
 #~ "aplicativos antigos)"
+
 #~ msgid ""
 #~ "The standard MIME type database (version 0.9 or later) was not found. The "
 #~ "filer will probably not show the correct types for different files. You "
@@ -4588,12 +5932,16 @@ msgstr "<b>Posição</b>"
 #~ "http://www.freedesktop.org/software/shared-mime-info\n"
 #~ "Se você ja instalou o pacote cheque as permissões(/usr/local/share /mime/"
 #~ "globs/ /usr/share/mime/globs)."
+
 #~ msgid "Icon '%s' not present in theme"
 #~ msgstr "O ícone '%s' não existe no tema"
+
 #~ msgid "Executable files"
 #~ msgstr "Executable files"
+
 #~ msgid "Ignore eXecutable bit for known extensions"
 #~ msgstr "Ignore eXecutable bit for known extensions"
+
 #~ msgid ""
 #~ "If a file has a known extension (eg '.gif') then ignore the executable "
 #~ "bit. This is useful if you have files on a Windows-type filesystem which "
@@ -4606,14 +5954,16 @@ msgstr "<b>Posição</b>"
 #, fuzzy
 #~ msgid "Umount"
 #~ msgstr "Desmontar"
+
 #~ msgid ""
 #~ "Pinboard icons cannot be drawn because ROX-Filer was compiled against GTK"
 #~ "+-2.0 but is running with GTK+-2.2. Please recompile it."
 #~ msgstr ""
 #~ "Ícones do desktop não podem ser desenhados porque ROX-FIler foi compilado "
 #~ "com o GTK+-2.0 mas não com o GTK+-2.2.Por favor recompileo"
+
 #~ msgid "No (gnome-vfs-config not found)"
 #~ msgstr "No (gnome-vfs-config not found)"
+
 #~ msgid "ROX icon theme not found... installing..."
 #~ msgstr "Tema do ROX não encontrado...instalando..."
-

--- a/ROX-Filer/src/po/pt_PT.po
+++ b/ROX-Filer/src/po/pt_PT.po
@@ -7,10 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pt_PT\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-08-21 16:42+0100\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2005-08-21 21:35+0100\n"
 "Last-Translator: Renato Caldas <seventhguardian@gmail.com>\n"
 "Language-Team: Português de Protugal <pt@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -18,50 +19,54 @@ msgstr ""
 "Plural-Forms:  nplurals=2; plural=(n != 1);\n"
 
 #: abox.c:127
-msgid "<dir>"
-msgstr "<dir>"
+msgid "<src>"
+msgstr ""
 
-#: abox.c:219
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "Sil_encioso"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Quiet"
 msgstr "Silencioso"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Não confirmar cada operação"
 
-#: abox.c:455 tips:61
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Nome"
 
-#: abox.c:461 menu.c:232
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Directoria"
 
-#: abox.c:550
+#: abox.c:546
 msgid "Expression:"
 msgstr "Expressão:"
 
-#: action.c:58
+#: action.c:57
 msgid "See the attr(5) man page for full details."
 msgstr "Veja a página do manual do attr(5) para mais detalhes."
 
-#: action.c:60
+#: action.c:59
 msgid "See the fsattr(5) man page for full details."
 msgstr "Veja a página do manual do fsattr(5) para mais detalhes."
 
-#: action.c:62
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr "Não parece que tenha suporte OS."
 
-#: action.c:188
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Referência para expressões de procura"
 
-#: action.c:199
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -100,11 +105,11 @@ msgid ""
 "<b>prune</b> (false, and prevents searching the contents of a directory)."
 msgstr ""
 
-#: action.c:246
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Referência para a mudança de permissões"
 
-#: action.c:257
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -135,11 +140,11 @@ msgid ""
 "See the chmod(1) man page for full details."
 msgstr ""
 
-#: action.c:298
+#: action.c:308
 msgid "Set type reference"
 msgstr "Referência para a definição de tipo"
 
-#: action.c:309
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -167,48 +172,55 @@ msgstr ""
 "não para directorias, dispositivos, pipes ou sockets, e então apenas\n"
 "em certo sistemas de ficheiros e onde o S.O. os implementa.\n"
 
-#: action.c:416
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Processo terminado.\n"
 
-#: action.c:432
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Houve um erro.\n"
 
-#: action.c:434
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Houve %d erros.\n"
 
-#: action.c:458
+#: action.c:516
 msgid "ERROR reading"
 msgstr "ERRO ao ler"
 
-#: action.c:501
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Pronto\n"
 
-#: action.c:557 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "ERRO"
 
-#: action.c:711 main.c:669 main.c:676 main.c:690
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Sim"
 
-#: action.c:714 main.c:671 main.c:678 main.c:690
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Não"
 
-#: action.c:732
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -216,7 +228,7 @@ msgstr ""
 "\n"
 "A pedir ao processo filho para terminar...\n"
 
-#: action.c:739
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -224,41 +236,41 @@ msgstr ""
 "\n"
 "A tentar MATAR processo em fuga...\n"
 
-#: action.c:892
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Contar o conteúdo de %s?"
 
-#: action.c:928
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Apagar %s'%s'?"
 
-#: action.c:929
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "PROTEGIDO CONTRA ESCRITA"
 
-#: action.c:936
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'A Apagar '%s'\n"
 
-#: action.c:949
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'Directoria '%s' apagada\n"
 
-#: action.c:982
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?Ejectar '%s'?"
 
-#: action.c:989
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Ejectar '%s'\n"
 
-#: action.c:1008
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -267,80 +279,95 @@ msgstr ""
 "!%s\n"
 "o ejectar falhou\n"
 
-#: action.c:1027 action.c:1046
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Verificar '%s'?"
 
-#: action.c:1043
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Condição de procura inválida - mude-a e tente de novo\n"
 
-#: action.c:1053
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(ao verificar '%s')\n"
 
-#: action.c:1127 action.c:1152
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Mudar permissões de '%s'?"
 
-#: action.c:1133
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'A mudar permisões de '%s'\n"
 
-#: action.c:1150
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Comando de modo inválido - mude-o e tente de novo\n"
 
-#: action.c:1207 action.c:1227
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?Mudar o tipo de '%s'?"
+
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Mudar o tipo de '%s'?"
 
-#: action.c:1224
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Tipo inválido - mude-o e tente de novo\n"
 
-#: action.c:1246
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'A mudar o tipo de '%s' para '%s'\n"
 
-#: action.c:1325
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'A mudar o tipo de '%s' para '%s'\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' já existe - %s?"
 
-#: action.c:1327
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "fundir conteúdos"
 
-#: action.c:1328
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "sobrepor"
 
-#: action.c:1344
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'A tentar copiar mesmo assim...\n"
 
-#: action.c:1353
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Copiar %s para %s?"
 
-#: action.c:1357
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'A copiar %s para %s\n"
 
-#: action.c:1372
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!ERRO: O destino já existe, mas não é uma directoria\n"
 
-#: action.c:1444
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -349,26 +376,7 @@ msgstr ""
 "!%s\n"
 "Não foi possível copiar '%s'\n"
 
-#: action.c:1488
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' já existe - sobrepor?"
-
-#: action.c:1503
-msgid "'Trying move anyway...\n"
-msgstr "'A tentar mover mesmo assim...\n"
-
-#: action.c:1511
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Mover %s para %s?"
-
-#: action.c:1515
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'A mover %s para %s\n"
-
-#: action.c:1523
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -377,45 +385,59 @@ msgstr ""
 "!%s\n"
 "Não foi possível mover %s para %s\n"
 
-#: action.c:1544
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'A tentar mover mesmo assim...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Mover %s para %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'A mover %s para %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!ERRO: Impossível copiar um objecto para si mesmo\n"
 
-#: action.c:1559
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!ERRO: Impossível mover/renomear um objecto para si mesmo\n"
 
-#: action.c:1571
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'A ligar %s a %s\n"
 
-#: action.c:1576
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Criar ligação para %s em %s?"
 
-#: action.c:1618
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'A montar %s\n"
 
-#: action.c:1619
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'A desmontar %s\n"
 
-#: action.c:1622
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?Montar %s?"
 
-#: action.c:1623
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?Desmontar %s?"
 
-#: action.c:1643
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -424,7 +446,7 @@ msgstr ""
 "!%s\n"
 "O montar falhou\n"
 
-#: action.c:1644
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -433,11 +455,11 @@ msgstr ""
 "!%s\n"
 "O desmontar falhou\n"
 
-#: action.c:1652
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(de qualquer modo agora parece estar montado)\n"
 
-#: action.c:1698
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -446,207 +468,232 @@ msgstr ""
 "'\n"
 "Total: %s ("
 
-#: action.c:1704
+#: action.c:2108
 msgid "file"
 msgstr "ficheiro"
 
-#: action.c:1704
+#: action.c:2108
 msgid "files"
 msgstr "ficheiros"
 
-#: action.c:1708
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "nenhuma directoria)\n"
 
-#: action.c:1712
+#: action.c:2116
 msgid "directory"
 msgstr "directoria"
 
-#: action.c:1713
+#: action.c:2117
 msgid "directories"
 msgstr "directorias"
 
-#: action.c:1754
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Nenhum ponto de montagem seleccionado!\n"
 
-#: action.c:1839
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Outra procura?"
 
-#: action.c:1869 action.c:1900
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' é uma ligação simbólica\n"
 
-#: action.c:1940
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "É necessário seleccionar alguns itens para procurar neles"
 
-#: action.c:1950 menu.c:223
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Procurar"
 
-#: action.c:1983
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "É necessário seleccionar alguns itens para contar"
 
-#: action.c:1987
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Uso do Disco"
 
-#: action.c:2021
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Montar / Desmontar"
 
-#: action.c:2034
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
-msgstr "O ROX-Filer ainda não suporta pontos de montagem no seu sistema. Desculpe."
+msgstr ""
+"O ROX-Filer ainda não suporta pontos de montagem no seu sistema. Desculpe."
 
-#: action.c:2048 menu.c:210 tips:209
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Apagar"
 
-#: action.c:2058 tips:214
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Forçar"
 
-#: action.c:2058
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Não confirmar ao apagar itens em que não tem premissão de escrever"
 
-#: action.c:2061 action.c:2116 action.c:2175 action.c:2228 action.c:2264
-#: tips:216
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Registo"
 
-#: action.c:2061
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Apenas criar registo das directorias ao serem apagadas"
 
-#: action.c:2078
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "É necessário escolher os itens cujas permissões quer alterar"
 
-#: action.c:2086
+#: action.c:2506
 #, fuzzy
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Tornar executavel/procuravel)"
 
-#: action.c:2088
+#: action.c:2508
 #, fuzzy
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (Fazer não-executavel/non-searchable)"
 
-#: action.c:2090
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Dar ao dono leitura+escrita)"
 
-#: action.c:2092
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Privado - acesso apenas pelo dono)"
 
-#: action.c:2094
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Acesso público, sem escrita)"
 
-#: action.c:2105 menu.c:184 menu.c:221 tips:76
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Permissões"
 
-#: action.c:2116 action.c:2175
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Não listar os ficheiros processados"
 
-#: action.c:2119 action.c:2178 tips:218
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Recursivo"
 
-#: action.c:2119
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Também alterar o conteúdo das subdirectorias"
 
-#: action.c:2123
+#: action.c:2547
 msgid "Command:"
 msgstr "Comando:"
 
-#: action.c:2151
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Tem que seleccionar o ficheiro cujo tipo quer alterar"
 
-#: action.c:2164
+#: action.c:2590
 msgid "Set type"
 msgstr "Definir tipo:"
 
-#: action.c:2178
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Alterar o conteúdo das subdirectorias"
 
-#: action.c:2185 infobox.c:615
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Tipo:"
 
-#: action.c:2214 dnd.c:124 menu.c:1999 tips:203
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Copiar"
 
-#: action.c:2224 action.c:2260 tips:220
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Não confirmar cada operação"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Apenas sobrepor se a fonte é mais recente que o destino."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Recente"
 
-#: action.c:2225 action.c:2261 tips:221
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Apenas sobrepor se a fonte é mais recente que o destino."
 
-#: action.c:2228
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "directorias"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Apenas criar registo das directorias ao serem movidas"
 
-#: action.c:2250 dnd.c:125 tips:205
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Mover"
 
-#: action.c:2264
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Não criar registo de cada ficheiro ao ser movido"
 
-#: action.c:2284 tips:207
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Criar Ligação"
 
-#: action.c:2303 appmenu.c:113
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Ejectar"
 
-#: action.c:2360
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "A apagar itens tais como "
 
-#: action.c:2364
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "A apagar o item "
 
-#: action.c:2366
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "A apagar os itens "
 
-#: action.c:2385
+#: action.c:2900
 msgid " and "
 msgstr " e "
 
-#: action.c:2394
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr " irá afectar alguns itens no pinboard ou no painel - apagá-lo mesmo?"
 
-#: action.c:2401
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr " irá afectar alguns itens no pinboard ou no painel - apagá-los mesmo?"
 
-#: appmenu.c:198
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<etiqueta em falta>"
 
-#: appmenu.c:295
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
@@ -655,82 +702,82 @@ msgstr ""
 "Crie ligações simbólicas para os programas que quiser nesta directoria. Eles "
 "aparecerão no menu para todos os itens deste tipo (%s/%s)."
 
-#: appmenu.c:339 menu.c:234
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Personalizar Menu..."
 
-#: appmenu.c:396 menu.c:251 toolbar.c:159
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Ajuda"
 
-#: bookmarks.c:147
-msgid "Path"
-msgstr "Caminho"
-
-#: bookmarks.c:155
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Título"
 
-#: bookmarks.c:304
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Caminho"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Não é possivel guardar nos favoritos o recurso não-local '%s'\n"
 
-#: bookmarks.c:312 bookmarks.c:630
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' não é uma directoria"
 
-#: bookmarks.c:518
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Deve primeiro seleccionar algumas linhas para apagar"
 
-#: bookmarks.c:542
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Coloque o cursor numa entrada na lista para a mover"
 
-#: bookmarks.c:562
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Este item já está no fim"
 
-#: bookmarks.c:636
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Não é possivel guardar nos favoritos directorias não-locais como '%s'"
 
-#: bookmarks.c:778
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Adicionar aos Favoritos"
 
-#: bookmarks.c:785
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Editar Favoritos"
 
-#: bookmarks.c:790
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Recentemente Visitados"
 
-#: bulk_rename.c:68
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Renomear ficheiros em grupo"
 
-#: bulk_rename.c:71
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Reverter"
 
-#: bulk_rename.c:76
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "Fazer da coluna Novo uma cópia da coluna Antigo"
 
-#: bulk_rename.c:81
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "_Renomear"
 
-#: bulk_rename.c:94
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Substituir:"
 
-#: bulk_rename.c:101
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -749,18 +796,20 @@ msgid "With:"
 msgstr "Por:"
 
 #: bulk_rename.c:116
+#, fuzzy
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 "A primeira correspondência em cada nome de ficheiro será substituida por "
 "esta expressão. Não há caracteres especiais."
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Aplicar"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
@@ -768,44 +817,45 @@ msgstr ""
 "Procurar-e-substituir nos ficheiros da coluna Novo. Os ficheiros não são "
 "realmente renomeados até clicar no botão Renomear, em baixo."
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Antigo nome"
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Novo nome"
 
-#: bulk_rename.c:259
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr "Nenhuma expressão (na coluna Novo) correspondeu à expressão dada"
 
-#: bulk_rename.c:264
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Um nome foi correspondido, mas o resultado foi o mesmo"
 
-#: bulk_rename.c:267
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d nomes foram correspondidos, mas os resultados foram os mesmos"
 
-#: bulk_rename.c:293
-msgid "Specify a regular expression to match, and a string to replace matches with."
+#: bulk_rename.c:330
+msgid ""
+"Specify a regular expression to match, and a string to replace matches with."
 msgstr ""
 "Especifique uma expressão regular a corresponder, e uma expressão para "
 "substituir as correspondências."
 
-#: bulk_rename.c:310
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (para '%s')"
 
-#: bulk_rename.c:343
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr "Um ficheiro chamado '%s' já existe. A abortar a renomeação em grupo."
 
-#: bulk_rename.c:348
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -816,12 +866,12 @@ msgstr ""
 "%s\n"
 "A abortar a renomeação em grupo."
 
-#: bulk_rename.c:410
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "O ficheiro chamado '%s' já existe"
 
-#: bulk_rename.c:421
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
@@ -830,57 +880,73 @@ msgstr ""
 "Alguns dos Novos nomes contém o caracter / (ex. '%s'). Isto fará com que os "
 "ficheiros acabem em directorias diferentes. Continuar?"
 
-#: bulk_rename.c:436
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Nenhum dos nomes foi mudado. Nada para fazer!"
 
-#: choices.c:428
-msgid "Choices migration"
-msgstr "Migração das escolhas"
+#: choices.c:434
+#, c-format
+msgid "%d directories could not be migrated"
+msgstr "Não foi possivel migrar %d directorias"
 
 #: choices.c:436
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Choices have been moved from \n"
-"<b>%s</b>\n"
+"%s\n"
 " to the new location \n"
-"<b>%s</b>\n"
+"%s\n"
+"%s"
 msgstr ""
 "As escolhas foram movidas de \n"
 "<b>%s</b>\n"
 " para a nova localização \n"
 "<b>%s</b>\n"
 
-#: choices.c:447
-#, c-format
-msgid "%d directories could not be migrated"
-msgstr "Não foi possivel migrar %d directorias"
-
-#: dir.c:982
-#, c-format
-#, fuzzy
+#: dir.c:1077
+#, fuzzy, c-format
 msgid "Can't stat directory: %s"
 msgstr "Não é possivel ver estatísticas da directoria: %s"
 
-#: dir.c:991
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Não é possivel abrir a directoria: %s"
 
-#: display.c:588
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Tamanho"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) falhou: %s"
 
-#: dnd.c:126
-msgid "Link (relative)"
-msgstr "Criar ligação (relativa)"
-
-#: dnd.c:127
-msgid "Link (absolute)"
-msgstr "Criar ligação (absoluta)"
-
-#: dnd.c:426
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Erro interno - mau tipo de info"
 
@@ -902,11 +968,15 @@ msgstr ""
 
 #: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
-msgstr "Desculpe - é necessário um destino do tipo text/uri-list ou XdndDirectSave0."
+msgstr ""
+"Desculpe - é necessário um destino do tipo text/uri-list ou XdndDirectSave0."
 
 #: dnd.c:621
-msgid "Sorry - I require a target type of text/uri-list or application/octet-stream."
-msgstr "Desculpe - é necessário um destino do tipo text/uri-list ou application/octet-stream."
+msgid ""
+"Sorry - I require a target type of text/uri-list or application/octet-stream."
+msgstr ""
+"Desculpe - é necessário um destino do tipo text/uri-list ou application/"
+"octet-stream."
 
 #: dnd.c:691
 #, fuzzy, c-format
@@ -927,7 +997,8 @@ msgstr "Destino desconhecido"
 
 #: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
-msgstr "Aplicação remota não consegue ou não quer enviar-me os dados - desculpe"
+msgstr ""
+"Aplicação remota não consegue ou não quer enviar-me os dados - desculpe"
 
 #: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
@@ -953,56 +1024,84 @@ msgid "No URIs in the text/uri-list (nothing to do!)"
 msgstr "Não há URI's no text/uri-list (nada para fazer!)"
 
 #: dnd.c:993
-msgid "Can't get data from remote machine (application/octet-stream not provided)"
-msgstr "Não é possível obter dados da máquina remota (application/octet-stream não disponibilizado)"
+msgid ""
+"Can't get data from remote machine (application/octet-stream not provided)"
+msgstr ""
+"Não é possível obter dados da máquina remota (application/octet-stream não "
+"disponibilizado)"
 
-#: dnd.c:1016
-msgid "Some of these files are on a different machine - they will be ignored - sorry"
-msgstr "Alguns destes ficheiros estão numa máquina diferente - eles serão ignorados - desculpe"
+#: dnd.c:1015 menu.c:2406
+msgid ""
+"Some of these files are on a different machine - they will be ignored - sorry"
+msgstr ""
+"Alguns destes ficheiros estão numa máquina diferente - eles serão ignorados "
+"- desculpe"
 
-#: dnd.c:1023
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
-msgstr "Nenhum destes ficheiros está na máquina local - não consigo operar em ficheiros remotos múltiplos - desculpe."
+msgstr ""
+"Nenhum destes ficheiros está na máquina local - não consigo operar em "
+"ficheiros remotos múltiplos - desculpe."
 
-#: dnd.c:1036
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Requisitada uma acção desconhecida"
 
-#: dnd.c:1044
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Erro ao obter a lista de ficheiros: %s"
 
-#: dropbox.c:114
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Criar ligação (relativa)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Criar ligação (absoluta)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Criar ligação (relativa)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Criar ligação (absoluta)"
+
+#: dropbox.c:112
 msgid "Show"
 msgstr "Mostrar"
 
-#: dropbox.c:120
+#: dropbox.c:118
 msgid "Show the current choice in a filer window"
 msgstr "Mostrar a escolha actual numa janela do gestor"
 
-#: dropbox.c:174
+#: dropbox.c:172
 msgid "<nothing>"
 msgstr "<nada>"
 
-#: dropbox.c:239
+#: dropbox.c:237
 msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
-msgstr "Não consigo mostrar o item definido actualmente, já que nada está definido actualmente. Arraste algo para mim!"
+msgstr ""
+"Não consigo mostrar o item definido actualmente, já que nada está definido "
+"actualmente. Arraste algo para mim!"
 
-#: dropbox.c:263
+#: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
 msgstr "Desculpe, deve largar exactamente um ficheiro na área destinada."
 
-#: dropbox.c:273
+#: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr "Desculpe, não consigo usar '%s' porque não é um ficheiro local."
 
-#: dropbox.c:280 pinboard.c:853
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1011,7 +1110,7 @@ msgstr ""
 "Não é possivel aceder '%s':\n"
 "%s"
 
-#: filer.c:453
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1020,16 +1119,7 @@ msgstr ""
 "Erro ao actualizar '%s':\n"
 "%s\n"
 
-#: filer.c:457
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Erro ao actualizar '%s':\n"
-"%s"
-
-#: filer.c:562
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1039,363 +1129,422 @@ msgstr ""
 "\n"
 "Desmontar um dispositivo faz com que seja seguro remover o disco."
 
-#: filer.c:566
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 msgid "No change"
 msgstr "Sem alteração"
 
-#: filer.c:572 menu.c:862
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Desmontar"
 
-#: filer.c:669
-msgid "Directory missing/deleted"
-msgstr "Directoria em falta/apagada"
-
-#: filer.c:1031
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
 "Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"O grupo %s não está definido. Seleccione alguns ficheiros e pressione Ctrl+%"
-"s para definir o grupo.Pressione apenas %s para re-seleccionar os ficheiros "
+"O grupo %s não está definido. Seleccione alguns ficheiros e pressione Ctrl+"
+"%s para definir o grupo.Pressione apenas %s para re-seleccionar os ficheiros "
 "mais tarde.\n"
 "Certifique-se que o NumLock está ligado ao usar o keypad."
 
-#: filer.c:1267
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Directoria '%s' não está acessível"
+#: filer.c:2655
+msgid "A"
+msgstr ""
 
-#: filer.c:1419
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Directoria '%s' não encontrada."
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
 
-#: filer.c:1713
-msgid "Cancel"
-msgstr "Cancelar"
+#: filer.c:2659 find.c:923
+msgid "G"
+msgstr "G"
 
-#: filer.c:2002
+#: filer.c:2664
 msgid "S"
 msgstr "A"
 
-#: filer.c:2004
+#: filer.c:2669
 msgid "T"
 msgstr "M"
 
-#: filer.c:2026
+#: filer.c:2670
+msgid "D"
+msgstr ""
+
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
+#, c-format
+msgid "Glob (%s), "
+msgstr ""
+
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Actualizando, "
 
-#: filer.c:2028
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Miniaturas, "
 
-#: filer.c:2304
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Miniaturas, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Ligação simbólica para "
 
-#: filer.c:2335
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "O nome do ficheiro não é um UTF-8 válido. Deve renomeá-lo.\n"
 
-#: filer.c:2643 menu.c:1989
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "O item já não existe!"
 
-#: filer.c:3327
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Seleccione as propriedades de visualização a guardar"
 
-#: filer.c:3334
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Seleccione as propriedades de visualização a guardar"
+
+#: filer.c:4727
 msgid "Position"
 msgstr "Posição"
 
-#: filer.c:3339 toolbar.c:135 toolbar.c:139 tips:64
-msgid "Size"
-msgstr "Tamanho"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Janela"
 
-#: filer.c:3344
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Mostrar Escondidos"
 
-#: filer.c:3350
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Estilo de visualização"
 
-#: filer.c:3356
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Tipo e ordem de organização"
 
-#: filer.c:3361 toolbar.c:143
+#: filer.c:4754
 msgid "Details"
 msgstr "Detalhes"
 
-#: filer.c:3366 tips:115 tips:116
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Miniaturas"
 
-#: filer.c:3372
+#: filer.c:4765
 msgid "Filter"
 msgstr "Filtro"
 
-#: find.c:487
+#: find.c:485
 #, fuzzy
 msgid "And"
 msgstr "E"
 
-#: find.c:511
+#: find.c:509
 #, fuzzy
 msgid "Not"
 msgstr "Não"
 
-#: find.c:554
+#: find.c:552
 msgid "system"
 msgstr ""
 
-#: find.c:562
+#: find.c:560
 msgid "prune"
 msgstr ""
 
-#: find.c:650
+#: find.c:648
 #, fuzzy
 msgid "After"
 msgstr "Depois"
 
-#: find.c:652
+#: find.c:650
 #, fuzzy
 msgid "Before"
 msgstr "Antes"
 
-#: find.c:746
+#: find.c:744
 msgid "IsReg"
 msgstr ""
 
-#: find.c:748
+#: find.c:746
 msgid "IsLink"
 msgstr ""
 
-#: find.c:750
+#: find.c:748
 msgid "IsDir"
 msgstr ""
 
-#: find.c:752
+#: find.c:750
 msgid "IsChar"
 msgstr ""
 
-#: find.c:754
+#: find.c:752
 msgid "IsBlock"
 msgstr ""
 
-#: find.c:756
+#: find.c:754
 msgid "IsDev"
 msgstr ""
 
-#: find.c:758
+#: find.c:756
 msgid "IsPipe"
 msgstr ""
 
-#: find.c:760
+#: find.c:758
 msgid "IsSocket"
 msgstr ""
 
-#: find.c:762
+#: find.c:760
 msgid "IsDoor"
 msgstr ""
 
-#: find.c:764
+#: find.c:762
 msgid "IsSUID"
 msgstr ""
 
-#: find.c:766
+#: find.c:764
 msgid "IsSGID"
 msgstr ""
 
-#: find.c:768
+#: find.c:766
 msgid "IsSticky"
 msgstr ""
 
-#: find.c:770
+#: find.c:768
 msgid "IsReadable"
 msgstr ""
 
-#: find.c:772
+#: find.c:770
 msgid "IsWriteable"
 msgstr ""
 
-#: find.c:774
+#: find.c:772
 msgid "IsExecutable"
 msgstr ""
 
-#: find.c:776
+#: find.c:774
 msgid "IsEmpty"
 msgstr ""
 
-#: find.c:778
+#: find.c:776
 msgid "IsMine"
 msgstr ""
 
-#: find.c:906
+#: find.c:904
 msgid "Now"
 msgstr ""
 
-#: find.c:919
+#: find.c:917
 msgid "Byte"
 msgstr "Byte"
 
-#: find.c:919
+#: find.c:917
 msgid "Bytes"
 msgstr "Bytes"
 
-#: find.c:921
+#: find.c:919
 msgid "Kb"
 msgstr "Kb"
 
-#: find.c:921
+#: find.c:919
 msgid "K"
 msgstr "K"
 
-#: find.c:923
+#: find.c:921
 msgid "Mb"
 msgstr "Mb"
 
-#: find.c:923
+#: find.c:921
 msgid "M"
 msgstr "M"
 
-#: find.c:925
+#: find.c:923
 msgid "Gb"
 msgstr "Gb"
 
 #: find.c:925
-msgid "G"
-msgstr "G"
-
-#: find.c:927
 #, fuzzy
 msgid "Sec"
 msgstr "Seg"
 
-#: find.c:927
+#: find.c:925
 #, fuzzy
 msgid "Secs"
 msgstr "Segs"
 
-#: find.c:929
+#: find.c:927
 msgid "Min"
 msgstr "Min"
 
-#: find.c:929
+#: find.c:927
 msgid "Mins"
 msgstr "Mins"
 
-#: find.c:931
+#: find.c:929
 #, fuzzy
 msgid "Hour"
 msgstr "Hora"
 
-#: find.c:931
+#: find.c:929
 #, fuzzy
 msgid "Hours"
 msgstr "Horas"
 
-#: find.c:933
+#: find.c:931
 #, fuzzy
 msgid "Day"
 msgstr "Dia"
 
-#: find.c:933
+#: find.c:931
 #, fuzzy
 msgid "Days"
 msgstr "Dias"
 
-#: find.c:935
+#: find.c:933
 #, fuzzy
 msgid "Week"
 msgstr "Semana"
 
-#: find.c:935
+#: find.c:933
 #, fuzzy
 msgid "Weeks"
 msgstr "Semanas"
 
-#: find.c:937
+#: find.c:935
 #, fuzzy
 msgid "Year"
 msgstr "Ano"
 
-#: find.c:937
+#: find.c:935
 #, fuzzy
 msgid "Years"
 msgstr "Anos"
 
-#: find.c:946
+#: find.c:944
 #, fuzzy
 msgid "Ago"
 msgstr "Atrás"
 
-#: find.c:948
+#: find.c:946
 #, fuzzy
 msgid "Hence"
 msgstr "Desde"
 
-#: find.c:963
+#: find.c:961
 msgid "atime"
 msgstr ""
 
-#: find.c:965
+#: find.c:963
 msgid "ctime"
 msgstr ""
 
-#: find.c:967
+#: find.c:965
 msgid "mtime"
 msgstr ""
 
-#: find.c:969
+#: find.c:967
 #, fuzzy
 msgid "size"
 msgstr "tamanho"
 
-#: find.c:971
+#: find.c:969
 msgid "inode"
 msgstr ""
 
-#: find.c:973
+#: find.c:971
 msgid "nlinks"
 msgstr ""
 
-#: find.c:975
+#: find.c:973
 msgid "uid"
 msgstr "uid"
 
-#: find.c:977
+#: find.c:975
 msgid "gid"
 msgstr "gid"
 
-#: find.c:979
+#: find.c:977
 #, fuzzy
 msgid "blocks"
 msgstr "blocos"
 
-#: gtksavebox.c:251
+#: gtksavebox.c:249
 msgid "Save As:"
 msgstr "Guardar Como:"
 
-#: gtksavebox.c:397
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "SemNome"
 
-#: gtksavebox.c:473
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
 msgstr ""
-"A aplicação remota quer usar o Direct Save, mas não consigo ler a propriedade"
-"XdndDirectSave0 (type text/plain).\n"
+"A aplicação remota quer usar o Direct Save, mas não consigo ler a "
+"propriedadeXdndDirectSave0 (type text/plain).\n"
 
-#: gtksavebox.c:598
+#: gtksavebox.c:602
 #, fuzzy
 msgid ""
 "Drag the icon to a directory viewer\n"
@@ -1404,7 +1553,7 @@ msgstr ""
 "Arraste o ícone para um visualizador de directorias\n"
 "(ou introduza o caminho completo)"
 
-#: gui_support.c:331
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1412,46 +1561,51 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:400
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
-msgstr "Tentar ler um ficheiro XML como um ficheiro de texto. O ficheiro '%s' pode estar corrompido."
+msgstr ""
+"Tentar ler um ficheiro XML como um ficheiro de texto. O ficheiro '%s' pode "
+"estar corrompido."
 
-#: gui_support.c:417
-#, c-format
+#: gui_support.c:542
+#, fuzzy, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
 "This may be due to upgrading from a previous version of ROX-Filer. Open the "
-"Options window and click on Save.\n"
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
 "Erro no ficheiro '%s' na linha %d: \n"
 "\"%s\"\n"
-"Isto pode ser devido a ter actualizado de uma versão antiga do ROX-Filer. Abra"
-"a janela Opções e clique em Guardar.\n"
+"Isto pode ser devido a ter actualizado de uma versão antiga do ROX-Filer. "
+"Abraa janela Opções e clique em Guardar.\n"
 "Os próximos erros serão ignorados."
 
-#: gui_support.c:1000
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Quebra de linha incorrecta ou em falta nos dados text/uri-list"
 
-#: gui_support.c:1332
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "Não foi possivel abrir o ficheiro '%s': %s"
 
-#: gui_support.c:1376
+#: gui_support.c:1517
 #, c-format
-msgid "Failed to load image '%s': reason not known, probably a corrupt image file"
+msgid ""
+"Failed to load image '%s': reason not known, probably a corrupt image file"
 msgstr ""
 "Não foi possivel carregar a image '%s': razão desconhecida, provavelmente um "
 "ficheiro de imagem corrompido"
 
-#: gui_support.c:1427
+#: gui_support.c:1583
+#, fuzzy, c-format
 msgid ""
-"This program cannot be run, as the 0launch command is not available. It can "
-"be downloaded from here:\n"
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
@@ -1460,7 +1614,7 @@ msgstr ""
 "\n"
 "http://0install.net/injector.html"
 
-#: i18n.c:38
+#: i18n.c:39
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
@@ -1468,157 +1622,180 @@ msgstr ""
 "Note que tem que guardar as suas escolhas e reiniciar o programa para que as "
 "novas definições de linguagem tenham efeito."
 
-#: icon.c:78
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(clique para definir)"
 
-#: icon.c:133
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:134 menu.c:252
-msgid "About ROX-Filer..."
-msgstr "Acerca do ROX-Filer"
-
-#: icon.c:135 menu.c:253
-msgid "Show Help Files"
-msgstr "Mostrar Ficheiros de Ajuda"
-
-#: icon.c:136 menu.c:254
-msgid "Manual"
-msgstr "Manual"
-
-#: icon.c:138 menu.c:230
-msgid "Options..."
-msgstr "Opções..."
-
-#: icon.c:139 menu.c:239
-msgid "Home Directory"
-msgstr "Directoria Home"
-
-#: icon.c:140 icon.c:1340 menu.c:206 type.c:212
-msgid "File"
-msgstr "Ficheiro"
-
-#: icon.c:141 menu.c:212 menu.c:875
-#, fuzzy
-msgid "Shift Open"
-msgstr "Abrir Com Shift"
-
-#: icon.c:142 menu.c:218
-msgid "Properties"
-msgstr "Propriedades"
-
-#: icon.c:143 menu.c:216
-#, fuzzy
-msgid "Set Run Action..."
-msgstr "Definir Run Action..."
-
-#: icon.c:144 menu.c:217
-msgid "Set Icon..."
-msgstr "Definir Ícone..."
-
-#: icon.c:145 icon.c:806
-msgid "Edit Item"
-msgstr "Editar Item"
-
-#: icon.c:146
-msgid "Show Location"
-msgstr "Mostrar Localização"
-
-#: icon.c:147
-msgid "Remove Item(s)"
-msgstr "Remover Item(s)"
-
-#: icon.c:278 menu.c:764
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:291
+#: icon.c:311
 msgid "Nothing"
 msgstr "Nada"
 
-#: icon.c:547
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "A localização deve conter pelo menos um caracter!"
 
-#: icon.c:613
+#: icon.c:641
+#, c-format
+msgid "You must unlock '%s' before removing it"
+msgstr ""
+
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "É necessário que primeiro seleccione alguns itens a remover"
 
-#: icon.c:627
+#: icon.c:657
+msgid "An item must be unlocked before it can be removed."
+msgstr ""
+
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Tem que abrir o menu sobre um item"
 
-#: icon.c:652 menu.c:1260
+#: icon.c:696 menu.c:1586
 #, fuzzy
 msgid "You can only set the run action for a regular file"
 msgstr "Apenas pode definir a run action para um ficheiro regular"
 
-#: icon.c:738
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Pressione o atalho desejado (ex, Control+F1)"
 
-#: icon.c:760
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Não foi possivel obter a captura do teclado!"
 
-#: icon.c:809
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Editar Item"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Clicar no ícone abre:"
 
-#: icon.c:819
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Argumentos a passar (para executáveis):"
 
-#: icon.c:833
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "O texto mostrado por baixo do ícone é:"
 
-#: icon.c:846
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "O atalho de teclado é:"
 
-#: infobox.c:112
+#: icon.c:910
+#, fuzzy
+msgid "Locked"
+msgstr "Socket"
+
+#: icon.c:915
+msgid "Locking an item prevents it from being accidentally removed"
+msgstr ""
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Acerca do ROX-Filer"
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Mostrar Ficheiros de Ajuda"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Manual"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Opções..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Directoria Home"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Ficheiro"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+#, fuzzy
+msgid "Shift Open"
+msgstr "Abrir Com Shift"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Propriedades"
+
+#: icon.c:1403 menu.c:712
+#, fuzzy
+msgid "Set Run Action..."
+msgstr "Definir Run Action..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Definir Ícone..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Mostrar Localização"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Remover Item(s)"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
 msgstr "Tem a certeza que pretende abrir %d janelas?"
 
-#: infobox.c:113
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Mostrar Info"
 
-#: infobox.c:135 menu.c:769
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(mau utf-8)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Mostrar Ficheiros de _Ajuda"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Permissões</b>"
 
-#: infobox.c:286
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>O conteúdo indica...</b>"
 
-#: infobox.c:423 infobox.c:560 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Apenas criar registo das directorias ao serem movidas"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "bytes"
 
-#: infobox.c:446
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Não foi possível ler tamanho"
 
-#: infobox.c:504
+#: infobox.c:543
 #, fuzzy, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' já não é um symlink"
 
-#: infobox.c:511
+#: infobox.c:550
 #, fuzzy, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1627,7 +1804,7 @@ msgstr ""
 "Não foi possivel desligar '%s':\n"
 "%s"
 
-#: infobox.c:516
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1638,147 +1815,196 @@ msgstr ""
 "%s\n"
 "(nota: a ligação antiga foi apagada)"
 
-#: infobox.c:539 tips:271
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Erro:"
 
-#: infobox.c:546
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Directoria real:"
 
-#: infobox.c:549
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Dono, Grupo:"
 
-#: infobox.c:556 infobox.c:571 infobox.c:580
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Tamanho:"
 
-#: infobox.c:581
+#: infobox.c:621
 msgid "Scanning"
 msgstr ""
 
-#: infobox.c:602
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr ""
 
-#: infobox.c:609
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Mudado:"
 
-#: infobox.c:611
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Modificado:"
 
-#: infobox.c:613
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Acedido:"
 
-#: infobox.c:621
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Atributos extendidos:"
 
-#: infobox.c:623
+#: infobox.c:667
 msgid "Present"
 msgstr "Presente"
 
-#: infobox.c:624
+#: infobox.c:668
 msgid "None"
 msgstr "Nenhum"
 
-#: infobox.c:625
+#: infobox.c:669
 msgid "Not supported"
 msgstr "Não suportado"
 
-#: infobox.c:637
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Destino da ligação:"
 
-#: infobox.c:649 infobox.c:652
+#: infobox.c:693 infobox.c:696
 #, fuzzy
 msgid "Run action:"
 msgstr "Run action:"
 
-#: infobox.c:649
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Executar ficheiro"
 
-#: infobox.c:744
+#: infobox.c:805
+#, fuzzy
+msgid "Comment"
+msgstr "Comando:"
+
+#: infobox.c:807
+#, fuzzy
+msgid "Execute"
+msgstr "Executar ficheiro"
+
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<nada ainda>"
 
-#: infobox.c:814
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "o ficheiro(1) diz... %s"
 
-#: infobox.c:871
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Não foi possivel alterar permissões: %s"
 
-#: infobox.c:889
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Dono"
 
-#: infobox.c:891
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Grupo"
 
-#: infobox.c:893
+#: infobox.c:974
 msgid "World"
 msgstr "Mundo"
 
-#: infobox.c:896
+#: infobox.c:977
 msgid "Read"
 msgstr "Ler"
 
-#: infobox.c:898
+#: infobox.c:980
 msgid "Write"
 msgstr "Escrever"
 
-#: infobox.c:900
+#: infobox.c:983
 msgid "Exec"
 msgstr "Executar"
 
-#: infobox.c:917
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:924
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:931
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Fixo"
 
-#: infobox.c:953
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<nada>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Ligação simbólica"
 
-#: infobox.c:956
+#: infobox.c:1092
 #, fuzzy
 msgid "ROX application"
 msgstr "Aplicação ROX"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "mounted"
 msgstr "montado"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "desmontado"
 
-#: infobox.c:968
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Ponto de montagem para %s (%s)"
 
-#: infobox.c:971
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Ponto de montagem (%s)"
+
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d itens"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Copiar..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "Editar Item"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Datas"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Opções"
 
 #: main.c:95
 msgid ""
@@ -1815,7 +2041,7 @@ msgstr ""
 "\n"
 
 #: main.c:115
-#, fuzzy
+#, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Open each directory or file listed, or the current working\n"
@@ -1837,10 +2063,12 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
-"Report bugs to "
+"Report bugs to %s.\n"
+"Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
 "Uso: ROX-Filer/AppRun [OPÇÃO]... [FICHEIRO]...\n"
 "Abrir cada directoria ou ficheiro listado, ou a directoria de\n"
@@ -1870,15 +2098,7 @@ msgstr ""
 "\n"
 "Report bugs to "
 
-#: main.c:136
-msgid ""
-".\n"
-"Home page (including updated versions): http://rox.sourceforge.net/\n"
-msgstr ""
-".\n"
-"Página web (incluindo versões actualizadas): http://rox.sourceforge.net/\n"
-
-#: main.c:234
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1890,7 +2110,7 @@ msgstr ""
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Tentando continuar..."
 
-#: main.c:377
+#: main.c:399
 #, fuzzy
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
@@ -1899,277 +2119,373 @@ msgstr ""
 "O argumento -o já não é usado. Pode em vez disso ligar a override redirect a "
 "partir da caixa Opções."
 
-#: main.c:484
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "A correr como utilizador '%s'"
 
-#: main.c:661
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Compilado com o GTK versão %s\n"
 
-#: main.c:662
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "A correr com o GTK versão %d.%d.%d\n"
 
-#: main.c:666
+#: main.c:693
 msgid "features set at compile time"
 msgstr "características definidas ao compilar"
 
-#: main.c:667
+#: main.c:694
 msgid "Large File Support"
 msgstr "Suporte para ficheiros grandes (LFS)"
 
-#: main.c:674
-msgid "Dnotify support"
-msgstr "Suporte para Dnotify"
-
-#: main.c:681
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Compatibilidade binária"
 
-#: main.c:683
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Sim (pode correr com versões do glibc antigas)"
 
-#: main.c:685
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Não (apsymbols.h não encontrado)"
 
-#: main.c:689
+#: main.c:709
 msgid "Extended attribute support"
 msgstr "Suporte para atributos extendidos"
 
-#: menu.c:180 tips:53
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr "Não foi possivel abrir o ficheiro '%s': %s"
+
+#: main.c:895
+#, c-format
+msgid ""
+"Left-click to run %s.\n"
+"Right-click for a list of versions."
+msgstr ""
+
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Erro ao criar '%s': %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Guardar Como:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Visualização"
 
-#: menu.c:181 tips:58
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "Ícones"
 
-#: menu.c:182
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "Ícones, Com..."
 
-#: menu.c:183 tips:75
-msgid "Sizes"
-msgstr "Tamanhos"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Tema dos ícones"
 
-#: menu.c:185 tips:255
-msgid "Types"
-msgstr "Tipos"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Permissões"
 
-#: menu.c:186 tips:78
-msgid "Times"
-msgstr "Datas"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Ícones, Com..."
 
-#: menu.c:187 tips:59 tips:93
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "Lista"
 
-#: menu.c:189
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "Ícones Maiores"
 
-#: menu.c:190
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "Ícones Menores"
 
-#: menu.c:191 tips:72
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Automático"
 
-#: menu.c:193
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Organizar por Nome"
 
-#: menu.c:194
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Organizar por Tipo"
 
-#: menu.c:195
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Organizar por Data"
 
-#: menu.c:196
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Organizar por Data"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Organizar por Data"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Organizar por Tamanho"
 
-#: menu.c:197
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Permissões"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "Organizar por Dono"
 
-#: menu.c:198
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "Organizar por Grupo"
 
-#: menu.c:199
+#: menu.c:671
 msgid "Reversed"
 msgstr "Ordem Inversa"
 
-#: menu.c:201
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "Mostrar Escondidos"
 
-#: menu.c:202
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Mostrar Ficheiros de Ajuda"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "nenhuma directoria)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "Filtrar Ficheiros..."
 
-#: menu.c:203
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Filtrar Ficheiros..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "Mostrar Miniaturas"
 
-#: menu.c:204
+#: menu.c:683
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: menu.c:205
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Actualizar"
+
+#: menu.c:686
 msgid "Save Display Settings..."
 msgstr "Guardar Definições de Visualização..."
 
-#: menu.c:207
-msgid "Copy..."
-msgstr "Copiar..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Guardar Definições de Visualização..."
 
-#: menu.c:208
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Contar"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "Renomear..."
 
-#: menu.c:209
+#: menu.c:700
 msgid "Link..."
 msgstr "Criar Ligação..."
 
-#: menu.c:213
-msgid "Open AVFS"
-msgstr ""
-
-#: menu.c:214
+#: menu.c:708
 msgid "Send To..."
 msgstr "Enviar Para..."
 
-#: menu.c:219
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Atributos extendidos"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Contar"
 
-#: menu.c:220
+#: menu.c:723
 msgid "Set Type..."
 msgstr "Definir Tipo..."
 
-#: menu.c:224 toolbar.c:155
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Seleccionar"
 
-#: menu.c:225
+#: menu.c:733
 msgid "Select All"
 msgstr "Seleccionar Todos"
 
-#: menu.c:226
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "Limpar Selecção"
 
-#: menu.c:227
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "Inverter Selecção"
 
-#: menu.c:228
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "Seleccionar por Nome..."
 
-#: menu.c:229
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Seleccionar Se..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Seleccionar Se..."
 
-#: menu.c:231
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Novo"
 
-#: menu.c:233
+#: menu.c:752
 msgid "Blank file"
 msgstr "Ficheiro em branco"
 
-#: menu.c:235 tasklist.c:308
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Janela"
 
-#: menu.c:236
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "Directoria Acima, Nova Janela"
 
-#: menu.c:237
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "Directoria Acima, Mesma Janela"
 
-#: menu.c:238
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "Nova Janela"
 
-#: menu.c:240
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "Mostrar Favoritos"
 
-#: menu.c:241
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Mostrar Info"
+
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "Seguir Ligações Simbólicas"
 
-#: menu.c:242
+#: menu.c:769
 msgid "Resize Window"
 msgstr "Redimensionar Janela"
 
-#: menu.c:245
+#: menu.c:771
 msgid "Close Window"
 msgstr "Fechar Janela"
 
-#: menu.c:247
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Introduzir Caminho..."
 
-#: menu.c:248
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Comando de 'Shell'..."
 
-#: menu.c:249
+#: menu.c:780
 msgid "Terminal Here"
 msgstr "Terminal Aqui"
 
-#: menu.c:250
+#: menu.c:782
 msgid "Switch to Terminal"
 msgstr "Mudar para o Terminal"
 
-#: menu.c:718
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr ""
-"Deve usar Shift+Clique de Menu sobre um ficheiro para o enviar para algum "
-"lado"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Personalizar Menu..."
 
-#: menu.c:754
+#: menu.c:976
 msgid "Next Click"
 msgstr "Próximo Clique"
 
-#: menu.c:776
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d itens"
 
-#: menu.c:864
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "Abrir desmontado"
 
-#: menu.c:867
+#: menu.c:1097
 msgid "Show Target"
 msgstr "Mostrar Destino"
 
-#: menu.c:869
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "Entrar"
 
-#: menu.c:871
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "Abrir Como Texto"
 
-#: menu.c:1031
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2183,15 +2499,15 @@ msgstr ""
 "da biblioteca de C, ou pode simplesmente ser necessário montar o sistema de "
 "ficheiros com as opções de montagem correctas ('user_xattr' em Linux)."
 
-#: menu.c:1037
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr "Definir o tipo não é suportado por alguns destes ficheiros"
 
-#: menu.c:1072
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "Ligação _relativa"
 
-#: menu.c:1078
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2205,43 +2521,57 @@ msgstr ""
 "directoria de raíz - use deste modo se a ligação poderá ser movida, mas o "
 "destino deverá permanecer no mesmo sítio."
 
-#: menu.c:1148
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "O novo caminho não é absoluto"
 
-#: menu.c:1214
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
-msgstr "A ligação a partir de '%s' já existe. Substituir por uma ligação a '%s'?"
+msgstr ""
+"A ligação a partir de '%s' já existe. Substituir por uma ligação a '%s'?"
 
-#: menu.c:1220
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Substituir"
 
-#: menu.c:1351 menu.c:1392 menu.c:1452
-msgid "Create"
-msgstr "Criar"
-
-#: menu.c:1352
+#: menu.c:1704
 msgid "NewDir"
 msgstr "NovaDir"
 
-#: menu.c:1366 menu.c:1372
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Erro ao criar '%s': %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Criar"
 
-#: menu.c:1393
+#: menu.c:1755
 msgid "NewFile"
 msgstr "NovoFicheiro"
 
-#: menu.c:1411
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "Erro ao criar ficheiro: não foi possivel encontrar o modelo para %s"
 
-#: menu.c:1482
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Crie ligações simbólicas para os programas que quiser nesta directoria. Eles "
+"aparecerão no menu para todos os itens deste tipo (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2253,8 +2583,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "O menu `Enviar Para' permite enviar facilmente ficheiros para uma aplicação. "
 "As aplicações listadas são as das seguintes directorias:\n"
@@ -2269,7 +2600,7 @@ msgstr ""
 "serão apenas apresentadas para ficheiros daquele tipo. `.group' é mostrado "
 "apenas quando múltiplos ficheiros estão seleccionados."
 
-#: menu.c:1493
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
@@ -2277,11 +2608,11 @@ msgstr ""
 "Irei agora mostrar-lhe a sua directoria 'Enviar Para'; nela deverá criar "
 "ligações simbólicas (Ctrl+Shift arrastar) para as aplicações que pretender."
 
-#: menu.c:1496 menu.c:1536
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr "A sua variavel CHOICESPATH não permite a personalização - desculpe."
 
-#: menu.c:1529
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2301,7 +2632,7 @@ msgstr ""
 "%s\n"
 "%s\n"
 
-#: menu.c:1534
+#: menu.c:1936
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
@@ -2309,15 +2640,21 @@ msgstr ""
 "Irei agora mostrar-lhe a sua directoria de Modelos; nela deverá colocar os "
 "ficheiros-modelo que pretender."
 
-#: menu.c:1651
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Personalizar"
 
-#: menu.c:1717
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Personalizar Menu..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Este já é o nome canónico para esta directoria."
 
-#: menu.c:1748
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2325,77 +2662,104 @@ msgstr ""
 "Não é possivel abrir uma segunda vista para esta directoria porque a opção "
 "`Janelas únicas' está activada na janela Opções."
 
-#: menu.c:1869
-msgid "Copy ... ?"
-msgstr "Copiar ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1872
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Copiar %s para %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Copiar %s para %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Renomear ... ?"
 
-#: menu.c:1875
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Criar ligação ... ?"
 
-#: menu.c:1878
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Abrir com Shift ... ?"
 
-#: menu.c:1881
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Propriedades de ... ?"
 
-#: menu.c:1884
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Atributos extendidos"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Definir tipo de ... ?"
 
-#: menu.c:1887
+#: menu.c:2479
 #, fuzzy
 msgid "Set run action for ... ?"
 msgstr "Definir run action para ... ?"
 
-#: menu.c:1890
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Definir ícone de ... ?"
 
-#: menu.c:1893
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Enviar ... para ... ?"
 
-#: menu.c:1896
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "APAGAR ... ?"
 
-#: menu.c:1899
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Contar o tamanho de ... ?"
 
-#: menu.c:1902
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Definir permissões de ... ?"
 
-#: menu.c:1905
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Procurar dentro de ... ?"
 
-#: menu.c:1908
+#: menu.c:2500
 #, fuzzy
-msgid "Look inside ... ?"
-msgstr "Entrar em ... ?"
+msgid "Copy ... to clipboard ?"
+msgstr "Copiar ... ?"
 
-#: menu.c:1972
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Não é possivel fazer isto a mais que um item de cada vez"
 
-#: menu.c:2004
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Renomear"
 
-#: menu.c:2009
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Criar Ligação"
 
-#: menu.c:2041
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2417,7 +2781,7 @@ msgstr ""
 "\tgtk-can-change-accels = 1\n"
 "\t(isto funciona se NÃO estiver a usar XSETTINGS)"
 
-#: menu.c:2052
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2437,32 +2801,41 @@ msgstr ""
 "A tecla aparecerá ao lado do item do menu, e de futuro poderá simplesmente "
 "pressionar essa tecla sem ter que abrir o menu."
 
-#: menu.c:2067
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Definir atalhos de teclado"
 
-#: minibuffer.c:131
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Ir Para:"
 
-#: minibuffer.c:132
+#: minibuffer.c:141
 #, fuzzy
 msgid "Shell:"
 msgstr "Comando:"
 
-#: minibuffer.c:133
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Seleccionar Se:"
 
-#: minibuffer.c:134
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Seleccionar Nome:"
 
-#: minibuffer.c:135
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Seleccionar Se:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Padrão:"
 
-#: minibuffer.c:264
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 #, fuzzy
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
@@ -2471,14 +2844,27 @@ msgstr ""
 "Introduza o nome de um ficheiro e eu mostra-lo-ei por si. Pressione Tab para "
 "preencher a correspondência mais longa. Escape fecha o minibuffer."
 
-#: minibuffer.c:270
+#: minibuffer.c:326
 #, fuzzy
-msgid "Enter a shell command to execute. Click on a file to add it to the buffer."
+msgid ""
+"Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
 "Introduza um comando 'shell' a executar. Clique num ficheiro para adicioná-"
 "lo ao buffer."
 
-#: minibuffer.c:275
+#: minibuffer.c:331
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2489,7 +2875,7 @@ msgid ""
 "*.png means any name ending in '.png'"
 msgstr ""
 
-#: minibuffer.c:287
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
@@ -2497,41 +2883,56 @@ msgstr ""
 "Introduza um padrão a ser correspondido para os ficheiros mostrados. Um "
 "filtro vazio desactiva a filtragem."
 
-#: minibuffer.c:907
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Introduza um padrão a ser correspondido para os ficheiros mostrados. Um "
+"filtro vazio desactiva a filtragem."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Condição de busca inválida"
 
-#: mount.c:374
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s total, %s usado, %s livre (%.1f %%)"
 
-#: options.c:277
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "O ROX-Filer converteu o seu ficheiro Options para o novo formato XML"
 
-#: options.c:535 options.c:1258
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(usar predefinição)"
 
-#: options.c:806
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Erro interno: %s ilegível"
 
-#: options.c:917
+#: options.c:929
 msgid "Options"
 msgstr "Opções"
 
-#: options.c:962
+#: options.c:974
 msgid "_Revert"
 msgstr "_Reverter"
 
-#: options.c:968
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
-msgstr "Restaurar todas as escolhas como estavam antes da caixa Opções ser aberta."
+msgstr ""
+"Restaurar todas as escolhas como estavam antes da caixa Opções ser aberta."
 
-#: options.c:983
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2540,24 +2941,34 @@ msgstr ""
 "As escolhas serão guardadas como:\n"
 "%s"
 
-#: options.c:991
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(CHOICESPATH não permite guardar)"
 
-#: options.c:1164 usericons.c:450
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Erro ao guardar %s: %s"
 
-#: options.c:1794
+#: options.c:1813
 msgid "Missing '='"
 msgstr "A faltar '='"
 
-#: panel.c:439
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr "Não foi possivel abrir o ficheiro '%s': %s"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "O seu antigo ficheiro de painel foi convertido para o novo formato XML"
 
-#: panel.c:546
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
@@ -2565,20 +2976,20 @@ msgstr ""
 "Você tentou fechar o painel via gestor de janelas - normalmente penso que "
 "foi acidental... fechar mesmo?"
 
-#: panel.c:639
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "A faltar < ou > no ficheiro de config do painel"
 
-#: panel.c:1519
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Erro ao guardar o painel %s: %s"
 
-#: panel.c:1835
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "O applet saiu sem sequer criar um widget!"
 
-#: panel.c:1934
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2587,66 +2998,61 @@ msgstr ""
 "Erro ao correr o applet:\n"
 "%s"
 
-#: panel.c:2335
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "Tem a certeza que pretende abrir %d janelas?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Remover Item(s)"
+
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Opções do Painel..."
 
-#: panel.c:2427
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Monitor xinerama %d indisponível"
 
-#: panel.c:2502
-msgid "Panel Options"
-msgstr "Opções do Painel"
+#: panel.c:2897
+msgid "Top"
+msgstr ""
 
-#: panel.c:2517
-#, c-format
-msgid "Panel: %s"
-msgstr "Painel: %s"
-
-#: panel.c:2525
-msgid "Select the panel's position:"
-msgstr "Seleccione a posição do painel:"
-
-#: panel.c:2531
-msgid "Top-edge panel"
-msgstr "Painel na borda superior do ecrâ"
-
-#: panel.c:2532
-msgid "Top edge"
-msgstr "Borda superior"
-
-#: panel.c:2533
-msgid "Bottom edge panel"
-msgstr "Painel na borda inferior do ecrâ"
-
-#: panel.c:2534
-msgid "Bottom edge"
+#: panel.c:2899
+#, fuzzy
+msgid "Bottom"
 msgstr "Borda inferior"
 
-#: panel.c:2535
-msgid "Left edge panel"
-msgstr "Painel na borda esquerda do ecrâ"
-
-#: panel.c:2536
-msgid "Left edge"
+#: panel.c:2901
+#, fuzzy
+msgid "Left"
 msgstr "Borda esquerda"
 
-#: panel.c:2537
-msgid "Right-edge panel"
-msgstr "Painel na borda direita do ecrâ"
-
-#: panel.c:2538
-msgid "Right edge"
+#: panel.c:2903
+#, fuzzy
+msgid "Right"
 msgstr "Borda direita"
+
+#: panel.c:2905
+#, fuzzy
+msgid "Default"
+msgstr "Tamanho predefinido:"
+
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "Desconhecido"
 
 #: pinboard.c:354
 #, fuzzy
 msgid "Your old pinboard file has been converted to the new XML format."
-msgstr "O seu antigo ficheiro do pinboard foi convertido para o novo formato XML."
+msgstr ""
+"O seu antigo ficheiro do pinboard foi convertido para o novo formato XML."
 
-#: pinboard.c:635
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
@@ -2656,7 +3062,7 @@ msgstr ""
 "uma directoria de aplicação para a caixa Definir Fundo, ou (para "
 "programadores) passe-a para o método SOAP SetBackdropApp."
 
-#: pinboard.c:654
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2670,51 +3076,63 @@ msgstr ""
 "Programadores: o ficheiro AppInfo.xml da aplicação tem que conter o elemento "
 "CanSetBackdrop, como descrito no manual do ROX-Filer's."
 
-#: pinboard.c:674
+#: pinboard.c:750
 msgid "Set backdrop"
 msgstr "Definir fundo"
 
-#: pinboard.c:685
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
 msgstr "Escolha um estilo e arraste para aqui uma imagem:"
 
-#: pinboard.c:698
+#: pinboard.c:774
 msgid "Centre the image without scaling it"
 msgstr "Centrar a imagem sem a escalar"
 
-#: pinboard.c:699
+#: pinboard.c:775
 msgid "Centre"
 msgstr "Centrada"
 
-#: pinboard.c:700
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr "Escalar a imagem para caber no fundo, sem a distorcer"
 
-#: pinboard.c:702
+#: pinboard.c:778
 msgid "Scale"
 msgstr "Escalada"
 
-#: pinboard.c:703
+#: pinboard.c:779
+#, fuzzy
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr "Escalar a imagem para caber no fundo, sem a distorcer"
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Filtro"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
 msgstr "Esticar a imagem para preencher a área de fundo"
 
-#: pinboard.c:704
+#: pinboard.c:783
 msgid "Stretch"
 msgstr "Esticada"
 
-#: pinboard.c:705
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr "Fazer um mosaico com a imagem sobre a área de fundo"
 
-#: pinboard.c:706
+#: pinboard.c:785
 msgid "Tile"
 msgstr "Mosaico"
 
-#: pinboard.c:711
+#: pinboard.c:790
 msgid "Drop an image here"
 msgstr "Largue uma imagem aqui"
 
-#: pinboard.c:772
+#: pinboard.c:851
 #, fuzzy
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
@@ -2723,7 +3141,7 @@ msgstr ""
 "Nenhum pinboard estava em uso... o pinboard 'Default' foi seleccionado. Use "
 "'rox -p=Default' para activalo de futuro."
 
-#: pinboard.c:866
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
@@ -2731,24 +3149,29 @@ msgstr ""
 "Apenas ficheiros (e certas aplicações) podem ser usadas para definir a "
 "imagem de fundo."
 
-#: pinboard.c:1471
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "A faltar '>' na etiqueta do ícone"
 
-#: pinboard.c:1480
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "A faltar '>' depois da etiqueta do ícone"
 
-#: pinboard.c:1565
+#: pinboard.c:1704
 #, fuzzy, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Erro ao guardar o pinboard %s: %s"
 
-#: pinboard.c:2109
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Fundo de ecrâ..."
 
-#: pinboard.c:2202
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Painel"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2759,7 +3182,7 @@ msgstr ""
 "%s\n"
 "Fundo de ecrâ removido."
 
-#: pixmaps.c:991
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2768,87 +3191,40 @@ msgstr ""
 "Não é possivel apagar as miniaturas em %s:\n"
 "%s"
 
-#: pixmaps.c:1012
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Não há miniaturas a apagar"
 
-#: pixmaps.c:1025
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Limpar a cache de miniaturas"
 
-#: remote.c:624
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Estilo desconhecido '%s'"
 
-#: remote.c:646
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Tipo dedetalhes desconhecido '%s'"
 
-#: remote.c:674
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Tipo de organização desconhecido '%s'"
 
-#: remote.c:1117
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Tentar invocar o método SOAP desconhecido '%s'"
 
-#: rox_gettext.c:95
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Ficheiro de tradução .gmo inválido (demasiado pequeno): %s"
-
-#: rox_gettext.c:108
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Ficheiro de tradução .gmo inválido (número GNU magic não encontrado): %s"
-
-#: run.c:96 run.c:141
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "O programa %s não foi ecnontrado - apagado?"
 
-#: run.c:287
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "O ficheiro não existe, ou não consigo aceder-lhe: %s"
-
-#: run.c:292
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "Não sei como abrir '%s'"
-
-#: run.c:323
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"Aplicação:\n"
-"Isto é uma directoria de aplicação - pode corrê-la como um programa, ou abri-"
-"la (mantenha pressionado o Shift enquanto a abre). A maioria das aplicações "
-"disponibiliza a sua própria ajuda aqui, mas esta não."
-
-#: run.c:407
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "Não foi possivel enviar dados para o programa: %s"
-
-#: run.c:437
-#, c-format
-msgid "Could not read link: %s"
-msgstr "Não foi possivel ler a ligação: %s"
-
-#: run.c:465
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr "Ligação quebrada (ou não tem permissões para a seguir): %s"
-
-#: run.c:502
+#: run.c:359
 #, fuzzy, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
@@ -2859,7 +3235,7 @@ msgstr ""
 "definir uma run action escolhendo `Set Run Action' a partir do menu "
 "Ficheiro, ou pode apenas arrastar o ficheiro para uma aplicação.%s"
 
-#: run.c:508
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -2871,186 +3247,64 @@ msgstr ""
 "Nota: Se este é o programa de computador que deseja correr, é necessário que "
 "defina o bit executavel escolhendo Permissões a partir do menu Ficheiro."
 
-#: support.c:272
-msgid "B"
-msgstr "B"
-
-#: support.c:351
-msgid "byte"
-msgstr "byte"
-
-#: toolbar.c:115
-msgid "Close"
-msgstr "Fechar"
-
-#: toolbar.c:115
-msgid "Close filer window"
-msgstr "Fechar janela do gestor"
-
-#: toolbar.c:119
-msgid "Up"
-msgstr "Acima"
-
-#: toolbar.c:119
-msgid "Change to parent directory"
-msgstr "Ir para a directoria acima"
-
-#: toolbar.c:123
-msgid "Home"
-msgstr "Home"
-
-#: toolbar.c:123
-msgid "Change to home directory"
-msgstr "Ir para a directoria home"
-
-#: toolbar.c:127
-msgid "Bookmarks"
-msgstr "Favoritos"
-
-#: toolbar.c:127
-msgid "Bookmarks menu"
-msgstr "Menu Favoritos"
-
-#: toolbar.c:131
-msgid "Scan"
-msgstr "Actualizar"
-
-#: toolbar.c:131
-msgid "Rescan directory contents"
-msgstr "Actualizar o conteúdo da directoria"
-
-#: toolbar.c:135
-msgid "Change icon size"
-msgstr "Mudar tamanho dos ícones"
-
-#: toolbar.c:139
-msgid "Automatic size mode"
-msgstr "Modo tamanho automático"
-
-#: toolbar.c:143
-msgid "Show extra details"
-msgstr "Mostrar detalhes extra"
-
-#: toolbar.c:147
-msgid "Sort"
-msgstr "Organizar"
-
-#: toolbar.c:147
-msgid "Change sort criteria"
-msgstr "Mudar o critério de organização"
-
-#: toolbar.c:151
-msgid "Hidden"
-msgstr "Escondidos"
-
-#: toolbar.c:151
-msgid "Show/hide hidden files"
-msgstr "Mostrar/esconder ficheiros escondidos"
-
-#: toolbar.c:155
-msgid "Select all/invert selection"
-msgstr "Seleccionar todos/inverter selecção"
-
-#: toolbar.c:159
-msgid "Show ROX-Filer help"
-msgstr "Mostrar a ajuda do ROX-Filer"
-
-#: toolbar.c:220
+#: run.c:373
 #, c-format
-msgid " (%u hidden)"
-msgstr " (%u escondido)"
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "O ficheiro não existe, ou não consigo aceder-lhe: %s"
 
-#: toolbar.c:228 tips:81
-msgid "items"
-msgstr "itens"
-
-#: toolbar.c:228
-msgid "item"
-msgstr "item"
-
-#: toolbar.c:231
+#: run.c:378
 #, c-format
-msgid "No items%s"
-msgstr "Nenhum item%s"
+msgid "I don't know how to open '%s'"
+msgstr "Não sei como abrir '%s'"
 
-#: toolbar.c:250
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' já não é um symlink"
+
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "Directoria '%s' não está acessível"
+
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "Não executável %s"
+
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Erro no manipulador %s: %s"
+
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
+msgstr ""
+"Aplicação:\n"
+"Isto é uma directoria de aplicação - pode corrê-la como um programa, ou abri-"
+"la (mantenha pressionado o Shift enquanto a abre). A maioria das aplicações "
+"disponibiliza a sua própria ajuda aqui, mas esta não."
+
+#: run.c:549
 #, c-format
-msgid "%u selected (%s)"
-msgstr "%u seleccionado(s) (%s)"
+msgid "Could not send data to program: %s"
+msgstr "Não foi possivel enviar dados para o programa: %s"
 
-#: toolbar.c:422
-msgid "Sort by name"
-msgstr "Organizar por nome"
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "Não foi possivel ler a ligação: %s"
 
-#: toolbar.c:422
-msgid "Sort by type"
-msgstr "Organizar por tipo"
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
+msgstr "Ligação quebrada (ou não tem permissões para a seguir): %s"
 
-#: toolbar.c:422
-msgid "Sort by date"
-msgstr "Organizar por data"
-
-#: toolbar.c:423
-msgid "Sort by size"
-msgstr "Organizar por tamanho"
-
-#: toolbar.c:423
-msgid "Sort by owner"
-msgstr "Organizar por dono"
-
-#: toolbar.c:423
-msgid "Sort by group"
-msgstr "Organizar por grupo"
-
-#: toolbar.c:457
-msgid "ascending"
-msgstr "ascendente"
-
-#: toolbar.c:457
-msgid "descending"
-msgstr "descendente"
-
-#: type.c:203
-msgid "Sym link"
-msgstr "Ligação"
-
-#: type.c:205
-msgid "Mount point"
-msgstr "Ponto de montagem"
-
-#: type.c:207
-msgid "App dir"
-msgstr "Dir aplic"
-
-#: type.c:214
-msgid "Dir"
-msgstr "Dir"
-
-#: type.c:216
-msgid "Char dev"
-msgstr "Disp caract."
-
-#: type.c:218
-msgid "Block dev"
-msgstr "Disp blocos"
-
-#: type.c:220
-msgid "Pipe"
-msgstr "Pipe"
-
-#: type.c:222
-msgid "Socket"
-msgstr "Socket"
-
-#: type.c:224
-msgid "Door"
-msgstr "Porta"
-
-#: type.c:227
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#: type.c:355
+#: run.c:785
 #, fuzzy, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3076,11 +3330,280 @@ msgstr ""
 "se precisa de preocupar. Caso contrário, deve verificar, ou simplesmente até "
 "apagar todas as run actions existentes."
 
-#: type.c:368
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w(Corrigir problema de segurança)"
 
-#: type.c:498
+#: support.c:288
+msgid " "
+msgstr ""
+
+#: support.c:381
+msgid "byte"
+msgstr "byte"
+
+#: support.c:1531 support.c:1585
+#, fuzzy, c-format
+msgid "Failed to open and stat file '%s': %s"
+msgstr "Não foi possivel abrir o ficheiro '%s': %s"
+
+#: support.c:1542 support.c:1596
+#, fuzzy, c-format
+msgid "Failed to mmap file '%s': %s"
+msgstr "Não foi possivel abrir o ficheiro '%s': %s"
+
+#: toolbar.c:116
+msgid "Close"
+msgstr "Fechar"
+
+#: toolbar.c:116
+msgid "Close filer window"
+msgstr "Fechar janela do gestor"
+
+#: toolbar.c:120
+msgid "Up"
+msgstr "Acima"
+
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
+
+#: toolbar.c:126
+msgid "Home"
+msgstr "Home"
+
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
+
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
+
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
+
+#: toolbar.c:138
+msgid "Scan"
+msgstr "Actualizar"
+
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
+
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Tamanho"
+
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automático"
+
+#: toolbar.c:155
+msgid "Automatic size mode"
+msgstr "Modo tamanho automático"
+
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Lista"
+
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
+msgid "Sort"
+msgstr "Organizar"
+
+#: toolbar.c:165
+msgid "Change sort criteria"
+msgstr "Mudar o critério de organização"
+
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
+
+#: toolbar.c:169
+msgid ""
+"Left: Show/hide hidden files\n"
+"Right: Show/hide thumbnails"
+msgstr ""
+
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "Seleccionar todos/inverter selecção"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
+msgid "Show ROX-Filer help"
+msgstr "Mostrar a ajuda do ROX-Filer"
+
+#: toolbar.c:270
+#, c-format
+msgid " (%u hidden)"
+msgstr " (%u escondido)"
+
+#: toolbar.c:276 tips:79
+msgid "items"
+msgstr "itens"
+
+#: toolbar.c:276
+msgid "item"
+msgstr "item"
+
+#: toolbar.c:279
+#, c-format
+msgid "No items%s"
+msgstr "Nenhum item%s"
+
+#: toolbar.c:298
+#, c-format
+msgid "%u selected (%s)"
+msgstr "%u seleccionado(s) (%s)"
+
+#: toolbar.c:535
+msgid "Sort by name"
+msgstr "Organizar por nome"
+
+#: toolbar.c:535
+msgid "Sort by type"
+msgstr "Organizar por tipo"
+
+#: toolbar.c:535
+msgid "Sort by date"
+msgstr "Organizar por data"
+
+#: toolbar.c:535
+msgid "Sort by size"
+msgstr "Organizar por tamanho"
+
+#: toolbar.c:536
+msgid "Sort by owner"
+msgstr "Organizar por dono"
+
+#: toolbar.c:536
+msgid "Sort by group"
+msgstr "Organizar por grupo"
+
+#: toolbar.c:568
+msgid "ascending"
+msgstr "ascendente"
+
+#: toolbar.c:568
+msgid "descending"
+msgstr "descendente"
+
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
+msgid "Sym link"
+msgstr "Ligação"
+
+#: type.c:223
+msgid "Mount point"
+msgstr "Ponto de montagem"
+
+#: type.c:225
+msgid "App dir"
+msgstr "Dir aplic"
+
+#: type.c:232
+msgid "Dir"
+msgstr "Dir"
+
+#: type.c:234
+msgid "Char dev"
+msgstr "Disp caract."
+
+#: type.c:236
+msgid "Block dev"
+msgstr "Disp blocos"
+
+#: type.c:238
+msgid "Pipe"
+msgstr "Pipe"
+
+#: type.c:240
+msgid "Socket"
+msgstr "Socket"
+
+#: type.c:242
+msgid "Door"
+msgstr "Porta"
+
+#: type.c:245
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3091,112 +3614,102 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:679
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Isto não é um programa! Dê-me antes uma aplicação!"
 
-#: type.c:740
+#: type.c:839
 msgid "No run action defined"
 msgstr "Nenhuma acção definida"
 
-#: type.c:766
+#: type.c:843
 #, fuzzy, c-format
 msgid "Error in handler %s: %s"
 msgstr "Erro no manipulador %s: %s"
 
-#: type.c:781
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Aplicação inválida %s (mau AppRun)"
 
-#: type.c:792
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "Não executável %s"
 
-#: type.c:825
+#: type.c:902
 msgid "Set run action"
 msgstr "Definir acção"
 
-#: type.c:831
+#: type.c:908
 #, fuzzy
-msgid "If a handler for the specific type isn't set up, use this as the default."
+msgid ""
+"If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 "Se não estiver definido um handler para um tipo específico, usar este como "
 "predefinição."
 
-#: type.c:833
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Definir predifinição para todos `%s/<anything>'"
 
-#: type.c:837
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Usar esta aplicação para todos os ficheiros com este tipo MIME."
 
-#: type.c:839
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Apenas para o tipo `%s' (%s/%s)"
 
-#: type.c:845
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Largue uma aplicação adequada aqui"
 
-#: type.c:860
+#: type.c:963
 msgid "OR"
 msgstr "OU"
 
-#: type.c:867
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Introduza um comando de terminal:"
 
-#: type.c:896
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Usar Comando"
 
-#: type.c:926
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
-msgstr "Uma run action já existe e é um programa bastante grande - tem a certeza que deseja apagá-la?"
+msgstr ""
+"Uma run action já existe e é um programa bastante grande - tem a certeza que "
+"deseja apagá-la?"
 
-#: type.c:937
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Não é possivel remover %s: %s"
 
-#: type.c:974
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "A variavel CHOICESPATH não permite guardar as escolhas"
 
-#: type.c:1249
-#, c-format
-msgid "Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr "O tema de ícones '%s' não contém ícones MIME. A usar em vez dele o tema predefinido do ROX."
-
-#: type.c:1264
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason, or %s is a "
-"link to an invalid directory)"
+"%s"
 msgstr ""
-"Não foi possivel criar ligação simbólica '%s':\n"
-"%s\n"
-"\n"
-"(isto pode significar que o tema do ROX pode já lá existir, mas o ícone "
-"'mime-application:postscript' não pôde ser carregado por alguma razão, ou "
-"%s é uma ligação para uma directoria inválida)"
+"Não foi possivel desligar '%s':\n"
+"%s"
 
-#: usericons.c:181
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "O caminho introduzido não existe. O ícone não foi alterado."
 
-#: usericons.c:191 usericons.c:616
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3206,12 +3719,12 @@ msgstr ""
 "formato que eu entenda, ou talvez as permissões estejam erradas?\n"
 "O ícone não foi alterado."
 
-#: usericons.c:238
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Apagar mesmo o ícone '%s'?"
 
-#: usericons.c:242
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3220,61 +3733,68 @@ msgstr ""
 "Não é possivel apagar '%s':\n"
 "%s"
 
-#: usericons.c:270
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Definir ícone"
 
-#: usericons.c:279
-msgid "Use a copy of the image as the default for all files of these MIME types."
+#: usericons.c:290
+msgid ""
+"Use a copy of the image as the default for all files of these MIME types."
 msgstr ""
 "Usar uma cópia da imagem como predefinição para todos os ficheiros deste "
 "tipo MIME."
 
-#: usericons.c:281
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Definir o ícone para todos `%s/<anything>'"
 
-#: usericons.c:286
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "Usar uma cópia da imagem para todos os ficheiros deste tipo MIME."
 
-#: usericons.c:288
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Para todos os ficheiros do tipo `%s' (%s/%s)"
 
-#: usericons.c:294
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
-msgstr "Adicionar o nome do ficheiro e da imagem para a sua lista pessoal. As definições serão perdidas se a imagem ou o ficheiro forem movidos."
+msgstr ""
+"Adicionar o nome do ficheiro e da imagem para a sua lista pessoal. As "
+"definições serão perdidas se a imagem ou o ficheiro forem movidos."
 
-#: usericons.c:297
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Apenas para o ficheiro `%s'"
 
-#: usericons.c:305
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
 "This is usually the best option if you can write to the directory."
-msgstr "Copiar a imagem para dentro da directoria como um ficheiro escondido chamado .'DirIcon'. Todos os utilizadores verão o ícone, e poderá mover a directorias sem problemas. Esta é normalmente a melhor opção se puder escrever na directoria."
+msgstr ""
+"Copiar a imagem para dentro da directoria como um ficheiro escondido "
+"chamado .'DirIcon'. Todos os utilizadores verão o ícone, e poderá mover a "
+"directorias sem problemas. Esta é normalmente a melhor opção se puder "
+"escrever na directoria."
 
-#: usericons.c:311
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Copiar imagem para a directoria"
 
-#: usericons.c:317
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Large um ficheiro de ícone aqui"
 
-#: usericons.c:587
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "CHOICESPATH não permite definir o ícone"
 
-#: usericons.c:631
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3283,148 +3803,71 @@ msgstr ""
 "Erro ao criar a imagem '%s':\n"
 "%s"
 
-#: view_details.c:1009
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
+msgid "Mono font"
+msgstr ""
+
+#: view_details.c:1019
+msgid "Font for displaying mono-spaced text"
+msgstr ""
+
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Nome"
 
-#: view_details.c:1012
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Tipo"
 
-#: view_details.c:1015
-msgid "_Permissions"
-msgstr "_Permissões"
-
-#: view_details.c:1016
-msgid "_Owner"
-msgstr "_Dono"
-
-#: view_details.c:1018
-msgid "_Group"
-msgstr "_Grupo"
-
-#: view_details.c:1020
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Tamanho"
 
-#: view_details.c:1022
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Permissões"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_Dono"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Grupo"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "_Modificado"
 
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Atributos extendidos"
+
 #: tips:1
-msgid "Translation"
-msgstr "Tradução"
-
-#: tips:2
-msgid "Language"
-msgstr "Linguagem"
-
-#: tips:3
-msgid "Use the LANG environment variable"
-msgstr "Usar a variavel de sistema LANG"
-
-#: tips:4
-msgid "Basque"
-msgstr "Basco"
-
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Chinês (tradicional)"
-
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Chinês (simplificado)"
-
-#: tips:7
-msgid "Czech"
-msgstr "Checo"
-
-#: tips:8
-msgid "Danish"
-msgstr "Dinamarquês"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Holandês"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Inglês (sem tradução)"
-
-#: tips:11
-msgid "Estonian"
-msgstr "Estónio"
-
-#: tips:12
-msgid "Finnish"
-msgstr "Finlandês"
-
-#: tips:13
-msgid "French"
-msgstr "Francês"
-
-#: tips:14
-msgid "German"
-msgstr "Alemão"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Húngaro"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Japonês"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "Norueguês"
-
-#: tips:18
-msgid "Italian"
-msgstr "Italiano"
-
-#: tips:19
-msgid "Polish"
-msgstr "Polaco"
-
-#: tips:20
-msgid "Portuguese (Portugal)"
-msgstr "Português (Portugal)"
-
-#: tips:21
-msgid "Portuguese (Brasil)"
-msgstr "Português (Brasil)"
-
-#: tips:22
-#, fuzzy
-msgid "Romanian"
-msgstr "Romaniano"
-
-#: tips:23
-msgid "Russian"
-msgstr "Russo"
-
-#: tips:24
-msgid "Spanish"
-msgstr "Espanhol"
-
-#: tips:25
-msgid "Swedish"
-msgstr "Sueco"
-
-#: tips:26
 msgid "Filer windows"
 msgstr "Janelas do gestor"
 
-#: tips:27
+#: tips:2
 msgid "Auto-resize filer windows"
 msgstr "Auto-redimensionar janelas"
 
-#: tips:28
+#: tips:3
 msgid "Never automatically resize"
 msgstr "Nunca redimensionar automaticamente"
 
-#: tips:29
+#: tips:4
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
@@ -3432,11 +3875,11 @@ msgstr ""
 "Terá que redimensionar as janelas manualmente, usando o gestor de janelas, o "
 "menu 'Redimensionar Janela' ou fazendo duplo clique no fundo da janela."
 
-#: tips:30
+#: tips:5
 msgid "Resize when changing the display style"
 msgstr "Redimensionar ao mudar o estilo de visualização"
 
-#: tips:31
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
@@ -3444,11 +3887,11 @@ msgstr ""
 "Ao mudar o tamanho dos ícones ou quais os detalhes a serem mostrados, a "
 "janela redimensiona-se por si."
 
-#: tips:32
+#: tips:7
 msgid "Always resize"
 msgstr "Redimensionar sempre"
 
-#: tips:33
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
@@ -3456,15 +3899,16 @@ msgstr ""
 "A janela do gestor de ficheiros redimensionar-se-á sempre que parecer útil "
 "(isto é, ao mudar de directoria ou estilo de visualização)."
 
-#: tips:34
+#: tips:9
 msgid "Largest window size:"
 msgstr "Tamanho máximo da janela:"
 
-#: tips:35
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:36
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
@@ -3472,15 +3916,29 @@ msgstr ""
 "O tamanho máximo, em percentagem do tamanho do ecrâ, a que a janela será "
 "auto-redimensionada."
 
-#: tips:37
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Tamanho máximo da janela:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"O tamanho máximo, em percentagem do tamanho do ecrâ, a que a janela será "
+"auto-redimensionada."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Comportamento da janela"
 
-#: tips:38
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Flags curtas na barra de título"
 
-#: tips:39
+#: tips:17
 #, fuzzy
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
@@ -3489,11 +3947,11 @@ msgstr ""
 "Usar letras únicas em vez de palavras para os indicadores Em Busca, Todos e "
 "Miniaturas na barra de título."
 
-#: tips:40
+#: tips:18
 msgid "Unique windows"
 msgstr "Janelas únicas"
 
-#: tips:41
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3501,11 +3959,34 @@ msgstr ""
 "Se abrir uma directoria que já esteja aberta noutra janela, com esta opção "
 "essa janela será fechada."
 
-#: tips:42
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Janela"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Nova janela com o botão 1"
 
-#: tips:43
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3515,11 +3996,11 @@ msgstr ""
 "numa nova janela, com esta opção activa. Clicar com o botão 2 (o do meio) "
 "reutiliza a janela actual."
 
-#: tips:44
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Navegação por um único clique"
 
-#: tips:45 tips:138
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
@@ -3529,11 +4010,11 @@ msgstr ""
 "Control pressionado. Se a opção estiver desactivada, clicar uma vez "
 "selecciona o item, e o duplo-clique abre-o."
 
-#: tips:46
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Duplo-clique no fundo redimensiona"
 
-#: tips:47
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
@@ -3541,15 +4022,15 @@ msgstr ""
 "Se activada, o duplo-clique no fundo da janeça redimensiona-a, tal como "
 "clicar no botão 'Modo tamanho automático', na barra de ferramentas."
 
-#: tips:48
+#: tips:30
 msgid "Sorting"
 msgstr "Organização"
 
-#: tips:49
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Directorias aparecem primeiro (para organizar por nome)"
 
-#: tips:50
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
@@ -3557,11 +4038,11 @@ msgstr ""
 "Se activada, as directorias aparecerão sempre antes de tudo, ao organizar "
 "por nome."
 
-#: tips:51
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Maiúsculas primeiro (para organizar por nome)"
 
-#: tips:52
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
@@ -3569,15 +4050,58 @@ msgstr ""
 "Se activada, os ficheiros cujo nome começa com maiúscula aparecem antes dos "
 "que começam por minúscula."
 
-#: tips:54
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Directorias aparecem primeiro (para organizar por nome)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Seg"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "Suporte para atributos extendidos"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "Predefinições para novas janelas"
 
-#: tips:55
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "Herdar opções da janela fonte"
 
-#: tips:56
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
@@ -3586,27 +4110,38 @@ msgstr ""
 "serão herdadas da janela fonte se possível; caso contrário serão usadas as "
 "predefinições abaixo."
 
-#: tips:57
+#: tips:48
 msgid "View type:"
 msgstr "Tipo de visualização:"
 
-#: tips:60
+#: tips:51
 msgid "Sort by:"
 msgstr "Organizar por:"
 
-#: tips:62 tips:77
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Tipo"
 
-#: tips:63
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Data"
 
-#: tips:65
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Data"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Data"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Mostrar ficheiros escondidos"
 
-#: tips:66
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
@@ -3614,43 +4149,75 @@ msgstr ""
 "Com esta opção activa os ficheiros cujos nomes começam por um ponto serão "
 "também mostrados; caso contrário, serão escondidos."
 
-#: tips:67
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Mostrar ficheiros escondidos"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Com esta opção activa os ficheiros cujos nomes começam por um ponto serão "
+"também mostrados; caso contrário, serão escondidos."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Ícones Enormes"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "pixels"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "Ícones"
 
-#: tips:68
+#: tips:67
 msgid "Default size:"
 msgstr "Tamanho predefinido:"
 
-#: tips:69
+#: tips:68
 msgid "Huge Icons"
 msgstr "Ícones Enormes"
 
-#: tips:70 tips:246
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Ícones Grandes"
 
-#: tips:71 tips:245
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "Ícones Pequenos"
 
-#: tips:73
+#: tips:72
 msgid "Default details:"
 msgstr "Detalhes predefinidos:"
 
-#: tips:74
+#: tips:73
 msgid "No details"
 msgstr "Sem detalhes"
 
-#: tips:79
-msgid "Automatic small icons:"
+#: tips:74
+msgid "Sizes"
+msgstr "Tamanhos"
+
+#: tips:77
+msgid "Times"
+msgstr "Datas"
+
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "Ícones pequenos automáticos:"
 
 #: tips:80
-msgid "Change at:"
-msgstr "Mudar aos:"
-
-#: tips:82
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3660,67 +4227,96 @@ msgstr ""
 "directoria contém um número  de itens maior que este, eles serão mostrados "
 "usando Ícones Pequenos, caso contrário usando Ícones Grandes."
 
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Ícones Grandes"
+
 #: tips:83
-msgid "Max width (Large icons):"
-msgstr "Largura máxima (Ícones Grandes):"
-
-#: tips:84 tips:87
-msgid "pixels"
-msgstr "pixels"
-
-#: tips:85
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "Texto mais largo que isto é partido em duas linhas, no modo Ícones Grandes. "
 "No modo Ícones Enormes, o texto é partido quando é 50% mais largo que isto."
 
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
 #: tips:86
-msgid "(Small Icons):"
-msgstr "(Ícones Pequenos):"
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
+
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
 
 #: tips:88
-msgid "Maximum width for the text beside a Small Icon."
-msgstr "Largura máxima do texto ao lado de um Ícone Pequeno."
-
-#: tips:89
-msgid "Order small icons vertically"
-msgstr "Ordenar ícones pequenos verticalmente"
-
-#: tips:90
 #, fuzzy
-msgid "If this option is on, then small icons are arranged in columns, not rows."
-msgstr ""
-"Com esta opção activa, os ícones pequenos serão ordenados verticalmente, em "
-"vez de horizontalmente."
-
-#: tips:91
-msgid "Order large icons vertically"
-msgstr "Ordenar ícones grandes verticalmente"
-
-#: tips:92
-#, fuzzy
-msgid "If this option is on, then large icons are arranged in columns, not rows."
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
 msgstr ""
 "Com esta opção activa, os ícones grandes serão ordenados verticalmente, em "
 "vez de horizontalmente."
 
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "(Ícones Pequenos):"
+
+#: tips:91
+msgid "Maximum width for the text beside a Small Icon."
+msgstr "Largura máxima do texto ao lado de um Ícone Pequeno."
+
+#: tips:92
+msgid "Order small icons vertically"
+msgstr "Ordenar ícones pequenos verticalmente"
+
+#: tips:93
+#, fuzzy
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
+msgstr ""
+"Com esta opção activa, os ícones pequenos serão ordenados verticalmente, em "
+"vez de horizontalmente."
+
 #: tips:94
+msgid "Order large icons vertically"
+msgstr "Ordenar ícones grandes verticalmente"
+
+#: tips:95
+#, fuzzy
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
+msgstr ""
+"Com esta opção activa, os ícones grandes serão ordenados verticalmente, em "
+"vez de horizontalmente."
+
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Mostrar cabeçalhos"
 
-#: tips:95
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr ""
 "Com esta opção activa os cabeçalhos das colunas no modo Lista serão "
 "mostrados."
 
-#: tips:96
+#: tips:102
 msgid "Show full type"
 msgstr "Mostrar tipo completo"
 
-#: tips:97
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
@@ -3728,40 +4324,151 @@ msgstr ""
 "Com esta opção activa a descrição completa do tipo de cada objecto é "
 "mostrada, em vez de um pequeno sumário do seu tipo básico."
 
-#: tips:98
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Largura máxima do texto ao lado de um Ícone Pequeno."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Mostrar cabeçalhos"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Com esta opção activa os cabeçalhos das colunas no modo Lista serão "
+"mostrados."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Com esta opção activa os cabeçalhos das colunas no modo Lista serão "
+"mostrados."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Com esta opção activa os cabeçalhos das colunas no modo Lista serão "
+"mostrados."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Com esta opção activa os cabeçalhos das colunas no modo Lista serão "
+"mostrados."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Com esta opção activa os cabeçalhos das colunas no modo Lista serão "
+"mostrados."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Com esta opção activa os cabeçalhos das colunas no modo Lista serão "
+"mostrados."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "_Modificado"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Com esta opção activa os cabeçalhos das colunas no modo Lista serão "
+"mostrados."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Com esta opção activa os cabeçalhos das colunas no modo Lista serão "
+"mostrados."
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Com esta opção activa os cabeçalhos das colunas no modo Lista serão "
+"mostrados."
+
+#: tips:130
 #, fuzzy
 msgid "Tools/Minibuffer"
 msgstr "Ferramentas/Minibuffer"
 
-#: tips:99
+#: tips:131
 msgid "Toolbar"
 msgstr "Barra de ferramentas"
 
-#: tips:100
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Tipo de barra:"
 
-#: tips:101
+#: tips:133
 msgid "No toolbar"
 msgstr "Sem barra"
 
-#: tips:102
+#: tips:134
 msgid "Icons only"
 msgstr "Apenas ícones"
 
-#: tips:103
+#: tips:135
 msgid "Text under icons"
 msgstr "Texto sob os ícones"
 
-#: tips:104
+#: tips:136
 msgid "Text beside icons"
 msgstr "Texto ao lado dos ícones"
 
-#: tips:105
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Apenas imagem"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Mostrar o total de itens"
 
-#: tips:106
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3771,15 +4478,15 @@ msgstr ""
 "como o número de itens escondidos (se os houver). Quando há uma selecção, "
 "mostra o número de itens seleccionados, e o seu tamanho total."
 
-#: tips:107
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Seleccione os botões que quer na barra de ferramentas:"
 
-#: tips:108
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "A largura da barra de ferramentas define a largura mínima da janela"
 
-#: tips:109
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
@@ -3787,32 +4494,52 @@ msgstr ""
 "Cada janela do gestor é forçada a ser larg o suficiente para mostrar toda a "
 "barra de ferramentas"
 
-#: tips:110
+#: tips:143
 msgid "Minibuffer"
 msgstr ""
 
-#: tips:111
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Apitar se a completação com o Tab falhar"
 
-#: tips:112
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
 "letter varies)."
 msgstr ""
 
-#: tips:113
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Apitar se houver várias correspondências"
 
-#: tips:114
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
 msgstr ""
 
-#: tips:117
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Gestor de Download"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Erro no manipulador %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
@@ -3820,11 +4547,11 @@ msgstr ""
 "Quando as miniaturas são activadas, cada ficheiro de imagem numa directoria "
 "é carregado e uma miniatura dele é mostrada."
 
-#: tips:118
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Mostrar miniaturas de imagens"
 
-#: tips:119
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
@@ -3832,30 +4559,104 @@ msgstr ""
 "Esta é a predefinição para novas janelas. Use o menu Visualização para "
 "activar/desactivar as miniaturas em janelas individuais."
 
-#: tips:120
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Mostrar miniaturas de imagens"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "Miniaturas de vídeo"
 
-#: tips:121
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Cache de miniaturas"
 
-#: tips:122
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "Para acelerar as coisas, as miniaturas geradas são guardadas na directoria "
 "escondida ~/.thumbnails. Clique aqui para remover todas as miniaturas "
 "guardadas em cache. Elas serão criadas de novo se necessário."
 
-#: tips:123 tips:196
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
+#, fuzzy
+msgid "Manage thumbnails"
+msgstr "Mostrar miniaturas de imagens"
+
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Miniaturas de vídeo"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Seg"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 #, fuzzy
 msgid "Pinboard"
 msgstr "Pinboard"
 
-#: tips:124
+#: tips:177
 #, fuzzy
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
@@ -3864,47 +4665,47 @@ msgstr ""
 "Ao usar um pinboard, pode arrastar ficheiros e aplicações para o fundo de "
 "ecrâ para criar atalhos para eles."
 
-#: tips:125 tips:242
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Aparência"
 
-#: tips:126
+#: tips:179
 msgid "Foreground:"
 msgstr "Primeiro plano:"
 
-#: tips:127
+#: tips:180
 msgid "Text shadow:"
 msgstr "Sombra do texto:"
 
-#: tips:128
+#: tips:181
 msgid "Background:"
 msgstr "Fundo:"
 
-#: tips:129
+#: tips:182
 msgid "No shadow"
 msgstr "Sem sombra"
 
-#: tips:130
+#: tips:183
 msgid "Thin"
 msgstr "Fina"
 
-#: tips:131
+#: tips:184
 msgid "Thick"
 msgstr "Espessa"
 
-#: tips:132
+#: tips:185
 msgid "Use custom font:"
 msgstr "Usar tipo de letra personalizado:"
 
-#: tips:133
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "O tipo de letra usado para o texto mostrado por baixo dos ícones"
 
-#: tips:134
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Escala rápida de imagens"
 
-#: tips:135
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
@@ -3912,20 +4713,20 @@ msgstr ""
 "Escolhe entre o método rápido e o lento de escalar imagens de fundo. O "
 "método lento pode dar melhores resultados."
 
-#: tips:136
+#: tips:189
 #, fuzzy
 msgid "Pinboard behaviour"
 msgstr "Comportamento do pinboard"
 
-#: tips:137
+#: tips:190
 msgid "Single-click to open"
 msgstr "Clique único para abrir"
 
-#: tips:139
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Manter ícones dentro dos limites do ecrâ"
 
-#: tips:140
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
@@ -3933,39 +4734,39 @@ msgstr ""
 "Com esta opção activa, os ícones do pinboard são sempre mantidos "
 "completamente dentro dos limites do ecrâ, incluindo a etiqueta."
 
-#: tips:141
+#: tips:194
 msgid "Icon grid step:"
 msgstr " da grelha:"
 
-#: tips:142
+#: tips:195
 msgid "Fine"
 msgstr "Fino"
 
-#: tips:143
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "Usar uma grelha de 2 pixeis para posicionar os icones no desktop."
 
-#: tips:144
+#: tips:197
 msgid "Medium"
 msgstr "Medio"
 
-#: tips:145
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "Usar uma grelha de 16 pixeis para posicionar os icones no desktop."
 
-#: tips:146
+#: tips:199
 msgid "Coarse"
 msgstr "Largo"
 
-#: tips:147
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "Usar uma grelha de 32 pixeis para posicionar os icones no desktop."
 
-#: tips:148 tips:150
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Janelas iconificadas"
 
-#: tips:149
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
@@ -3975,11 +4776,11 @@ msgstr ""
 "janelas, e vários programas, incluindo o ROX-Filer, podem ser usados para "
 "mostrar janelas iconificadas."
 
-#: tips:151
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Mostrar janelas iconificadas"
 
-#: tips:152
+#: tips:205
 #, fuzzy
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
@@ -3990,11 +4791,11 @@ msgstr ""
 "pequeno botão no pinboard. Requere um gestor de janelas compativel, e o "
 "pinboard tem que estar em uso."
 
-#: tips:153
+#: tips:206
 msgid "Show per workspace"
 msgstr "Mostrar por área de trabalho"
 
-#: tips:154
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
@@ -4002,39 +4803,39 @@ msgstr ""
 "Se esta opção está activa, o gestor apenas mostra as janelas iconificadas "
 "associadas à área de trabalho actual."
 
-#: tips:155
+#: tips:208
 msgid "Iconify to the"
 msgstr "Iconificar para o canto"
 
-#: tips:156
+#: tips:209
 msgid "top-left"
 msgstr "superior-esquerdo"
 
-#: tips:157
+#: tips:210
 msgid "top-right"
 msgstr "superior-direito"
 
-#: tips:158
+#: tips:211
 msgid "bottom-left"
 msgstr "inferior-esquerdo"
 
-#: tips:159
+#: tips:212
 msgid "bottom-right"
 msgstr "inferior-direito"
 
-#: tips:160
+#: tips:213
 msgid ", going"
 msgstr ", na"
 
-#: tips:161
+#: tips:214
 msgid "horizontally"
 msgstr "horizontal"
 
-#: tips:162
+#: tips:215
 msgid "vertically"
 msgstr "vertical"
 
-#: tips:163
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4046,117 +4847,47 @@ msgstr ""
 "Gnome. Para evitar isto pode definir margens superior e inferior, onde os "
 "ícones não serão colocados. O gestor já sabe do seu próprio painel."
 
-#: tips:164
+#: tips:217
 msgid "Top margin"
 msgstr "Margem superior"
 
-#: tips:165
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Altura da área 'proibida' na parte de cima do ecrâ."
 
-#: tips:166
+#: tips:219
 msgid "Bottom margin"
 msgstr "Margem inferior"
 
-#: tips:167
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "Altura da área 'proibida' na parte de baixo do ecrâ."
 
-#: tips:168
-msgid "Panels"
-msgstr "Paineis"
+#: tips:221
+#, fuzzy
+msgid "Left margin"
+msgstr "Margem superior"
 
-#: tips:169
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr ""
-"Paineis são barras de ícones que percorrem o lado do ecrâ. Veja o manual "
-"para informações sobre como usar os paineis."
+#: tips:222
+#, fuzzy
+msgid "Width of no-go area at left of screen."
+msgstr "Altura da área 'proibida' na parte de cima do ecrâ."
 
-#: tips:170
-msgid "Panel style"
-msgstr "Estilo do painel"
+#: tips:223
+#, fuzzy
+msgid "Right margin"
+msgstr "Margem inferior"
 
-#: tips:171
-msgid "Image and text"
-msgstr "Imagem e texto"
+#: tips:224
+#, fuzzy
+msgid "Width of no-go area at right of screen."
+msgstr "Altura da área 'proibida' na parte de cima do ecrâ."
 
-#: tips:172
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Cada ícone do painel é mostrado com uma imagem e algum texto."
-
-#: tips:173
-msgid "Image only for applications"
-msgstr "Apenas imagem para aplicações"
-
-#: tips:174
-msgid "Applications have just an image, everything else has both an image and text."
-msgstr "Aplicações têm apenas uma imagem, todo o resto tem tanto imagem como texto."
-
-#: tips:175
-msgid "Image only"
-msgstr "Apenas imagem"
-
-#: tips:176
-msgid "Only the image is shown."
-msgstr "Apenas é mostrada a imagem."
-
-#: tips:177
-msgid "Panel width (thin)"
-msgstr "Espessura do painel (fino)"
-
-#: tips:178
-msgid "(thick)"
-msgstr "(espesso)"
-
-#: tips:179
-msgid "The size of the panels."
-msgstr "O tamanho dos paineis."
-
-#: tips:180
-msgid "Do not cover panel"
-msgstr "Não cobrir o painel"
-
-#: tips:181
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
-msgstr ""
-"Pedir ao gestor de janelas para não cobrir nenhuma parte dos paineis ao "
-"maximizar janelas. Alguns gestores de janelas podem não cumprir isto. Se "
-"desactivada, pede apenas que não sejam cobertos alguns pixeis na borda do "
-"ecrâ, de modo a permitir a elevação automática."
-
-#: tips:182
-msgid "Xinerama"
-msgstr "Xinerama"
-
-#: tips:183
-msgid "Confine to Xinerama monitor"
-msgstr "Confinar ao monitor Xinerama"
-
-#: tips:184
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
-msgstr ""
-"Se tem um sistema Xinerama multi-monitor, use esta opção para confinar os "
-"paineis a apenas um monitor, em vez de os reproduzir em cada ecrâ."
-
-#: tips:185
-msgid "The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr ""
-"O monitor ao qual os paineis estão confinados no modo Xinerama (numerado a "
-"partir de 0)."
-
-#: tips:186
+#: tips:225
 msgid "Desktop"
 msgstr "Desktop"
 
-#: tips:187
+#: tips:226
 #, fuzzy
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
@@ -4165,66 +4896,59 @@ msgstr ""
 "Ao ser corrido por um gestor de sessão (tal como o ROX-Session) o gestor de "
 "ficheiros pode abrir um painel e/ou o pinboard.  Aqui pode configurar qual."
 
-#: tips:188
+#: tips:227
 msgid "Panel only"
 msgstr "Apenas painel"
 
-#: tips:189
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Apenas é mostrado um painel"
 
-#: tips:190
+#: tips:229
 #, fuzzy
 msgid "Pinboard only"
 msgstr "Apenas pinboard"
 
-#: tips:191
+#: tips:230
 #, fuzzy
 msgid "Only the pinboard is shown."
 msgstr "Apenas é mostrado o pinboard"
 
-#: tips:192
+#: tips:231
 #, fuzzy
 msgid "Panel and pinboard"
 msgstr "Painel e pinboard"
 
-#: tips:193
+#: tips:232
 #, fuzzy
 msgid "Both a panel and a pinboard are shown."
 msgstr "Tanto o painel como o pinboard são mostrados"
 
-#: tips:194
-msgid "Panel"
-msgstr "Painel"
-
-#: tips:195
-msgid "Enter the name of the panel to show here."
-msgstr "Introduza aqui o nome do painel a ser mostrado."
-
-#: tips:197
+#: tips:234
 #, fuzzy
 msgid "Enter the name of the pinboard to show here."
 msgstr "Introduza aqui o nome do pinboard a ser mostrado."
 
-#: tips:198
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr ""
 "Alterações aqui têm efeito na próxima vez que o gestor de ficheiros for "
 "corrido."
 
-#: tips:199
+#: tips:236
+#, fuzzy
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 "O gestor de sessões activa estas opções ao usar os argumentos -S ou --rox-"
 "session para o rox."
 
-#: tips:200
+#: tips:237
 msgid "Action windows"
 msgstr "Janelas de acção"
 
-#: tips:201
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4232,63 +4956,110 @@ msgstr ""
 "As janelas de acção aparecem quando inicia uma operação\n"
 "de fundo, tal como copiar ou apagar ficheiros."
 
-#: tips:202
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Iniciar logo (silenciosamente) estas acções"
 
-#: tips:204
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Copiar ficheiros sem confirmar primeiro."
 
-#: tips:206
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Mover ficheiros sem confirmar primeiro."
 
-#: tips:208
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Criar ligações a ficheiros sem confirmar primeiro."
 
-#: tips:210
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Apagar ficheiros sem confirmar primeiro."
 
-#: tips:211
+#: tips:248
 msgid "Mount"
 msgstr "Montar"
 
-#: tips:212
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Montar e desmontar sistemas de ficheiros sem confirmar primeiro."
 
-#: tips:213
+#: tips:250
 msgid "Default settings"
 msgstr "Predefinições"
 
-#: tips:215
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Forçar"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "Não confirmar ao apagar itens em que não tem premissão de escrever."
 
-#: tips:217
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Não mostrar tanta informação na área de mensagens."
 
-#: tips:219
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Também alterar o conteúdo das subdirectorias."
 
-#: tips:222
+#: tips:263
+#, fuzzy
+msgid "Mount commands"
+msgstr "Ponto de montagem"
+
+#: tips:264
+#, fuzzy
+msgid "Mount command"
+msgstr "Ponto de montagem"
+
+#: tips:265
+msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
+msgstr ""
+
+#: tips:266
+#, fuzzy
+msgid "Unmount command"
+msgstr "Desmontar"
+
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "_Usar Comando"
+
+#: tips:269
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Arrastar e Largar"
 
-#: tips:223
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Arrastar para ícones"
 
-#: tips:224
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Permitir arrastar para ícones nas janelas do gestor de ficheiros"
 
-#: tips:225
+#: tips:275
 #, fuzzy
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
@@ -4296,62 +5067,71 @@ msgid ""
 "will put it into that directory, or load it into the program."
 msgstr ""
 "Com esta opção activa, pode arrastar um ficheiro sobre uma directoria ou "
-"programa na janela do gestor de ficheiros. O item será salientado ao fazer isto, e largando o ficheiro este será colocado naquela directoria, ou aberto com aquele programa."
+"programa na janela do gestor de ficheiros. O item será salientado ao fazer "
+"isto, e largando o ficheiro este será colocado naquela directoria, ou aberto "
+"com aquele programa."
 
-#: tips:226
+#: tips:276
 msgid "Directories spring open"
 msgstr "Directorias abrem automaticamente"
 
-#: tips:227
+#: tips:277
 #, fuzzy
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
 "short while."
-msgstr "Esta opção, que requere que a opção acima também esteja activa, faz com que a directoria salientada se abra automaticamente depois do ficheiro ser seguro sobre ela durante algum tempo."
+msgstr ""
+"Esta opção, que requere que a opção acima também esteja activa, faz com que "
+"a directoria salientada se abra automaticamente depois do ficheiro ser "
+"seguro sobre ela durante algum tempo."
 
-#: tips:228
+#: tips:278
 msgid "Spring delay:"
 msgstr "Atraso:"
 
-#: tips:229
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:230
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
 "have any effect."
-msgstr "Esta opção define quanto tempo, em ms, tem que segurar um ficheiro sobre uma directoria para que ela abra automaticamente. A opção acima tem que ser activada para que isto tenha algum efeito."
+msgstr ""
+"Esta opção define quanto tempo, em ms, tem que segurar um ficheiro sobre uma "
+"directoria para que ela abra automaticamente. A opção acima tem que ser "
+"activada para que isto tenha algum efeito."
 
-#: tips:231
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Ao arrastar ficheiros com o botão esquerdo"
 
-#: tips:232 tips:236
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Mostrar um menu com as acções possíveis"
 
-#: tips:233
+#: tips:283
 msgid "Copy the files"
 msgstr "Copiar os ficheiros"
 
-#: tips:234
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
-msgstr "Note que pode sempre fazer o menu aparecer, arrastando com o Alt pressionado."
+msgstr ""
+"Note que pode sempre fazer o menu aparecer, arrastando com o Alt pressionado."
 
-#: tips:235
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Ao arrastar ficheiros com o botão do meio"
 
-#: tips:237
+#: tips:287
 msgid "Move the files"
 msgstr "Mover os ficheiros"
 
-#: tips:238
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
@@ -4359,11 +5139,11 @@ msgstr ""
 "Note que pode sempre fazer o menu aparecer, arrastando com o botão esquerdo "
 "e mantendo o Alt pressionado."
 
-#: tips:239
+#: tips:289
 msgid "Download handler"
 msgstr "Gestor de Download"
 
-#: tips:240
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4375,35 +5155,35 @@ msgstr ""
 "ficheiros, e a directoria actual é o destino. Ex:\n"
 "xterm -e wget $1"
 
-#: tips:241
+#: tips:291
 msgid "Menus"
 msgstr "Menus"
 
-#: tips:243
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Tamanho dos ícones em menus:"
 
-#: tips:244
+#: tips:294
 msgid "No Icons"
 msgstr "Sem Ícones"
 
-#: tips:247
+#: tips:297
 msgid "Same as current window"
 msgstr "O mesmo que na janela actual"
 
-#: tips:248
+#: tips:298
 msgid "Same as default"
 msgstr "O mesmo que por definição"
 
-#: tips:249
+#: tips:299
 msgid "Behaviour"
 msgstr "Comportamento"
 
-#: tips:250
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Menu Ficheiro ao clicar com o botão direito"
 
-#: tips:251
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
@@ -4412,23 +5192,27 @@ msgstr ""
 "direito com ficheiros seleccionados (o menu principal pode ser acedido "
 "mantendo o Control pressionado)"
 
-#: tips:252
+#: tips:302
 msgid "Terminal emulator program"
 msgstr "Programa de terminal"
 
-#: tips:253
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr "O programa a correr quando escolhe 'Terminal Aqui' a partir do menu."
 
-#: tips:254
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Atalhos de teclado"
 
-#: tips:256
+#: tips:305
+msgid "Types"
+msgstr "Tipos"
+
+#: tips:306
 msgid "MIME types"
 msgstr "Tipos MIME"
 
-#: tips:257
+#: tips:307
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
@@ -4437,23 +5221,23 @@ msgstr ""
 "correcto para cada ficheiro, e depois escolhe o ícone adequado para esse "
 "tipo."
 
-#: tips:258
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "Editar regras MIME"
 
-#: tips:259
+#: tips:309
 msgid "Themes"
 msgstr "Temas"
 
-#: tips:260
+#: tips:310
 msgid "Icon theme"
 msgstr "Tema dos ícones"
 
-#: tips:261
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "Os temas devem ser colocados na directoria ~/.icons."
 
-#: tips:262
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
@@ -4461,41 +5245,41 @@ msgstr ""
 "Use a caixa 'Definir Ícone...' para definir o ícone para cada tipo MIME. "
 "Note que os ícones assim definidos sobrepõem-se aos do tema seleccionado."
 
-#: tips:263
+#: tips:313
 msgid "Colours"
 msgstr "Cores"
 
-#: tips:264
+#: tips:314
 msgid "File type colours"
 msgstr "Cores dos tipos de ficheiro"
 
-#: tips:265
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Colorir ficheiros de acordo com o seu tipo"
 
-#: tips:266
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr ""
 "Nomes de ficheiros (e detalhes) são coloridos de acordo com o tipo de "
 "ficheiro."
 
-#: tips:267
+#: tips:317
 msgid "Directory:"
 msgstr "Directoria:"
 
-#: tips:268
+#: tips:318
 msgid "Regular file:"
 msgstr "Ficheiro regular:"
 
-#: tips:269
+#: tips:319
 msgid "Pipe:"
 msgstr "Pipe:"
 
-#: tips:270
+#: tips:320
 msgid "Socket:"
 msgstr "Socket:"
 
-#: tips:272
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
@@ -4504,19 +5288,19 @@ msgstr ""
 "ou um ficheiro que o gestor de ficheiros não consegue examinar por causa das "
 "suas permissões."
 
-#: tips:273
+#: tips:323
 msgid "Character device:"
 msgstr "Dispositivo de caracter:"
 
-#: tips:274
+#: tips:324
 msgid "Block device:"
 msgstr "Dispositivo de blocos:"
 
-#: tips:275
+#: tips:325
 msgid "Door:"
 msgstr "Porta:"
 
-#: tips:276
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
@@ -4524,31 +5308,60 @@ msgstr ""
 "Ficheiros Porta são como sockets ou pipes, mas apenas foram vistos em "
 "Solaris."
 
-#: tips:277
+#: tips:327
 msgid "Executable file:"
 msgstr "Ficheiro executável:"
 
-#: tips:278
+#: tips:328
 msgid "Application directory:"
 msgstr "Directoria de aplicação:"
 
-#: tips:279
+#: tips:329
 msgid "Unknown type:"
 msgstr "Tipo desconhecido:"
 
-#: tips:280
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Fundo:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Usar tipo de letra personalizado:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
-#: tips:281
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Problemas com gestores de janelas"
 
-#: tips:282
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
-msgstr "Sobrepor-se ao gestor de janelas no controlo do pinboard e dos paineis."
+msgstr ""
+"Sobrepor-se ao gestor de janelas no controlo do pinboard e dos paineis."
 
-#: tips:283
+#: tips:340
 #, fuzzy
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
@@ -4563,11 +5376,12 @@ msgstr ""
 "frente quando clica nele, títulos e outras decorações aparecerem à volta das "
 "janelas, ou estas aparecerem em listas de escolha de janelas."
 
-#: tips:284
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
-msgstr "Passar todos os cliques do rato no fundo do ecrâ para o gestor de janelas."
+msgstr ""
+"Passar todos os cliques do rato no fundo do ecrâ para o gestor de janelas."
 
-#: tips:285
+#: tips:342
 #, fuzzy
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
@@ -4579,12 +5393,12 @@ msgstr ""
 "activa os eventos serão em vez disso passados para o gestor de janelas. "
 "Cliques nos ícones não serão passados."
 
-#: tips:286
+#: tips:343
 #, fuzzy
 msgid "Blackbox root menus hack"
 msgstr "Hack dos menus de raíz do Blackbox"
 
-#: tips:287
+#: tips:344
 #, fuzzy
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
@@ -4597,28 +5411,52 @@ msgstr ""
 "que estes gestores de janelas mudem o seu comportamento em novas versões, de "
 "forma a que isto não seja mais necessário."
 
-#: tips:288
+#: tips:345
 #, fuzzy
 msgid "Panel is a 'dock'"
 msgstr "O painel é uma 'doca'"
 
-#: tips:289
+#: tips:346
+#, fuzzy
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 "Desactive esta opção se o painel fica acima de outras janela contra a sua "
 "vontade. Requere que reinicie a aplicação para que tenha efeito."
 
-#: tips:290
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Estilo do painel"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Arrastar e largar"
 
-#: tips:291
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Não usar hostnames"
 
-#: tips:292
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4628,15 +5466,11 @@ msgstr ""
 "necessitar que esta opção esteja activada. Use-a se ao arrastar ficheiros "
 "para uma aplicação o ponteiro mostra um sinal +, mas o largar não funciona."
 
-#: tips:293
-msgid "Extended attributes"
-msgstr "Atributos extendidos"
-
-#: tips:294
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Não usar atributos extendidos"
 
-#: tips:295
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4648,3 +5482,414 @@ msgstr ""
 "desactivado, o tipo MIME do ficheiro é apenas derivado do nome do ficheiro e "
 "a janela de propriedades não reporta atributos extendidos."
 
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Borda inferior"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "Borda direita"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "Directoria Home"
+
+#: ../Templates.ui.h:4
+msgid "Panel Options"
+msgstr "Opções do Painel"
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Imagem e texto"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Cada ícone do painel é mostrado com uma imagem e algum texto."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Apenas imagem para aplicações"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"Aplicações têm apenas uma imagem, todo o resto tem tanto imagem como texto."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Apenas imagem"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Apenas é mostrada a imagem."
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Espessura do painel (fino)"
+
+#: ../Templates.ui.h:12
+#, fuzzy
+msgid "The size of this panel."
+msgstr "O tamanho dos paineis."
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Tradução"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "Não cobrir o painel"
+
+#: ../Templates.ui.h:19
+#, fuzzy
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Pedir ao gestor de janelas para não cobrir nenhuma parte dos paineis ao "
+"maximizar janelas. Alguns gestores de janelas podem não cumprir isto. Se "
+"desactivada, pede apenas que não sejam cobertos alguns pixeis na borda do "
+"ecrâ, de modo a permitir a elevação automática."
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Estilo do painel"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Confinar ao monitor Xinerama"
+
+#: ../Templates.ui.h:22
+#, fuzzy
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Se tem um sistema Xinerama multi-monitor, use esta opção para confinar os "
+"paineis a apenas um monitor, em vez de os reproduzir em cada ecrâ."
+
+#: ../Templates.ui.h:23
+#, fuzzy
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+"O monitor ao qual os paineis estão confinados no modo Xinerama (numerado a "
+"partir de 0)."
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "Xinerama"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr "Borda direita"
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr "Borda esquerda"
+
+#: ../Templates.ui.h:27
+msgid "Bottom edge"
+msgstr "Borda inferior"
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr "Borda superior"
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "<b>Permissões</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<dir>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' já existe - sobrepor?"
+
+#~ msgid "Choices migration"
+#~ msgstr "Migração das escolhas"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Erro ao actualizar '%s':\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Directoria em falta/apagada"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Directoria '%s' não encontrada."
+
+#~ msgid "Cancel"
+#~ msgstr "Cancelar"
+
+#~ msgid ""
+#~ ".\n"
+#~ "Home page (including updated versions): http://rox.sourceforge.net/\n"
+#~ msgstr ""
+#~ ".\n"
+#~ "Página web (incluindo versões actualizadas): http://rox.sourceforge.net/\n"
+
+#~ msgid "Dnotify support"
+#~ msgstr "Suporte para Dnotify"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Deve usar Shift+Clique de Menu sobre um ficheiro para o enviar para algum "
+#~ "lado"
+
+#, fuzzy
+#~ msgid "Look inside ... ?"
+#~ msgstr "Entrar em ... ?"
+
+#~ msgid "Panel: %s"
+#~ msgstr "Painel: %s"
+
+#~ msgid "Select the panel's position:"
+#~ msgstr "Seleccione a posição do painel:"
+
+#~ msgid "Top-edge panel"
+#~ msgstr "Painel na borda superior do ecrâ"
+
+#~ msgid "Bottom edge panel"
+#~ msgstr "Painel na borda inferior do ecrâ"
+
+#~ msgid "Left edge panel"
+#~ msgstr "Painel na borda esquerda do ecrâ"
+
+#~ msgid "Right-edge panel"
+#~ msgstr "Painel na borda direita do ecrâ"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Ficheiro de tradução .gmo inválido (demasiado pequeno): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr ""
+#~ "Ficheiro de tradução .gmo inválido (número GNU magic não encontrado): %s"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Ir para a directoria acima"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Ir para a directoria home"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Favoritos"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Menu Favoritos"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Actualizar o conteúdo da directoria"
+
+#~ msgid "Change icon size"
+#~ msgstr "Mudar tamanho dos ícones"
+
+#~ msgid "Show extra details"
+#~ msgstr "Mostrar detalhes extra"
+
+#~ msgid "Hidden"
+#~ msgstr "Escondidos"
+
+#~ msgid "Show/hide hidden files"
+#~ msgstr "Mostrar/esconder ficheiros escondidos"
+
+#~ msgid ""
+#~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
+#~ "instead."
+#~ msgstr ""
+#~ "O tema de ícones '%s' não contém ícones MIME. A usar em vez dele o tema "
+#~ "predefinido do ROX."
+
+#~ msgid ""
+#~ "Failed to create symlink '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(this may mean that the ROX theme already exists there, but the 'mime-"
+#~ "application:postscript' icon couldn't be loaded for some reason, or %s is "
+#~ "a link to an invalid directory)"
+#~ msgstr ""
+#~ "Não foi possivel criar ligação simbólica '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(isto pode significar que o tema do ROX pode já lá existir, mas o ícone "
+#~ "'mime-application:postscript' não pôde ser carregado por alguma razão, ou "
+#~ "%s é uma ligação para uma directoria inválida)"
+
+#~ msgid "Language"
+#~ msgstr "Linguagem"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "Usar a variavel de sistema LANG"
+
+#~ msgid "Basque"
+#~ msgstr "Basco"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Chinês (tradicional)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Chinês (simplificado)"
+
+#~ msgid "Czech"
+#~ msgstr "Checo"
+
+#~ msgid "Danish"
+#~ msgstr "Dinamarquês"
+
+#~ msgid "Dutch"
+#~ msgstr "Holandês"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Inglês (sem tradução)"
+
+#~ msgid "Estonian"
+#~ msgstr "Estónio"
+
+#~ msgid "Finnish"
+#~ msgstr "Finlandês"
+
+#~ msgid "French"
+#~ msgstr "Francês"
+
+#~ msgid "German"
+#~ msgstr "Alemão"
+
+#~ msgid "Hungarian"
+#~ msgstr "Húngaro"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonês"
+
+#~ msgid "Norwegian"
+#~ msgstr "Norueguês"
+
+#~ msgid "Italian"
+#~ msgstr "Italiano"
+
+#~ msgid "Polish"
+#~ msgstr "Polaco"
+
+#~ msgid "Portuguese (Portugal)"
+#~ msgstr "Português (Portugal)"
+
+#~ msgid "Portuguese (Brasil)"
+#~ msgstr "Português (Brasil)"
+
+#, fuzzy
+#~ msgid "Romanian"
+#~ msgstr "Romaniano"
+
+#~ msgid "Russian"
+#~ msgstr "Russo"
+
+#~ msgid "Spanish"
+#~ msgstr "Espanhol"
+
+#~ msgid "Swedish"
+#~ msgstr "Sueco"
+
+#~ msgid "Change at:"
+#~ msgstr "Mudar aos:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Largura máxima (Ícones Grandes):"
+
+#~ msgid "Panels"
+#~ msgstr "Paineis"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Paineis são barras de ícones que percorrem o lado do ecrâ. Veja o manual "
+#~ "para informações sobre como usar os paineis."
+
+#~ msgid "(thick)"
+#~ msgstr "(espesso)"
+
+#~ msgid "Enter the name of the panel to show here."
+#~ msgstr "Introduza aqui o nome do painel a ser mostrado."

--- a/ROX-Filer/src/po/ro.po
+++ b/ROX-Filer/src/po/ro.po
@@ -6,59 +6,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ro\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-08-09 14:02+0100\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2004-07-03 16:03+0300\n"
 "Last-Translator: Florin Cosma <cosma_florin@yahoo.com>\n"
 "Language-Team: Romanian <cosma_florin@yahoo.com>\n"
+"Language: ro\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-2\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: abox.c:127
-msgid "<dir>"
-msgstr "<dir>"
+msgid "<src>"
+msgstr ""
 
-#: abox.c:219
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Fara mesaje"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Quiet"
 msgstr "Fara mesaje"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Don't confirm every operation"
-msgstr "Nu confirma toate opera˛iile"
+msgstr "Nu confirma toate opera≈£iile"
 
-#: abox.c:455 tips:60
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Nume"
 
-#: abox.c:461 menu.c:232
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Director"
 
-#: abox.c:550
+#: abox.c:546
 msgid "Expression:"
 msgstr "Expresie:"
 
-#: action.c:58
+#: action.c:57
 msgid "See the attr(5) man page for full details."
 msgstr ""
 
-#: action.c:60
+#: action.c:59
 msgid "See the fsattr(5) man page for full details."
 msgstr ""
 
-#: action.c:62
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr ""
 
-#: action.c:188
+#: action.c:198
 msgid "Find expression reference"
-msgstr "Cauta expresia referin˛a"
+msgstr "Cauta expresia referin≈£a"
 
-#: action.c:199
+#: action.c:209
 #, fuzzy
 msgid ""
 "<u>Quick Start</u>\n"
@@ -98,19 +103,19 @@ msgid ""
 "<b>prune</b> (false, and prevents searching the contents of a directory)."
 msgstr ""
 "<u>Start rapid</u>\n"
-"Pune numele fi∫ierului care-l cau˛i Óntre apostrofuri (ghilimele simple)†:\n"
-"<b>'index.html'</b> (pentru a cauta un fi∫ier numit 'index.html')\n"
+"Pune numele fi≈üierului care-l cau≈£i √Æntre apostrofuri (ghilimele simple)¬†:\n"
+"<b>'index.html'</b> (pentru a cauta un fi≈üier numit 'index.html')\n"
 "\n"
 "<u>Exemple</u>\n"
-"<b>'*.htm', '*.html'</b> (cauta fi∫iere HTML)\n"
+"<b>'*.htm', '*.html'</b> (cauta fi≈üiere HTML)\n"
 "<b>IsDir 'lib'</b> (cauta un director numit 'lib')\n"
 "<b>IsReg 'core'</b> (cauta un fisier normal numit 'core')\n"
-"<b>! (IsDir, IsReg)</b> (nu este un director, nu este un fi∫ier normal)\n"
-"<b>data ultimei modificari cu o zi in urma ∫i dimensiunea > 1Mb</b> (mare ∫i "
+"<b>! (IsDir, IsReg)</b> (nu este un director, nu este un fi≈üier normal)\n"
+"<b>data ultimei modificari cu o zi in urma ≈üi dimensiunea > 1Mb</b> (mare ≈üi "
 "recent modificat)\n"
-"<b>'CVS' prune, isReg</b> (un fi∫ier normal care nu este in CVS)\n"
-"<b>IsReg system(grep -q fred \\\"%\\\")</b> (fi∫ier normal care con˛ine "
-"cuv‚ntul 'fred')\n"
+"<b>'CVS' prune, isReg</b> (un fi≈üier normal care nu este in CVS)\n"
+"<b>IsReg system(grep -q fred \\\"%\\\")</b> (fi≈üier normal care con≈£ine "
+"cuv√¢ntul 'fred')\n"
 "\n"
 "<u>Teste simple</u>\n"
 "<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
@@ -118,29 +123,29 @@ msgstr ""
 "<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
 "(drepturi)\n"
 "<b>IsEmpty, IsMine</b>\n"
-"Un cuv‚nt Óntre ghilimele simple este un cuv‚nt Ón stilul shell-lui, cu "
+"Un cuv√¢nt √Æntre ghilimele simple este un cuv√¢nt √Æn stilul shell-lui, cu "
 "metacaractere. Daca\n"
-"con˛ine un slash (bara de frac˛ie), atunci cautarea se face cu calea\n"
-"data†; altfel cautarea se face numai dupa numele fi∫ierului dat.\n"
+"con≈£ine un slash (bara de frac≈£ie), atunci cautarea se face cu calea\n"
+"data¬†; altfel cautarea se face numai dupa numele fi≈üierului dat.\n"
 "\n"
-"<u>Compara˛ii</u>\n"
+"<u>Compara≈£ii</u>\n"
 "<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (compara doua valori)\n"
-"<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (dimensiunea fi∫ierelor)\n"
+"<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (dimensiunea fi≈üierelor)\n"
 "<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (date)\n"
 "<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
 "(valori)\n"
 "\n"
-"<u>Func˛ii speciale</u>\n"
-"<b>system(comanda)</b> (adevarat daca 'comanda' Óntoarce un rezultat zero;\n"
-"o intrare % in 'comanda' este inlocuita cu numele caii fi∫ierului curent)\n"
+"<u>Func≈£ii speciale</u>\n"
+"<b>system(comanda)</b> (adevarat daca 'comanda' √Æntoarce un rezultat zero;\n"
+"o intrare % in 'comanda' este inlocuita cu numele caii fi≈üierului curent)\n"
 "<b>prune</b> (fals, previne cautarea in directorul specificat).\n"
 
-#: action.c:246
+#: action.c:256
 #, fuzzy
 msgid "Change permissions reference"
-msgstr "Cauta expresia referin˛a"
+msgstr "Cauta expresia referin≈£a"
 
-#: action.c:257
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -170,39 +175,39 @@ msgid ""
 "\n"
 "See the chmod(1) man page for full details."
 msgstr ""
-"In mod normal, po˛i selecta o comanda din meniu (apasa\n"
-"pe sageata de l‚nga casu˛a comenzii). Alta data, ai nevoie de mai mult...\n"
+"In mod normal, po≈£i selecta o comanda din meniu (apasa\n"
+"pe sageata de l√¢nga casu≈£a comenzii). Alta data, ai nevoie de mai mult...\n"
 "\n"
 "Formatul unei comenzi este : <b>SCHIMBA, SCHIMBA, ...</b>\n"
-"Fiecare <b>SCHIMBA</b> are forma†: <b>CINE CUM DREPTURI</b>\n"
-"<b>CINE</b> este o combina˛ie de <b>u</b>, <b>g</b> ∫i <b>o</b> care "
+"Fiecare <b>SCHIMBA</b> are forma¬†: <b>CINE CUM DREPTURI</b>\n"
+"<b>CINE</b> este o combina≈£ie de <b>u</b>, <b>g</b> ≈üi <b>o</b> care "
 "determina daca se schimba drepturile pentru\n"
-"utilizator (propritar), pentru grup ori pentru al˛ii.\n"
+"utilizator (propritar), pentru grup ori pentru al≈£ii.\n"
 "<b>CUM</b> este <b>+</b>, <b>-</b> sau <b>=</b> pentru a adauga, a anula sau "
 "pentru a fixa exact drepturile.\n"
-"<b>DREPTURI</b> este o combina˛ie de litere <b>rwxXstugo</b>\n"
+"<b>DREPTURI</b> este o combina≈£ie de litere <b>rwxXstugo</b>\n"
 "\n"
-"Textul intre paranteze ∫i spa˛ille sunt ignorate.\n"
+"Textul intre paranteze ≈üi spa≈£ille sunt ignorate.\n"
 "\n"
 "<u>Exemple</u>\n"
-"<b>u+rw</b>†: proprietarul fi∫ierului ob˛ine drepturi citire ∫i de scriere\n"
-"<b>g=u</b>†: drepturile grupului sunt la fel cu cele ale proprietarului\n"
-"<b>o=u-w</b>†: al˛ii ob˛in drepturi la fel cu ale propritarului mai pu˛in, "
+"<b>u+rw</b>¬†: proprietarul fi≈üierului ob≈£ine drepturi citire ≈üi de scriere\n"
+"<b>g=u</b>¬†: drepturile grupului sunt la fel cu cele ale proprietarului\n"
+"<b>o=u-w</b>¬†: al≈£ii ob≈£in drepturi la fel cu ale propritarului mai pu≈£in, "
 "dreptul de scriere\n"
-"<b>a+x</b>†: toata lumea ob˛ine dreptul de execu˛ie/acces - identic cu <b>ugo"
+"<b>a+x</b>¬†: toata lumea ob≈£ine dreptul de execu≈£ie/acces - identic cu <b>ugo"
 "+x</b>\n"
-"<b>a+X</b>†: directoarele devin accesibile pentru to˛i ; fi∫ierele\n"
+"<b>a+X</b>¬†: directoarele devin accesibile pentru to≈£i ; fi≈üierele\n"
 "care au putut fi executate de oricibe, vor putea fi executate de oricine\n"
-"<b>u+rw, go+r</b>†: doua comenzi Ón una !\n"
-"<b>u+s</b>†: se seteaza bitul SetUID - nu are efect asupra fi∫ierelor "
+"<b>u+rw, go+r</b>¬†: doua comenzi √Æn una !\n"
+"<b>u+s</b>¬†: se seteaza bitul SetUID - nu are efect asupra fi≈üierelor "
 "script\n"
-"<b>755</b>†: se seteaza drepturile direct"
+"<b>755</b>¬†: se seteaza drepturile direct"
 
-#: action.c:298
+#: action.c:308
 msgid "Set type reference"
-msgstr "Seteaza tipul referin˛a"
+msgstr "Seteaza tipul referin≈£a"
 
-#: action.c:309
+#: action.c:319
 #, fuzzy
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
@@ -218,197 +223,219 @@ msgid ""
 "directories, devices, pipes or sockets, and then only\n"
 "on certain file systems and where the OS implements them.\n"
 msgstr ""
-"In mod normal managerul de fi∫iere ROX determina tipul unui fisier normal "
+"In mod normal managerul de fi≈üiere ROX determina tipul unui fisier normal "
 "prin\n"
 "compararea numelui sau cu un tipar. Pentru a schimba tipul unui fisier, "
 "trebuie\n"
 "schimbat numele lui.\n"
 "\n"
-"Sistemele de fi∫iere noi suporta a∫a numitele \"Atribute extinse\" \n"
+"Sistemele de fi≈üiere noi suporta a≈üa numitele \"Atribute extinse\" \n"
 "care pot fi folosite pentru a pastra date suplimentare ca parametri. \n"
-"Managerul de fi∫iere ROX folose∫te parametrul user.mime_type\n"
+"Managerul de fi≈üiere ROX folose≈üte parametrul user.mime_type\n"
 "pentru a pastra tipul de fisier.\n"
 "\n"
-"Tipul fi∫ierelor este suportat doar pentru fi∫iere obi∫nuite, \n"
-"nu pentru directoare, dispozitive, pipe-uri sau sochet-uri, ∫i \n"
-"doar pentru sistemele de fi∫iere unde sistemul de operare la implementat.\n"
+"Tipul fi≈üierelor este suportat doar pentru fi≈üiere obi≈ünuite, \n"
+"nu pentru directoare, dispozitive, pipe-uri sau sochet-uri, ≈üi \n"
+"doar pentru sistemele de fi≈üiere unde sistemul de operare la implementat.\n"
 "\n"
 
-#: action.c:416
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Proces terminat.\n"
 
-#: action.c:432
-msgid "There was one error.\n"
-msgstr "S-a Ónregistrat o eroare.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
+msgstr "S-a √Ænregistrat o eroare.\n"
 
-#: action.c:434
-#, c-format
-msgid "There were %d errors.\n"
-msgstr "S-au Ónregistrat %d erori.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
+msgstr "S-au √Ænregistrat %d erori.\n"
 
-#: action.c:458
+#: action.c:516
 msgid "ERROR reading"
 msgstr "Eroare citind"
 
-#: action.c:501
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Terminat\n"
 
-#: action.c:557 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "Eroare"
 
-#: action.c:711 main.c:674 main.c:681 main.c:688
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Da"
 
-#: action.c:714 main.c:676 main.c:690
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Nu"
 
-#: action.c:732
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
 msgstr ""
 "\n"
-"Solicita procesului copil sa Óncheie execu˛ia...\n"
+"Solicita procesului copil sa √Æncheie execu≈£ia...\n"
 
-#: action.c:739
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
 msgstr ""
 "\n"
-"Incerc sa Ónchei execu˛ia procesului care ruleaza...\n"
+"Incerc sa √Ænchei execu≈£ia procesului care ruleaza...\n"
 
-#: action.c:892
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
-msgstr "?Numar con˛inutul %s ?"
+msgstr "?Numar con≈£inutul %s ?"
 
-#: action.c:928
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Sterge %s'%s' ?"
 
-#: action.c:929
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "Protejat la scriere "
 
-#: action.c:936
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
-msgstr "'Sterg‚nd '%s'\n"
+msgstr "'Sterg√¢nd '%s'\n"
 
-#: action.c:949
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
-msgstr "'Directorul '%s' a fost ∫ters\n"
+msgstr "'Directorul '%s' a fost ≈üters\n"
 
-#: action.c:982
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?Scoate '%s' ?"
 
-#: action.c:989
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Scoate '%s'\n"
 
-#: action.c:1008
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
 "eject failed\n"
 msgstr ""
 "!%s\n"
-"scoaterea a e∫uat\n"
+"scoaterea a e≈üuat\n"
 
-#: action.c:1027 action.c:1046
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Verifica '%s' ?"
 
-#: action.c:1043
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
-msgstr "!Condi˛ie de cautare invalida - schimba ∫i incearca din nou\n"
+msgstr "!Condi≈£ie de cautare invalida - schimba ≈üi incearca din nou\n"
 
-#: action.c:1053
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(in timp ce se verifica '%s')\n"
 
-#: action.c:1127 action.c:1152
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Schimba drepturile pentru '%s' ?"
 
-#: action.c:1133
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Schimband drepturile pentru '%s'\n"
 
-#: action.c:1150
+#: action.c:1274
 #, fuzzy
 msgid "!Invalid mode command - change it and try again\n"
-msgstr "!Mod invalid - schimba ∫i incearca din nou\n"
+msgstr "!Mod invalid - schimba ≈üi incearca din nou\n"
 
-#: action.c:1207 action.c:1227
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?Schimba tipul pentru '%s' ?"
+
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Schimba tipul pentru '%s' ?"
 
-#: action.c:1224
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
-msgstr "!Tip invalid - schimba ∫i incearca din nou\n"
+msgstr "!Tip invalid - schimba ≈üi incearca din nou\n"
 
-#: action.c:1246
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
-msgstr "'Schimb‚nd tipul '%s' Ón '%s'\n"
+msgstr "'Schimb√¢nd tipul '%s' √Æn '%s'\n"
 
-#: action.c:1325
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'Schimb√¢nd tipul '%s' √Æn '%s'\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' exista deja - %s ?"
 
-#: action.c:1327
+#: action.c:1550 action.c:1859
 msgid "merge contents"
-msgstr "fuzioneaza con˛inutul"
+msgstr "fuzioneaza con≈£inutul"
 
-#: action.c:1328
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "scrie peste"
 
-#: action.c:1344
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Incearca sa copiezi oricum...\n"
 
-#: action.c:1353
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Copiaza %s ca %s ?"
 
-#: action.c:1357
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Copiind %s ca %s\n"
 
-#: action.c:1372
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
-msgstr "!Eroare : destina˛ia exista deja, dar nu este un director\n"
+msgstr "!Eroare : destina≈£ia exista deja, dar nu este un director\n"
 
-#: action.c:1444
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -417,26 +444,7 @@ msgstr ""
 "!%s\n"
 "Nu se poate copia '%s'\n"
 
-#: action.c:1488
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' exista deja - scriu peste ?"
-
-#: action.c:1503
-msgid "'Trying move anyway...\n"
-msgstr "'Incearca sa mu˛i oricum...\n"
-
-#: action.c:1511
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Muta %s ca %s ?"
-
-#: action.c:1515
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Mut‚nd %s ca %s\n"
-
-#: action.c:1523
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -445,67 +453,81 @@ msgstr ""
 "!%s\n"
 "Nu se poate muta %s ca %s\n"
 
-#: action.c:1544
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Incearca sa mu≈£i oricum...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Muta %s ca %s ?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Mut√¢nd %s ca %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
-msgstr "!Eroare : nu se poate copia obiectul peste el insu∫i\n"
+msgstr "!Eroare : nu se poate copia obiectul peste el insu≈üi\n"
 
-#: action.c:1559
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
-msgstr "!Eroare : nu se poate muta/redenumi obiectul peste el insu∫i\n"
+msgstr "!Eroare : nu se poate muta/redenumi obiectul peste el insu≈üi\n"
 
-#: action.c:1571
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
-msgstr "'Leg‚nd %s ca %s\n"
+msgstr "'Leg√¢nd %s ca %s\n"
 
-#: action.c:1576
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Leaga %s ca %s ?"
 
-#: action.c:1618
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
-msgstr "'Mont‚nd %s\n"
+msgstr "'Mont√¢nd %s\n"
 
-#: action.c:1619
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
-msgstr "'Demont‚nd %s\n"
+msgstr "'Demont√¢nd %s\n"
 
-#: action.c:1622
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?Monteaza %s ?"
 
-#: action.c:1623
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?Demonteaza %s ?"
 
-#: action.c:1643
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
 "Mount failed\n"
 msgstr ""
 "!%s\n"
-"Montarea a e∫uat\n"
+"Montarea a e≈üuat\n"
 
-#: action.c:1644
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
 "Unmount failed\n"
 msgstr ""
 "!%s\n"
-"Demontarea a e∫uat\n"
+"Demontarea a e≈üuat\n"
 
-#: action.c:1652
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(pare sa fie montat oricum)\n"
 
-#: action.c:1698
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -514,300 +536,324 @@ msgstr ""
 "'\n"
 "Total: %s ("
 
-#: action.c:1704
+#: action.c:2108
 msgid "file"
-msgstr "fi∫ier"
+msgstr "fi≈üier"
 
-#: action.c:1704
+#: action.c:2108
 msgid "files"
-msgstr "fi∫iere"
+msgstr "fi≈üiere"
 
-#: action.c:1708
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "nu exista directoarele)\n"
 
-#: action.c:1712
+#: action.c:2116
 msgid "directory"
 msgstr "director"
 
-#: action.c:1713
+#: action.c:2117
 msgid "directories"
 msgstr "directoare"
 
-#: action.c:1754
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Nu a fost selectat un punct de montare !\n"
 
-#: action.c:1839
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Inca o cautare?"
 
-#: action.c:1869 action.c:1900
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' este o legatura simbolica\n"
 
-#: action.c:1940
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr ""
-"Este nevoie sa selectezi anumite elemente Óntre care sa se faca cautarea"
+"Este nevoie sa selectezi anumite elemente √Æntre care sa se faca cautarea"
 
-#: action.c:1950 menu.c:223
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Cauta"
 
-#: action.c:1983
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Este nevoie sa selectezi anumite elemente care sa fie numarate"
 
-#: action.c:1987
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Umplerea discului"
 
-#: action.c:2021
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Monteaza / Demonteaza"
 
-#: action.c:2034
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr ""
-"Managerul de fi∫iere ROX nu suporta montarea Ón sistemul tau de operare. "
+"Managerul de fi≈üiere ROX nu suporta montarea √Æn sistemul tau de operare. "
 "Scuze."
 
-#: action.c:2048 menu.c:210 tips:208
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Sterge"
 
-#: action.c:2058 tips:213
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
-msgstr "For˛eaza"
+msgstr "For≈£eaza"
 
-#: action.c:2058
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
-msgstr "Nu confirma ∫tergerea obictelor protejate la scriere"
+msgstr "Nu confirma ≈ütergerea obictelor protejate la scriere"
 
-#: action.c:2061 action.c:2116 action.c:2175 action.c:2228 action.c:2264
-#: tips:215
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Rezumat"
 
-#: action.c:2061
+#: action.c:2479
 msgid "Only log directories being deleted"
-msgstr "Numai directoarele log vor fi ∫terse"
+msgstr "Numai directoarele log vor fi ≈üterse"
 
-#: action.c:2078
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "Trbuie sa selectezi elementele la care vrei sa schimbi drepturile"
 
-#: action.c:2086
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Fa-le executabile/cautabile)"
 
-#: action.c:2088
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (Fa-le non-executabile/non-cautabile)"
 
-#: action.c:2090
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Seteaza proprietarul cu drepturi de citire+scriere)"
 
-#: action.c:2092
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Acces privat - are acces numai proprietarul)"
 
-#: action.c:2094
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Acces public, fara scriere)"
 
-#: action.c:2105 menu.c:184 menu.c:221 tips:75
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Drepturi"
 
-#: action.c:2116 action.c:2175
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
-msgstr "Nu lista fi∫ierele procesate"
+msgstr "Nu lista fi≈üierele procesate"
 
-#: action.c:2119 action.c:2178 tips:217
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Recursiv"
 
-#: action.c:2119
+#: action.c:2543
 msgid "Also change contents of subdirectories"
-msgstr "Schimba ∫i con˛inutul subdirectoarelor"
+msgstr "Schimba ≈üi con≈£inutul subdirectoarelor"
 
-#: action.c:2123
+#: action.c:2547
 msgid "Command:"
 msgstr "Comanda:"
 
-#: action.c:2151
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Trebuie sa selectezi elementele al caror tip vrei sa-l schimbi"
 
-#: action.c:2164
+#: action.c:2590
 msgid "Set type"
 msgstr "Seteaza tipul"
 
-#: action.c:2178
+#: action.c:2608
 msgid "Change contents of subdirectories"
-msgstr "Schimba con˛inutul subdirectoarelor"
+msgstr "Schimba con≈£inutul subdirectoarelor"
 
-#: action.c:2185 infobox.c:615
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Tip:"
 
-#: action.c:2214 dnd.c:124 menu.c:1999 tips:202
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Copiaza"
 
-#: action.c:2224 action.c:2260 tips:219
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Nu confirma toate opera≈£iile"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Scrie peste doar atunci cand sursa este mai noua decat destina≈£ia."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Mai recent"
 
-#: action.c:2225 action.c:2261 tips:220
-msgid "Only over-write if source is newer than destination."
-msgstr "Scrie peste doar atunci cand sursa este mai noua decat destina˛ia."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
+msgstr "Scrie peste doar atunci cand sursa este mai noua decat destina≈£ia."
 
-#: action.c:2228
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "directoare"
+
+#: action.c:2695
 #, fuzzy
 msgid "Only log directories as they are copied"
-msgstr "Numai directoarele log vor fi ∫terse"
+msgstr "Numai directoarele log vor fi ≈üterse"
 
-#: action.c:2250 dnd.c:125 tips:204
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Muta"
 
-#: action.c:2264
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr ""
 
-#: action.c:2284 tips:206
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Leaga"
 
-#: action.c:2303 appmenu.c:113
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Scoate"
 
-#: action.c:2360
+#: action.c:2875
 msgid "Deleting items such as "
-msgstr "Sterg‚nd elemente cum ar fi "
+msgstr "Sterg√¢nd elemente cum ar fi "
 
-#: action.c:2364
+#: action.c:2879
 msgid "Deleting the item "
-msgstr "Sterg‚nd elementul "
+msgstr "Sterg√¢nd elementul "
 
-#: action.c:2366
+#: action.c:2881
 msgid "Deleting the items "
-msgstr "Sterg‚nd elementele "
+msgstr "Sterg√¢nd elementele "
 
-#: action.c:2385
+#: action.c:2900
 msgid " and "
-msgstr " ∫i "
+msgstr " ≈üi "
 
-#: action.c:2394
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr ""
-" vor fi afectate anumite elemente din scurtaturi ∫i panouri - chiar vrei s„-"
-"l ∫tergi ?"
+" vor fi afectate anumite elemente din scurtaturi ≈üi panouri - chiar vrei sƒÉ-"
+"l ≈ütergi ?"
 
-#: action.c:2401
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr ""
-" vor fi afectate anumite elemente din scurtaturi ∫i panouri - chiar vrei s„ "
-"le ∫terge˛i ?"
+" vor fi afectate anumite elemente din scurtaturi ≈üi panouri - chiar vrei sƒÉ "
+"le ≈üterge≈£i ?"
 
-#: appmenu.c:198
+#: appmenu.c:206
 msgid "<missing label>"
-msgstr "<eticheta lips„>"
+msgstr "<eticheta lipsƒÉ>"
 
-#: appmenu.c:295
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
 "menu for all items of this type (%s/%s)."
 msgstr ""
-"Leag„ orice program vrei in acest director. Vor ap„rea Ón meniu pentru toate "
+"LeagƒÉ orice program vrei in acest director. Vor apƒÉrea √Æn meniu pentru toate "
 "elementele de acest tip (%s/%s)."
 
-#: appmenu.c:339 menu.c:234
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
-msgstr "Personalizeaz„ meniul..."
+msgstr "PersonalizeazƒÉ meniul..."
 
-#: appmenu.c:396 menu.c:251 toolbar.c:159
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Ajutor"
 
-#: bookmarks.c:147
-msgid "Path"
-msgstr "Cale"
-
-#: bookmarks.c:155
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Titlu"
 
-#: bookmarks.c:304
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Cale"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
-msgstr "Nu pot Ónsemna resursa non-local„ '%s'\n"
+msgstr "Nu pot √Ænsemna resursa non-localƒÉ '%s'\n"
 
-#: bookmarks.c:312 bookmarks.c:630
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s'nu este un director"
 
-#: bookmarks.c:518
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
-msgstr "Trebuie s„ selectezi anumite r‚nduri care s„ fie ∫terse"
+msgstr "Trebuie sƒÉ selectezi anumite r√¢nduri care sƒÉ fie ≈üterse"
 
-#: bookmarks.c:542
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
-msgstr "Plaseaz„ cursorul pe o intrare Ón list„ pentru a o muta"
+msgstr "PlaseazƒÉ cursorul pe o intrare √Æn listƒÉ pentru a o muta"
 
-#: bookmarks.c:562
+#: bookmarks.c:755
 msgid "This item is already at the end"
-msgstr "Acest element este deja la sf‚r∫it"
+msgstr "Acest element este deja la sf√¢r≈üit"
 
-#: bookmarks.c:636
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
-msgstr "Nu pot Ónsemna directoare non-locale ca '%s'"
+msgstr "Nu pot √Ænsemna directoare non-locale ca '%s'"
 
-#: bookmarks.c:778
+#: bookmarks.c:998
 msgid "Add New Bookmark"
-msgstr "Adaug„ un semn nou"
+msgstr "AdaugƒÉ un semn nou"
 
-#: bookmarks.c:785
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
-msgstr "Editeaz„ semnele"
+msgstr "EditeazƒÉ semnele"
 
-#: bookmarks.c:790
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Recent vizitate"
 
-#: bulk_rename.c:68
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr ""
 
-#: bulk_rename.c:71
+#: bulk_rename.c:72
 #, fuzzy
 msgid "Reset"
 msgstr "_Revenire"
 
-#: bulk_rename.c:76
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr ""
 
-#: bulk_rename.c:81
+#: bulk_rename.c:82
 #, fuzzy
 msgid "_Rename"
-msgstr "Redenume∫te"
+msgstr "Redenume≈üte"
 
-#: bulk_rename.c:94
+#: bulk_rename.c:95
 #, fuzzy
 msgid "Replace:"
-msgstr "_Inlocuie∫te"
+msgstr "_Inlocuie≈üte"
 
-#: bulk_rename.c:101
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -823,58 +869,59 @@ msgstr "Scrie"
 
 #: bulk_rename.c:116
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr ""
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
 msgstr ""
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr ""
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 #, fuzzy
 msgid "New name"
-msgstr "Redenume∫te"
+msgstr "Redenume≈üte"
 
-#: bulk_rename.c:259
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr ""
 
-#: bulk_rename.c:264
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr ""
 
-#: bulk_rename.c:267
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr ""
 
-#: bulk_rename.c:293
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr ""
 
-#: bulk_rename.c:310
+#: bulk_rename.c:347
 #, fuzzy, c-format
 msgid "%s (for '%s')"
 msgstr "%s '%s'"
 
-#: bulk_rename.c:343
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr ""
 
-#: bulk_rename.c:348
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -882,95 +929,111 @@ msgid ""
 "Aborting bulk rename."
 msgstr ""
 
-#: bulk_rename.c:410
+#: bulk_rename.c:447
 #, fuzzy, c-format
 msgid "A file called '%s' already exists"
 msgstr "?'%s' exista deja - %s ?"
 
-#: bulk_rename.c:421
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
 "files to end up in different directories. Continue?"
 msgstr ""
 
-#: bulk_rename.c:436
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr ""
 
-#: choices.c:428
-#, fuzzy
-msgid "Choices migration"
-msgstr "Chinois (traditionnel)"
+#: choices.c:434
+#, c-format
+msgid "%d directories could not be migrated"
+msgstr ""
 
 #: choices.c:436
 #, c-format
 msgid ""
 "Choices have been moved from \n"
-"<b>%s</b>\n"
+"%s\n"
 " to the new location \n"
-"<b>%s</b>\n"
+"%s\n"
+"%s"
 msgstr ""
 
-#: choices.c:447
-#, c-format
-msgid "%d directories could not be migrated"
-msgstr ""
-
-#: dir.c:982
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Nu se poate afla starea directorului: %s"
 
-#: dir.c:991
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Nu pot deschide directorul: %s"
 
-#: display.c:588
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Dimensiune"
+
+#: display.c:705
+msgid "‚î§"
+msgstr ""
+
+#: display.c:706
+msgid "‚îê"
+msgstr ""
+
+#: display.c:707
+msgid "‚îò"
+msgstr ""
+
+#: display.c:709
+msgid "‚îú"
+msgstr ""
+
+#: display.c:709
+msgid "‚îå"
+msgstr ""
+
+#: display.c:710
+msgid "‚îº"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
-msgstr "lstat(2) a e∫uat: %s"
+msgstr "lstat(2) a e≈üuat: %s"
 
-#: dnd.c:126
-msgid "Link (relative)"
-msgstr ""
-
-#: dnd.c:127
-msgid "Link (absolute)"
-msgstr ""
-
-#: dnd.c:426
+#: dnd.c:423
 msgid "Internal error - bad info type"
-msgstr "Eroare intern„ - tip gre∫it"
+msgstr "Eroare internƒÉ - tip gre≈üit"
 
 #: dnd.c:565
 msgid "Drag a directory here to bookmark it."
-msgstr "Trage un director aici pentru a fi Ónsemnat."
+msgstr "Trage un director aici pentru a fi √Ænsemnat."
 
 #: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
-msgstr "Eroare de protocal XDS : numele fi∫ierului nu con˛ine '/'\n"
+msgstr "Eroare de protocal XDS : numele fi≈üierului nu con≈£ine '/'\n"
 
 #: dnd.c:605
 msgid ""
 "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
 "plain) did not contain a leafname\n"
 msgstr ""
-"Destina˛ia XdndDirectSave0 este data, dar atomul XdndDirectSave0 (de tip "
-"text/plain) nu con˛ine un nume de fi∫ier\n"
+"Destina≈£ia XdndDirectSave0 este data, dar atomul XdndDirectSave0 (de tip "
+"text/plain) nu con≈£ine un nume de fi≈üier\n"
 
 #: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
 msgstr ""
-"Scuze - este necesara o destina˛ie de tip text/uri-lista sau XdndDirectSave0."
+"Scuze - este necesara o destina≈£ie de tip text/uri-lista sau XdndDirectSave0."
 
 #: dnd.c:621
 msgid ""
 "Sorry - I require a target type of text/uri-list or application/octet-stream."
 msgstr ""
-"Scuze - este necesara o destina˛ie de tip text/uri-lista sau aplica˛ie/∫ir "
-"de octe˛i."
+"Scuze - este necesara o destina≈£ie de tip text/uri-lista sau aplica≈£ie/≈üir "
+"de octe≈£i."
 
 #: dnd.c:691
 #, c-format
@@ -983,11 +1046,11 @@ msgstr ""
 
 #: dnd.c:766
 msgid "Unknown target"
-msgstr "Destina˛ie necunoscuta"
+msgstr "Destina≈£ie necunoscuta"
 
 #: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
-msgstr "Aplica˛ia Óndepartata nu poate sau nu vrea sa trimita date - scuze"
+msgstr "Aplica≈£ia √Ændepartata nu poate sau nu vrea sa trimita date - scuze"
 
 #: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
@@ -997,8 +1060,8 @@ msgstr ""
 #: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
 msgstr ""
-"Scuze, nu pot afi∫a un meniu de ac˛iuni pentru un fi∫ier Óndepartat / date "
-"pe r‚nduri."
+"Scuze, nu pot afi≈üa un meniu de ac≈£iuni pentru un fi≈üier √Ændepartat / date "
+"pe r√¢nduri."
 
 #: dnd.c:861
 msgid "UntitledData"
@@ -1007,72 +1070,88 @@ msgstr "Date fara titlu"
 #: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
-msgstr "Eroare la salvarea fi∫ierului: %s"
+msgstr "Eroare la salvarea fi≈üierului: %s"
 
 #: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
-msgstr "Nu exista URI-uri Ón text/lista de uri-uri (nimic de facut)"
+msgstr "Nu exista URI-uri √Æn text/lista de uri-uri (nimic de facut)"
 
 #: dnd.c:993
 msgid ""
 "Can't get data from remote machine (application/octet-stream not provided)"
 msgstr ""
-"Imposibil de ob˛inut date de la ma∫ina Óndepartata (aplica˛ia/∫irul de "
-"acte˛i nedisponibil)"
+"Imposibil de ob≈£inut date de la ma≈üina √Ændepartata (aplica≈£ia/≈üirul de "
+"acte≈£i nedisponibil)"
 
-#: dnd.c:1016
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
-"C‚teva din aceste fi∫iere sunt pe o alta ma∫ina - vor fi ignorate - scuze"
+"C√¢teva din aceste fi≈üiere sunt pe o alta ma≈üina - vor fi ignorate - scuze"
 
-#: dnd.c:1023
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
 msgstr ""
-"Nici unul din aceste fi∫iere nu sunt locale - nu se poate opera pe mai multe "
-"fi∫iere Óndepartate - scuze."
+"Nici unul din aceste fi≈üiere nu sunt locale - nu se poate opera pe mai multe "
+"fi≈üiere √Ændepartate - scuze."
 
-#: dnd.c:1036
+#: dnd.c:1040
 msgid "Unknown action requested"
-msgstr "Ac˛iune solicitata necunoscuta"
+msgstr "Ac≈£iune solicitata necunoscuta"
 
-#: dnd.c:1044
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
-msgstr "Eroare Ón ob˛inerea listei de fi∫iere: %s"
+msgstr "Eroare √Æn ob≈£inerea listei de fi≈üiere: %s"
 
-#: dropbox.c:114
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr ""
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr ""
+
+#: dnd.c:1109
+msgid "Link (relative, sym path)"
+msgstr ""
+
+#: dnd.c:1110
+msgid "Link (absolute, sym path)"
+msgstr ""
+
+#: dropbox.c:112
 msgid "Show"
 msgstr "Arata"
 
-#: dropbox.c:120
+#: dropbox.c:118
 msgid "Show the current choice in a filer window"
-msgstr "Arata op˛iunile curente Ón fereastra managerului de fi∫iere"
+msgstr "Arata op≈£iunile curente √Æn fereastra managerului de fi≈üiere"
 
-#: dropbox.c:174
+#: dropbox.c:172
 msgid "<nothing>"
 msgstr "<nimic>"
 
-#: dropbox.c:239
+#: dropbox.c:237
 msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
 msgstr ""
-"Nu pot sa-˛i arat elementul curent setat, deoarece nu este setat nimic.Trage "
-"ceva peste mine†!"
+"Nu pot sa-≈£i arat elementul curent setat, deoarece nu este setat nimic.Trage "
+"ceva peste mine¬†!"
 
-#: dropbox.c:263
+#: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
-msgstr "Scuze, trebuie sa eliberezi exact un fi∫ier Ón aria desemnata."
+msgstr "Scuze, trebuie sa eliberezi exact un fi≈üier √Æn aria desemnata."
 
-#: dropbox.c:273
+#: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
-msgstr "Scuze, nu pot utiliza '%s' deoarece nu este un fi∫ier local."
+msgstr "Scuze, nu pot utiliza '%s' deoarece nu este un fi≈üier local."
 
-#: dropbox.c:280 pinboard.c:853
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1081,25 +1160,16 @@ msgstr ""
 "Nu pot accesa '%s' :\n"
 "%s"
 
-#: filer.c:453
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
 "%s\n"
 msgstr ""
-"Eroare la scanarea '%s'†:\n"
+"Eroare la scanarea '%s'¬†:\n"
 "%s\n"
 
-#: filer.c:457
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Eroare la scanarea '%s'†:\n"
-"%s"
-
-#: filer.c:562
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1109,355 +1179,414 @@ msgstr ""
 "\n"
 "Demontarea unui dispozitiv face sigura scoaterea discului."
 
-#: filer.c:566
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 #, fuzzy
 msgid "No change"
 msgstr "Nimic"
 
-#: filer.c:572 menu.c:862
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Demonteaza"
 
-#: filer.c:669
-msgid "Directory missing/deleted"
-msgstr "Director lipsa/∫ters"
-
-#: filer.c:1031
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
 "Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"Grupul %s nu este definit. Selecteaza anumite fi∫iere ∫i apasa Ctrl+%s "
-"pentru a seta un grup. Apasa %s pentru a reselecta aceste fi∫iere mai "
+"Grupul %s nu este definit. Selecteaza anumite fi≈üiere ≈üi apasa Ctrl+%s "
+"pentru a seta un grup. Apasa %s pentru a reselecta aceste fi≈üiere mai "
 "tarziu.\n"
 "Asigura-te ca NumLock este activ daca utilizezi o tastatura."
 
-#: filer.c:1267
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Diectorul '%s' nu este accesibil"
+#: filer.c:2655
+msgid "A"
+msgstr "T"
 
-#: filer.c:1419
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Directorul '%s' nu se gase∫te."
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
 
-#: filer.c:1713
-msgid "Cancel"
-msgstr "Anuleaza"
+#: filer.c:2659 find.c:923
+msgid "G"
+msgstr ""
 
-#: filer.c:2002
+#: filer.c:2664
 msgid "S"
 msgstr "L"
 
-#: filer.c:2004
+#: filer.c:2669
 msgid "T"
 msgstr "I"
 
-#: filer.c:2026
-msgid "Scanning, "
-msgstr "Scan‚nd, "
+#: filer.c:2670
+msgid "D"
+msgstr ""
 
-#: filer.c:2028
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
+#, c-format
+msgid "Glob (%s), "
+msgstr ""
+
+#: filer.c:2694
+msgid "Scanning, "
+msgstr "Scan√¢nd, "
+
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Monstre, "
 
-#: filer.c:2304
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Monstre, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Legatura simbolica la "
 
-#: filer.c:2335
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
-msgstr "Numele fi∫ierului nu este UTF-8 valid. Redenume∫te-l\n"
+msgstr "Numele fi≈üierului nu este UTF-8 valid. Redenume≈üte-l\n"
 
-#: filer.c:2643 menu.c:1989
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "Obiectul nu mai exista!"
 
-#: filer.c:3327
+#: filer.c:4451
+msgid "‚ñº"
+msgstr ""
+
+#: filer.c:4451
+msgid "‚ñΩ"
+msgstr ""
+
+#: filer.c:4462
+msgid "‚ñ∑"
+msgstr ""
+
+#: filer.c:4462
+msgid "‚ñ∂"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
-msgstr "Selecteaza proprieta˛ile afi∫ajului pentru a fi salvate"
+msgstr "Selecteaza proprieta≈£ile afi≈üajului pentru a fi salvate"
 
-#: filer.c:3334
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Selecteaza proprieta≈£ile afi≈üajului pentru a fi salvate"
+
+#: filer.c:4727
 msgid "Position"
-msgstr "Pozi˛ie"
+msgstr "Pozi≈£ie"
 
-#: filer.c:3339 toolbar.c:135 toolbar.c:139 tips:63
-msgid "Size"
-msgstr "Dimensiune"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Fereastra"
 
-#: filer.c:3344
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Arata fisierele ascunse"
 
-#: filer.c:3350
-msgid "Display style"
-msgstr "Afi∫eaza stilul"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
+msgstr "Afi≈üeaza stilul"
 
-#: filer.c:3356
+#: filer.c:4749
 #, fuzzy
 msgid "Sort type and order"
 msgstr "Sorteaza dupa tip si ordoneaza"
 
-#: filer.c:3361 toolbar.c:143
+#: filer.c:4754
 msgid "Details"
 msgstr "Detalii"
 
-#: filer.c:3366 tips:114 tips:115
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Monstre"
 
-#: filer.c:3372
+#: filer.c:4765
 msgid "Filter"
 msgstr "Filtru"
 
-#: find.c:487
+#: find.c:485
 msgid "And"
 msgstr "Si"
 
-#: find.c:511
+#: find.c:509
 msgid "Not"
 msgstr "Nu"
 
-#: find.c:554
+#: find.c:552
 msgid "system"
 msgstr "sistem"
 
-#: find.c:562
+#: find.c:560
 msgid "prune"
 msgstr "exclude"
 
-#: find.c:650
+#: find.c:648
 msgid "After"
 msgstr "Dupa"
 
-#: find.c:652
+#: find.c:650
 msgid "Before"
 msgstr "Inainte"
 
-#: find.c:746
+#: find.c:744
 msgid "IsReg"
 msgstr "EsteReg"
 
-#: find.c:748
+#: find.c:746
 msgid "IsLink"
 msgstr "EsteLegatura"
 
-#: find.c:750
+#: find.c:748
 msgid "IsDir"
 msgstr "EsteDirector"
 
-#: find.c:752
+#: find.c:750
 msgid "IsChar"
 msgstr "EsteCaracter"
 
-#: find.c:754
+#: find.c:752
 msgid "IsBlock"
 msgstr "EsteBloc"
 
-#: find.c:756
+#: find.c:754
 msgid "IsDev"
 msgstr "EsteDispozitiv"
 
-#: find.c:758
+#: find.c:756
 msgid "IsPipe"
 msgstr "EsteTeava"
 
-#: find.c:760
+#: find.c:758
 msgid "IsSocket"
 msgstr "EsteSocket"
 
-#: find.c:762
+#: find.c:760
 msgid "IsDoor"
 msgstr "EstePoarta"
 
-#: find.c:764
+#: find.c:762
 msgid "IsSUID"
 msgstr "EsteSUID"
 
-#: find.c:766
+#: find.c:764
 msgid "IsSGID"
 msgstr "EsteSGID"
 
-#: find.c:768
+#: find.c:766
 msgid "IsSticky"
-msgstr "EsteSub˛iat"
+msgstr "EsteSub≈£iat"
 
-#: find.c:770
+#: find.c:768
 msgid "IsReadable"
 msgstr "SePoateCiti"
 
-#: find.c:772
+#: find.c:770
 msgid "IsWriteable"
 msgstr "SePoateScrie"
 
-#: find.c:774
+#: find.c:772
 msgid "IsExecutable"
 msgstr "EsteExecutabil"
 
-#: find.c:776
+#: find.c:774
 msgid "IsEmpty"
 msgstr "EsteGol"
 
-#: find.c:778
+#: find.c:776
 msgid "IsMine"
 msgstr "EsteAlMeu"
 
-#: find.c:906
+#: find.c:904
 msgid "Now"
 msgstr "Acum"
 
-#: find.c:919
+#: find.c:917
 msgid "Byte"
 msgstr "Octet"
 
-#: find.c:919
+#: find.c:917
 msgid "Bytes"
-msgstr "Octe˛i"
+msgstr "Octe≈£i"
 
-#: find.c:921
+#: find.c:919
 msgid "Kb"
 msgstr ""
 
-#: find.c:921
+#: find.c:919
 msgid "K"
 msgstr ""
 
-#: find.c:923
+#: find.c:921
 msgid "Mb"
 msgstr ""
 
-#: find.c:923
+#: find.c:921
 msgid "M"
 msgstr ""
 
-#: find.c:925
+#: find.c:923
 msgid "Gb"
 msgstr ""
 
 #: find.c:925
-msgid "G"
-msgstr ""
-
-#: find.c:927
 msgid "Sec"
 msgstr "Secunda"
 
-#: find.c:927
+#: find.c:925
 msgid "Secs"
 msgstr "Secunde"
 
-#: find.c:929
+#: find.c:927
 msgid "Min"
 msgstr "Minut"
 
-#: find.c:929
+#: find.c:927
 msgid "Mins"
 msgstr "Minute"
 
-#: find.c:931
+#: find.c:929
 msgid "Hour"
 msgstr "Ora"
 
-#: find.c:931
+#: find.c:929
 msgid "Hours"
 msgstr "Ore"
 
-#: find.c:933
+#: find.c:931
 msgid "Day"
 msgstr "Zi"
 
-#: find.c:933
+#: find.c:931
 msgid "Days"
 msgstr "Zile"
 
-#: find.c:935
+#: find.c:933
 msgid "Week"
-msgstr "Saptam‚na"
+msgstr "Saptam√¢na"
+
+#: find.c:933
+msgid "Weeks"
+msgstr "Saptam√¢ni"
 
 #: find.c:935
-msgid "Weeks"
-msgstr "Saptam‚ni"
-
-#: find.c:937
 msgid "Year"
 msgstr "An"
 
-#: find.c:937
+#: find.c:935
 msgid "Years"
 msgstr "Ani"
 
-#: find.c:946
+#: find.c:944
 msgid "Ago"
 msgstr "Pana acum"
 
-#: find.c:948
+#: find.c:946
 msgid "Hence"
 msgstr "De aici incolo"
 
-#: find.c:963
+#: find.c:961
 msgid "atime"
 msgstr "atime"
 
-#: find.c:965
+#: find.c:963
 msgid "ctime"
 msgstr "ctime"
 
-#: find.c:967
+#: find.c:965
 msgid "mtime"
 msgstr "mtime"
 
-#: find.c:969
+#: find.c:967
 msgid "size"
 msgstr "dimensiune"
 
-#: find.c:971
+#: find.c:969
 msgid "inode"
 msgstr "inode"
 
-#: find.c:973
+#: find.c:971
 msgid "nlinks"
 msgstr "nlinks"
 
-#: find.c:975
+#: find.c:973
 msgid "uid"
 msgstr "uid"
 
-#: find.c:977
+#: find.c:975
 msgid "gid"
 msgstr "gid"
 
-#: find.c:979
+#: find.c:977
 msgid "blocks"
 msgstr "blocuri"
 
-#: gtksavebox.c:251
+#: gtksavebox.c:249
 msgid "Save As:"
 msgstr "Salveaza ca:"
 
-#: gtksavebox.c:397
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Fara nume"
 
-#: gtksavebox.c:473
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
 msgstr ""
-"Aplica˛ia Óndepartata vrea sa utilizeze Salvarea directa, dar nu se poate "
+"Aplica≈£ia √Ændepartata vrea sa utilizeze Salvarea directa, dar nu se poate "
 "citi proprietatea XdndDirectSave0 (tip text/plain).\n"
 
-#: gtksavebox.c:598
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
 msgstr ""
-"Trage icoana Óntr-o fereastra a unui director\n"
+"Trage icoana √Æntr-o fereastra a unui director\n"
 "(ori introdu calea completa)"
 
-#: gui_support.c:331
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1465,209 +1594,234 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:400
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr ""
-"Incerc sa citext fi∫ierul XML ca un fi∫ier text. Fi∫ierul '%s' s-ar putea sa "
+"Incerc sa citext fi≈üierul XML ca un fi≈üier text. Fi≈üierul '%s' s-ar putea sa "
 "fie corupt."
 
-#: gui_support.c:417
-#, c-format
+#: gui_support.c:542
+#, fuzzy, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
 "This may be due to upgrading from a previous version of ROX-Filer. Open the "
-"Options window and click on Save.\n"
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
-"Eroare Ón fi∫ierul '%s' la linia %d : \n"
+"Eroare √Æn fi≈üierul '%s' la linia %d : \n"
 "\"%s\"\n"
 "Cauza poate fi din upgradarea de la o versiune anterioara a managerului de "
-"fi∫iere ROX. Deschide fereastra op˛iuni ∫i apasa butonul Salveaza."
+"fi≈üiere ROX. Deschide fereastra op≈£iuni ≈üi apasa butonul Salveaza."
 
-#: gui_support.c:1000
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
-msgstr "Linie incorecta sau lipsa Ón datele text/uri-lista"
+msgstr "Linie incorecta sau lipsa √Æn datele text/uri-lista"
 
-#: gui_support.c:1332
+#: gui_support.c:1473
 #, fuzzy, c-format
 msgid "Failed to open file '%s': %s"
 msgstr ""
 "Imposibil de a desface legatura '%s' :\n"
 "%s"
 
-#: gui_support.c:1376
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
 msgstr ""
 
-#: gui_support.c:1427
+#: gui_support.c:1583
+#, c-format
 msgid ""
-"This program cannot be run, as the 0launch command is not available. It can "
-"be downloaded from here:\n"
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
 
-#: i18n.c:38
+#: i18n.c:39
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
 msgstr ""
-"Pentru ca schimbarea limbii sa aiba efect trebuie salvate schimbarile ∫i "
-"repornit managerul de fi∫iere."
+"Pentru ca schimbarea limbii sa aiba efect trebuie salvate schimbarile ≈üi "
+"repornit managerul de fi≈üiere."
 
-#: icon.c:78
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(apasa pentru a seta)"
 
-#: icon.c:133
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:134 menu.c:252
-msgid "About ROX-Filer..."
-msgstr "Despre ROX-Filer..."
-
-#: icon.c:135 menu.c:253
-msgid "Show Help Files"
-msgstr "Arata fi∫ierele documenta˛ie"
-
-#: icon.c:136 menu.c:254
-msgid "Manual"
-msgstr "Manual"
-
-#: icon.c:138 menu.c:230
-msgid "Options..."
-msgstr "Op˛iuni..."
-
-#: icon.c:139 menu.c:239
-msgid "Home Directory"
-msgstr "Directorul acasa"
-
-#: icon.c:140 icon.c:1340 menu.c:206 type.c:212
-msgid "File"
-msgstr "Fi∫ier"
-
-#: icon.c:141 menu.c:212 menu.c:875
-msgid "Shift Open"
-msgstr "Shift deschide"
-
-#: icon.c:142 menu.c:218
-msgid "Properties"
-msgstr "Proprieta˛i"
-
-#: icon.c:143 menu.c:216
-msgid "Set Run Action..."
-msgstr "Seteaza ac˛iunea de execu˛ie..."
-
-#: icon.c:144 menu.c:217
-msgid "Set Icon..."
-msgstr "Seteaza icoana..."
-
-#: icon.c:145 icon.c:806
-msgid "Edit Item"
-msgstr "Editeaza elementul"
-
-#: icon.c:146
-msgid "Show Location"
-msgstr "Arata loca˛ia"
-
-#: icon.c:147
-msgid "Remove Item(s)"
-msgstr "Indeparteaza elementul(le)"
-
-#: icon.c:278 menu.c:764
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:291
+#: icon.c:311
 msgid "Nothing"
 msgstr "Nimic"
 
-#: icon.c:547
+#: icon.c:576
 msgid "The location must contain at least one character!"
-msgstr "Loca˛ia trebuie sa con˛ina cel pu˛in un caracter!"
+msgstr "Loca≈£ia trebuie sa con≈£ina cel pu≈£in un caracter!"
 
-#: icon.c:613
+#: icon.c:641
+#, c-format
+msgid "You must unlock '%s' before removing it"
+msgstr ""
+
+#: icon.c:651
 msgid "You must first select some items to remove"
-msgstr "Trebuie Óntai sa selectezi anumite elemente pentru a fi Óndepartate"
+msgstr "Trebuie √Æntai sa selectezi anumite elemente pentru a fi √Ændepartate"
 
-#: icon.c:627
+#: icon.c:657
+msgid "An item must be unlocked before it can be removed."
+msgstr ""
+
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Trebuie sa deschizi un meniu deasupra unui element"
 
-#: icon.c:652 menu.c:1260
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
-msgstr "Po˛i selecta doar ac˛iunea de execu˛ie a unui fi∫ier normal"
+msgstr "Po≈£i selecta doar ac≈£iunea de execu≈£ie a unui fi≈üier normal"
 
-#: icon.c:738
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Apasa pe legatura dorita (ex, Control+F1)"
 
-#: icon.c:760
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Imposibil de captat evenimentul de la tastatura!"
 
-#: icon.c:809
-msgid "Clicking the icon opens:"
-msgstr "Apas‚nd pe icoana se deschide:"
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Editeaza elementul"
 
-#: icon.c:819
+#: icon.c:853
+msgid "Clicking the icon opens:"
+msgstr "Apas√¢nd pe icoana se deschide:"
+
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr ""
 
-#: icon.c:833
+#: icon.c:877
 msgid "The text displayed under the icon is:"
-msgstr "Textul afi∫at sub icoana este:"
+msgstr "Textul afi≈üat sub icoana este:"
 
-#: icon.c:846
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "Scurtatura pentru tastatura este:"
 
-#: infobox.c:112
-#, c-format
-msgid "Are you sure you want to open %d windows?"
-msgstr "E∫ti sigur ca vrei sa deschizi fereastra %d ?"
+#: icon.c:910
+#, fuzzy
+msgid "Locked"
+msgstr "Socket"
+
+#: icon.c:915
+msgid "Locking an item prevents it from being accidentally removed"
+msgstr ""
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Despre ROX-Filer..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Arata fi≈üierele documenta≈£ie"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Manual"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Op≈£iuni..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Directorul acasa"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Fi≈üier"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Shift deschide"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Proprieta≈£i"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Seteaza ac≈£iunea de execu≈£ie..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Seteaza icoana..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Arata loca≈£ia"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Indeparteaza elementul(le)"
 
 #: infobox.c:113
-msgid "Show Info"
-msgstr "Arata fereastra cu informa˛ii"
+#, c-format
+msgid "Are you sure you want to open %d windows?"
+msgstr "E≈üti sigur ca vrei sa deschizi fereastra %d ?"
 
-#: infobox.c:135 menu.c:769
+#: infobox.c:114
+msgid "Show Info"
+msgstr "Arata fereastra cu informa≈£ii"
+
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(utf-8 incorect)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
-msgstr "Arata fi∫ierele cu _documenta˛ie"
+msgstr "Arata fi≈üierele cu _documenta≈£ie"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Drepturi</b>"
 
-#: infobox.c:286
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
-msgstr "<b>Con˛inutul indica...</b>"
+msgstr "<b>Con≈£inutul indica...</b>"
 
-#: infobox.c:423 infobox.c:560 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Numai directoarele log vor fi ≈üterse"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
-msgstr "octe˛i"
+msgstr "octe≈£i"
 
-#: infobox.c:446
+#: infobox.c:480
 #, fuzzy
 msgid "Failed to read size"
 msgstr "Imposibil de scanat"
 
-#: infobox.c:504
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' nu mai este o legatura simbolica"
 
-#: infobox.c:511
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1676,7 +1830,7 @@ msgstr ""
 "Imposibil de a desface legatura '%s' :\n"
 "%s"
 
-#: infobox.c:516
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1685,148 +1839,197 @@ msgid ""
 msgstr ""
 "Imposibil de creat legatura simbolica din '%s' :\n"
 "%s\n"
-"(nota: vechea legatura a fost ∫tearsa)"
+"(nota: vechea legatura a fost ≈ütearsa)"
 
-#: infobox.c:539 tips:270
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Eroare:"
 
-#: infobox.c:546
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Directorul real:"
 
-#: infobox.c:549
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Proprietar, grup:"
 
-#: infobox.c:556 infobox.c:571 infobox.c:580
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Dimensiune:"
 
-#: infobox.c:581
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Scaneaza"
 
-#: infobox.c:602
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Imposibil de scanat"
 
-#: infobox.c:609
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Data ultimei shimbari:"
 
-#: infobox.c:611
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Data ultimei modificari:"
 
-#: infobox.c:613
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Data ultimului acces:"
 
-#: infobox.c:621
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr ""
 
-#: infobox.c:623
+#: infobox.c:667
 msgid "Present"
 msgstr ""
 
-#: infobox.c:624
+#: infobox.c:668
 msgid "None"
 msgstr "Nimic"
 
-#: infobox.c:625
+#: infobox.c:669
 #, fuzzy
 msgid "Not supported"
 msgstr "Suport dnotify"
 
-#: infobox.c:637
+#: infobox.c:681
 msgid "Link target:"
-msgstr "Destina˛ia legaturii:"
+msgstr "Destina≈£ia legaturii:"
 
-#: infobox.c:649 infobox.c:652
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
-msgstr "Executa ac˛iunea:"
+msgstr "Executa ac≈£iunea:"
 
-#: infobox.c:649
+#: infobox.c:693
 msgid "Execute file"
-msgstr "Excuta fi∫ierul"
+msgstr "Excuta fi≈üierul"
 
-#: infobox.c:744
+#: infobox.c:805
+#, fuzzy
+msgid "Comment"
+msgstr "Comanda:"
+
+#: infobox.c:807
+#, fuzzy
+msgid "Execute"
+msgstr "Excuta fi≈üierul"
+
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<nimica inca>"
 
-#: infobox.c:814
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "file(1) zice... %s"
 
-#: infobox.c:871
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Nu pot schimba drepturile: %s"
 
-#: infobox.c:889
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Proprietar"
 
-#: infobox.c:891
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Grup"
 
-#: infobox.c:893
+#: infobox.c:974
 msgid "World"
 msgstr "Lumea"
 
-#: infobox.c:896
+#: infobox.c:977
 msgid "Read"
-msgstr "Cite∫te"
+msgstr "Cite≈üte"
 
-#: infobox.c:898
+#: infobox.c:980
 msgid "Write"
 msgstr "Scrie"
 
-#: infobox.c:900
+#: infobox.c:983
 msgid "Exec"
 msgstr "Executa"
 
-#: infobox.c:917
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:924
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:931
+#: infobox.c:1015
 msgid "Sticky"
-msgstr "Sub˛iat"
+msgstr "Sub≈£iat"
 
-#: infobox.c:953
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<nimic>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Legatura simbolica"
 
-#: infobox.c:956
+#: infobox.c:1092
 msgid "ROX application"
-msgstr "Aplica˛ia ROX"
+msgstr "Aplica≈£ia ROX"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "mounted"
 msgstr "montat"
 
-#: infobox.c:964
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "demontat"
 
-#: infobox.c:968
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Punctul de montare pentru %s (%s)"
 
-#: infobox.c:971
+#: infobox.c:1107
 #, fuzzy, c-format
 msgid "Mount point (%s)"
 msgstr "Punct de montare (%s)"
+
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d obiecte"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Copiaza..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "Editeaza elementul"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Data & timp"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Op≈£iuni"
 
 #: main.c:95
 #, fuzzy
@@ -1839,19 +2042,19 @@ msgid ""
 "For more information about these matters, see the file named COPYING.\n"
 msgstr ""
 "Drept de autor (C) 2003 Thomas Leonard.\n"
-"ROX-Filer este distribuit fara nici o garan˛ie,\n"
-"Ón condi˛iile prevazute de lege.\n"
-"Po˛i redistribui copii ale managerului de fi∫iere ROX-Filer\n"
-"sub condi˛iile Licen˛ei publice generale GNU.\n"
-"Pentru mai multe informa˛ii vezi fi∫ierul COPYING.\n"
+"ROX-Filer este distribuit fara nici o garan≈£ie,\n"
+"√Æn condi≈£iile prevazute de lege.\n"
+"Po≈£i redistribui copii ale managerului de fi≈üiere ROX-Filer\n"
+"sub condi≈£iile Licen≈£ei publice generale GNU.\n"
+"Pentru mai multe informa≈£ii vezi fi≈üierul COPYING.\n"
 
 #: main.c:104
 msgid "Try `ROX-Filer/AppRun --help' for more information.\n"
-msgstr "Incerca `AppRun --help' pentru mai multe informa˛ii.\n"
+msgstr "Incerca `AppRun --help' pentru mai multe informa≈£ii.\n"
 
 #: main.c:107
 msgid "Try `ROX-Filer/AppRun -h' for more information.\n"
-msgstr "Incerca `AppRun -h' pentru mai multe informa˛ii.\n"
+msgstr "Incerca `AppRun -h' pentru mai multe informa≈£ii.\n"
 
 #: main.c:109
 msgid ""
@@ -1859,12 +2062,12 @@ msgid ""
 "you must use the short versions instead.\n"
 "\n"
 msgstr ""
-"NOTE : votre systËme ne supporte pas les options longues - \n"
-"vous devez utiliser les versions courtes ‡ la place.\n"
+"NOTE : votre systƒçme ne supporte pas les options longues - \n"
+"vous devez utiliser les versions courtes ≈ï la place.\n"
 "\n"
 
 #: main.c:115
-#, fuzzy
+#, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Open each directory or file listed, or the current working\n"
@@ -1886,42 +2089,38 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
-"Report bugs to "
-msgstr ""
-"Syntaxe : ROX-Filer/AppRun [OPTION]... [FICHIER]...\n"
-"Ouvre chaque rÈpertoire ou fichier listÈ, ou le rÈpertoire de travail\n"
-"courant si aucun argument n'est donnÈ.\n"
-"\n"
-"  -b, --bottom=PANNEAU\touvre PANNEAU en bas comme panneau\n"
-"  -c, --client-id=ID\tutilisÈ pour la gestion de sessions\n"
-"  -d, --dir=R…PERTOIRE\touvre R…PERTOIRE comme rÈpertoire (pas application)\n"
-"  -D, --close=R…P\tferme R…PERTOIRE et ses sous-rÈpertoires\n"
-"  -h, --help\t\taffiche cette aide et quitte\n"
-"  -l, --left=PANNEAU\touvre PANNEAU ‡ gauche comme panneau\n"
-"  -m, --mime-type=FICH\taffiche le type MIME de FICHIER et quitte\n"
-"  -n, --new\t\tlance une nouvelle copie†; pour dÈbugger le filer\n"
-"  -p, --pinboard=PUN\tutilise le punaiseur PUN comme punaiseur\n"
-"  -r, --right=PANNEAU\touvre PANNEAU ‡ droite comme panneau\n"
-"  -R, --RPC\t\tinvoque la mÈthode d'appel lue sur stdin\n"
-"  -s, --show=FICHIER\touvre un rÈpertoire montrant FICHIER\n"
-"  -t, --top=PANNEAU\touvre PANNEAU en haut comme panneau\n"
-"  -u, --user\t\taffiche le nom de l'utilisateur dans chaque fenÍtre\n"
-"  -v, --version\t\taffiche les info concernant cette version et quitte\n"
-"  -x, --examine=FICH\tFICHIER a changÈ - le rÈ-examiner\n"
-"\n"
-"Rendre compte des bugs ‡ <tal197@users.sourceforge.net>.\n"
-"Page web (dont les versions mises ‡ jour): http://rox.sourceforge.net/\n"
-
-#: main.c:136
-msgid ""
-".\n"
+"Report bugs to %s.\n"
 "Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
+"Syntaxe : ROX-Filer/AppRun [OPTION]... [FICHIER]...\n"
+"Ouvre chaque r√©pertoire ou fichier list√©, ou le r√©pertoire de travail\n"
+"courant si aucun argument n'est donn√©.\n"
+"\n"
+"  -b, --bottom=PANNEAU\touvre PANNEAU en bas comme panneau\n"
+"  -c, --client-id=ID\tutilis√© pour la gestion de sessions\n"
+"  -d, --dir=R√âPERTOIRE\touvre R√âPERTOIRE comme r√©pertoire (pas application)\n"
+"  -D, --close=R√âP\tferme R√âPERTOIRE et ses sous-r√©pertoires\n"
+"  -h, --help\t\taffiche cette aide et quitte\n"
+"  -l, --left=PANNEAU\touvre PANNEAU ≈ï gauche comme panneau\n"
+"  -m, --mime-type=FICH\taffiche le type MIME de FICHIER et quitte\n"
+"  -n, --new\t\tlance une nouvelle copie¬†; pour d√©bugger le filer\n"
+"  -p, --pinboard=PUN\tutilise le punaiseur PUN comme punaiseur\n"
+"  -r, --right=PANNEAU\touvre PANNEAU ≈ï droite comme panneau\n"
+"  -R, --RPC\t\tinvoque la m√©thode d'appel lue sur stdin\n"
+"  -s, --show=FICHIER\touvre un r√©pertoire montrant FICHIER\n"
+"  -t, --top=PANNEAU\touvre PANNEAU en haut comme panneau\n"
+"  -u, --user\t\taffiche le nom de l'utilisateur dans chaque fenƒôtre\n"
+"  -v, --version\t\taffiche les info concernant cette version et quitte\n"
+"  -x, --examine=FICH\tFICHIER a chang√© - le r√©-examiner\n"
+"\n"
+"Rendre compte des bugs ≈ï <tal197@users.sourceforge.net>.\n"
+"Page web (dont les versions mises ≈ï jour): http://rox.sourceforge.net/\n"
 
-#: main.c:234
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1929,286 +2128,384 @@ msgid ""
 "Trying to continue..."
 msgstr ""
 
-#: main.c:382
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
 msgstr "Argumentul -o nu mai este folosit."
 
-#: main.c:489
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Ruleaza ca utilizator '%s'"
 
-#: main.c:666
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Compilat cu GTK versiunea %s\n"
 
-#: main.c:667
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Ruleaza cu GTK versiunean %d.%d.%d\n"
 
-#: main.c:671
-msgid "features set at compile time"
-msgstr "func˛ionalita˛i fixate Ón timpul compilarii"
-
-#: main.c:672
-msgid "Large File Support"
-msgstr "Suport pentru fi∫iere mari"
-
-#: main.c:679
-msgid "GNOME-VFS library"
-msgstr "biblioteca GNOME-VFS"
-
-#: main.c:683
-msgid "No (need 2.8.0 or later)"
-msgstr ""
-
-#: main.c:686
-msgid "Dnotify support"
-msgstr "Suport dnotify"
-
 #: main.c:693
+msgid "features set at compile time"
+msgstr "func≈£ionalita≈£i fixate √Æn timpul compilarii"
+
+#: main.c:694
+msgid "Large File Support"
+msgstr "Suport pentru fi≈üiere mari"
+
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Compatibilitate binara"
 
-#: main.c:695
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Da (poate rula cu versiuni mai vechi ale glibc)"
 
-#: main.c:697
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Nu (apsymbols.h nu este gasit)"
 
-#: menu.c:180 tips:52
-msgid "Display"
-msgstr "Afi∫aj"
+#: main.c:709
+#, fuzzy
+msgid "Extended attribute support"
+msgstr "Nu utiliza numele gazdei"
 
-#: menu.c:181 tips:57
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr ""
+"Imposibil de a desface legatura '%s' :\n"
+"%s"
+
+#: main.c:895
+#, c-format
+msgid ""
+"Left-click to run %s.\n"
+"Right-click for a list of versions."
+msgstr ""
+
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Eroare la crearea '%s'¬†: %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Salveaza ca:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
+msgid "Display"
+msgstr "Afi≈üaj"
+
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "Sub forma de icoane"
 
-#: menu.c:182
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "Icoane, cu..."
 
-#: menu.c:183 tips:74
-msgid "Sizes"
-msgstr "Dimensiuni"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Tema icoanelor"
 
-#: menu.c:185 tips:254
-msgid "Types"
-msgstr "Tipuri"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Drepturi"
 
-#: menu.c:186 tips:77
-msgid "Times"
-msgstr "Data & timp"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Icoane, cu..."
 
-#: menu.c:187 tips:58 tips:92
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "Sub forma de lista"
 
-#: menu.c:189
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "Icoane mari"
 
-#: menu.c:190
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "Icoane mici"
 
-#: menu.c:191 tips:71
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Automatic"
 
-#: menu.c:193
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Sorteaza dupa nume"
 
-#: menu.c:194
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Sorteaza dupa tip"
 
-#: menu.c:195
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Sorteaza dupa data"
 
-#: menu.c:196
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Sorteaza dupa data"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Sorteaza dupa data"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Sorteaza dupa dimensiune"
 
-#: menu.c:197
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Drepturi"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "Sorteaza dupa proprietar"
 
-#: menu.c:198
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "Sorteaza dupa grup"
 
-#: menu.c:199
+#: menu.c:671
 msgid "Reversed"
 msgstr "Invers"
 
-#: menu.c:201
+#: menu.c:675
 msgid "Show Hidden"
-msgstr "Arata fi∫ierele ascunse"
+msgstr "Arata fi≈üierele ascunse"
 
-#: menu.c:202
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Arata fi≈üierele documenta≈£ie"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "nu exista directoarele)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
-msgstr "Filtreaza fi∫ierele..."
+msgstr "Filtreaza fi≈üierele..."
 
-#: menu.c:203
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Filtreaza fi≈üierele..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
 msgid "Show Thumbnails"
-msgstr "Arata monstre din fi∫iere imagine"
+msgstr "Arata monstre din fi≈üiere imagine"
 
-#: menu.c:204
+#: menu.c:683
 msgid "Refresh"
 msgstr "Actualizeaza"
 
-#: menu.c:205
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Actualizeaza"
+
+#: menu.c:686
 msgid "Save Display Settings..."
-msgstr "Salveaza setarile afi∫ajului..."
+msgstr "Salveaza setarile afi≈üajului..."
 
-#: menu.c:207
-msgid "Copy..."
-msgstr "Copiaza..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Salveaza setarile afi≈üajului..."
 
-#: menu.c:208
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Numara"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
-msgstr "Redenume∫te..."
+msgstr "Redenume≈üte..."
 
-#: menu.c:209
+#: menu.c:700
 msgid "Link..."
 msgstr "Leaga..."
 
-#: menu.c:213
-msgid "Open AVFS"
-msgstr "Deschide AVFS"
-
-#: menu.c:214
+#: menu.c:708
 msgid "Send To..."
 msgstr "Trimite la..."
 
-#: menu.c:219
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Nu utiliza numele gazdei"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Numara"
 
-#: menu.c:220
+#: menu.c:723
 msgid "Set Type..."
 msgstr "Seteaza tipul..."
 
-#: menu.c:224 toolbar.c:155
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Selecteaza"
 
-#: menu.c:225
+#: menu.c:733
 msgid "Select All"
 msgstr "Selecteaza tot"
 
-#: menu.c:226
+#: menu.c:735
 msgid "Clear Selection"
-msgstr "Sterge selec˛ia"
+msgstr "Sterge selec≈£ia"
 
-#: menu.c:227
+#: menu.c:736
 msgid "Invert Selection"
-msgstr "Inverseaza selec˛ia"
+msgstr "Inverseaza selec≈£ia"
 
-#: menu.c:228
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "Selectaza dupa nume..."
 
-#: menu.c:229
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Selecteaza daca..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Selecteaza daca..."
 
-#: menu.c:231
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Nou"
 
-#: menu.c:233
+#: menu.c:752
 msgid "Blank file"
-msgstr "Fi∫ier gol"
+msgstr "Fi≈üier gol"
 
-#: menu.c:235 tasklist.c:308
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Fereastra"
 
-#: menu.c:236
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "Parinte, fereastra noua"
 
-#: menu.c:237
+#: menu.c:759
 msgid "Parent, Same Window"
-msgstr "Parinte, acea∫i fereastra"
+msgstr "Parinte, acea≈üi fereastra"
 
-#: menu.c:238
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "Fereastra noua"
 
-#: menu.c:240
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "Arata semnele"
 
-#: menu.c:241
-msgid "Follow Symbolic Links"
-msgstr "Urmare∫te legatura simbolica"
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Arata fereastra cu informa≈£ii"
 
-#: menu.c:242
+#: menu.c:768
+msgid "Follow Symbolic Links"
+msgstr "Urmare≈üte legatura simbolica"
+
+#: menu.c:769
 msgid "Resize Window"
 msgstr "Redimensioneaza fereastra"
 
-#: menu.c:245
+#: menu.c:771
 msgid "Close Window"
 msgstr "Inchide fereastra"
 
-#: menu.c:247
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Introdu calea..."
 
-#: menu.c:248
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Comanda shell..."
 
-#: menu.c:249
-msgid "Xterm Here"
+#: menu.c:780
+#, fuzzy
+msgid "Terminal Here"
 msgstr "Xterm aici"
 
-#: menu.c:250
-msgid "Switch to xterm"
+#: menu.c:782
+#, fuzzy
+msgid "Switch to Terminal"
 msgstr "Comuta pe xterm"
 
-#: menu.c:718
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr ""
-"Trebuie sa execu˛i Shift+click pe meniu pentru atrimite fi∫ierul undeva"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "PersonalizeazƒÉ meniul..."
 
-#: menu.c:754
+#: menu.c:976
 msgid "Next Click"
 msgstr "Urmatorul click"
 
-#: menu.c:776
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d obiecte"
 
-#: menu.c:864
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "Deschide nemontat"
 
-#: menu.c:867
+#: menu.c:1097
 msgid "Show Target"
-msgstr "Arata destina˛ia"
+msgstr "Arata destina≈£ia"
 
-#: menu.c:869
+#: menu.c:1099
 msgid "Look Inside"
-msgstr "Prive∫te Ón interior"
+msgstr "Prive≈üte √Æn interior"
 
-#: menu.c:871
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "Deschide ca text"
 
-#: menu.c:1031
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2217,15 +2514,15 @@ msgid ""
 "mount option ('user_xattr' on Linux)."
 msgstr ""
 
-#: menu.c:1037
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr ""
 
-#: menu.c:1072
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "_Legatura relativa"
 
-#: menu.c:1078
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2233,50 +2530,63 @@ msgid ""
 "may move but the target will stay put."
 msgstr ""
 "Daca este activa, legatura simbolica va pastra calea de la legatura la "
-"fi∫ieryl destina˛ie. Utilizeaza aceasta daca legatura ∫i destina˛ia vor fi "
-"mutate Ónpreuna.\n"
+"fi≈üieryl destina≈£ie. Utilizeaza aceasta daca legatura ≈üi destina≈£ia vor fi "
+"mutate √Ænpreuna.\n"
 "Daca este inactiva, va fi pastrata calea de la directorul radacina - "
-"utilizeaza aceasta daca legatura poate fi mutata dar destina˛ia nu."
+"utilizeaza aceasta daca legatura poate fi mutata dar destina≈£ia nu."
 
-#: menu.c:1148
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "Calea noua nu este absoluta"
 
-#: menu.c:1214
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr ""
-"Legatura simbolica de la '%s' exista deja. Inlocuie∫te-o cu o legatura la '%"
-"s' ?"
+"Legatura simbolica de la '%s' exista deja. Inlocuie≈üte-o cu o legatura la "
+"'%s' ?"
 
-#: menu.c:1220
+#: menu.c:1546
 msgid "_Replace"
-msgstr "_Inlocuie∫te"
+msgstr "_Inlocuie≈üte"
 
-#: menu.c:1351 menu.c:1392 menu.c:1452
-msgid "Create"
-msgstr "Creaza"
-
-#: menu.c:1352
+#: menu.c:1704
 msgid "NewDir"
 msgstr "DirectorNou"
 
-#: menu.c:1366 menu.c:1372
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Eroare la crearea '%s'†: %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Creaza"
 
-#: menu.c:1393
+#: menu.c:1755
 msgid "NewFile"
-msgstr "Fi∫ierNou"
+msgstr "Fi≈üierNou"
 
-#: menu.c:1411
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
-msgstr "Eroare Ón crearea fi∫ierului†: nu pot gasi modelul pentru %s"
+msgstr "Eroare √Æn crearea fi≈üierului¬†: nu pot gasi modelul pentru %s"
 
-#: menu.c:1482
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"LeagƒÉ orice program vrei in acest director. Vor apƒÉrea √Æn meniu pentru toate "
+"elementele de acest tip (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2288,35 +2598,36 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
-"Meniul 'Trimite la' furnizeaza cale rapida pentru a trimite un fi∫ier unei "
-"aplica˛ii. Aplica˛iile sunt acelea listate Ón urmatoarele directoare:\n"
+"Meniul 'Trimite la' furnizeaza cale rapida pentru a trimite un fi≈üier unei "
+"aplica≈£ii. Aplica≈£iile sunt acelea listate √Æn urmatoarele directoare:\n"
 "\n"
 "%s\n"
 "%s\n"
-"Meniul 'Trimite la' poate fi deschis prin Shift+click Ón meniu pe un "
-"fi∫ier.\n"
+"Meniul 'Trimite la' poate fi deschis prin Shift+click √Æn meniu pe un "
+"fi≈üier.\n"
 "\n"
 "Utilizare avansata:\n"
-"Po˛i crea de asemenea subdirectoare numite `.text_html', `.text', etc. care "
-"vor fi afi∫ate numai pentru fi∫iere de acest tip. '.group' este afi∫at numai "
-"c‚nd sun selectate mai multe fi∫iere."
+"Po≈£i crea de asemenea subdirectoare numite `.text_html', `.text', etc. care "
+"vor fi afi≈üate numai pentru fi≈üiere de acest tip. '.group' este afi≈üat numai "
+"c√¢nd sun selectate mai multe fi≈üiere."
 
-#: menu.c:1493
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
 msgstr ""
-"I-˛i voi arata directorul TrimiteLa; trebuie sa legi (Ctrl+Shift trage) "
-"orice aplica˛ie vrei Ón el."
+"I-≈£i voi arata directorul TrimiteLa; trebuie sa legi (Ctrl+Shift trage) "
+"orice aplica≈£ie vrei √Æn el."
 
-#: menu.c:1496 menu.c:1536
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr "Setarea variabilei CHOICESPATH nu permite modificari - scuze."
 
-#: menu.c:1529
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2328,100 +2639,134 @@ msgid ""
 "%s\n"
 msgstr ""
 
-#: menu.c:1534
+#: menu.c:1936
 #, fuzzy
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
 msgstr ""
-"I-˛i voi arata directorul TrimiteLa; trebuie sa legi (Ctrl+Shift trage) "
-"orice aplica˛ie vrei Ón el."
+"I-≈£i voi arata directorul TrimiteLa; trebuie sa legi (Ctrl+Shift trage) "
+"orice aplica≈£ie vrei √Æn el."
 
-#: menu.c:1651
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Personalizeaza"
 
-#: menu.c:1717
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "PersonalizeazƒÉ meniul..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Acesta este deja un nume canonic pentru acest director."
 
-#: menu.c:1748
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
 msgstr ""
-"Nu po˛i deschide a doua fereastra a acestui director deoarece a fost "
-"selectata op˛iunea 'Fereastra unica' Ón ferestra op˛iuni."
+"Nu po≈£i deschide a doua fereastra a acestui director deoarece a fost "
+"selectata op≈£iunea 'Fereastra unica' √Æn ferestra op≈£iuni."
 
-#: menu.c:1869
-msgid "Copy ... ?"
-msgstr "Copiaza ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1872
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Copiaza %s ca %s ?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Copiaza %s ca %s ?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
-msgstr "Redenume∫te ... ?"
+msgstr "Redenume≈üte ... ?"
 
-#: menu.c:1875
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Legatura simbolica ... ?"
 
-#: menu.c:1878
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Shift deschide ... ?"
 
-#: menu.c:1881
+#: menu.c:2468
 msgid "Properties of ... ?"
-msgstr "Proprieta˛ile ... ?"
+msgstr "Proprieta≈£ile ... ?"
 
-#: menu.c:1884
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Nu utiliza numele gazdei"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Seteaza tipul la ... ?"
 
-#: menu.c:1887
+#: menu.c:2479
 msgid "Set run action for ... ?"
-msgstr "Seteaza ac˛iunea de execu˛ie pentru ... ?"
+msgstr "Seteaza ac≈£iunea de execu≈£ie pentru ... ?"
 
-#: menu.c:1890
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Seteaza icoana pentru ... ?"
 
-#: menu.c:1893
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Trimite ... la ... ?"
 
-#: menu.c:1896
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "STERGE ... ?"
 
-#: menu.c:1899
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Calculeaza dimensiunea pentru ... ?"
 
-#: menu.c:1902
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Seteaza drepturile ... ?"
 
-#: menu.c:1905
+#: menu.c:2497
 msgid "Search inside ... ?"
-msgstr "Cauta Ón interior ... ?"
+msgstr "Cauta √Æn interior ... ?"
 
-#: menu.c:1908
-msgid "Look inside ... ?"
-msgstr "Prive∫te Ón interior ... ?"
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Copiaza ... ?"
 
-#: menu.c:1972
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
-msgstr "Nu po˛i face asta de mai multe ori Ón acela∫i timp"
+msgstr "Nu po≈£i face asta de mai multe ori √Æn acela≈üi timp"
 
-#: menu.c:2004
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
-msgstr "Redenume∫te"
+msgstr "Redenume≈üte"
 
-#: menu.c:2009
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Legatura simbolica"
 
-#: menu.c:2041
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2433,17 +2778,17 @@ msgid ""
 "\tgtk-can-change-accels = 1\n"
 "\t(this only works if NOT using XSETTINGS)"
 msgstr ""
-"Scurtaturile definite de utilizator sunt dezactivate implicit Ón GTK2, ∫i nu "
-"po˛i sa-l activezi. Po˛i sa activezi aceasta op˛iune prin:\n"
+"Scurtaturile definite de utilizator sunt dezactivate implicit √Æn GTK2, ≈üi nu "
+"po≈£i sa-l activezi. Po≈£i sa activezi aceasta op≈£iune prin:\n"
 "\n"
-"1) utiliz‚nd un manger XSettings, ca ROX-Session sau gnome-settings-daemon, "
+"1) utiliz√¢nd un manger XSettings, ca ROX-Session sau gnome-settings-daemon, "
 "ori\n"
 "\n"
-"2) adaug‚nd aceasta linie Ón ~/.gtkrc-2.0†:\n"
+"2) adaug√¢nd aceasta linie √Æn ~/.gtkrc-2.0¬†:\n"
 "\tgtk-can-change-accels = 1\n"
-"\t(aceasta func˛ioneaza daca nu se utilizeaza XSettings)"
+"\t(aceasta func≈£ioneaza daca nu se utilizeaza XSettings)"
 
-#: menu.c:2052
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2456,53 +2801,82 @@ msgid ""
 msgstr ""
 "Pentru a seta o scurtatura catre tastatura a unui element al meniului:\n"
 "\n"
-"- deschide meniul Óntr-o fereastra a managerului de fi∫iere,\n"
+"- deschide meniul √Æntr-o fereastra a managerului de fi≈üiere,\n"
 "- muta indicatorul mouse-ului deasupra elemntului dorit,\n"
-"- apasa tasta pe care vrei sa o ata∫ezi.\n"
+"- apasa tasta pe care vrei sa o ata≈üezi.\n"
 "\n"
-"Tasta va aparea l‚nga elementul de meniu ∫i po˛i apasa tasta fara a deschide "
+"Tasta va aparea l√¢nga elementul de meniu ≈üi po≈£i apasa tasta fara a deschide "
 "meniul."
 
-#: menu.c:2067
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Seteaza scurtaturile pentru tastatura"
 
-#: minibuffer.c:131
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Dute la:"
 
-#: minibuffer.c:132
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Shell:"
 
-#: minibuffer.c:133
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Selecteaza daca:"
 
-#: minibuffer.c:134
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Selecteaza dupa nume:"
 
-#: minibuffer.c:135
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Selecteaza daca:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Tipar:"
 
-#: minibuffer.c:264
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
 msgstr ""
-"Introdu numele unui fi∫ier ∫i fi∫ierul va fi afi∫at. Apasa tasta Tab pentru "
-"a gasi cea mai lunga potrivire. Apasa tasta Esc pentru a ∫nchide minibuffer."
+"Introdu numele unui fi≈üier ≈üi fi≈üierul va fi afi≈üat. Apasa tasta Tab pentru "
+"a gasi cea mai lunga potrivire. Apasa tasta Esc pentru a ≈ünchide minibuffer."
 
-#: minibuffer.c:270
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
-"Introdu o comanda shell pentru afi executata. Fa click pe un fi∫ier pentru "
+"Introdu o comanda shell pentru afi executata. Fa click pe un fi≈üier pentru "
 "afi adaugat la buffer."
 
-#: minibuffer.c:275
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Introdu un tipar pentru a selecta fi≈üierele care se potrivesc:\n"
+"\n"
+"? √Ænseamna orice caracter\n"
+"* √Ænseamna zero sau mai multe caractere\n"
+"[aA] √Ænseamna 'a' ori 'A'\n"
+"[a-z] √Ænseamna toate caracterele de la a la z (litere mici)\n"
+"*.png √Ænseamna orice nume care se termina cu '.png'"
+
+#: minibuffer.c:340
 #, fuzzy
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
@@ -2513,188 +2887,204 @@ msgid ""
 "[a-z] means any character from a to z (lowercase)\n"
 "*.png means any name ending in '.png'"
 msgstr ""
-"Introdu un tipar pentru a selecta fi∫ierele care se potrivesc:\n"
+"Introdu un tipar pentru a selecta fi≈üierele care se potrivesc:\n"
 "\n"
-"? Ónseamna orice caracter\n"
-"* Ónseamna zero sau mai multe caractere\n"
-"[aA] Ónseamna 'a' ori 'A'\n"
-"[a-z] Ónseamna toate caracterele de la a la z (litere mici)\n"
-"*.png Ónseamna orice nume care se termina cu '.png'"
+"? √Ænseamna orice caracter\n"
+"* √Ænseamna zero sau mai multe caractere\n"
+"[aA] √Ænseamna 'a' ori 'A'\n"
+"[a-z] √Ænseamna toate caracterele de la a la z (litere mici)\n"
+"*.png √Ænseamna orice nume care se termina cu '.png'"
 
-#: minibuffer.c:287
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
 msgstr ""
-"Introdu un tipar pentru a afi∫a fi∫ierele care se potrivesc. Un filtru gol "
+"Introdu un tipar pentru a afi≈üa fi≈üierele care se potrivesc. Un filtru gol "
 "dezactiveaza filtrarea."
 
-#: minibuffer.c:895
-msgid "Invalid Find condition"
-msgstr "Condi˛ie de cautare invalida"
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Introdu un tipar pentru a afi≈üa fi≈üierele care se potrivesc. Un filtru gol "
+"dezactiveaza filtrarea."
 
-#: mount.c:374
+#: minibuffer.c:1045
+msgid "Invalid Find condition"
+msgstr "Condi≈£ie de cautare invalida"
+
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr ""
 
-#: options.c:277
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr ""
-"Managerul de fi∫iere ROX-Filer a convertit fi∫ierul de Op˛iuni Ón noul "
+"Managerul de fi≈üiere ROX-Filer a convertit fi≈üierul de Op≈£iuni √Æn noul "
 "format XML"
 
-#: options.c:535 options.c:1258
+#: options.c:560 options.c:1250
 msgid "(use default)"
-msgstr "(folose∫te setarile implicite)"
+msgstr "(folose≈üte setarile implicite)"
 
-#: options.c:806
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
-msgstr "Eroare interna†: %s nedisponibila"
+msgstr "Eroare interna¬†: %s nedisponibila"
 
-#: options.c:917
+#: options.c:929
 msgid "Options"
-msgstr "Op˛iuni"
+msgstr "Op≈£iuni"
 
-#: options.c:962
+#: options.c:974
 msgid "_Revert"
 msgstr "_Revenire"
 
-#: options.c:968
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr ""
-"Restabile∫te toate op˛iunile la fel cum au fost c‚nd a fost deschisa "
-"fereastra Op˛iuni."
+"Restabile≈üte toate op≈£iunile la fel cum au fost c√¢nd a fost deschisa "
+"fereastra Op≈£iuni."
 
-#: options.c:983
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
 "%s"
 msgstr ""
-"Op˛iunile vor fi salvate ca:\n"
+"Op≈£iunile vor fi salvate ca:\n"
 "%s"
 
-#: options.c:991
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(salvarea dezactivata de CHOICESPATH)"
 
-#: options.c:1164 usericons.c:450
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
-msgstr "Eroare salv‚nd %s: %s"
+msgstr "Eroare salv√¢nd %s: %s"
 
-#: options.c:1794
+#: options.c:1813
 msgid "Missing '='"
-msgstr "Lipse∫te '='"
+msgstr "Lipse≈üte '='"
 
-#: panel.c:439
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr ""
+"Imposibil de a desface legatura '%s' :\n"
+"%s"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
-msgstr "Fi∫ierul vechi al panoului a fost convertit Ón noul format XML."
+msgstr "Fi≈üierul vechi al panoului a fost convertit √Æn noul format XML."
 
-#: panel.c:546
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
 msgstr ""
-"Ai Óncercat sa Ónchizi un panou prin intermediul managerului de ferestre - "
-"In mod uzual aceasta este o eroare... vrei sa-l Ónchizi ?"
+"Ai √Æncercat sa √Ænchizi un panou prin intermediul managerului de ferestre - "
+"In mod uzual aceasta este o eroare... vrei sa-l √Ænchizi ?"
 
-#: panel.c:639
+#: panel.c:771
 msgid "Missing < or > in panel config file"
-msgstr "Lipse∫te '<' ori '>' Ón fi∫ierul de configurare al panoului"
+msgstr "Lipse≈üte '<' ori '>' √Æn fi≈üierul de configurare al panoului"
 
-#: panel.c:1519
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
-msgstr "Eroare Ón crearea panoului %s: %s"
+msgstr "Eroare √Æn crearea panoului %s: %s"
 
-#: panel.c:1835
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
-msgstr "Applet-ul ∫i-a Óncheiat execu˛ia fara a crea un obiect!"
+msgstr "Applet-ul ≈üi-a √Æncheiat execu≈£ia fara a crea un obiect!"
 
-#: panel.c:1934
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
 "%s"
 msgstr ""
-"Eroare Ón rularea applet-ului:\n"
+"Eroare √Æn rularea applet-ului:\n"
 "%s"
 
-#: panel.c:2335
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "E≈üti sigur ca vrei sa deschizi fereastra %d ?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Indeparteaza elementul(le)"
+
+#: panel.c:2777
 #, fuzzy
 msgid "Panel Options..."
-msgstr "Op˛iuni..."
+msgstr "Op≈£iuni..."
 
-#: panel.c:2427
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Monitorul Xinerama %d nu este disponibil"
 
-#: panel.c:2502
+#: panel.c:2897
+msgid "Top"
+msgstr ""
+
+#: panel.c:2899
 #, fuzzy
-msgid "Panel Options"
-msgstr "Op˛iuni"
-
-#: panel.c:2517
-#, fuzzy, c-format
-msgid "Panel: %s"
-msgstr "Panouri"
-
-#: panel.c:2525
-msgid "Select the panel's position:"
-msgstr ""
-
-#: panel.c:2531
-msgid "Top-edge panel"
-msgstr ""
-
-#: panel.c:2532
-msgid "Top edge"
-msgstr ""
-
-#: panel.c:2533
-msgid "Bottom edge panel"
-msgstr ""
-
-#: panel.c:2534
-#, fuzzy
-msgid "Bottom edge"
+msgid "Bottom"
 msgstr "Marginea inferioara"
 
-#: panel.c:2535
-msgid "Left edge panel"
+#: panel.c:2901
+msgid "Left"
 msgstr ""
 
-#: panel.c:2536
-msgid "Left edge"
+#: panel.c:2903
+msgid "Right"
 msgstr ""
 
-#: panel.c:2537
-msgid "Right-edge panel"
-msgstr ""
+#: panel.c:2905
+#, fuzzy
+msgid "Default"
+msgstr "Dimensiune implicita:"
 
-#: panel.c:2538
-msgid "Right edge"
-msgstr ""
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "Necunoscut"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
-msgstr "Fi∫ierul vechi al scurtaturii a fost convertit Ón noul format XML."
+msgstr "Fi≈üierul vechi al scurtaturii a fost convertit √Æn noul format XML."
 
-#: pinboard.c:635
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
 "the SOAP SetBackdropApp method."
 msgstr ""
-"Gestionarul fundalului trebuie sa fie un director aplica˛ie. Trage un "
-"director aplica˛ie Ón fereastra de dialog 'Seteaza fundalul', ori (pentru "
+"Gestionarul fundalului trebuie sa fie un director aplica≈£ie. Trage un "
+"director aplica≈£ie √Æn fereastra de dialog 'Seteaza fundalul', ori (pentru "
 "programatori) transmite-l metodei SOAP SetBackdropApp."
 
-#: pinboard.c:654
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2702,200 +3092,171 @@ msgid ""
 "Programmers: the application's AppInfo.xml must contain the CanSetBackdrop "
 "element, as described in ROX-Filer's manual."
 msgstr ""
-"Po˛i seta fundalul numai cu o imagine sau un program care ∫tie sa gestioneze "
-"fundalul managerului de fi∫iere ROX-Filer.\n"
+"Po≈£i seta fundalul numai cu o imagine sau un program care ≈ütie sa gestioneze "
+"fundalul managerului de fi≈üiere ROX-Filer.\n"
 "\n"
-"Programatori: fi∫ierul AppInfo.xml trebuie sa con˛ina elementul "
-"CanSetBackdrop, cum este descris Ón manualul ROX-Filer."
+"Programatori: fi≈üierul AppInfo.xml trebuie sa con≈£ina elementul "
+"CanSetBackdrop, cum este descris √Æn manualul ROX-Filer."
 
-#: pinboard.c:674
+#: pinboard.c:750
 msgid "Set backdrop"
 msgstr "Seteaza imaginea din fundal"
 
-#: pinboard.c:685
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
-msgstr "Alege un stil ∫i trage o imagine Ón el:"
+msgstr "Alege un stil ≈üi trage o imagine √Æn el:"
 
-#: pinboard.c:698
+#: pinboard.c:774
 msgid "Centre the image without scaling it"
 msgstr "Centreaza imaginea fara a o scala"
 
-#: pinboard.c:699
+#: pinboard.c:775
 msgid "Centre"
 msgstr "Centrat"
 
-#: pinboard.c:700
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr "Scaleaza imaginea pentru a umple fundalul, fara a o distorsiona"
 
-#: pinboard.c:702
+#: pinboard.c:778
 msgid "Scale"
 msgstr "Scaleaza"
 
-#: pinboard.c:703
+#: pinboard.c:779
+#, fuzzy
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr "Scaleaza imaginea pentru a umple fundalul, fara a o distorsiona"
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Filtru"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
 msgstr "Dimensioneaza imaginea pentru a umple fundalul"
 
-#: pinboard.c:704
+#: pinboard.c:783
 msgid "Stretch"
 msgstr "Dimensioneaza"
 
-#: pinboard.c:705
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr "Paveaza fundalul cu imaginea respectiva"
 
-#: pinboard.c:706
+#: pinboard.c:785
 msgid "Tile"
 msgstr "Paveaza"
 
-#: pinboard.c:711
+#: pinboard.c:790
 msgid "Drop an image here"
 msgstr "Elibereaza o imagine aici"
 
-#: pinboard.c:772
+#: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
 msgstr ""
-"Nici o scurtatura nua fost Ón uz... scurtatura 'Implicita'a fost selectata. "
-"Utilizeaza  'rox -p=Default' pentru a activa aceasta op˛iune."
+"Nici o scurtatura nua fost √Æn uz... scurtatura 'Implicita'a fost selectata. "
+"Utilizeaza  'rox -p=Default' pentru a activa aceasta op≈£iune."
 
-#: pinboard.c:866
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
 msgstr ""
-"Numai fi∫iere (∫i anumite aplica˛ii) pot fi utilizate pentru a seta imaginea "
+"Numai fi≈üiere (≈üi anumite aplica≈£ii) pot fi utilizate pentru a seta imaginea "
 "de fundal."
 
-#: pinboard.c:1471
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
-msgstr "Lipse∫te '>' Ón textul icoanei"
+msgstr "Lipse≈üte '>' √Æn textul icoanei"
 
-#: pinboard.c:1480
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
-msgstr "Lipse∫te ',' dupa textul icoanei"
+msgstr "Lipse≈üte ',' dupa textul icoanei"
 
-#: pinboard.c:1565
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
-msgstr "Eroare Ón salvarea scurtaturii %s†: %s"
+msgstr "Eroare √Æn salvarea scurtaturii %s¬†: %s"
 
-#: pinboard.c:2109
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Imagine de fond..."
 
-#: pinboard.c:2202
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Panouri"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
 "%s\n"
 "Backdrop removed."
 msgstr ""
-"Eroare Ón Óncarcarea imaginii de fundal:\n"
+"Eroare √Æn √Æncarcarea imaginii de fundal:\n"
 "%s\n"
-"Fundal Óndepartat."
+"Fundal √Ændepartat."
 
-#: pixmaps.c:991
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
 "%s"
 msgstr ""
-"Nu pot ∫terge monstrele de imagine din %s†:\n"
+"Nu pot ≈üterge monstrele de imagine din %s¬†:\n"
 "%s"
 
-#: pixmaps.c:1012
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
-msgstr "Nu sunt monstre de imagini de ∫ters"
+msgstr "Nu sunt monstre de imagini de ≈üters"
 
-#: pixmaps.c:1025
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
-msgstr "Gole∫te depozitul de monstre de imagini de pe disc"
+msgstr "Gole≈üte depozitul de monstre de imagini de pe disc"
 
-#: remote.c:624
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Stil necunoscut '%s'"
 
-#: remote.c:646
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Tip de detalii necunoscut '%s'"
 
-#: remote.c:674
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Tip de sortare necunoscut '%s'"
 
-#: remote.c:1117
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Tentativa de invocare aunei metode SOAP necunoscute '%s'"
 
-#: rox_gettext.c:95
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Fi∫ier de traducere .gmo invalid (prea scurt): %s"
-
-#: rox_gettext.c:108
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Fi∫ier de traducere .gmo invalid (numarul magic GNU nu este gasit): %s"
-
-#: run.c:96 run.c:141
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
-msgstr "Programul %s nu este gasit - ∫ters ?"
+msgstr "Programul %s nu este gasit - ≈üters ?"
 
-#: run.c:287
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "Fi∫ierul nu exista, sau nu poate fi accesat†: %s"
-
-#: run.c:292
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "Nu ∫tiu cum sa-l deschid '%s'"
-
-#: run.c:323
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"Aplicatie:\n"
-"Acesta este un director aplica˛ie - po˛i sa-l rulezi ca un program, ori po˛i "
-"sa-l deschizi (˛ine tasta Shift apasata Ón timp ce-l deschizi)."
-
-#: run.c:407
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "Nu se pot trimite datele catre program: %s"
-
-#: run.c:437
-#, c-format
-msgid "Could not read link: %s"
-msgstr "Nu se poate citi legatura: %s"
-
-#: run.c:465
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr "Legatura simbolica incorecta (sau nu ai permisiunea s-o folose∫ti): %s"
-
-#: run.c:502
+#: run.c:359
 #, fuzzy, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
 "action by choosing `Set Run Action' from the File menu, or you can just drag "
 "the file to an application.%s"
 msgstr ""
-"Nu este specificata o ac˛iune de execu˛ie pentru fi∫ierele de tipul (%s/%s) "
-"- po˛i seta o ac˛iune de execu˛ie aleg‚nd 'Seteaza ac˛iunea de execu˛ie' di "
-"meniul Fi∫ier, sau po˛i trage un fi∫ier peste o aplica˛ie"
+"Nu este specificata o ac≈£iune de execu≈£ie pentru fi≈üierele de tipul (%s/%s) "
+"- po≈£i seta o ac≈£iune de execu≈£ie aleg√¢nd 'Seteaza ac≈£iunea de execu≈£ie' di "
+"meniul Fi≈üier, sau po≈£i trage un fi≈üier peste o aplica≈£ie"
 
-#: run.c:508
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -2903,186 +3264,63 @@ msgid ""
 "the execute bit by choosing Permissions from the File menu."
 msgstr ""
 
-#: support.c:272
-msgid "B"
-msgstr "O"
-
-#: support.c:351
-msgid "byte"
-msgstr "octet"
-
-#: toolbar.c:115
-msgid "Close"
-msgstr "Inchide"
-
-#: toolbar.c:115
-msgid "Close filer window"
-msgstr "Inchide fereastra managerului de fi∫iere"
-
-#: toolbar.c:119
-msgid "Up"
-msgstr "Sus"
-
-#: toolbar.c:119
-msgid "Change to parent directory"
-msgstr "Schimba la fereastra parinte"
-
-#: toolbar.c:123
-msgid "Home"
-msgstr "Acasa"
-
-#: toolbar.c:123
-msgid "Change to home directory"
-msgstr "Schimba la directorul acasa"
-
-#: toolbar.c:127
-msgid "Bookmarks"
-msgstr "Semne"
-
-#: toolbar.c:127
-msgid "Bookmarks menu"
-msgstr "Meniul semnelor"
-
-#: toolbar.c:131
-msgid "Scan"
-msgstr "Scaneaza"
-
-#: toolbar.c:131
-msgid "Rescan directory contents"
-msgstr "Rescaneaza con˛inutul directorului"
-
-#: toolbar.c:135
-msgid "Change icon size"
-msgstr "Schimba dimensiunea icoanei"
-
-#: toolbar.c:139
-msgid "Automatic size mode"
-msgstr "Modul de dimensiune automat"
-
-#: toolbar.c:143
-msgid "Show extra details"
-msgstr "Arata detalii suplimentare"
-
-#: toolbar.c:147
-msgid "Sort"
-msgstr "Sorteaza"
-
-#: toolbar.c:147
-msgid "Change sort criteria"
-msgstr "Schimba criteriul de sortare"
-
-#: toolbar.c:151
-msgid "Hidden"
-msgstr "Ascuns"
-
-#: toolbar.c:151
-msgid "Show/hide hidden files"
-msgstr "Arata/ascunde fi∫ierele ascunse"
-
-#: toolbar.c:155
-msgid "Select all/invert selection"
-msgstr "Selecteaza tot/inverseaza selec˛ia"
-
-#: toolbar.c:159
-msgid "Show ROX-Filer help"
-msgstr "Arata documenta˛ia ROX-Filer"
-
-#: toolbar.c:220
+#: run.c:373
 #, c-format
-msgid " (%u hidden)"
-msgstr " (%u ascuns(e))"
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "Fi≈üierul nu exista, sau nu poate fi accesat¬†: %s"
 
-#: toolbar.c:228 tips:80
-msgid "items"
-msgstr "obiecte"
-
-#: toolbar.c:228
-msgid "item"
-msgstr "obiect"
-
-#: toolbar.c:231
+#: run.c:378
 #, c-format
-msgid "No items%s"
-msgstr "Nu exista obiecte%s"
+msgid "I don't know how to open '%s'"
+msgstr "Nu ≈ütiu cum sa-l deschid '%s'"
 
-#: toolbar.c:250
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' nu mai este o legatura simbolica"
+
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "Diectorul '%s' nu este accesibil"
+
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "%s neexecutabil"
+
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Eroare √Æn gestionarul %s¬†: %s"
+
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
+msgstr ""
+"Aplicatie:\n"
+"Acesta este un director aplica≈£ie - po≈£i sa-l rulezi ca un program, ori po≈£i "
+"sa-l deschizi (≈£ine tasta Shift apasata √Æn timp ce-l deschizi)."
+
+#: run.c:549
 #, c-format
-msgid "%u selected (%s)"
-msgstr "%u selectat(e) (%s)"
+msgid "Could not send data to program: %s"
+msgstr "Nu se pot trimite datele catre program: %s"
 
-#: toolbar.c:422
-msgid "Sort by name"
-msgstr "Sortat dupa nume"
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "Nu se poate citi legatura: %s"
 
-#: toolbar.c:422
-msgid "Sort by type"
-msgstr "Sortat dupa tip"
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
+msgstr "Legatura simbolica incorecta (sau nu ai permisiunea s-o folose≈üti): %s"
 
-#: toolbar.c:422
-msgid "Sort by date"
-msgstr "Sortat dupa data"
-
-#: toolbar.c:423
-msgid "Sort by size"
-msgstr "Sortat dupa dimensiune"
-
-#: toolbar.c:423
-msgid "Sort by owner"
-msgstr "Sortat dupa proprietar"
-
-#: toolbar.c:423
-msgid "Sort by group"
-msgstr "Sortat dupa grup"
-
-#: toolbar.c:457
-msgid "ascending"
-msgstr "ascendent"
-
-#: toolbar.c:457
-msgid "descending"
-msgstr "descendent"
-
-#: type.c:203
-msgid "Sym link"
-msgstr "Legatura"
-
-#: type.c:205
-msgid "Mount point"
-msgstr "Punct de montare"
-
-#: type.c:207
-msgid "App dir"
-msgstr "Dir. ap."
-
-#: type.c:214
-msgid "Dir"
-msgstr "Dir"
-
-#: type.c:216
-msgid "Char dev"
-msgstr "Disp. car."
-
-#: type.c:218
-msgid "Block dev"
-msgstr "Disp. bloc"
-
-#: type.c:220
-msgid "Pipe"
-msgstr "Teava"
-
-#: type.c:222
-msgid "Socket"
-msgstr "Socket"
-
-#: type.c:224
-msgid "Door"
-msgstr "Poarta"
-
-#: type.c:227
-msgid "Unknown"
-msgstr "Necunoscut"
-
-#: type.c:355
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3097,406 +3335,599 @@ msgid ""
 "actions."
 msgstr ""
 "Executabilul '%s' poate fi scris de toata lumea! Refuza sa ruleze. Te rog "
-"schimba drepturile (aceasta problema poate fi cauzata de o greseala Ón "
-"versiunile anterioare ale managerului de fi∫iere).\n"
+"schimba drepturile (aceasta problema poate fi cauzata de o greseala √Æn "
+"versiunile anterioare ale managerului de fi≈üiere).\n"
 "\n"
-"Av‚nd ac˛iuni de execu˛ie care pot scrise de oricine, asta Ónseamna ca "
-"oricine poate Ónlocui ac˛iunea de execu˛ie cu una mali˛ioasa.\n"
+"Av√¢nd ac≈£iuni de execu≈£ie care pot scrise de oricine, asta √Ænseamna ca "
+"oricine poate √Ænlocui ac≈£iunea de execu≈£ie cu una mali≈£ioasa.\n"
 "\n"
-"Daca ai Óncredere Ón cei ce pot scrie aceste fi∫iere, atunci nu este nici o "
-"problema. Altfel, trebuie sa verifici, sau sa ∫tergi toate ac˛iunile de "
-"execu˛ie."
+"Daca ai √Æncredere √Æn cei ce pot scrie aceste fi≈üiere, atunci nu este nici o "
+"problema. Altfel, trebuie sa verifici, sau sa ≈ütergi toate ac≈£iunile de "
+"execu≈£ie."
 
-#: type.c:368
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Corecteaza problema de securitate)"
 
-#: type.c:498
+#: support.c:288
+msgid " "
+msgstr ""
+
+#: support.c:381
+msgid "byte"
+msgstr "octet"
+
+#: support.c:1531 support.c:1585
+#, fuzzy, c-format
+msgid "Failed to open and stat file '%s': %s"
+msgstr ""
+"Imposibil de a desface legatura '%s' :\n"
+"%s"
+
+#: support.c:1542 support.c:1596
+#, fuzzy, c-format
+msgid "Failed to mmap file '%s': %s"
+msgstr ""
+"Imposibil de a desface legatura '%s' :\n"
+"%s"
+
+#: toolbar.c:116
+msgid "Close"
+msgstr "Inchide"
+
+#: toolbar.c:116
+msgid "Close filer window"
+msgstr "Inchide fereastra managerului de fi≈üiere"
+
+#: toolbar.c:120
+msgid "Up"
+msgstr "Sus"
+
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
+
+#: toolbar.c:126
+msgid "Home"
+msgstr "Acasa"
+
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
+
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
+
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
+
+#: toolbar.c:138
+msgid "Scan"
+msgstr "Scaneaza"
+
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
+
+#: toolbar.c:143
+#, fuzzy
+msgid "Size‚îº"
+msgstr "Dimensiune"
+
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ‚îò : Huge\n"
+"  ‚î§ : Large\n"
+"  ‚îê : Small\n"
+"  ‚îå, ‚îú : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Automatic"
+
+#: toolbar.c:155
+msgid "Automatic size mode"
+msgstr "Modul de dimensiune automat"
+
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Sub forma de lista"
+
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
+msgid "Sort"
+msgstr "Sorteaza"
+
+#: toolbar.c:165
+msgid "Change sort criteria"
+msgstr "Schimba criteriul de sortare"
+
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
+
+#: toolbar.c:169
+msgid ""
+"Left: Show/hide hidden files\n"
+"Right: Show/hide thumbnails"
+msgstr ""
+
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "Selecteaza tot/inverseaza selec≈£ia"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "‚óã"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ‚ñΩ: No settings\n"
+"  ‚ñº: Own settings\n"
+"  ‚ñ∂: Parent settings\n"
+"  ‚ñ∑: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
+msgid "Show ROX-Filer help"
+msgstr "Arata documenta≈£ia ROX-Filer"
+
+#: toolbar.c:270
+#, c-format
+msgid " (%u hidden)"
+msgstr " (%u ascuns(e))"
+
+#: toolbar.c:276 tips:79
+msgid "items"
+msgstr "obiecte"
+
+#: toolbar.c:276
+msgid "item"
+msgstr "obiect"
+
+#: toolbar.c:279
+#, c-format
+msgid "No items%s"
+msgstr "Nu exista obiecte%s"
+
+#: toolbar.c:298
+#, c-format
+msgid "%u selected (%s)"
+msgstr "%u selectat(e) (%s)"
+
+#: toolbar.c:535
+msgid "Sort by name"
+msgstr "Sortat dupa nume"
+
+#: toolbar.c:535
+msgid "Sort by type"
+msgstr "Sortat dupa tip"
+
+#: toolbar.c:535
+msgid "Sort by date"
+msgstr "Sortat dupa data"
+
+#: toolbar.c:535
+msgid "Sort by size"
+msgstr "Sortat dupa dimensiune"
+
+#: toolbar.c:536
+msgid "Sort by owner"
+msgstr "Sortat dupa proprietar"
+
+#: toolbar.c:536
+msgid "Sort by group"
+msgstr "Sortat dupa grup"
+
+#: toolbar.c:568
+msgid "ascending"
+msgstr "ascendent"
+
+#: toolbar.c:568
+msgid "descending"
+msgstr "descendent"
+
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
+msgid "Sym link"
+msgstr "Legatura"
+
+#: type.c:223
+msgid "Mount point"
+msgstr "Punct de montare"
+
+#: type.c:225
+msgid "App dir"
+msgstr "Dir. ap."
+
+#: type.c:232
+msgid "Dir"
+msgstr "Dir"
+
+#: type.c:234
+msgid "Char dev"
+msgstr "Disp. car."
+
+#: type.c:236
+msgid "Block dev"
+msgstr "Disp. bloc"
+
+#: type.c:238
+msgid "Pipe"
+msgstr "Teava"
+
+#: type.c:240
+msgid "Socket"
+msgstr "Socket"
+
+#: type.c:242
+msgid "Door"
+msgstr "Poarta"
+
+#: type.c:245
+msgid "Unknown"
+msgstr "Necunoscut"
+
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
 "gimp \"$@\""
 msgstr ""
-"Introdu o comanda shell care va fi Óncarcata \"$@\" Óntr-un program adecvat. "
+"Introdu o comanda shell care va fi √Æncarcata \"$@\" √Æntr-un program adecvat. "
 "Ex.:\n"
 "\n"
 "gimp \"$@\""
 
-#: type.c:679
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
-msgstr "Acesta nu este un program! Este necesara o aplica˛ie adevarata!"
+msgstr "Acesta nu este un program! Este necesara o aplica≈£ie adevarata!"
 
-#: type.c:740
+#: type.c:839
 msgid "No run action defined"
-msgstr "Nu a fost definita o ac˛iune de execu˛ie"
+msgstr "Nu a fost definita o ac≈£iune de execu≈£ie"
 
-#: type.c:766
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
-msgstr "Eroare Ón gestionarul %s†: %s"
+msgstr "Eroare √Æn gestionarul %s¬†: %s"
 
-#: type.c:781
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
-msgstr "Aplica˛ia %s este invalida"
+msgstr "Aplica≈£ia %s este invalida"
 
-#: type.c:792
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "%s neexecutabil"
 
-#: type.c:825
+#: type.c:902
 msgid "Set run action"
-msgstr "Seteaza ac˛iunea de execu˛ie"
+msgstr "Seteaza ac≈£iunea de execu≈£ie"
 
-#: type.c:831
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 "Daca nu este setat un gestionar pentru acest tip specific, utilizeaza "
 "aceastaca setare implicita."
 
-#: type.c:833
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Seteaza setarile implicite pentru toate `%s/<orice>'"
 
-#: type.c:837
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
-msgstr "Utilizeaza aceasta pentru toate fi∫ierele cu acest tip MIME."
+msgstr "Utilizeaza aceasta pentru toate fi≈üierele cu acest tip MIME."
 
-#: type.c:839
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Numai pentru tipul `%s' (%s/%s)"
 
-#: type.c:845
+#: type.c:922
 msgid "Drop a suitable application here"
-msgstr "Elibereaza o aplica˛ie aici"
+msgstr "Elibereaza o aplica≈£ie aici"
 
-#: type.c:860
+#: type.c:963
 msgid "OR"
 msgstr "OR"
 
-#: type.c:867
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Introdu o camanda shell:"
 
-#: type.c:896
+#: type.c:1000
 #, fuzzy
 msgid "_Use Command"
 msgstr "Comanda:"
 
-#: type.c:926
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
 msgstr ""
-"O ac˛iune de execu˛ie exista deja ∫i este un program mare - chiar vrei s-o "
-"∫tergi?"
+"O ac≈£iune de execu≈£ie exista deja ≈üi este un program mare - chiar vrei s-o "
+"≈ütergi?"
 
-#: type.c:937
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
-msgstr "Nu pot Óndeparta %s : %s"
+msgstr "Nu pot √Ændeparta %s : %s"
 
-#: type.c:974
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "Salvarea schimbarilor este dezacyivata de variabila CHOICESPATH"
 
-#: type.c:1249
-#, c-format
-msgid ""
-"Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr ""
-"Tema icoanelor '%s' nu con˛ine icoane MIME. Se utilizeaza tema ROX implicita."
-
-#: type.c:1263
+#: type.c:1395
 #, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason)"
+"%s"
 msgstr ""
+"Imposibil de creat legatura simbolica '%s' :\n"
+"%s"
 
-#: usericons.c:181
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "Calea pe care ai introdu-so nu exista. Icoana nu a fost schimbata."
 
-#: usericons.c:191 usericons.c:616
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
 "The icon has not been changed."
 msgstr ""
-"Imposibil de Óncarcat fi∫ierul imagine - poate este Óntr-un format "
+"Imposibil de √Æncarcat fi≈üierul imagine - poate este √Æntr-un format "
 "necunoscut, sau drepturile de acces nu permit acest lucru?\n"
 "Icoana nu a fost schimbata."
 
-#: usericons.c:238
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
-msgstr "Chiar vrei sa ∫tergi icoana '%s'†?"
+msgstr "Chiar vrei sa ≈ütergi icoana '%s'¬†?"
 
-#: usericons.c:242
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
 "%s"
 msgstr ""
-"Nu pot ∫terge '%s' :\n"
+"Nu pot ≈üterge '%s' :\n"
 "%s"
 
-#: usericons.c:270
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Seteaza icoana"
 
-#: usericons.c:279
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr ""
-"Utilizeaza o copie a imaginii ca implicita pentru toate fi∫ierele cu acest "
+"Utilizeaza o copie a imaginii ca implicita pentru toate fi≈üierele cu acest "
 "tip MIME."
 
-#: usericons.c:281
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Seteaza icoana pentru toate `%s/<orice>'"
 
-#: usericons.c:286
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr ""
-"Utilizeaza o copie a imaginii pentru toate fi∫ierele cu acest tip MIME."
+"Utilizeaza o copie a imaginii pentru toate fi≈üierele cu acest tip MIME."
 
-#: usericons.c:288
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
-msgstr "Pentru toate fi∫ierele de acest tip `%s' (%s/%s)"
+msgstr "Pentru toate fi≈üierele de acest tip `%s' (%s/%s)"
 
-#: usericons.c:294
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
 msgstr ""
-"Adauga fi∫ierul ∫i numele fi∫ierului imagine la lista personala. Setarile se "
-"vor pierde daca imaginea ori fi∫ierul vor fi mutate."
+"Adauga fi≈üierul ≈üi numele fi≈üierului imagine la lista personala. Setarile se "
+"vor pierde daca imaginea ori fi≈üierul vor fi mutate."
 
-#: usericons.c:297
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
-msgstr "Numai pentru acest fi∫ier `%s'"
+msgstr "Numai pentru acest fi≈üier `%s'"
 
-#: usericons.c:305
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
 "This is usually the best option if you can write to the directory."
 msgstr ""
-"Copiaza imaginea Ón director, ca un fi∫ier ascuns numit '.DirIcon'. To˛i "
-"utilizatorii vor vedea icoana, ∫i directorul se paote muta Ón siguran˛a."
+"Copiaza imaginea √Æn director, ca un fi≈üier ascuns numit '.DirIcon'. To≈£i "
+"utilizatorii vor vedea icoana, ≈üi directorul se paote muta √Æn siguran≈£a."
 
-#: usericons.c:311
+#: usericons.c:322
 msgid "Copy image into directory"
-msgstr "Copiaza imaginea Ón directorul"
+msgstr "Copiaza imaginea √Æn directorul"
 
-#: usericons.c:317
+#: usericons.c:328
 msgid "Drop an icon file here"
-msgstr "Elibereaza un fi∫ier icoana aici"
+msgstr "Elibereaza un fi≈üier icoana aici"
 
-#: usericons.c:587
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "Setarea iconelor dezactivata de CHOICESPATH "
 
-#: usericons.c:631
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
 "%s"
 msgstr ""
-"Eraore Ón crearea imaginii '%s'†:\n"
+"Eraore √Æn crearea imaginii '%s'¬†:\n"
 "%s"
 
-#: view_details.c:1009
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
+msgid "Mono font"
+msgstr ""
+
+#: view_details.c:1019
+msgid "Font for displaying mono-spaced text"
+msgstr ""
+
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Nume"
 
-#: view_details.c:1012
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Tip"
 
-#: view_details.c:1015
-msgid "_Permissions"
-msgstr "_Drepturi"
-
-#: view_details.c:1016
-msgid "_Owner"
-msgstr "_Proprietar"
-
-#: view_details.c:1018
-msgid "_Group"
-msgstr "_Grup"
-
-#: view_details.c:1020
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Dimensiune"
 
-#: view_details.c:1022
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Drepturi"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_Proprietar"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Grup"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "Ultima _modificare"
 
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr ""
+
 #: tips:1
-msgid "Translation"
-msgstr "Traducere"
+msgid "Filer windows"
+msgstr "Fereastra managerului de fi≈üiere"
 
 #: tips:2
-msgid "Language"
-msgstr "Limba"
+msgid "Auto-resize filer windows"
+msgstr "Auto-dimensioneaza fereastra managerului de fi≈üiere"
 
 #: tips:3
-msgid "Use the LANG environment variable"
-msgstr "Utilizeaza variabila LANG"
+msgid "Never automatically resize"
+msgstr "Nu redimensiona automat fereastra managerului de fi≈üiere"
 
 #: tips:4
-msgid "Basque"
-msgstr ""
-
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Chinois (traditionnel)"
-
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Chinois (simplifiÈ)"
-
-#: tips:7
-msgid "Czech"
-msgstr "TchËque"
-
-#: tips:8
-msgid "Danish"
-msgstr "Danois"
-
-#: tips:9
-msgid "Dutch"
-msgstr "NÈerlandais"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Engleza (fara traducere)"
-
-#: tips:11
-msgid "Estonian"
-msgstr ""
-
-#: tips:12
-#, fuzzy
-msgid "Finnish"
-msgstr "Danois"
-
-#: tips:13
-msgid "French"
-msgstr "Franceza"
-
-#: tips:14
-msgid "German"
-msgstr "Germana"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Maghiara"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Japonais"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "NorvÈgien"
-
-#: tips:18
-msgid "Italian"
-msgstr "Italiana"
-
-#: tips:19
-msgid "Polish"
-msgstr "Polonais"
-
-#: tips:20
-msgid "Portuguese (Brasil)"
-msgstr ""
-
-#: tips:21
-msgid "Romanian"
-msgstr ""
-
-#: tips:22
-msgid "Russian"
-msgstr "Russe"
-
-#: tips:23
-msgid "Spanish"
-msgstr "Spaniola"
-
-#: tips:24
-msgid "Swedish"
-msgstr "SuÈdois"
-
-#: tips:25
-msgid "Filer windows"
-msgstr "Fereastra managerului de fi∫iere"
-
-#: tips:26
-msgid "Auto-resize filer windows"
-msgstr "Auto-dimensioneaza fereastra managerului de fi∫iere"
-
-#: tips:27
-msgid "Never automatically resize"
-msgstr "Nu redimensiona automat fereastra managerului de fi∫iere"
-
-#: tips:28
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
 msgstr ""
-"Va trebui sa redimensionezi fereastra manual, utiliz‚nd managerul de "
-"ferestre, fie prin meniul 'Redimensioneaza fereastra' sau fac‚nd dublu click "
-"Ón fundalul ferestrei"
+"Va trebui sa redimensionezi fereastra manual, utiliz√¢nd managerul de "
+"ferestre, fie prin meniul 'Redimensioneaza fereastra' sau fac√¢nd dublu click "
+"√Æn fundalul ferestrei"
 
-#: tips:29
+#: tips:5
 msgid "Resize when changing the display style"
-msgstr "Redimensioneaza c‚nd schimb stilul de afi∫aj"
+msgstr "Redimensioneaza c√¢nd schimb stilul de afi≈üaj"
 
-#: tips:30
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
 msgstr ""
-"Schimb‚nd dimensiunea icoanelor sau care detalii sunt afi∫ate fereastra se "
+"Schimb√¢nd dimensiunea icoanelor sau care detalii sunt afi≈üate fereastra se "
 "va redimensiona pentru d-voastra."
 
-#: tips:31
+#: tips:7
 msgid "Always resize"
 msgstr "Intodeauna se redimensioneaza"
 
-#: tips:32
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
 msgstr ""
-"Managerul de fi∫iere va redimensiona ferestrele c‚nd va crede de cuviin˛a "
-"(c‚nd se va schimba directorul ori stilul de afi∫aj)."
+"Managerul de fi≈üiere va redimensiona ferestrele c√¢nd va crede de cuviin≈£a "
+"(c√¢nd se va schimba directorul ori stilul de afi≈üaj)."
 
-#: tips:33
+#: tips:9
 msgid "Largest window size:"
 msgstr "Fereastra cu dimensiunea cea mai mare:"
 
-#: tips:34
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:35
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
@@ -3504,151 +3935,269 @@ msgstr ""
 "Cea mai mare dimensiune, ca procentaj din dimensiunea ecranului, dimensiune "
 "la care ferestrele vor fi dimensionate."
 
-#: tips:36
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Fereastra cu dimensiunea cea mai mare:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Cea mai mare dimensiune, ca procentaj din dimensiunea ecranului, dimensiune "
+"la care ferestrele vor fi dimensionate."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Comportamentul ferestrelor"
 
-#: tips:37
+#: tips:16
 msgid "Short titlebar flags"
-msgstr "Prescurtari Ón bara de titlu"
+msgstr "Prescurtari √Æn bara de titlu"
 
-#: tips:38
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
 msgstr ""
-"Se utilizeaza litere Ón schimbul unor cuvinte ca Scaneaza, Toate sau Index "
+"Se utilizeaza litere √Æn schimbul unor cuvinte ca Scaneaza, Toate sau Index "
 "in bara de titlu."
 
-#: tips:39
+#: tips:18
 msgid "Unique windows"
 msgstr "Fereastra unica"
 
-#: tips:40
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
 msgstr ""
-"Daca deschizi un director ∫i acesta mai este deschis Óntr-o alta fereastra, "
-"atunci aceasta op˛iune cauzeaza Ónchiderea celeilalte ferestre."
+"Daca deschizi un director ≈üi acesta mai este deschis √Æntr-o alta fereastra, "
+"atunci aceasta op≈£iune cauzeaza √Ænchiderea celeilalte ferestre."
 
-#: tips:41
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Fereastra"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "O noua ferestra la butonul 1"
 
-#: tips:42
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
 "reuse the current window."
 msgstr ""
-"Fac‚nd click cu butonul 1 al mouse-ului (butonul din st‚nga) se deschide un "
-"director Óntr-o fereastra noua. Fac‚nd click cu butonul 2 al mouse-ului (din "
+"Fac√¢nd click cu butonul 1 al mouse-ului (butonul din st√¢nga) se deschide un "
+"director √Æntr-o fereastra noua. Fac√¢nd click cu butonul 2 al mouse-ului (din "
 "dreapta) se va folosi ferestra curenta."
 
-#: tips:43
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Navigare cu un singur click"
 
-#: tips:44 tips:137
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
 "things."
 msgstr ""
-"Fac‚nd click pe un element ele se va deschide. Se apasa tasta Ctrl pentru a "
-"selecta acel obiect. Daca nu este activata aceasta op˛iune, fac‚nd un click "
+"Fac√¢nd click pe un element ele se va deschide. Se apasa tasta Ctrl pentru a "
+"selecta acel obiect. Daca nu este activata aceasta op≈£iune, fac√¢nd un click "
 "pe element el se va selecta, la doua el se va deschide."
 
-#: tips:45
+#: tips:28
 msgid "Double-click on background resizes"
-msgstr "Dublu click Ón fundalul ferestrei redimensioneaza fereastra"
+msgstr "Dublu click √Æn fundalul ferestrei redimensioneaza fereastra"
 
-#: tips:46
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
 msgstr ""
-"Daca este activa, dublu click Ón fundalul ferestrei va redimensiona "
-"fereastra, ca ∫i cum s-ar apasa butonul de dimensionare Automatic din bara "
+"Daca este activa, dublu click √Æn fundalul ferestrei va redimensiona "
+"fereastra, ca ≈üi cum s-ar apasa butonul de dimensionare Automatic din bara "
 "de unelte."
 
-#: tips:47
+#: tips:30
 msgid "Sorting"
 msgstr "Sorteaza"
 
-#: tips:48
+#: tips:31
 msgid "Directories come first (for sort by name)"
-msgstr "Directoarele sunt afi∫ate primele (sortate dupa nume)"
+msgstr "Directoarele sunt afi≈üate primele (sortate dupa nume)"
 
-#: tips:49
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
 msgstr ""
-"Daca aceasta op˛iune este activa atunci acestea vor aparea Ónaintea "
+"Daca aceasta op≈£iune este activa atunci acestea vor aparea √Ænaintea "
 "tuturora, sortate dupa nume."
 
-#: tips:50
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Numele cu majuscule sunt primele (pentru sortarea dupa nume)"
 
-#: tips:51
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
 msgstr ""
-"Daca aceasta op˛iune este activa atunci toate fi∫ierele al caror nume Óncepe "
-"cu litera mare vor fi afi∫ate Ónaintea celor care Óncep cu litera mica."
+"Daca aceasta op≈£iune este activa atunci toate fi≈üierele al caror nume √Æncepe "
+"cu litera mare vor fi afi≈üate √Ænaintea celor care √Æncep cu litera mica."
 
-#: tips:53
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Directoarele sunt afi≈üate primele (sortate dupa nume)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Secunda"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "Nu utiliza numele gazdei"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
-msgstr "Op˛iuni implicite pentru o noua ferestra"
+msgstr "Op≈£iuni implicite pentru o noua ferestra"
 
-#: tips:54
+#: tips:46
 msgid "Inherit options from source window"
-msgstr "Mo∫tene∫te op˛iunile de la fereastra sursa"
+msgstr "Mo≈ütene≈üte op≈£iunile de la fereastra sursa"
 
-#: tips:55
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
 msgstr ""
-"Daca aceasta op˛iune este activa, atunci op˛iunile de afi∫are pentru o noua "
-"fereastra sunt mo∫tenite de la fereastra sursa, daca este posibil, daca nu, "
+"Daca aceasta op≈£iune este activa, atunci op≈£iunile de afi≈üare pentru o noua "
+"fereastra sunt mo≈ütenite de la fereastra sursa, daca este posibil, daca nu, "
 "se adopta setarile implicite."
 
-#: tips:56
+#: tips:48
 msgid "View type:"
-msgstr "Tipul de afi∫aj:"
+msgstr "Tipul de afi≈üaj:"
 
-#: tips:59
+#: tips:51
 msgid "Sort by:"
 msgstr "Sorteaza dupa:"
 
-#: tips:61 tips:76
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Tip"
 
-#: tips:62
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Data"
 
-#: tips:64
-msgid "Show hidden files"
-msgstr "Arata fi∫ierele ascunse"
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Data"
 
-#: tips:65
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Data"
+
+#: tips:58
+msgid "Show hidden files"
+msgstr "Arata fi≈üierele ascunse"
+
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
 msgstr ""
-"Daca aceasta op˛iune este activa atunci toate fi∫ierele al caror nume Óncepe "
-"cu punct vor fi afi∫te, altfel nu."
+"Daca aceasta op≈£iune este activa atunci toate fi≈üierele al caror nume √Æncepe "
+"cu punct vor fi afi≈üte, altfel nu."
 
-#: tips:66
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Arata fi≈üierele ascunse"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Daca aceasta op≈£iune este activa atunci toate fi≈üierele al caror nume √Æncepe "
+"cu punct vor fi afi≈üte, altfel nu."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Icoane imense"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "pixeli"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
-msgstr "Afi∫eaza sub forma de icoane"
+msgstr "Afi≈üeaza sub forma de icoane"
 
 #: tips:67
 msgid "Default size:"
@@ -3658,11 +4207,11 @@ msgstr "Dimensiune implicita:"
 msgid "Huge Icons"
 msgstr "Icoane imense"
 
-#: tips:69 tips:245
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Icoane mari"
 
-#: tips:70 tips:244
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "Icoane mici"
 
@@ -3674,731 +4223,935 @@ msgstr "Detalii implicite:"
 msgid "No details"
 msgstr "Fara detalii"
 
+#: tips:74
+msgid "Sizes"
+msgstr "Dimensiuni"
+
+#: tips:77
+msgid "Times"
+msgstr "Data & timp"
+
 #: tips:78
-msgid "Automatic small icons:"
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "Icoane mici automate:"
 
-#: tips:79
-msgid "Change at:"
-msgstr "Schimba la:"
-
-#: tips:81
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
 "used."
 msgstr ""
-"C‚nd este selectat modul de dimensionare automata a icoanelor: daca "
-"directorul con˛ine multe icoane se vor folosi Icoane mici, altfel se vor "
+"C√¢nd este selectat modul de dimensionare automata a icoanelor: daca "
+"directorul con≈£ine multe icoane se vor folosi Icoane mici, altfel se vor "
 "folosi Icoane Mari."
 
-#: tips:82
-msgid "Max width (Large icons):"
-msgstr "La˛ime maxima (Icoane mari):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Icoane mari"
 
-#: tips:83 tips:86
-msgid "pixels"
-msgstr "pixeli"
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
+msgstr ""
+"Textul mai lat de at√¢t va fi spart √Æn doua linii √Æn modul Icoane mari. In "
+"modul Icoane uria≈üe, textul este √Æmpar≈£it la 50% din dimensiune."
 
 #: tips:84
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+msgid "(Wrapped, Details):"
 msgstr ""
-"Textul mai lat de at‚t va fi spart Ón doua linii Ón modul Icoane mari. In "
-"modul Icoane uria∫e, textul este Ómpar˛it la 50% din dimensiune."
 
-#: tips:85
-msgid "(Small Icons):"
-msgstr "(Icoane mici):"
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
 
 #: tips:87
-msgid "Maximum width for the text beside a Small Icon."
-msgstr "La˛ime maxima pentru textul de sub icoanele mici."
+msgid "Wrap by characters"
+msgstr ""
 
 #: tips:88
-msgid "Order small icons vertically"
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
 msgstr ""
 
 #: tips:89
-msgid ""
-"If this option is on, then small icons are ordered vertically, not "
-"horizontally."
-msgstr ""
-
-#: tips:90
-msgid "Order large icons vertically"
-msgstr ""
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "(Icoane mici):"
 
 #: tips:91
-msgid ""
-"If this option is on, then large icons are sorted vertically, not "
-"horizontally."
+msgid "Maximum width for the text beside a Small Icon."
+msgstr "La≈£ime maxima pentru textul de sub icoanele mici."
+
+#: tips:92
+msgid "Order small icons vertically"
 msgstr ""
 
 #: tips:93
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
+msgstr ""
+
+#: tips:94
+msgid "Order large icons vertically"
+msgstr ""
+
+#: tips:95
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
+msgstr ""
+
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Arata capul coloanelor"
 
-#: tips:94
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr ""
-"Daca aceasta op˛iune este activa atunci capul coloanelor va fi afi∫at "
-"Ónmodul de afi∫are sub forma de lista."
+"Daca aceasta op≈£iune este activa atunci capul coloanelor va fi afi≈üat "
+"√Ænmodul de afi≈üare sub forma de lista."
 
-#: tips:95
+#: tips:102
 #, fuzzy
 msgid "Show full type"
 msgstr "Sortat dupa tip"
 
-#: tips:96
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr ""
 
-#: tips:97
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "La≈£ime maxima pentru textul de sub icoanele mici."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Arata capul coloanelor"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Daca aceasta op≈£iune este activa atunci capul coloanelor va fi afi≈üat "
+"√Ænmodul de afi≈üare sub forma de lista."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Daca aceasta op≈£iune este activa atunci capul coloanelor va fi afi≈üat "
+"√Ænmodul de afi≈üare sub forma de lista."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Daca aceasta op≈£iune este activa atunci capul coloanelor va fi afi≈üat "
+"√Ænmodul de afi≈üare sub forma de lista."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Daca aceasta op≈£iune este activa atunci capul coloanelor va fi afi≈üat "
+"√Ænmodul de afi≈üare sub forma de lista."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Daca aceasta op≈£iune este activa atunci capul coloanelor va fi afi≈üat "
+"√Ænmodul de afi≈üare sub forma de lista."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Daca aceasta op≈£iune este activa atunci capul coloanelor va fi afi≈üat "
+"√Ænmodul de afi≈üare sub forma de lista."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "Ultima _modificare"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Daca aceasta op≈£iune este activa atunci capul coloanelor va fi afi≈üat "
+"√Ænmodul de afi≈üare sub forma de lista."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Daca aceasta op≈£iune este activa atunci capul coloanelor va fi afi≈üat "
+"√Ænmodul de afi≈üare sub forma de lista."
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Daca aceasta op≈£iune este activa atunci capul coloanelor va fi afi≈üat "
+"√Ænmodul de afi≈üare sub forma de lista."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Unelte/minibuffer"
 
-#: tips:98
+#: tips:131
 msgid "Toolbar"
 msgstr "Bara de unelte"
 
-#: tips:99
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Tipul barii de unelte:"
 
-#: tips:100
+#: tips:133
 #, fuzzy
 msgid "No toolbar"
 msgstr "Bara de unelte"
 
-#: tips:101
+#: tips:134
 msgid "Icons only"
 msgstr "Numai icoane"
 
-#: tips:102
+#: tips:135
 msgid "Text under icons"
 msgstr "Text sub icoane"
 
-#: tips:103
+#: tips:136
 msgid "Text beside icons"
-msgstr "Text l‚nga icoane"
+msgstr "Text l√¢nga icoane"
 
-#: tips:104
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Numai imagine"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Arata totalul obictelor"
 
-#: tips:105
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
 "selected items and their combined size."
 msgstr ""
-"Afi∫eaza numarul elementelor dintr-o fereastra a managerului de fi∫iere, la "
-"fel numarul fi∫ierelor ascunse (daca sunt). C‚nd este o selec˛ie, arata "
-"numarul elementelor selectate ∫i dimensiunea totala."
+"Afi≈üeaza numarul elementelor dintr-o fereastra a managerului de fi≈üiere, la "
+"fel numarul fi≈üierelor ascunse (daca sunt). C√¢nd este o selec≈£ie, arata "
+"numarul elementelor selectate ≈üi dimensiunea totala."
 
-#: tips:106
+#: tips:140
 msgid "Select the buttons you want on the bar:"
-msgstr "Selecteaza butoanele pe care le vrei Ón bara:"
+msgstr "Selecteaza butoanele pe care le vrei √Æn bara:"
 
-#: tips:107
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr ""
 
-#: tips:108
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
 msgstr ""
 
-#: tips:109
+#: tips:143
 msgid "Minibuffer"
 msgstr "Minibuffer"
 
-#: tips:110
+#: tips:144
 msgid "Beep if Tab-completion fails"
-msgstr "Avertizeaza sonor daca la apasarea tastei Tab nu se Ónt‚mpla nimic"
+msgstr "Avertizeaza sonor daca la apasarea tastei Tab nu se √Ænt√¢mpla nimic"
 
-#: tips:111
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
 "letter varies)."
 msgstr ""
-"C‚nd se utilizeaza 'Introdu calea...' Ón minibuffer ∫i se apasa tasta Tab, "
-"avertizeaza sonor daca nu se Ónt‚mpla nimic (din cauza mai multor motive)."
+"C√¢nd se utilizeaza 'Introdu calea...' √Æn minibuffer ≈üi se apasa tasta Tab, "
+"avertizeaza sonor daca nu se √Ænt√¢mpla nimic (din cauza mai multor motive)."
 
-#: tips:112
+#: tips:146
 msgid "Beep if there are several matches"
-msgstr "Avertizeaza sonor daca daca s-au Ónregistrat potriviri la cautare"
+msgstr "Avertizeaza sonor daca daca s-au √Ænregistrat potriviri la cautare"
 
-#: tips:113
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
 msgstr ""
-"C‚nd se utilizeaza 'Introdu calea...' Ón minibuffer ∫i se apasa tasta Tab, "
-"avertizeaza sonor daca s-au inregistrat potriviri Ón numele a cel pu˛in unui "
-"fi∫ier."
+"C√¢nd se utilizeaza 'Introdu calea...' √Æn minibuffer ≈üi se apasa tasta Tab, "
+"avertizeaza sonor daca s-au inregistrat potriviri √Æn numele a cel pu≈£in unui "
+"fi≈üier."
 
-#: tips:116
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Gestionarul de descarcari web"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Eroare √Æn gestionarul %s¬†: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
 msgstr ""
-"C‚nd este activata op˛iunea Monstre, fiecare fi∫ier imagine este Óncarcat ∫i "
-"o mica monstra din el este afi∫ta."
+"C√¢nd este activata op≈£iunea Monstre, fiecare fi≈üier imagine este √Æncarcat ≈üi "
+"o mica monstra din el este afi≈üta."
 
-#: tips:117
+#: tips:155
 msgid "Show image thumbnails"
-msgstr "Arata monstre din fi∫ere imagine"
+msgstr "Arata monstre din fi≈üere imagine"
 
-#: tips:118
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
 msgstr ""
 "Aceasta este setarea implicita pentru ferestrele noi. Utilizeaza meniul "
-"Afi∫aj pentru a activa/dezactiva aceasta op˛iune pentru fiecare feresatra Ón "
+"Afi≈üaj pentru a activa/dezactiva aceasta op≈£iune pentru fiecare feresatra √Æn "
 "parte."
 
-#: tips:119
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Arata monstre din fi≈üere imagine"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 #, fuzzy
 msgid "Video thumbnails"
-msgstr "Arata monstre din fi∫iere imagine"
+msgstr "Arata monstre din fi≈üiere imagine"
 
-#: tips:120
+#: tips:160
 msgid "Thumbnails cache"
-msgstr "Depoziteaza monstrele fi∫ierelor imagine"
+msgstr "Depoziteaza monstrele fi≈üierelor imagine"
 
-#: tips:121
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
-"Pentru a accelera acesta op˛iune, monstrele generate sunt stocate Ón "
-"directorul ascuns ~/.thumbnails. Apasa aici pentru a ∫terge aceste depozite. "
-"Ele vor fi generate c‚nd este nevoie."
+"Pentru a accelera acesta op≈£iune, monstrele generate sunt stocate √Æn "
+"directorul ascuns ~/.thumbnails. Apasa aici pentru a ≈üterge aceste depozite. "
+"Ele vor fi generate c√¢nd este nevoie."
 
-#: tips:122 tips:195
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
+#, fuzzy
+msgid "Manage thumbnails"
+msgstr "Arata monstre din fi≈üere imagine"
+
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Arata monstre din fi≈üiere imagine"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Secunda"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Scurtaturi"
 
-#: tips:123
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
 msgstr ""
-"C‚nd utilizezi scurtaturi, po˛i sa tragi fi∫iere ∫i aplica˛ii pe spa˛iul de "
+"C√¢nd utilizezi scurtaturi, po≈£i sa tragi fi≈üiere ≈üi aplica≈£ii pe spa≈£iul de "
 "lucru pentru a crea scurtaturi catre ele."
 
-#: tips:124 tips:241
+#: tips:178 tips:292
 msgid "Appearance"
-msgstr "Decora˛ii"
+msgstr "Decora≈£ii"
 
-#: tips:125
+#: tips:179
 msgid "Foreground:"
 msgstr "Prim plan:"
 
-#: tips:126
+#: tips:180
 msgid "Text shadow:"
 msgstr "Umbra textului:"
 
-#: tips:127
+#: tips:181
 msgid "Background:"
 msgstr "Fond:"
 
-#: tips:128
+#: tips:182
 #, fuzzy
 msgid "No shadow"
 msgstr "Umbra textului:"
 
-#: tips:129
+#: tips:183
 msgid "Thin"
-msgstr "Sub˛ire"
+msgstr "Sub≈£ire"
 
-#: tips:130
+#: tips:184
 msgid "Thick"
 msgstr "Gros"
 
-#: tips:131
+#: tips:185
 msgid "Use custom font:"
 msgstr "Utilizeaza fontul:"
 
-#: tips:132
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Tipul de caracter utilizat pentru textul de sub icoane"
 
-#: tips:133
+#: tips:187
 msgid "Fast scaling of images"
 msgstr ""
 
-#: tips:134
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
 msgstr ""
 
-#: tips:135
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Comportarea scurtaturilor"
 
-#: tips:136
+#: tips:190
 msgid "Single-click to open"
 msgstr "Simplu click pentru a deschide"
 
-#: tips:138
+#: tips:192
 msgid "Keep icons within screen limits"
-msgstr "Tine icoanele Ón limita spa˛iului ecranului"
+msgstr "Tine icoanele √Æn limita spa≈£iului ecranului"
 
-#: tips:139
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
 msgstr ""
-"C‚nd aceasta op˛iune este activa, icoanele scurtaturilor sunt ˛inute Ón "
-"limita spa˛iului ecranului, incluz‚nd ∫i textul de sub icoana."
+"C√¢nd aceasta op≈£iune este activa, icoanele scurtaturilor sunt ≈£inute √Æn "
+"limita spa≈£iului ecranului, incluz√¢nd ≈üi textul de sub icoana."
 
-#: tips:140
+#: tips:194
 msgid "Icon grid step:"
-msgstr "Pasul de pozi˛ionare al icoanelor:"
+msgstr "Pasul de pozi≈£ionare al icoanelor:"
 
-#: tips:141
+#: tips:195
 msgid "Fine"
 msgstr "Fin"
 
-#: tips:142
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr ""
-"Utilizeaza un caroiaj de 2 pixeli pentru a pozi˛iona icoanele Ón ap˛iul de "
+"Utilizeaza un caroiaj de 2 pixeli pentru a pozi≈£iona icoanele √Æn ap≈£iul de "
 "lucru."
 
-#: tips:143
+#: tips:197
 msgid "Medium"
 msgstr "Mediu"
 
-#: tips:144
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr ""
-"Utilizeaza un caroiaj de 16 pixeli pentru a pozi˛iona icoanele Ón ap˛iul de "
+"Utilizeaza un caroiaj de 16 pixeli pentru a pozi≈£iona icoanele √Æn ap≈£iul de "
 "lucru."
 
-#: tips:145
+#: tips:199
 msgid "Coarse"
 msgstr "Larg"
 
-#: tips:146
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr ""
-"Utilizeaza un caroiaj de 32 pixeli pentru a pozi˛iona icoanele Ón ap˛iul de "
+"Utilizeaza un caroiaj de 32 pixeli pentru a pozi≈£iona icoanele √Æn ap≈£iul de "
 "lucru."
 
-#: tips:147 tips:149
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Iconificarea ferestrelor"
 
-#: tips:148
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
 "windows."
 msgstr ""
 "Majoritatea managerelor de ferestre ofera un mod de a iconifica (ori "
-"minimiza) o ferestra, ∫i diferite programe, incluz‚nd ∫i ROX, pot fi "
-"folosite pentru a afi∫a o fereastra iconificata."
+"minimiza) o ferestra, ≈üi diferite programe, incluz√¢nd ≈üi ROX, pot fi "
+"folosite pentru a afi≈üa o fereastra iconificata."
 
-#: tips:150
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Arata ferestrele iconificate"
 
-#: tips:151
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
 "pinboard must be in use."
 msgstr ""
-"Daca aceasta op˛iune este activa, atunci managerul de fi∫iere va reprezenta "
-"fiecare fereastra iconificata ca un mic buton Óntr-o bara de fi∫iere ∫i "
-"aplica˛ii. Este necesar un manager de ferestre compatibil ∫i sa fie activata "
-"barele de fi∫iere ∫i aplica˛ii."
+"Daca aceasta op≈£iune este activa, atunci managerul de fi≈üiere va reprezenta "
+"fiecare fereastra iconificata ca un mic buton √Æntr-o bara de fi≈üiere ≈üi "
+"aplica≈£ii. Este necesar un manager de ferestre compatibil ≈üi sa fie activata "
+"barele de fi≈üiere ≈üi aplica≈£ii."
 
-#: tips:152
+#: tips:206
 msgid "Show per workspace"
 msgstr ""
 
-#: tips:153
+#: tips:207
 #, fuzzy
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
 msgstr ""
-"Daca aceasta op˛iune este activa, atunci managerul de fi∫iere va reprezenta "
-"fiecare fereastra iconificata ca un mic buton Óntr-o bara de fi∫iere ∫i "
-"aplica˛ii. Este necesar un manager de ferestre compatibil ∫i sa fie activata "
-"barele de fi∫iere ∫i aplica˛ii."
+"Daca aceasta op≈£iune este activa, atunci managerul de fi≈üiere va reprezenta "
+"fiecare fereastra iconificata ca un mic buton √Æntr-o bara de fi≈üiere ≈üi "
+"aplica≈£ii. Este necesar un manager de ferestre compatibil ≈üi sa fie activata "
+"barele de fi≈üiere ≈üi aplica≈£ii."
 
-#: tips:154
+#: tips:208
 msgid "Iconify to the"
 msgstr "Iconifica pe"
 
-#: tips:155
+#: tips:209
 msgid "top-left"
-msgstr "sus-st‚nga"
+msgstr "sus-st√¢nga"
 
-#: tips:156
+#: tips:210
 msgid "top-right"
 msgstr "sus-dreapta"
 
-#: tips:157
+#: tips:211
 msgid "bottom-left"
-msgstr "jos-st‚nga"
+msgstr "jos-st√¢nga"
 
-#: tips:158
+#: tips:212
 msgid "bottom-right"
 msgstr "jos-dreapta"
 
-#: tips:159
+#: tips:213
 msgid ", going"
 msgstr ", se duce"
 
-#: tips:160
+#: tips:214
 msgid "horizontally"
 msgstr "orizontal"
 
-#: tips:161
+#: tips:215
 msgid "vertically"
 msgstr "vertical"
 
-#: tips:162
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
 "or bottom margin to avoid placing the icons there. The filer already knows "
 "about its own panel."
 msgstr ""
-"In anumite cazuri managerul de fi∫iere nu ∫tie despre aranjarea spa˛iului de "
-"lucru ∫i pune ferestrele iconificate, de exemplu, Ón panoul Gnome. Po˛i "
+"In anumite cazuri managerul de fi≈üiere nu ≈ütie despre aranjarea spa≈£iului de "
+"lucru ≈üi pune ferestrele iconificate, de exemplu, √Æn panoul Gnome. Po≈£i "
 "defini marginea superioara sau inferioara unde icoanele sa fie plasate. "
-"Managerul de fi∫iere ∫tie despre panoul propriu."
+"Managerul de fi≈üiere ≈ütie despre panoul propriu."
 
-#: tips:163
+#: tips:217
 msgid "Top margin"
 msgstr "Marginea superioara"
 
-#: tips:164
+#: tips:218
 msgid "Height of no-go area at top of screen."
-msgstr "La˛imea zonei superioare de excluziune."
+msgstr "La≈£imea zonei superioare de excluziune."
 
-#: tips:165
+#: tips:219
 msgid "Bottom margin"
 msgstr "Marginea inferioara"
 
-#: tips:166
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
-msgstr "La˛imea zonei inferioare de excluziune."
+msgstr "La≈£imea zonei inferioare de excluziune."
 
-#: tips:167
-msgid "Panels"
-msgstr "Panouri"
+#: tips:221
+#, fuzzy
+msgid "Left margin"
+msgstr "Marginea superioara"
 
-#: tips:168
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr "Panourile sunt bari de icoane situate de-a lungul marginii ecranului."
+#: tips:222
+#, fuzzy
+msgid "Width of no-go area at left of screen."
+msgstr "La≈£imea zonei superioare de excluziune."
 
-#: tips:169
-msgid "Panel style"
-msgstr "Stilul panoului"
+#: tips:223
+#, fuzzy
+msgid "Right margin"
+msgstr "Marginea inferioara"
 
-#: tips:170
-msgid "Image and text"
-msgstr "Imagine ∫i text"
+#: tips:224
+#, fuzzy
+msgid "Width of no-go area at right of screen."
+msgstr "La≈£imea zonei superioare de excluziune."
 
-#: tips:171
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Fiecare icoana a panoului este reprezentata de o imagine ∫i text."
-
-#: tips:172
-msgid "Image only for applications"
-msgstr "Numai imagini pentru aplica˛ii"
-
-#: tips:173
-msgid ""
-"Applications have just an image, everything else has both an image and text."
-msgstr "Aplica˛iile au numai o imagine, restul au ∫i imagine ∫i text."
-
-#: tips:174
-msgid "Image only"
-msgstr "Numai imagine"
-
-#: tips:175
-msgid "Only the image is shown."
-msgstr "Este reprezentata numai imaginea."
-
-#: tips:176
-msgid "Panel width (thin)"
-msgstr "La˛imea panoului (sub˛ire)"
-
-#: tips:177
-msgid "(thick)"
-msgstr "(gros)"
-
-#: tips:178
-msgid "The size of the panels."
-msgstr "Dimensiunea panoului."
-
-#: tips:179
-msgid "Do not cover panel"
-msgstr ""
-
-#: tips:180
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
-msgstr ""
-
-#: tips:181
-msgid "Xinerama"
-msgstr "Xinerama"
-
-#: tips:182
-msgid "Confine to Xinerama monitor"
-msgstr "Limiteaza la un monitor"
-
-#: tips:183
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
-msgstr ""
-"Daca op˛iunea Xinerama multi-monitor este activa, utilizeaza aceasta op˛iune "
-"pentru a limita un panou pe un singur monitor, Ón loc sa fie Ómpar˛it pe "
-"doua."
-
-#: tips:184
-msgid ""
-"The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr ""
-"Monitorul ∫i panourile sunt limitate Ón modul Xinerama (numerotat de la 0)."
-
-#: tips:185
+#: tips:225
 msgid "Desktop"
 msgstr ""
 
-#: tips:186
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
 msgstr ""
 
-#: tips:187
+#: tips:227
 #, fuzzy
 msgid "Panel only"
 msgstr "Numai imagine"
 
-#: tips:188
+#: tips:228
 #, fuzzy
 msgid "Only a panel is shown."
 msgstr "Este reprezentata numai imaginea."
 
-#: tips:189
+#: tips:229
 #, fuzzy
 msgid "Pinboard only"
 msgstr "Scurtaturi"
 
-#: tips:190
+#: tips:230
 #, fuzzy
 msgid "Only the pinboard is shown."
 msgstr "Este reprezentata numai imaginea."
 
-#: tips:191
+#: tips:231
 #, fuzzy
 msgid "Panel and pinboard"
 msgstr "Scurtaturi"
 
-#: tips:192
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr ""
 
-#: tips:193
-#, fuzzy
-msgid "Panel"
-msgstr "Panouri"
-
-#: tips:194
-msgid "Enter the name of the panel to show here."
-msgstr ""
-
-#: tips:196
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr ""
 
-#: tips:197
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr ""
 
-#: tips:198
+#: tips:236
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 
-#: tips:199
+#: tips:237
 msgid "Action windows"
-msgstr "Ferestrele de ac˛iune"
+msgstr "Ferestrele de ac≈£iune"
 
-#: tips:200
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
 msgstr ""
-"Ferestrele de ac˛iune apar c‚nd se lanseaza o opera˛ie\n"
-"Ón fundal, ca de exemplu copierea sau ∫tergerea fi∫ierelor."
+"Ferestrele de ac≈£iune apar c√¢nd se lanseaza o opera≈£ie\n"
+"√Æn fundal, ca de exemplu copierea sau ≈ütergerea fi≈üierelor."
 
-#: tips:201
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Arata fara dialoguri aceste ferestre"
 
-#: tips:203
+#: tips:241
 msgid "Copy files without confirming first."
-msgstr "Copiaza fi∫ierele fara a confirma la Ónceput."
+msgstr "Copiaza fi≈üierele fara a confirma la √Ænceput."
 
-#: tips:205
+#: tips:243
 msgid "Move files without confirming first."
-msgstr "Muta fi∫ierele fara a confirma la Ónceput."
+msgstr "Muta fi≈üierele fara a confirma la √Ænceput."
 
-#: tips:207
+#: tips:245
 msgid "Create links to files without confirming first."
-msgstr "Creaza legaturi Óntre fi∫iere fara a confirma la Ónceput."
+msgstr "Creaza legaturi √Æntre fi≈üiere fara a confirma la √Ænceput."
 
-#: tips:209
+#: tips:247
 msgid "Delete files without confirming first."
-msgstr "Sterge fi∫ierele fara a confirma la Ónceput."
+msgstr "Sterge fi≈üierele fara a confirma la √Ænceput."
 
-#: tips:210
+#: tips:248
 msgid "Mount"
 msgstr "Monteaza"
 
-#: tips:211
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr ""
-"Monteaza ∫i demonteaza sistemele de fi∫iere fara a confirma la Ónceput."
+"Monteaza ≈üi demonteaza sistemele de fi≈üiere fara a confirma la √Ænceput."
 
-#: tips:212
+#: tips:250
 msgid "Default settings"
-msgstr "Op˛iuni implicite"
+msgstr "Op≈£iuni implicite"
 
-#: tips:214
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "For≈£eaza"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
-msgstr "Nu confirma ∫tergerea elementelor care nu se pot scrie."
+msgstr "Nu confirma ≈ütergerea elementelor care nu se pot scrie."
 
-#: tips:216
+#: tips:254
 msgid "Don't display so much information in the message area."
-msgstr "Afi∫eaza informa˛ii minime Ón aria de mesaje."
+msgstr "Afi≈üeaza informa≈£ii minime √Æn aria de mesaje."
 
-#: tips:218
+#: tips:256
 msgid "Also change contents of subdirectories."
-msgstr "Schimba ∫i con˛inutul subdirectoarelor."
+msgstr "Schimba ≈üi con≈£inutul subdirectoarelor."
 
-#: tips:221
+#: tips:263
+#, fuzzy
+msgid "Mount commands"
+msgstr "Punct de montare"
+
+#: tips:264
+#, fuzzy
+msgid "Mount command"
+msgstr "Punct de montare"
+
+#: tips:265
+msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
+msgstr ""
+
+#: tips:266
+#, fuzzy
+msgid "Unmount command"
+msgstr "Demonteaza"
+
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "Comanda:"
+
+#: tips:269
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
-msgstr "Trage ∫i elibereaza"
+msgstr "Trage ≈üi elibereaza"
 
-#: tips:222
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Trage pe icoane"
 
-#: tips:223
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
-msgstr "Permite tragerea pe icoane Ón managerul de fi∫iere"
+msgstr "Permite tragerea pe icoane √Æn managerul de fi≈üiere"
 
-#: tips:224
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
 "will put it into that directory, or load it into the program."
 msgstr ""
-"C‚nd aceasta este activa, po˛i trage un fi∫ier peste un subdirector sau un "
-"program Óntr-o fereastra a managerului de fi∫iere. Elementul va fi nuan˛at "
-"c‚nd faci asta ∫i ∫i eliber‚nd-ul el vafi pus Ón director, ori Óncarcat Ón "
+"C√¢nd aceasta este activa, po≈£i trage un fi≈üier peste un subdirector sau un "
+"program √Æntr-o fereastra a managerului de fi≈üiere. Elementul va fi nuan≈£at "
+"c√¢nd faci asta ≈üi ≈üi eliber√¢nd-ul el vafi pus √Æn director, ori √Æncarcat √Æn "
 "program."
 
-#: tips:225
+#: tips:276
 msgid "Directories spring open"
 msgstr "Directoarele simuleaza o selectare"
 
-#: tips:226
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
 "short while."
 msgstr ""
-"Aceasta op˛iune, care necesita op˛iunea dinainte sa fie activa, cauzeaza "
-"directorelor sa simuleze o selectare c‚nd fi∫ierul este ˛inut peste ele o "
+"Aceasta op≈£iune, care necesita op≈£iunea dinainte sa fie activa, cauzeaza "
+"directorelor sa simuleze o selectare c√¢nd fi≈üierul este ≈£inut peste ele o "
 "scurta perioada de timp."
 
-#: tips:227
+#: tips:278
 msgid "Spring delay:"
-msgstr "Int‚rzierea la simulare:"
+msgstr "Int√¢rzierea la simulare:"
 
-#: tips:228
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:229
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
 "have any effect."
 msgstr ""
-"Aceasta op˛iune seteaza c‚t timp, Ón ms, trebuie ˛inut un fi∫ier deasupra "
-"unui director Ónainte ca acesta sa simuleze o selec˛ie."
+"Aceasta op≈£iune seteaza c√¢t timp, √Æn ms, trebuie ≈£inut un fi≈üier deasupra "
+"unui director √Ænainte ca acesta sa simuleze o selec≈£ie."
 
-#: tips:230
+#: tips:281
 msgid "When dragging files with the left mouse button"
-msgstr "C‚nd trage˛i fi∫ierele cu butonul din st‚nga al mouse-ului"
+msgstr "C√¢nd trage≈£i fi≈üierele cu butonul din st√¢nga al mouse-ului"
 
-#: tips:231 tips:235
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
-msgstr "Arata un meniu al posibilelor ac˛iuni"
+msgstr "Arata un meniu al posibilelor ac≈£iuni"
 
-#: tips:232
+#: tips:283
 msgid "Copy the files"
-msgstr "Copiaza fi∫ierele"
+msgstr "Copiaza fi≈üierele"
 
-#: tips:233
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
-msgstr "Se poate face ca meniul sa apara, trag‚nd cu tasta Alt ˛inuta apasata."
+msgstr "Se poate face ca meniul sa apara, trag√¢nd cu tasta Alt ≈£inuta apasata."
 
-#: tips:234
+#: tips:285
 msgid "When dragging files with the middle mouse button"
-msgstr "C‚nd trage˛i fi∫ierele cu butonul din mijloc al mouse-ului"
+msgstr "C√¢nd trage≈£i fi≈üierele cu butonul din mijloc al mouse-ului"
 
-#: tips:236
+#: tips:287
 msgid "Move the files"
-msgstr "Muta fi∫ierele"
+msgstr "Muta fi≈üierele"
 
-#: tips:237
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
 msgstr ""
-"Se poate face ca meniul sa apara, trag‚nd cu butonul din st‚nga al mouse-"
-"ului ∫i cu tasta Alt ˛inuta apasata. "
+"Se poate face ca meniul sa apara, trag√¢nd cu butonul din st√¢nga al mouse-"
+"ului ≈üi cu tasta Alt ≈£inuta apasata. "
 
-#: tips:238
+#: tips:289
 msgid "Download handler"
 msgstr "Gestionarul de descarcari web"
 
-#: tips:239
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4406,91 +5159,97 @@ msgid ""
 "xterm -e wget $1"
 msgstr ""
 
-#: tips:240
+#: tips:291
 msgid "Menus"
 msgstr "Meniu"
 
-#: tips:242
+#: tips:293
 msgid "Size of icons in menus:"
-msgstr "Dimensiunea icoanelor Ón meniu:"
+msgstr "Dimensiunea icoanelor √Æn meniu:"
 
-#: tips:243
+#: tips:294
 msgid "No Icons"
 msgstr "Fara icoane"
 
-#: tips:246
+#: tips:297
 msgid "Same as current window"
 msgstr "La fel ca fereastra curenta"
 
-#: tips:247
+#: tips:298
 msgid "Same as default"
 msgstr "La fel ca cele implicite"
 
-#: tips:248
+#: tips:299
 msgid "Behaviour"
 msgstr "Comportament"
 
-#: tips:249
+#: tips:300
 msgid "File menu on right-click"
-msgstr "Meniul Fi∫ier la click cu butonul din dreapta"
+msgstr "Meniul Fi≈üier la click cu butonul din dreapta"
 
-#: tips:250
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
 msgstr ""
-"Arata meniul Fi∫ier Ón locul meniului principal c‚nd fac click cu butonul "
-"din dreapta pe un fi∫ier selectat (meniul principal poate fi accesat ˛in‚nd "
+"Arata meniul Fi≈üier √Æn locul meniului principal c√¢nd fac click cu butonul "
+"din dreapta pe un fi≈üier selectat (meniul principal poate fi accesat ≈£in√¢nd "
 "tasta Ctrl apasata)."
 
-#: tips:251
-msgid "`Xterm Here' program"
-msgstr "Programul pentru ´ Xterm aici†ª"
+#: tips:302
+#, fuzzy
+msgid "Terminal emulator program"
+msgstr "Programul pentru ≈§ Xterm aici¬†≈•"
 
-#: tips:252
-msgid "The program to launch when you choose `Xterm Here' from the menu."
+#: tips:303
+#, fuzzy
+msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr ""
-"Programul care va fi lansat c‚nd se alega op˛iunea ´†Xterm aici†ª din meniu."
+"Programul care va fi lansat c√¢nd se alega op≈£iunea ≈§¬†Xterm aici¬†≈• din meniu."
 
-#: tips:253
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Scurtaturi pentru tastatura"
 
-#: tips:255
+#: tips:305
+msgid "Types"
+msgstr "Tipuri"
+
+#: tips:306
 msgid "MIME types"
 msgstr "Tipul MIME"
 
-#: tips:256
+#: tips:307
 #, fuzzy
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
 msgstr ""
-"Mangerul de fi∫iere folose∫te un set de reguli pentru a determina tipul MIME "
-"al fiecarui fi∫ier normal Ón parte, ∫i alege o icoana potrivita pentru acest "
-"tip. Utilizeaza aplica˛ia MIME-Editor pentru a schimba regulile fi∫ier la "
+"Mangerul de fi≈üiere folose≈üte un set de reguli pentru a determina tipul MIME "
+"al fiecarui fi≈üier normal √Æn parte, ≈üi alege o icoana potrivita pentru acest "
+"tip. Utilizeaza aplica≈£ia MIME-Editor pentru a schimba regulile fi≈üier la "
 "tip:\n"
 "\n"
 "http://rox.sourceforge.net/mime_editor.html"
 
-#: tips:257
+#: tips:308
 msgid "Edit MIME rules"
 msgstr ""
 
-#: tips:258
+#: tips:309
 #, fuzzy
 msgid "Themes"
 msgstr "Data & timp"
 
-#: tips:259
+#: tips:310
 msgid "Icon theme"
 msgstr "Tema icoanelor"
 
-#: tips:260
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
-msgstr "Temele trebuie plasate Ón directorul ~/.icons."
+msgstr "Temele trebuie plasate √Æn directorul ~/.icons."
 
-#: tips:261
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
@@ -4498,94 +5257,122 @@ msgstr ""
 "Utilizeaza ferestra de dialog 'Seteaza icoana...'pentru a seta icoana pentru "
 "fiecare tip MIME. Aceste setari vor suprascrie setarile din tema selectata."
 
-#: tips:262
+#: tips:313
 msgid "Colours"
 msgstr "Culori"
 
-#: tips:263
+#: tips:314
 msgid "File type colours"
-msgstr "Tipul fi∫ierelor prin culori"
+msgstr "Tipul fi≈üierelor prin culori"
 
-#: tips:264
+#: tips:315
 msgid "Colour files based on their types"
-msgstr "Coloreaza fi∫ierele dupa tipul lor"
+msgstr "Coloreaza fi≈üierele dupa tipul lor"
 
-#: tips:265
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr ""
-"Numele fi∫ierelor (∫i detaliile) sunt colorate Ón concordan˛a cu tipul lor"
+"Numele fi≈üierelor (≈üi detaliile) sunt colorate √Æn concordan≈£a cu tipul lor"
 
-#: tips:266
+#: tips:317
 msgid "Directory:"
 msgstr "Director:"
 
-#: tips:267
+#: tips:318
 msgid "Regular file:"
-msgstr "Fi∫ier normal:"
+msgstr "Fi≈üier normal:"
 
-#: tips:268
+#: tips:319
 msgid "Pipe:"
-msgstr "Fi∫ier ˛eava:"
+msgstr "Fi≈üier ≈£eava:"
 
-#: tips:269
+#: tips:320
 msgid "Socket:"
 msgstr "Socket:"
 
-#: tips:271
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
 msgstr ""
-"Eroare, posibil o legatura care are ca destina˛ie un fi∫ier neexistent, ori "
-"un fi∫ier pe care managerul de fi∫iere nu are permisiunea sa-l examineze."
+"Eroare, posibil o legatura care are ca destina≈£ie un fi≈üier neexistent, ori "
+"un fi≈üier pe care managerul de fi≈üiere nu are permisiunea sa-l examineze."
 
-#: tips:272
+#: tips:323
 msgid "Character device:"
 msgstr "Dispozitiv caracter:"
 
-#: tips:273
+#: tips:324
 msgid "Block device:"
 msgstr "Dispozitiv bloc:"
 
-#: tips:274
+#: tips:325
 msgid "Door:"
-msgstr "Fi∫ier poarta:"
+msgstr "Fi≈üier poarta:"
 
-#: tips:275
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
 msgstr ""
-"Fi∫ierele poarta seamana pu˛in cu socket-urile sau fi∫ierele ˛eava, "
-"darexista numai Ón sistemul de operare Solaris."
+"Fi≈üierele poarta seamana pu≈£in cu socket-urile sau fi≈üierele ≈£eava, "
+"darexista numai √Æn sistemul de operare Solaris."
 
-#: tips:276
+#: tips:327
 msgid "Executable file:"
-msgstr "Fi∫ier executabil:"
+msgstr "Fi≈üier executabil:"
 
-#: tips:277
+#: tips:328
 msgid "Application directory:"
-msgstr "Directorul aplica˛ie:"
+msgstr "Directorul aplica≈£ie:"
 
-#: tips:278
+#: tips:329
 msgid "Unknown type:"
 msgstr "Tip necunoscut:"
 
-#: tips:279
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Fond:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Utilizeaza fontul:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Compatibilitate"
 
-#: tips:280
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Probleme ale managerului de ferestre"
 
-#: tips:281
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr ""
-"Intareste controlul managerului de fi∫iere asupra scurtaturilor ∫i a "
-"panourilor de fi∫iere ∫i aplica˛ii"
+"Intareste controlul managerului de fi≈üiere asupra scurtaturilor ≈üi a "
+"panourilor de fi≈üiere ≈üi aplica≈£ii"
 
-#: tips:282
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4593,86 +5380,105 @@ msgid ""
 "on it, titlebars and other decorations appearing around windows, or having "
 "them appear in window-select lists."
 msgstr ""
-"Anumite managere de fi∫iere nu suporta noul sistem extins de aspect al "
-"ferestrelor, ∫i trateaza scurtaturile ∫i panourile de fi∫iere ∫i aplica˛ii "
-"ca ferestre normale. Activeaza aceasta op˛iune pentru a remedia anumite "
-"probleme cum sunt: faptul ca fac‚nd click pe o scurtatura ea vine Ón fa˛a, "
-"bara de titlu sau alte decora˛iuni Ón jurul ferestrei sau apare Ón lista de "
+"Anumite managere de fi≈üiere nu suporta noul sistem extins de aspect al "
+"ferestrelor, ≈üi trateaza scurtaturile ≈üi panourile de fi≈üiere ≈üi aplica≈£ii "
+"ca ferestre normale. Activeaza aceasta op≈£iune pentru a remedia anumite "
+"probleme cum sunt: faptul ca fac√¢nd click pe o scurtatura ea vine √Æn fa≈£a, "
+"bara de titlu sau alte decora≈£iuni √Æn jurul ferestrei sau apare √Æn lista de "
 "ferestre."
 
-#: tips:283
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr ""
-"Redirec˛ioneaza toate click-urile de fundal ale mouse-ului catre managerul "
-"de fi∫iere"
+"Redirec≈£ioneaza toate click-urile de fundal ale mouse-ului catre managerul "
+"de fi≈üiere"
 
-#: tips:284
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
 "events to your window manager instead. Clicks on icons will not be forwarded."
 msgstr ""
-"In mod normal, click cu butonul din dreapta pe fundalul spa˛iului de lucru "
-"va deschide meniul scurtaturilor ∫i click cu butonul din st‚nga va ∫terge "
-"selec˛ia. Activeaza aceasta op˛iune pentru a redirec˛iona mesajele catre "
-"managerul de fi∫iere. Click-urile pe icoane nu vor fi redirec˛ionate."
+"In mod normal, click cu butonul din dreapta pe fundalul spa≈£iului de lucru "
+"va deschide meniul scurtaturilor ≈üi click cu butonul din st√¢nga va ≈üterge "
+"selec≈£ia. Activeaza aceasta op≈£iune pentru a redirec≈£iona mesajele catre "
+"managerul de fi≈üiere. Click-urile pe icoane nu vor fi redirec≈£ionate."
 
-#: tips:285
+#: tips:343
 msgid "Blackbox root menus hack"
-msgstr "Inbunata˛iri ale meniului radacina Blackbox"
+msgstr "Inbunata≈£iri ale meniului radacina Blackbox"
 
-#: tips:286
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
 "managers are expected to change their behaviour in new versions so that this "
 "isn't necessary."
 msgstr ""
-"Blackbox, Fluxbox ∫i alte managere de fi∫iere similare nu lucreaza corect cu "
-"scurtaturile managerului de fi∫iere ROX. Aceasta op˛iune activeaza anumite "
-"Ónbunata˛iri. Aceste managere de ferestre a∫teapta sa-∫i schimbe "
-"comportamentul Ón versiunile ulterioare, a∫a ca aceasta op˛iune nu va mai fi "
+"Blackbox, Fluxbox ≈üi alte managere de fi≈üiere similare nu lucreaza corect cu "
+"scurtaturile managerului de fi≈üiere ROX. Aceasta op≈£iune activeaza anumite "
+"√Ænbunata≈£iri. Aceste managere de ferestre a≈üteapta sa-≈üi schimbe "
+"comportamentul √Æn versiunile ulterioare, a≈üa ca aceasta op≈£iune nu va mai fi "
 "necesara."
 
-#: tips:287
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr ""
 
-#: tips:288
+#: tips:346
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 
-#: tips:289
-msgid "Drag and drop"
-msgstr "Trage ∫i elibereaza"
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Stilul panoului"
 
-#: tips:290
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
+msgid "Drag and drop"
+msgstr "Trage ≈üi elibereaza"
+
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Nu utiliza numele gazdei"
 
-#: tips:291
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
 "sign on the pointer but the drop doesn't work."
 msgstr ""
-"Anumite aplica˛ii vechi nu suporta complet protocolul XDND ∫i trebuie sa "
-"aiba activata aceasta op˛iune. Utilizeaza aceasta op˛iune daca trage˛i un "
-"fi∫ier intr-o aplica˛ie, apare semnul + langa indicatorului mouse-ului, dar "
-"ac˛iunea nu \"produce\" nimic."
+"Anumite aplica≈£ii vechi nu suporta complet protocolul XDND ≈üi trebuie sa "
+"aiba activata aceasta op≈£iune. Utilizeaza aceasta op≈£iune daca trage≈£i un "
+"fi≈üier intr-o aplica≈£ie, apare semnul + langa indicatorului mouse-ului, dar "
+"ac≈£iunea nu \"produce\" nimic."
 
-#: tips:292
-msgid "Extended attributes"
-msgstr ""
-
-#: tips:293
+#: tips:355
 #, fuzzy
 msgid "Don't use extended attributes"
 msgstr "Nu utiliza numele gazdei"
 
-#: tips:294
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4680,15 +5486,372 @@ msgid ""
 "the properties window does not report extended attributes."
 msgstr ""
 
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Marginea inferioara"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+msgid "Right gap:"
+msgstr ""
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "Directorul acasa"
+
+#: ../Templates.ui.h:4
+#, fuzzy
+msgid "Panel Options"
+msgstr "Op≈£iuni"
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Imagine ≈üi text"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Fiecare icoana a panoului este reprezentata de o imagine ≈üi text."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Numai imagini pentru aplica≈£ii"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr "Aplica≈£iile au numai o imagine, restul au ≈üi imagine ≈üi text."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Numai imagine"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Este reprezentata numai imaginea."
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "La≈£imea panoului (sub≈£ire)"
+
+#: ../Templates.ui.h:12
+#, fuzzy
+msgid "The size of this panel."
+msgstr "Dimensiunea panoului."
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Traducere"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr ""
+
+#: ../Templates.ui.h:19
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Stilul panoului"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Limiteaza la un monitor"
+
+#: ../Templates.ui.h:22
+#, fuzzy
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Daca op≈£iunea Xinerama multi-monitor este activa, utilizeaza aceasta op≈£iune "
+"pentru a limita un panou pe un singur monitor, √Æn loc sa fie √Æmpar≈£it pe "
+"doua."
+
+#: ../Templates.ui.h:23
+#, fuzzy
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+"Monitorul ≈üi panourile sunt limitate √Æn modul Xinerama (numerotat de la 0)."
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "Xinerama"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr ""
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr ""
+
+#: ../Templates.ui.h:27
+#, fuzzy
+msgid "Bottom edge"
+msgstr "Marginea inferioara"
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr ""
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "<b>Drepturi</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<dir>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' exista deja - scriu peste ?"
+
+#, fuzzy
+#~ msgid "Choices migration"
+#~ msgstr "Chinois (traditionnel)"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Eroare la scanarea '%s'¬†:\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Director lipsa/≈üters"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Directorul '%s' nu se gase≈üte."
+
+#~ msgid "Cancel"
+#~ msgstr "Anuleaza"
+
+#~ msgid "GNOME-VFS library"
+#~ msgstr "biblioteca GNOME-VFS"
+
+#~ msgid "Dnotify support"
+#~ msgstr "Suport dnotify"
+
+#~ msgid "Open AVFS"
+#~ msgstr "Deschide AVFS"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Trebuie sa execu≈£i Shift+click pe meniu pentru atrimite fi≈üierul undeva"
+
+#~ msgid "Look inside ... ?"
+#~ msgstr "Prive≈üte √Æn interior ... ?"
+
+#, fuzzy
+#~ msgid "Panel: %s"
+#~ msgstr "Panouri"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Fi≈üier de traducere .gmo invalid (prea scurt): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr ""
+#~ "Fi≈üier de traducere .gmo invalid (numarul magic GNU nu este gasit): %s"
+
+#~ msgid "B"
+#~ msgstr "O"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Schimba la fereastra parinte"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Schimba la directorul acasa"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Semne"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Meniul semnelor"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Rescaneaza con≈£inutul directorului"
+
+#~ msgid "Change icon size"
+#~ msgstr "Schimba dimensiunea icoanei"
+
+#~ msgid "Show extra details"
+#~ msgstr "Arata detalii suplimentare"
+
+#~ msgid "Hidden"
+#~ msgstr "Ascuns"
+
+#~ msgid "Show/hide hidden files"
+#~ msgstr "Arata/ascunde fi≈üierele ascunse"
+
+#~ msgid ""
+#~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
+#~ "instead."
+#~ msgstr ""
+#~ "Tema icoanelor '%s' nu con≈£ine icoane MIME. Se utilizeaza tema ROX "
+#~ "implicita."
+
+#~ msgid "Language"
+#~ msgstr "Limba"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "Utilizeaza variabila LANG"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Chinois (traditionnel)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Chinois (simplifi√©)"
+
+#~ msgid "Czech"
+#~ msgstr "Tchƒçque"
+
+#~ msgid "Danish"
+#~ msgstr "Danois"
+
+#~ msgid "Dutch"
+#~ msgstr "N√©erlandais"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Engleza (fara traducere)"
+
+#, fuzzy
+#~ msgid "Finnish"
+#~ msgstr "Danois"
+
+#~ msgid "French"
+#~ msgstr "Franceza"
+
+#~ msgid "German"
+#~ msgstr "Germana"
+
+#~ msgid "Hungarian"
+#~ msgstr "Maghiara"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonais"
+
+#~ msgid "Norwegian"
+#~ msgstr "Norv√©gien"
+
+#~ msgid "Italian"
+#~ msgstr "Italiana"
+
+#~ msgid "Polish"
+#~ msgstr "Polonais"
+
+#~ msgid "Russian"
+#~ msgstr "Russe"
+
+#~ msgid "Spanish"
+#~ msgstr "Spaniola"
+
+#~ msgid "Swedish"
+#~ msgstr "Su√©dois"
+
+#~ msgid "Change at:"
+#~ msgstr "Schimba la:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "La≈£ime maxima (Icoane mari):"
+
+#~ msgid "Panels"
+#~ msgstr "Panouri"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Panourile sunt bari de icoane situate de-a lungul marginii ecranului."
+
+#~ msgid "(thick)"
+#~ msgstr "(gros)"
+
 #~ msgid ""
 #~ "Error loading MIME database:\n"
 #~ "%s"
 #~ msgstr ""
-#~ "Eroare Ón Óncarcarea bazei de date MIME:\n"
+#~ "Eroare √Æn √Æncarcarea bazei de date MIME:\n"
 #~ "%s"
 
 #~ msgid "File '%s' corrupted!"
-#~ msgstr "Fi∫ierul '%s' este corupt !"
+#~ msgstr "Fi≈üierul '%s' este corupt !"
 
 #~ msgid ""
 #~ "The ~/.mime directory has moved. It should now be ~/.local/share/mime. "
@@ -4696,8 +5859,8 @@ msgstr ""
 #~ "applications)."
 #~ msgstr ""
 #~ "directorul ~/.mime a fost mutat. El trebuie sa fie ~/.local/share/mime. "
-#~ "Trebuie sa-l mu˛i acolo (∫i sa creezi o legatura simbolica de la ~/.mime "
-#~ "la el pentru ca aplica˛iile mai vechi sa ruleze)."
+#~ "Trebuie sa-l mu≈£i acolo (≈üi sa creezi o legatura simbolica de la ~/.mime "
+#~ "la el pentru ca aplica≈£iile mai vechi sa ruleze)."
 
 #~ msgid ""
 #~ "The standard MIME type database (version 0.9 or later) was not found. The "
@@ -4711,20 +5874,20 @@ msgstr ""
 #~ "share/mime/globs)."
 #~ msgstr ""
 #~ "Baza de date standard MIME (versiunea 0.9 sau ulterioara) nu a fost "
-#~ "gasita. Managerul de fi∫iere probabil nu va arata tipul corect pentru "
-#~ "diferitele fi∫iere. Trebuie sa descarci ∫i sa instalezi pachetul 'shared-"
-#~ "mime-info-0.9' din loca∫ia http://www.freedesktop.org/software/shared-"
+#~ "gasita. Managerul de fi≈üiere probabil nu va arata tipul corect pentru "
+#~ "diferitele fi≈üiere. Trebuie sa descarci ≈üi sa instalezi pachetul 'shared-"
+#~ "mime-info-0.9' din loca≈üia http://www.freedesktop.org/software/shared-"
 #~ "mime-info\n"
 #~ "\n"
 #~ "Daca ai instalat deja acest pachet, atunci verifica drepturile de citire "
-#~ "pentru fi∫iere (verifica /usr/local/share/mime/globs sau /usr/share/mime/"
+#~ "pentru fi≈üiere (verifica /usr/local/share/mime/globs sau /usr/share/mime/"
 #~ "globs)."
 
 #~ msgid "Icon '%s' not present in theme"
 #~ msgstr "Icoana '%s' nu este prezenta in tema"
 
 #~ msgid "Executable files"
-#~ msgstr "Fi∫ier executabil"
+#~ msgstr "Fi≈üier executabil"
 
 #~ msgid "Ignore eXecutable bit for known extensions"
 #~ msgstr "Ignora bitul executabil pentru extensiile cunoscute"
@@ -4734,8 +5897,8 @@ msgstr ""
 #~ "bit. This is useful if you have files on a Windows-type filesystem which "
 #~ "are being shown as executable programs."
 #~ msgstr ""
-#~ "Daca un fi∫ier are o extensie cunoscuta (ex. '.gif') atunci ignora bitul "
-#~ "executabil. Aceasta ete utila c‚nd fi∫ierele sunt pe un sistem de fi∫iere "
+#~ "Daca un fi≈üier are o extensie cunoscuta (ex. '.gif') atunci ignora bitul "
+#~ "executabil. Aceasta ete utila c√¢nd fi≈üierele sunt pe un sistem de fi≈üiere "
 #~ "de tip Windows, unde toate sunt executabile."
 
 #, fuzzy
@@ -4746,21 +5909,11 @@ msgstr ""
 #~ "Pinboard icons cannot be drawn because ROX-Filer was compiled against GTK"
 #~ "+-2.0 but is running with GTK+-2.2. Please recompile it."
 #~ msgstr ""
-#~ "Les icÙnes du punaiseur ne peuvent pas Ítre dessinÈes car ROX-Filer a ÈtÈ "
-#~ "compilÈ avec GTK+-2.0 mais tourne avec GTK+-2.2. Recompilez-le SVP."
+#~ "Les ic√¥nes du punaiseur ne peuvent pas ƒôtre dessin√©es car ROX-Filer a √©t√© "
+#~ "compil√© avec GTK+-2.0 mais tourne avec GTK+-2.2. Recompilez-le SVP."
 
 #~ msgid "No (gnome-vfs-config not found)"
 #~ msgstr "Nu (gnome-vfs-config nu este gasit)"
-
-#~ msgid ""
-#~ "Failed to create symlink '%s':\n"
-#~ "%s"
-#~ msgstr ""
-#~ "Imposibil de creat legatura simbolica '%s' :\n"
-#~ "%s"
-
-#~ msgid "A"
-#~ msgstr "T"
 
 #~ msgid "All, "
 #~ msgstr "Toate, "

--- a/ROX-Filer/src/po/ru.po
+++ b/ROX-Filer/src/po/ru.po
@@ -11,60 +11,65 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ru\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2008-01-17 04:44+0300\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2006-03-30 21:14+0400\n"
 "Last-Translator: Nikita E. Shalaev <smacker@mail.ru>\n"
 "Language-Team: Russian <ru@li.org>\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=KOI8-R\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.0.2\n"
 
-#: abox.c:125
-msgid "<dir>"
-msgstr "<каталог>"
+#: abox.c:127
+msgid "<src>"
+msgstr ""
 
-#: abox.c:218
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
-msgstr "Молча"
+msgstr "п°п╬п╩я┤п╟"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Quiet"
-msgstr "Молча"
+msgstr "п°п╬п╩я┤п╟"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Don't confirm every operation"
-msgstr "Не подтверждать каждую операцию"
+msgstr "п²п╣ п©п╬п╢я┌п╡п╣я─п╤п╢п╟я┌я▄ п╨п╟п╤п╢я┐я▌ п╬п©п╣я─п╟я├п╦я▌"
 
-#: abox.c:454 infobox.c:771 tips:36
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
-msgstr "Имя"
+msgstr "п≤п╪я▐"
 
-#: abox.c:460 menu.c:237
+#: abox.c:447 menu.c:751
 msgid "Directory"
-msgstr "Каталог"
+msgstr "п п╟я┌п╟п╩п╬пЁ"
 
-#: abox.c:549
+#: abox.c:546
 msgid "Expression:"
-msgstr "Выражение:"
+msgstr "п▓я▀я─п╟п╤п╣п╫п╦п╣:"
 
 #: action.c:57
 msgid "See the attr(5) man page for full details."
-msgstr "Обратитесь к руководству man attr (5 раздел) за подробной справкой."
+msgstr "п·п╠я─п╟я┌п╦я┌п╣я│я▄ п╨ я─я┐п╨п╬п╡п╬п╢я│я┌п╡я┐ man attr (5 я─п╟п╥п╢п╣п╩) п╥п╟ п©п╬п╢я─п╬п╠п╫п╬п╧ я│п©я─п╟п╡п╨п╬п╧."
 
 #: action.c:59
 msgid "See the fsattr(5) man page for full details."
-msgstr "Обратитесь к руководству man fsattr (5 раздел) за подробной справкой."
+msgstr "п·п╠я─п╟я┌п╦я┌п╣я│я▄ п╨ я─я┐п╨п╬п╡п╬п╢я│я┌п╡я┐ man fsattr (5 я─п╟п╥п╢п╣п╩) п╥п╟ п©п╬п╢я─п╬п╠п╫п╬п╧ я│п©я─п╟п╡п╨п╬п╧."
 
 #: action.c:61
 msgid "You do not appear to have OS support."
-msgstr "Видимо, нет поддержки операционной системы."
+msgstr "п▓п╦п╢п╦п╪п╬, п╫п╣я┌ п©п╬п╢п╢п╣я─п╤п╨п╦ п╬п©п╣я─п╟я├п╦п╬п╫п╫п╬п╧ я│п╦я│я┌п╣п╪я▀."
 
-#: action.c:191
+#: action.c:198
 msgid "Find expression reference"
-msgstr "Найти по заданному выражению"
+msgstr "п²п╟п╧я┌п╦ п©п╬ п╥п╟п╢п╟п╫п╫п╬п╪я┐ п╡я▀я─п╟п╤п╣п╫п╦я▌"
 
-#: action.c:202
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -102,48 +107,48 @@ msgid ""
 "a % in 'command' is replaced with the path of the current file)\n"
 "<b>prune</b> (false, and prevents searching the contents of a directory)."
 msgstr ""
-"<u>Быстрый старт</u>\n"
-"Введите имя искомого файла в одинарных кавычках:\n"
-"<b>'index.html'</b> (чтобы найти файл 'index.html')\n"
+"<u>п▒я▀я│я┌я─я▀п╧ я│я┌п╟я─я┌</u>\n"
+"п▓п╡п╣п╢п╦я┌п╣ п╦п╪я▐ п╦я│п╨п╬п╪п╬пЁп╬ я└п╟п╧п╩п╟ п╡ п╬п╢п╦п╫п╟я─п╫я▀я┘ п╨п╟п╡я▀я┤п╨п╟я┘:\n"
+"<b>'index.html'</b> (я┤я┌п╬п╠я▀ п╫п╟п╧я┌п╦ я└п╟п╧п╩ 'index.html')\n"
 "\n"
-"<u>Примеры</u>\n"
-"<b>'*.htm', '*.html'</b> (найти файлы HTML)\n"
-"<b>IsDir 'lib'</b> (найти каталоги с названием 'lib')\n"
-"<b>IsReg 'core'</b> (найти файлы с названием 'core')\n"
-"<b>! (IsDir, IsReg)</b> (не каталоги и не регулярные файлы)\n"
-"<b>mtime after 1 day ago and size > 1Mb</b> (большие, недавно "
-"модифицированные)\n"
-"<b>'CVS' prune, isreg</b> (регулярный файл вне CVS)\n"
-"<b>IsReg system(grep -q fred \"%\")</b> (содержащие слово 'fred')\n"
+"<u>п÷я─п╦п╪п╣я─я▀</u>\n"
+"<b>'*.htm', '*.html'</b> (п╫п╟п╧я┌п╦ я└п╟п╧п╩я▀ HTML)\n"
+"<b>IsDir 'lib'</b> (п╫п╟п╧я┌п╦ п╨п╟я┌п╟п╩п╬пЁп╦ я│ п╫п╟п╥п╡п╟п╫п╦п╣п╪ 'lib')\n"
+"<b>IsReg 'core'</b> (п╫п╟п╧я┌п╦ я└п╟п╧п╩я▀ я│ п╫п╟п╥п╡п╟п╫п╦п╣п╪ 'core')\n"
+"<b>! (IsDir, IsReg)</b> (п╫п╣ п╨п╟я┌п╟п╩п╬пЁп╦ п╦ п╫п╣ я─п╣пЁя┐п╩я▐я─п╫я▀п╣ я└п╟п╧п╩я▀)\n"
+"<b>mtime after 1 day ago and size > 1Mb</b> (п╠п╬п╩я▄я┬п╦п╣, п╫п╣п╢п╟п╡п╫п╬ "
+"п╪п╬п╢п╦я└п╦я├п╦я─п╬п╡п╟п╫п╫я▀п╣)\n"
+"<b>'CVS' prune, isreg</b> (я─п╣пЁя┐п╩я▐я─п╫я▀п╧ я└п╟п╧п╩ п╡п╫п╣ CVS)\n"
+"<b>IsReg system(grep -q fred \"%\")</b> (я│п╬п╢п╣я─п╤п╟я┴п╦п╣ я│п╩п╬п╡п╬ 'fred')\n"
 "\n"
-"<u>Простые условия</u>\n"
+"<u>п÷я─п╬я│я┌я▀п╣ я┐я│п╩п╬п╡п╦я▐</u>\n"
 "<b>IsReg, IsLink, IsDir, IsChar, IsBlock, IsDev, IsPipe, IsSocket, IsDoor</"
-"b> (типы)\n"
+"b> (я┌п╦п©я▀)\n"
 "<b>IsSUID, IsSGID, IsSticky, IsReadable, IsWriteable, IsExecutable</b> "
-"(доступ)\n"
+"(п╢п╬я│я┌я┐п©)\n"
 "<b>IsEmpty, IsMine</b>\n"
-"Шаблон в кавычках - то, что нужно искать (в стиле shell).\n"
-"Если он содержит косую черту, то подразумевается полный путь;\n"
-"в противном случае это просто имя.\n"
+"п╗п╟п╠п╩п╬п╫ п╡ п╨п╟п╡я▀я┤п╨п╟я┘ - я┌п╬, я┤я┌п╬ п╫я┐п╤п╫п╬ п╦я│п╨п╟я┌я▄ (п╡ я│я┌п╦п╩п╣ shell).\n"
+"п∙я│п╩п╦ п╬п╫ я│п╬п╢п╣я─п╤п╦я┌ п╨п╬я│я┐я▌ я┤п╣я─я┌я┐, я┌п╬ п©п╬п╢я─п╟п╥я┐п╪п╣п╡п╟п╣я┌я│я▐ п©п╬п╩п╫я▀п╧ п©я┐я┌я▄;\n"
+"п╡ п©я─п╬я┌п╦п╡п╫п╬п╪ я│п╩я┐я┤п╟п╣ я█я┌п╬ п©я─п╬я│я┌п╬ п╦п╪я▐.\n"
 "\n"
-"<u>Сравнения</u>\n"
-"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (сравнить два "
-"значения)\n"
-"<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (размеры файлов)\n"
-"<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (время)\n"
+"<u>п║я─п╟п╡п╫п╣п╫п╦я▐</u>\n"
+"<b>&lt;, &lt;=, =, !=, &gt;, &gt;=, After, Before</b> (я│я─п╟п╡п╫п╦я┌я▄ п╢п╡п╟ "
+"п╥п╫п╟я┤п╣п╫п╦я▐)\n"
+"<b>5 bytes, 1Kb, 2Mb, 3Gb</b> (я─п╟п╥п╪п╣я─я▀ я└п╟п╧п╩п╬п╡)\n"
+"<b>2 secs|mins|hours|days|weeks|years  ago|hence</b> (п╡я─п╣п╪я▐)\n"
 "<b>atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks</b> "
-"(значения)\n"
+"(п╥п╫п╟я┤п╣п╫п╦я▐)\n"
 "\n"
-"<u>Специальные</u>\n"
-"<b>system(command)</b> (истина, если 'command' возвращает ноль;\n"
-"знак % в 'command' замещается путём для текущего файла)\n"
-"<b>prune</b> (ложь, и запрет поиска внутри каталога)."
+"<u>п║п©п╣я├п╦п╟п╩я▄п╫я▀п╣</u>\n"
+"<b>system(command)</b> (п╦я│я┌п╦п╫п╟, п╣я│п╩п╦ 'command' п╡п╬п╥п╡я─п╟я┴п╟п╣я┌ п╫п╬п╩я▄;\n"
+"п╥п╫п╟п╨ % п╡ 'command' п╥п╟п╪п╣я┴п╟п╣я┌я│я▐ п©я┐я┌я▒п╪ п╢п╩я▐ я┌п╣п╨я┐я┴п╣пЁп╬ я└п╟п╧п╩п╟)\n"
+"<b>prune</b> (п╩п╬п╤я▄, п╦ п╥п╟п©я─п╣я┌ п©п╬п╦я│п╨п╟ п╡п╫я┐я┌я─п╦ п╨п╟я┌п╟п╩п╬пЁп╟)."
 
-#: action.c:249
+#: action.c:256
 msgid "Change permissions reference"
-msgstr "Изменить права доступа"
+msgstr "п≤п╥п╪п╣п╫п╦я┌я▄ п©я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟"
 
-#: action.c:260
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -173,42 +178,42 @@ msgid ""
 "\n"
 "See the chmod(1) man page for full details."
 msgstr ""
-"Обычно вы можете выбрать команду из меню (щелкните по стрелке за строкой \n"
-"ввода). Но иногда требуется больше...\n"
+"п·п╠я▀я┤п╫п╬ п╡я▀ п╪п╬п╤п╣я┌п╣ п╡я▀п╠я─п╟я┌я▄ п╨п╬п╪п╟п╫п╢я┐ п╦п╥ п╪п╣п╫я▌ (я┴п╣п╩п╨п╫п╦я┌п╣ п©п╬ я│я┌я─п╣п╩п╨п╣ п╥п╟ я│я┌я─п╬п╨п╬п╧ \n"
+"п╡п╡п╬п╢п╟). п²п╬ п╦п╫п╬пЁп╢п╟ я┌я─п╣п╠я┐п╣я┌я│я▐ п╠п╬п╩я▄я┬п╣...\n"
 "\n"
-"Формат команды:\n"
-"<B>ИЗМЕНЕНИЕ1, ИЗМЕНЕНИЕ2, ...</b>\n"
-"Каждое <B>ИЗМЕНЕНИЕ</b> представляет собой выражение:\n"
-"<B>КТО КАК ПРАВА</b>\n"
-"<B>КТО</b> - это комбинация из <b>u</b>, <b>g</b> и <b>o</b> которая "
-"определяет для кого менять права доступа:\n"
-" для владельца (user), группы (group) и для остальных (others)\n"
-"<B>КАК</b> - это знаки <b>+</b>, <b>-</b> или <b>=</b> для добавления, "
-"снятия или установки прав доступа.\n"
-"<B>ПРАВА</b> - это комбинация букв <b>rwxXstugo</b>\n"
+"п╓п╬я─п╪п╟я┌ п╨п╬п╪п╟п╫п╢я▀:\n"
+"<B>п≤п≈п°п∙п²п∙п²п≤п∙1, п≤п≈п°п∙п²п∙п²п≤п∙2, ...</b>\n"
+"п п╟п╤п╢п╬п╣ <B>п≤п≈п°п∙п²п∙п²п≤п∙</b> п©я─п╣п╢я│я┌п╟п╡п╩я▐п╣я┌ я│п╬п╠п╬п╧ п╡я▀я─п╟п╤п╣п╫п╦п╣:\n"
+"<B>п п╒п· п п░п  п÷п═п░п▓п░</b>\n"
+"<B>п п╒п·</b> - я█я┌п╬ п╨п╬п╪п╠п╦п╫п╟я├п╦я▐ п╦п╥ <b>u</b>, <b>g</b> п╦ <b>o</b> п╨п╬я┌п╬я─п╟я▐ "
+"п╬п©я─п╣п╢п╣п╩я▐п╣я┌ п╢п╩я▐ п╨п╬пЁп╬ п╪п╣п╫я▐я┌я▄ п©я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟:\n"
+" п╢п╩я▐ п╡п╩п╟п╢п╣п╩я▄я├п╟ (user), пЁя─я┐п©п©я▀ (group) п╦ п╢п╩я▐ п╬я│я┌п╟п╩я▄п╫я▀я┘ (others)\n"
+"<B>п п░п </b> - я█я┌п╬ п╥п╫п╟п╨п╦ <b>+</b>, <b>-</b> п╦п╩п╦ <b>=</b> п╢п╩я▐ п╢п╬п╠п╟п╡п╩п╣п╫п╦я▐, "
+"я│п╫я▐я┌п╦я▐ п╦п╩п╦ я┐я│я┌п╟п╫п╬п╡п╨п╦ п©я─п╟п╡ п╢п╬я│я┌я┐п©п╟.\n"
+"<B>п÷п═п░п▓п░</b> - я█я┌п╬ п╨п╬п╪п╠п╦п╫п╟я├п╦я▐ п╠я┐п╨п╡ <b>rwxXstugo</b>\n"
 "\n"
-"Текст в скобках и пробелы игнорируются.\n"
+"п╒п╣п╨я│я┌ п╡ я│п╨п╬п╠п╨п╟я┘ п╦ п©я─п╬п╠п╣п╩я▀ п╦пЁп╫п╬я─п╦я─я┐я▌я┌я│я▐.\n"
 "\n"
-"<U>Примеры:</u>\n"
-"<b>u+rw</b>: владелец файла получает права на чтение и запись\n"
-"<b>g=u</b>: для группы устанавливаются права идентичные правам владельца\n"
-"<b>o=u-w</b>: все остальные получают те же права доступа что и владелец, за "
-"исключением права на запись\n"
-"<b>a+x</b>: <B>все</b> получают право запуска, то же самое что и <b>ugo+x</"
+"<U>п÷я─п╦п╪п╣я─я▀:</u>\n"
+"<b>u+rw</b>: п╡п╩п╟п╢п╣п╩п╣я├ я└п╟п╧п╩п╟ п©п╬п╩я┐я┤п╟п╣я┌ п©я─п╟п╡п╟ п╫п╟ я┤я┌п╣п╫п╦п╣ п╦ п╥п╟п©п╦я│я▄\n"
+"<b>g=u</b>: п╢п╩я▐ пЁя─я┐п©п©я▀ я┐я│я┌п╟п╫п╟п╡п╩п╦п╡п╟я▌я┌я│я▐ п©я─п╟п╡п╟ п╦п╢п╣п╫я┌п╦я┤п╫я▀п╣ п©я─п╟п╡п╟п╪ п╡п╩п╟п╢п╣п╩я▄я├п╟\n"
+"<b>o=u-w</b>: п╡я│п╣ п╬я│я┌п╟п╩я▄п╫я▀п╣ п©п╬п╩я┐я┤п╟я▌я┌ я┌п╣ п╤п╣ п©я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟ я┤я┌п╬ п╦ п╡п╩п╟п╢п╣п╩п╣я├, п╥п╟ "
+"п╦я│п╨п╩я▌я┤п╣п╫п╦п╣п╪ п©я─п╟п╡п╟ п╫п╟ п╥п╟п©п╦я│я▄\n"
+"<b>a+x</b>: <B>п╡я│п╣</b> п©п╬п╩я┐я┤п╟я▌я┌ п©я─п╟п╡п╬ п╥п╟п©я┐я│п╨п╟, я┌п╬ п╤п╣ я│п╟п╪п╬п╣ я┤я┌п╬ п╦ <b>ugo+x</"
 "b>\n"
-"<b>a+X</b>: каталог становится доступным для всех, файлы которые кто-либо "
-"мог запускать разрешается запускать всем\n"
-"<b>u+rw, go+r</b>: две команды сразу\n"
-"<b>u+s</b>: установка бита SetUID\n"
-"<b>755</b>: установка прав доступа напрямую, в числовом формате\n"
+"<b>a+X</b>: п╨п╟я┌п╟п╩п╬пЁ я│я┌п╟п╫п╬п╡п╦я┌я│я▐ п╢п╬я│я┌я┐п©п╫я▀п╪ п╢п╩я▐ п╡я│п╣я┘, я└п╟п╧п╩я▀ п╨п╬я┌п╬я─я▀п╣ п╨я┌п╬-п╩п╦п╠п╬ "
+"п╪п╬пЁ п╥п╟п©я┐я│п╨п╟я┌я▄ я─п╟п╥я─п╣я┬п╟п╣я┌я│я▐ п╥п╟п©я┐я│п╨п╟я┌я▄ п╡я│п╣п╪\n"
+"<b>u+rw, go+r</b>: п╢п╡п╣ п╨п╬п╪п╟п╫п╢я▀ я│я─п╟п╥я┐\n"
+"<b>u+s</b>: я┐я│я┌п╟п╫п╬п╡п╨п╟ п╠п╦я┌п╟ SetUID\n"
+"<b>755</b>: я┐я│я┌п╟п╫п╬п╡п╨п╟ п©я─п╟п╡ п╢п╬я│я┌я┐п©п╟ п╫п╟п©я─я▐п╪я┐я▌, п╡ я┤п╦я│п╩п╬п╡п╬п╪ я└п╬я─п╪п╟я┌п╣\n"
 "\n"
-"Смотрите справку man chmod (1 раздел) для детального описания."
+"п║п╪п╬я┌я─п╦я┌п╣ я│п©я─п╟п╡п╨я┐ man chmod (1 я─п╟п╥п╢п╣п╩) п╢п╩я▐ п╢п╣я┌п╟п╩я▄п╫п╬пЁп╬ п╬п©п╦я│п╟п╫п╦я▐."
 
-#: action.c:301
+#: action.c:308
 msgid "Set type reference"
-msgstr "Присвоить заданный тип"
+msgstr "п÷я─п╦я│п╡п╬п╦я┌я▄ п╥п╟п╢п╟п╫п╫я▀п╧ я┌п╦п©"
 
-#: action.c:312
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -223,603 +228,632 @@ msgid ""
 "directories, devices, pipes or sockets, and then only\n"
 "on certain file systems and where the OS implements them.\n"
 msgstr ""
-"В общем случае ROX-Filer определяет тип файла, сопоставляя\n"
-"его имя с шаблоном. Чтобы изменить тип файла, приходится его\n"
-"переименовывать.\n"
+"п▓ п╬п╠я┴п╣п╪ я│п╩я┐я┤п╟п╣ ROX-Filer п╬п©я─п╣п╢п╣п╩я▐п╣я┌ я┌п╦п© я└п╟п╧п╩п╟, я│п╬п©п╬я│я┌п╟п╡п╩я▐я▐\n"
+"п╣пЁп╬ п╦п╪я▐ я│ я┬п╟п╠п╩п╬п╫п╬п╪. п╖я┌п╬п╠я▀ п╦п╥п╪п╣п╫п╦я┌я▄ я┌п╦п© я└п╟п╧п╩п╟, п©я─п╦я┘п╬п╢п╦я┌я│я▐ п╣пЁп╬\n"
+"п©п╣я─п╣п╦п╪п╣п╫п╬п╡я▀п╡п╟я┌я▄.\n"
 "\n"
-"Современные файловые системы могут поддерживать так называемые\n"
-"\"расширенные атрибуты\", которые могут быть использованы для хранения\n"
-"дополнительных данных о файле в виде набора параметров. Rox-Filer\n"
-"использует атрибут \"user.mime_type\", чтобы хранить типы файлов.\n"
+"п║п╬п╡я─п╣п╪п╣п╫п╫я▀п╣ я└п╟п╧п╩п╬п╡я▀п╣ я│п╦я│я┌п╣п╪я▀ п╪п╬пЁя┐я┌ п©п╬п╢п╢п╣я─п╤п╦п╡п╟я┌я▄ я┌п╟п╨ п╫п╟п╥я▀п╡п╟п╣п╪я▀п╣\n"
+"\"я─п╟я│я┬п╦я─п╣п╫п╫я▀п╣ п╟я┌я─п╦п╠я┐я┌я▀\", п╨п╬я┌п╬я─я▀п╣ п╪п╬пЁя┐я┌ п╠я▀я┌я▄ п╦я│п©п╬п╩я▄п╥п╬п╡п╟п╫я▀ п╢п╩я▐ я┘я─п╟п╫п╣п╫п╦я▐\n"
+"п╢п╬п©п╬п╩п╫п╦я┌п╣п╩я▄п╫я▀я┘ п╢п╟п╫п╫я▀я┘ п╬ я└п╟п╧п╩п╣ п╡ п╡п╦п╢п╣ п╫п╟п╠п╬я─п╟ п©п╟я─п╟п╪п╣я┌я─п╬п╡. Rox-Filer\n"
+"п╦я│п©п╬п╩я▄п╥я┐п╣я┌ п╟я┌я─п╦п╠я┐я┌ \"user.mime_type\", я┤я┌п╬п╠я▀ я┘я─п╟п╫п╦я┌я▄ я┌п╦п©я▀ я└п╟п╧п╩п╬п╡.\n"
 "\n"
-"Типы файлов поддерживаются только для обычных файлов, а не для\n"
-"каталогов, устройств, каналов ввода-вывода и сокетов, и только на\n"
-"определённых файловых системах, предусматривающих такую возможность.\n"
+"п╒п╦п©я▀ я└п╟п╧п╩п╬п╡ п©п╬п╢п╢п╣я─п╤п╦п╡п╟я▌я┌я│я▐ я┌п╬п╩я▄п╨п╬ п╢п╩я▐ п╬п╠я▀я┤п╫я▀я┘ я└п╟п╧п╩п╬п╡, п╟ п╫п╣ п╢п╩я▐\n"
+"п╨п╟я┌п╟п╩п╬пЁп╬п╡, я┐я│я┌я─п╬п╧я│я┌п╡, п╨п╟п╫п╟п╩п╬п╡ п╡п╡п╬п╢п╟-п╡я▀п╡п╬п╢п╟ п╦ я│п╬п╨п╣я┌п╬п╡, п╦ я┌п╬п╩я▄п╨п╬ п╫п╟\n"
+"п╬п©я─п╣п╢п╣п╩я▒п╫п╫я▀я┘ я└п╟п╧п╩п╬п╡я▀я┘ я│п╦я│я┌п╣п╪п╟я┘, п©я─п╣п╢я┐я│п╪п╟я┌я─п╦п╡п╟я▌я┴п╦я┘ я┌п╟п╨я┐я▌ п╡п╬п╥п╪п╬п╤п╫п╬я│я┌я▄.\n"
 "\n"
 
-#: action.c:419
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
-"Процесс остановлен.\n"
+"п÷я─п╬я├п╣я│я│ п╬я│я┌п╟п╫п╬п╡п╩п╣п╫.\n"
 
-#: action.c:435
-msgid "There was one error.\n"
-msgstr "Произошла одна ошибка.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
+msgstr "п÷я─п╬п╦п╥п╬я┬п╩п╟ п╬п╢п╫п╟ п╬я┬п╦п╠п╨п╟.\n"
 
-#: action.c:437
-#, c-format
-msgid "There were %d errors.\n"
-msgstr "Количество произошедших ошибок: %d\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
+msgstr "п п╬п╩п╦я┤п╣я│я┌п╡п╬ п©я─п╬п╦п╥п╬я┬п╣п╢я┬п╦я┘ п╬я┬п╦п╠п╬п╨: %d\n"
 
-#: action.c:461
+#: action.c:516
 msgid "ERROR reading"
-msgstr "Ошибка чтения"
+msgstr "п·я┬п╦п╠п╨п╟ я┤я┌п╣п╫п╦я▐"
 
-#: action.c:504
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
-"Готово\n"
+"п⌠п╬я┌п╬п╡п╬\n"
 
-#: action.c:560 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
-msgstr "ОШИБКА"
+msgstr "п·п╗п≤п▒п п░"
 
-#: action.c:714 main.c:693 main.c:700 main.c:714
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
-msgstr "Да"
+msgstr "п■п╟"
 
-#: action.c:717 main.c:695 main.c:702 main.c:714
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
-msgstr "Нет"
+msgstr "п²п╣я┌"
 
-#: action.c:735
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
 msgstr ""
 "\n"
-"Пытаюсь завершить дочерний процесс...\n"
+"п÷я▀я┌п╟я▌я│я▄ п╥п╟п╡п╣я─я┬п╦я┌я▄ п╢п╬я┤п╣я─п╫п╦п╧ п©я─п╬я├п╣я│я│...\n"
 
-#: action.c:742
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
 msgstr ""
 "\n"
-"Пытаюсь убить неконтролируемый процесс...\n"
+"п÷я▀я┌п╟я▌я│я▄ я┐п╠п╦я┌я▄ п╫п╣п╨п╬п╫я┌я─п╬п╩п╦я─я┐п╣п╪я▀п╧ п©я─п╬я├п╣я│я│...\n"
 
-#: action.c:895
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
-msgstr "?Подсчитать содержимое %s?"
+msgstr "?п÷п╬п╢я│я┤п╦я┌п╟я┌я▄ я│п╬п╢п╣я─п╤п╦п╪п╬п╣ %s?"
 
-#: action.c:931
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
-msgstr "?Удалить %s\"%s\"?"
+msgstr "?пёп╢п╟п╩п╦я┌я▄ %s\"%s\"?"
 
-#: action.c:932
+#: action.c:1047
 msgid "WRITE-PROTECTED "
-msgstr "Защищено от записи"
+msgstr "п≈п╟я┴п╦я┴п╣п╫п╬ п╬я┌ п╥п╟п©п╦я│п╦"
 
-#: action.c:939
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
-msgstr "'Удаление \"'%s\"\n"
+msgstr "'пёп╢п╟п╩п╣п╫п╦п╣ \"'%s\"\n"
 
-#: action.c:952
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
-msgstr "'Каталог \"%s\" удален\n"
+msgstr "'п п╟я┌п╟п╩п╬пЁ \"%s\" я┐п╢п╟п╩п╣п╫\n"
 
-#: action.c:985
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
-msgstr "?Извлечь диск \"%s\"?"
+msgstr "?п≤п╥п╡п╩п╣я┤я▄ п╢п╦я│п╨ \"%s\"?"
 
-#: action.c:992
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
-msgstr "'Извлечение диска \"%s\"\n"
+msgstr "'п≤п╥п╡п╩п╣я┤п╣п╫п╦п╣ п╢п╦я│п╨п╟ \"%s\"\n"
 
-#: action.c:1011
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
 "eject failed\n"
 msgstr ""
 "!%s\n"
-"!Ошибка: извлечь диск не удалось\n"
+"!п·я┬п╦п╠п╨п╟: п╦п╥п╡п╩п╣я┤я▄ п╢п╦я│п╨ п╫п╣ я┐п╢п╟п╩п╬я│я▄\n"
 
-#: action.c:1030 action.c:1049
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
-msgstr "?Проверить \"%s\"?"
+msgstr "?п÷я─п╬п╡п╣я─п╦я┌я▄ \"%s\"?"
 
-#: action.c:1046
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
-msgstr "!Неверные условия поиска - измените их и попробуйте снова\n"
+msgstr "!п²п╣п╡п╣я─п╫я▀п╣ я┐я│п╩п╬п╡п╦я▐ п©п╬п╦я│п╨п╟ - п╦п╥п╪п╣п╫п╦я┌п╣ п╦я┘ п╦ п©п╬п©я─п╬п╠я┐п╧я┌п╣ я│п╫п╬п╡п╟\n"
 
-#: action.c:1056
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
-msgstr "'(во время проверки \"%s\")\n"
+msgstr "'(п╡п╬ п╡я─п╣п╪я▐ п©я─п╬п╡п╣я─п╨п╦ \"%s\")\n"
 
-#: action.c:1130 action.c:1155
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
-msgstr "?Изменить права доступа для \"%s\"?"
+msgstr "?п≤п╥п╪п╣п╫п╦я┌я▄ п©я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟ п╢п╩я▐ \"%s\"?"
 
-#: action.c:1136
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
-msgstr "'Меняются права доступа для \"%s\"\n"
+msgstr "'п°п╣п╫я▐я▌я┌я│я▐ п©я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟ п╢п╩я▐ \"%s\"\n"
 
-#: action.c:1153
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
-msgstr "!Неверная команда режима - измените и попробуйте снова\n"
+msgstr "!п²п╣п╡п╣я─п╫п╟я▐ п╨п╬п╪п╟п╫п╢п╟ я─п╣п╤п╦п╪п╟ - п╦п╥п╪п╣п╫п╦я┌п╣ п╦ п©п╬п©я─п╬п╠я┐п╧я┌п╣ я│п╫п╬п╡п╟\n"
 
-#: action.c:1211
+#: action.c:1332
 #, c-format
 msgid "?Change contents of '%s'?"
-msgstr "?Изменить содержимое \"%s\"?"
+msgstr "?п≤п╥п╪п╣п╫п╦я┌я▄ я│п╬п╢п╣я─п╤п╦п╪п╬п╣ \"%s\"?"
 
-#: action.c:1214 action.c:1234
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
-msgstr "?Изменить тип \"%s\"?"
+msgstr "?п≤п╥п╪п╣п╫п╦я┌я▄ я┌п╦п© \"%s\"?"
 
-#: action.c:1231
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
-msgstr "!Неверный тип - измените и попробуйте снова\n"
-
-#: action.c:1253
-#, c-format
-msgid "'Changing type of '%s' to '%s'\n"
-msgstr "'Тип %s изменяется на \"%s\"\n"
-
-#: action.c:1276
-#, c-format
-msgid "'Not changing type of directory '%s'\n"
-msgstr "'Тип каталога \"%s\" не изменяется\n"
-
-#: action.c:1282
-#, c-format
-msgid "'Non-regular file '%s' not changed\n"
-msgstr "Файл \"%s\", не являющийся обычным, не изменён\n"
-
-#: action.c:1342
-#, c-format
-msgid "?'%s' already exists - %s?"
-msgstr "?\"%s\" уже существует - %s?"
-
-#: action.c:1344
-msgid "merge contents"
-msgstr "объединить содержимое"
-
-#: action.c:1345
-msgid "overwrite"
-msgstr "переписать"
-
-#: action.c:1361
-msgid "'Trying copy anyway...\n"
-msgstr "'Пытаюсь скопировать...\n"
-
-#: action.c:1370
-#, c-format
-msgid "?Copy %s as %s?"
-msgstr "?Копировать %s в %s?"
+msgstr "!п²п╣п╡п╣я─п╫я▀п╧ я┌п╦п© - п╦п╥п╪п╣п╫п╦я┌п╣ п╦ п©п╬п©я─п╬п╠я┐п╧я┌п╣ я│п╫п╬п╡п╟\n"
 
 #: action.c:1374
 #, c-format
+msgid "'Changing type of '%s' to '%s'\n"
+msgstr "'п╒п╦п© %s п╦п╥п╪п╣п╫я▐п╣я┌я│я▐ п╫п╟ \"%s\"\n"
+
+#: action.c:1397
+#, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'п╒п╦п© п╨п╟я┌п╟п╩п╬пЁп╟ \"%s\" п╫п╣ п╦п╥п╪п╣п╫я▐п╣я┌я│я▐\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr "п╓п╟п╧п╩ \"%s\", п╫п╣ я▐п╡п╩я▐я▌я┴п╦п╧я│я▐ п╬п╠я▀я┤п╫я▀п╪, п╫п╣ п╦п╥п╪п╣п╫я▒п╫\n"
+
+#: action.c:1548 action.c:1857
+#, c-format
+msgid "?'%s' already exists - %s?"
+msgstr "?\"%s\" я┐п╤п╣ я│я┐я┴п╣я│я┌п╡я┐п╣я┌ - %s?"
+
+#: action.c:1550 action.c:1859
+msgid "merge contents"
+msgstr "п╬п╠я┼п╣п╢п╦п╫п╦я┌я▄ я│п╬п╢п╣я─п╤п╦п╪п╬п╣"
+
+#: action.c:1551 action.c:1860
+msgid "overwrite"
+msgstr "п©п╣я─п╣п©п╦я│п╟я┌я▄"
+
+#: action.c:1570
+msgid "'Trying copy anyway...\n"
+msgstr "'п÷я▀я┌п╟я▌я│я▄ я│п╨п╬п©п╦я─п╬п╡п╟я┌я▄...\n"
+
+#: action.c:1579
+#, c-format
+msgid "?Copy %s as %s?"
+msgstr "?п п╬п©п╦я─п╬п╡п╟я┌я▄ %s п╡ %s?"
+
+#: action.c:1584 action.c:1717
+#, c-format
 msgid "'Copying %s as %s\n"
-msgstr "'%s копируется в %s\n"
+msgstr "'%s п╨п╬п©п╦я─я┐п╣я┌я│я▐ п╡ %s\n"
 
-#: action.c:1389
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
-msgstr "!ОШИБКА: указанное имя цели существует, но это не каталог\n"
+msgstr "!п·п╗п≤п▒п п░: я┐п╨п╟п╥п╟п╫п╫п╬п╣ п╦п╪я▐ я├п╣п╩п╦ я│я┐я┴п╣я│я┌п╡я┐п╣я┌, п╫п╬ я█я┌п╬ п╫п╣ п╨п╟я┌п╟п╩п╬пЁ\n"
 
-#: action.c:1461
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
 "Failed to copy '%s'\n"
 msgstr ""
 "!%s\n"
-"Не удалось скопировать \"%s\"\n"
+"п²п╣ я┐п╢п╟п╩п╬я│я▄ я│п╨п╬п©п╦я─п╬п╡п╟я┌я▄ \"%s\"\n"
 
-#: action.c:1505
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?\"%s\" уже существует - переписать?"
-
-#: action.c:1520
-msgid "'Trying move anyway...\n"
-msgstr "'Пытаюсь переместить...\n"
-
-#: action.c:1528
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Переместить %s в %s?"
-
-#: action.c:1532
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'%s перемещается в %s\n"
-
-#: action.c:1540
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
 "Failed to move %s as %s\n"
 msgstr ""
 "!%s\n"
-"Не удалось переместить %s в %s\n"
+"п²п╣ я┐п╢п╟п╩п╬я│я▄ п©п╣я─п╣п╪п╣я│я┌п╦я┌я▄ %s п╡ %s\n"
 
-#: action.c:1561
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'п÷я▀я┌п╟я▌я│я▄ п©п╣я─п╣п╪п╣я│я┌п╦я┌я▄...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?п÷п╣я─п╣п╪п╣я│я┌п╦я┌я▄ %s п╡ %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'%s п©п╣я─п╣п╪п╣я┴п╟п╣я┌я│я▐ п╡ %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
-msgstr "!ОШИБКА: Не могу скопировать объект в самого себя\n"
+msgstr "!п·п╗п≤п▒п п░: п²п╣ п╪п╬пЁя┐ я│п╨п╬п©п╦я─п╬п╡п╟я┌я▄ п╬п╠я┼п╣п╨я┌ п╡ я│п╟п╪п╬пЁп╬ я│п╣п╠я▐\n"
 
-#: action.c:1576
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
-msgstr "!ОШИБКА: Не могу переместить/переименовать объект в самого себя\n"
+msgstr "!п·п╗п≤п▒п п░: п²п╣ п╪п╬пЁя┐ п©п╣я─п╣п╪п╣я│я┌п╦я┌я▄/п©п╣я─п╣п╦п╪п╣п╫п╬п╡п╟я┌я▄ п╬п╠я┼п╣п╨я┌ п╡ я│п╟п╪п╬пЁп╬ я│п╣п╠я▐\n"
 
-#: action.c:1588
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
-msgstr "'Создаю ссылку для %s с именем %s\n"
+msgstr "'п║п╬п╥п╢п╟я▌ я│я│я▀п╩п╨я┐ п╢п╩я▐ %s я│ п╦п╪п╣п╫п╣п╪ %s\n"
 
-#: action.c:1593
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
-msgstr "?Создать ссылку для %s как %s?"
+msgstr "?п║п╬п╥п╢п╟я┌я▄ я│я│я▀п╩п╨я┐ п╢п╩я▐ %s п╨п╟п╨ %s?"
 
-#: action.c:1636
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
-msgstr "'Подсоединяется %s\n"
+msgstr "'п÷п╬п╢я│п╬п╣п╢п╦п╫я▐п╣я┌я│я▐ %s\n"
 
-#: action.c:1637
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
-msgstr "'Отсоединяется %s\n"
+msgstr "'п·я┌я│п╬п╣п╢п╦п╫я▐п╣я┌я│я▐ %s\n"
 
-#: action.c:1640
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
-msgstr "?Подсоединить %s?"
+msgstr "?п÷п╬п╢я│п╬п╣п╢п╦п╫п╦я┌я▄ %s?"
 
-#: action.c:1641
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
-msgstr "?Отсоединить %s?"
+msgstr "?п·я┌я│п╬п╣п╢п╦п╫п╦я┌я▄ %s?"
 
-#: action.c:1662
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
 "Mount failed\n"
 msgstr ""
 "!%s\n"
-"Подсоединить не удалось\n"
+"п÷п╬п╢я│п╬п╣п╢п╦п╫п╦я┌я▄ п╫п╣ я┐п╢п╟п╩п╬я│я▄\n"
 
-#: action.c:1663
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
 "Unmount failed\n"
 msgstr ""
 "!%s\n"
-"Отсоединить не удалось\n"
+"п·я┌я│п╬п╣п╢п╦п╫п╦я┌я▄ п╫п╣ я┐п╢п╟п╩п╬я│я▄\n"
 
-#: action.c:1671
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
-msgstr "'(похоже, что ресурс сейчас всё равно подсоединен)\n"
+msgstr "'(п©п╬я┘п╬п╤п╣, я┤я┌п╬ я─п╣я│я┐я─я│ я│п╣п╧я┤п╟я│ п╡я│я▒ я─п╟п╡п╫п╬ п©п╬п╢я│п╬п╣п╢п╦п╫п╣п╫)\n"
 
-#: action.c:1717
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
 "Total: %s ("
 msgstr ""
 "'\n"
-"Всего: %s ("
+"п▓я│п╣пЁп╬: %s ("
 
-#: action.c:1723
+#: action.c:2108
 msgid "file"
-msgstr "файл"
+msgstr "я└п╟п╧п╩"
 
-#: action.c:1723
+#: action.c:2108
 msgid "files"
-msgstr "файлы"
+msgstr "я└п╟п╧п╩я▀"
 
-#: action.c:1727
+#: action.c:2112
 msgid "no directories)\n"
-msgstr "нет каталогов)\n"
+msgstr "п╫п╣я┌ п╨п╟я┌п╟п╩п╬пЁп╬п╡)\n"
 
-#: action.c:1731
+#: action.c:2116
 msgid "directory"
-msgstr "каталог"
-
-#: action.c:1732
-msgid "directories"
-msgstr "каталоги"
-
-#: action.c:1773
-msgid "!No mount points selected!\n"
-msgstr "!Точка монтирования не выбрана\n"
-
-#: action.c:1858
-msgid "?Another search?"
-msgstr "?Искать снова?"
-
-#: action.c:1888 action.c:1919
-#, c-format
-msgid "!'%s' is a symbolic link\n"
-msgstr "!\"%s\" это символическая ссылка\n"
-
-#: action.c:1959
-msgid "You need to select some items to search through"
-msgstr "Вам нужно выбрать несколько объектов для поиска"
-
-#: action.c:1969 menu.c:228
-msgid "Find"
-msgstr "Найти"
-
-#: action.c:2002
-msgid "You need to select some items to count"
-msgstr "Вам надо выбрать объекты для подсчета"
-
-#: action.c:2006
-msgid "Disk Usage"
-msgstr "Использование диска"
-
-#: action.c:2042
-msgid "Mount / Unmount"
-msgstr "Подсоединить / Отсоединить"
-
-#: action.c:2059
-msgid "ROX-Filer does not yet support mount points on your system. Sorry."
-msgstr "ROX-Filer не поддерживает точки монтирования на вашей системе. Извините."
-
-#: action.c:2073 menu.c:216 tips:173
-msgid "Delete"
-msgstr "Удалить"
-
-#: action.c:2085 tips:178
-msgid "Force"
-msgstr "Принудительно"
-
-#: action.c:2085
-msgid "Don't confirm deletion of non-writeable items"
-msgstr "Не подтверждать удаление объектов, защищённых от записи"
-
-#: action.c:2088 action.c:2147 action.c:2210 action.c:2283 action.c:2323
-#: tips:180
-msgid "Brief"
-msgstr "Кратко"
-
-#: action.c:2088
-msgid "Only log directories being deleted"
-msgstr "Выводить только имена удаленных каталогов"
-
-#: action.c:2107
-msgid "You need to select the items whose permissions you want to change"
-msgstr "Вам нужно выбрать объекты, права доступа которых вы хотите изменить"
-
-#: action.c:2115
-msgid "a+x (Make executable/searchable)"
-msgstr "a+x (Сделать выполняемым/доступным для поиска)"
+msgstr "п╨п╟я┌п╟п╩п╬пЁ"
 
 #: action.c:2117
-msgid "a-x (Make non-executable/non-searchable)"
-msgstr "a-x (сделать невыполняемым/недоступным для поиска)"
+msgid "directories"
+msgstr "п╨п╟я┌п╟п╩п╬пЁп╦"
 
-#: action.c:2119
-msgid "u+rw (Give owner read+write)"
-msgstr "u+rw (Дать владельцу права на чтение и запись)"
+#: action.c:2155
+msgid "!No mount points selected!\n"
+msgstr "!п╒п╬я┤п╨п╟ п╪п╬п╫я┌п╦я─п╬п╡п╟п╫п╦я▐ п╫п╣ п╡я▀п╠я─п╟п╫п╟\n"
 
-#: action.c:2121
-msgid "go-rwx (Private - owner access only)"
-msgstr "go-rwx (Личный - доступ только для владельца)"
+#: action.c:2231
+msgid "?Another search?"
+msgstr "?п≤я│п╨п╟я┌я▄ я│п╫п╬п╡п╟?"
 
-#: action.c:2123
-msgid "go=u-w (Public access, not write)"
-msgstr "go=u-w (Общий доступ без записи)"
+#: action.c:2259 action.c:2291
+#, c-format
+msgid "!'%s' is a symbolic link\n"
+msgstr "!\"%s\" я█я┌п╬ я│п╦п╪п╡п╬п╩п╦я┤п╣я│п╨п╟я▐ я│я│я▀п╩п╨п╟\n"
 
-#: action.c:2134 menu.c:189 menu.c:226 tips:53
-msgid "Permissions"
-msgstr "Права доступа"
+#: action.c:2342
+msgid "You need to select some items to search through"
+msgstr "п▓п╟п╪ п╫я┐п╤п╫п╬ п╡я▀п╠я─п╟я┌я▄ п╫п╣я│п╨п╬п╩я▄п╨п╬ п╬п╠я┼п╣п╨я┌п╬п╡ п╢п╩я▐ п©п╬п╦я│п╨п╟"
 
-#: action.c:2147 action.c:2210
-msgid "Don't list processed files"
-msgstr "Не перечислять обработанные файлы"
+#: action.c:2352 menu.c:728
+msgid "Find"
+msgstr "п²п╟п╧я┌п╦"
 
-#: action.c:2150 action.c:2213 tips:182
-msgid "Recurse"
-msgstr "Рекурсивно"
+#: action.c:2387
+msgid "You need to select some items to count"
+msgstr "п▓п╟п╪ п╫п╟п╢п╬ п╡я▀п╠я─п╟я┌я▄ п╬п╠я┼п╣п╨я┌я▀ п╢п╩я▐ п©п╬п╢я│я┤п╣я┌п╟"
 
-#: action.c:2150
-msgid "Also change contents of subdirectories"
-msgstr "Изменять также и содержимое подкаталогов"
+#: action.c:2391
+msgid "Disk Usage"
+msgstr "п≤я│п©п╬п╩я▄п╥п╬п╡п╟п╫п╦п╣ п╢п╦я│п╨п╟"
 
-#: action.c:2154
-msgid "Command:"
-msgstr "Команда:"
+#: action.c:2429
+msgid "Mount / Unmount"
+msgstr "п÷п╬п╢я│п╬п╣п╢п╦п╫п╦я┌я▄ / п·я┌я│п╬п╣п╢п╦п╫п╦я┌я▄"
 
-#: action.c:2184
-msgid "You need to select the items whose type you want to change"
-msgstr "Вам нужно выбрать объекты, тип которых вы хотите изменить"
-
-#: action.c:2197
-msgid "Set type"
-msgstr "Установить тип"
-
-#: action.c:2213
-msgid "Change contents of subdirectories"
-msgstr "Изменять содержимое подкаталогов"
-
-#: action.c:2220 infobox.c:627
-msgid "Type:"
-msgstr "Тип:"
-
-#: action.c:2267 dnd.c:122 menu.c:2018 tips:167
-msgid "Copy"
-msgstr "Копировать"
-
-#: action.c:2279 action.c:2319 tips:184
-msgid "Newer"
-msgstr "Новый"
-
-#: action.c:2280 action.c:2320 tips:185
-msgid "Only over-write if source is newer than destination."
+#: action.c:2448
+msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr ""
-"Переписывать только в том случае, когда источник более новый, чем целевой "
-"файл"
+"ROX-Filer п╫п╣ п©п╬п╢п╢п╣я─п╤п╦п╡п╟п╣я┌ я┌п╬я┤п╨п╦ п╪п╬п╫я┌п╦я─п╬п╡п╟п╫п╦я▐ п╫п╟ п╡п╟я┬п╣п╧ я│п╦я│я┌п╣п╪п╣. п≤п╥п╡п╦п╫п╦я┌п╣."
 
-#: action.c:2283
+#: action.c:2462 menu.c:701 tips:246
+msgid "Delete"
+msgstr "пёп╢п╟п╩п╦я┌я▄"
+
+#: action.c:2476 action.c:2680 action.c:2737
+msgid "Force"
+msgstr "п÷я─п╦п╫я┐п╢п╦я┌п╣п╩я▄п╫п╬"
+
+#: action.c:2476
+msgid "Don't confirm deletion of non-writeable items"
+msgstr "п²п╣ п©п╬п╢я┌п╡п╣я─п╤п╢п╟я┌я▄ я┐п╢п╟п╩п╣п╫п╦п╣ п╬п╠я┼п╣п╨я┌п╬п╡, п╥п╟я┴п╦я┴я▒п╫п╫я▀я┘ п╬я┌ п╥п╟п©п╦я│п╦"
+
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
+msgid "Brief"
+msgstr "п я─п╟я┌п╨п╬"
+
+#: action.c:2479
+msgid "Only log directories being deleted"
+msgstr "п▓я▀п╡п╬п╢п╦я┌я▄ я┌п╬п╩я▄п╨п╬ п╦п╪п╣п╫п╟ я┐п╢п╟п╩п╣п╫п╫я▀я┘ п╨п╟я┌п╟п╩п╬пЁп╬п╡"
+
+#: action.c:2498
+msgid "You need to select the items whose permissions you want to change"
+msgstr "п▓п╟п╪ п╫я┐п╤п╫п╬ п╡я▀п╠я─п╟я┌я▄ п╬п╠я┼п╣п╨я┌я▀, п©я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟ п╨п╬я┌п╬я─я▀я┘ п╡я▀ я┘п╬я┌п╦я┌п╣ п╦п╥п╪п╣п╫п╦я┌я▄"
+
+#: action.c:2506
+msgid "a+x (Make executable/searchable)"
+msgstr "a+x (п║п╢п╣п╩п╟я┌я▄ п╡я▀п©п╬п╩п╫я▐п╣п╪я▀п╪/п╢п╬я│я┌я┐п©п╫я▀п╪ п╢п╩я▐ п©п╬п╦я│п╨п╟)"
+
+#: action.c:2508
+msgid "a-x (Make non-executable/non-searchable)"
+msgstr "a-x (я│п╢п╣п╩п╟я┌я▄ п╫п╣п╡я▀п©п╬п╩п╫я▐п╣п╪я▀п╪/п╫п╣п╢п╬я│я┌я┐п©п╫я▀п╪ п╢п╩я▐ п©п╬п╦я│п╨п╟)"
+
+#: action.c:2510
+msgid "u+rw (Give owner read+write)"
+msgstr "u+rw (п■п╟я┌я▄ п╡п╩п╟п╢п╣п╩я▄я├я┐ п©я─п╟п╡п╟ п╫п╟ я┤я┌п╣п╫п╦п╣ п╦ п╥п╟п©п╦я│я▄)"
+
+#: action.c:2512
+msgid "go-rwx (Private - owner access only)"
+msgstr "go-rwx (п⌡п╦я┤п╫я▀п╧ - п╢п╬я│я┌я┐п© я┌п╬п╩я▄п╨п╬ п╢п╩я▐ п╡п╩п╟п╢п╣п╩я▄я├п╟)"
+
+#: action.c:2514
+msgid "go=u-w (Public access, not write)"
+msgstr "go=u-w (п·п╠я┴п╦п╧ п╢п╬я│я┌я┐п© п╠п╣п╥ п╥п╟п©п╦я│п╦)"
+
+#: action.c:2525 menu.c:724 tips:75 tips:118
+msgid "Permissions"
+msgstr "п÷я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟"
+
+#: action.c:2540 action.c:2605
+msgid "Don't list processed files"
+msgstr "п²п╣ п©п╣я─п╣я┤п╦я│п╩я▐я┌я▄ п╬п╠я─п╟п╠п╬я┌п╟п╫п╫я▀п╣ я└п╟п╧п╩я▀"
+
+#: action.c:2543 action.c:2608 tips:255
+msgid "Recurse"
+msgstr "п═п╣п╨я┐я─я│п╦п╡п╫п╬"
+
+#: action.c:2543
+msgid "Also change contents of subdirectories"
+msgstr "п≤п╥п╪п╣п╫я▐я┌я▄ я┌п╟п╨п╤п╣ п╦ я│п╬п╢п╣я─п╤п╦п╪п╬п╣ п©п╬п╢п╨п╟я┌п╟п╩п╬пЁп╬п╡"
+
+#: action.c:2547
+msgid "Command:"
+msgstr "п п╬п╪п╟п╫п╢п╟:"
+
+#: action.c:2577
+msgid "You need to select the items whose type you want to change"
+msgstr "п▓п╟п╪ п╫я┐п╤п╫п╬ п╡я▀п╠я─п╟я┌я▄ п╬п╠я┼п╣п╨я┌я▀, я┌п╦п© п╨п╬я┌п╬я─я▀я┘ п╡я▀ я┘п╬я┌п╦я┌п╣ п╦п╥п╪п╣п╫п╦я┌я▄"
+
+#: action.c:2590
+msgid "Set type"
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ я┌п╦п©"
+
+#: action.c:2608
+msgid "Change contents of subdirectories"
+msgstr "п≤п╥п╪п╣п╫я▐я┌я▄ я│п╬п╢п╣я─п╤п╦п╪п╬п╣ п©п╬п╢п╨п╟я┌п╟п╩п╬пЁп╬п╡"
+
+#: action.c:2615 infobox.c:659
+msgid "Type:"
+msgstr "п╒п╦п©:"
+
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
+msgid "Copy"
+msgstr "п п╬п©п╦я─п╬п╡п╟я┌я▄"
+
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "п²п╣ п©п╬п╢я┌п╡п╣я─п╤п╢п╟я┌я▄ п╨п╟п╤п╢я┐я▌ п╬п©п╣я─п╟я├п╦я▌"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr ""
+"п÷п╣я─п╣п©п╦я│я▀п╡п╟я┌я▄ я┌п╬п╩я▄п╨п╬ п╡ я┌п╬п╪ я│п╩я┐я┤п╟п╣, п╨п╬пЁп╢п╟ п╦я│я┌п╬я┤п╫п╦п╨ п╠п╬п╩п╣п╣ п╫п╬п╡я▀п╧, я┤п╣п╪ я├п╣п╩п╣п╡п╬п╧ "
+"я└п╟п╧п╩"
+
+#: action.c:2687 action.c:2744 tips:259
+msgid "Newer"
+msgstr "п²п╬п╡я▀п╧"
+
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
+msgstr ""
+"п÷п╣я─п╣п©п╦я│я▀п╡п╟я┌я▄ я┌п╬п╩я▄п╨п╬ п╡ я┌п╬п╪ я│п╩я┐я┤п╟п╣, п╨п╬пЁп╢п╟ п╦я│я┌п╬я┤п╫п╦п╨ п╠п╬п╩п╣п╣ п╫п╬п╡я▀п╧, я┤п╣п╪ я├п╣п╩п╣п╡п╬п╧ "
+"я└п╟п╧п╩"
+
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "п╨п╟я┌п╟п╩п╬пЁп╦"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
-msgstr "При копировании только протоколировать каталоги"
+msgstr "п÷я─п╦ п╨п╬п©п╦я─п╬п╡п╟п╫п╦п╦ я┌п╬п╩я▄п╨п╬ п©я─п╬я┌п╬п╨п╬п╩п╦я─п╬п╡п╟я┌я▄ п╨п╟я┌п╟п╩п╬пЁп╦"
 
-#: action.c:2307 dnd.c:123 tips:169
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
-msgstr "Переместить"
+msgstr "п÷п╣я─п╣п╪п╣я│я┌п╦я┌я▄"
 
-#: action.c:2323
+#: action.c:2752
 msgid "Don't log each file as it is moved"
-msgstr "Не протоколировать перемещение каждого файла"
+msgstr "п²п╣ п©я─п╬я┌п╬п╨п╬п╩п╦я─п╬п╡п╟я┌я▄ п©п╣я─п╣п╪п╣я┴п╣п╫п╦п╣ п╨п╟п╤п╢п╬пЁп╬ я└п╟п╧п╩п╟"
 
-#: action.c:2346 tips:171
+#: action.c:2775 tips:244
 msgid "Link"
-msgstr "Ссылка"
+msgstr "п║я│я▀п╩п╨п╟"
 
-#: action.c:2369 appmenu.c:111 filer.c:593
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
-msgstr "Извлечь диск"
+msgstr "п≤п╥п╡п╩п╣я┤я▄ п╢п╦я│п╨"
 
-#: action.c:2437
+#: action.c:2875
 msgid "Deleting items such as "
-msgstr "Удаление объектов, таких как "
+msgstr "пёп╢п╟п╩п╣п╫п╦п╣ п╬п╠я┼п╣п╨я┌п╬п╡, я┌п╟п╨п╦я┘ п╨п╟п╨ "
 
-#: action.c:2441
+#: action.c:2879
 msgid "Deleting the item "
-msgstr "Удаление объекта "
+msgstr "пёп╢п╟п╩п╣п╫п╦п╣ п╬п╠я┼п╣п╨я┌п╟ "
 
-#: action.c:2443
+#: action.c:2881
 msgid "Deleting the items "
-msgstr "Удаление объектов "
+msgstr "пёп╢п╟п╩п╣п╫п╦п╣ п╬п╠я┼п╣п╨я┌п╬п╡ "
 
-#: action.c:2462
+#: action.c:2900
 msgid " and "
-msgstr " и "
+msgstr " п╦ "
 
-#: action.c:2471
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr ""
-"Это затронет некоторые объекты на витрине или на панели - действительно "
-"удалить?"
+"п╜я┌п╬ п╥п╟я┌я─п╬п╫п╣я┌ п╫п╣п╨п╬я┌п╬я─я▀п╣ п╬п╠я┼п╣п╨я┌я▀ п╫п╟ п╡п╦я┌я─п╦п╫п╣ п╦п╩п╦ п╫п╟ п©п╟п╫п╣п╩п╦ - п╢п╣п╧я│я┌п╡п╦я┌п╣п╩я▄п╫п╬ "
+"я┐п╢п╟п╩п╦я┌я▄?"
 
-#: action.c:2478
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr ""
-"Это затронет некоторые объекты на витрине или на панели - действительно "
-"удалить их?"
+"п╜я┌п╬ п╥п╟я┌я─п╬п╫п╣я┌ п╫п╣п╨п╬я┌п╬я─я▀п╣ п╬п╠я┼п╣п╨я┌я▀ п╫п╟ п╡п╦я┌я─п╦п╫п╣ п╦п╩п╦ п╫п╟ п©п╟п╫п╣п╩п╦ - п╢п╣п╧я│я┌п╡п╦я┌п╣п╩я▄п╫п╬ "
+"я┐п╢п╟п╩п╦я┌я▄ п╦я┘?"
 
-#: appmenu.c:197
+#: appmenu.c:206
 msgid "<missing label>"
-msgstr "<нет метки>"
+msgstr "<п╫п╣я┌ п╪п╣я┌п╨п╦>"
 
-#: appmenu.c:319
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
 "menu for all items of this type (%s/%s)."
 msgstr ""
-"Создайте в этом каталоге символическую ссылку на любую программу - и она "
-"будет появляться в меню для всех файлов этого типа (%s/%s)."
+"п║п╬п╥п╢п╟п╧я┌п╣ п╡ я█я┌п╬п╪ п╨п╟я┌п╟п╩п╬пЁп╣ я│п╦п╪п╡п╬п╩п╦я┤п╣я│п╨я┐я▌ я│я│я▀п╩п╨я┐ п╫п╟ п╩я▌п╠я┐я▌ п©я─п╬пЁя─п╟п╪п╪я┐ - п╦ п╬п╫п╟ "
+"п╠я┐п╢п╣я┌ п©п╬я▐п╡п╩я▐я┌я▄я│я▐ п╡ п╪п╣п╫я▌ п╢п╩я▐ п╡я│п╣я┘ я└п╟п╧п╩п╬п╡ я█я┌п╬пЁп╬ я┌п╦п©п╟ (%s/%s)."
 
-#: appmenu.c:363 menu.c:239
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
-msgstr "Дополнить меню..."
+msgstr "п■п╬п©п╬п╩п╫п╦я┌я▄ п╪п╣п╫я▌..."
 
-#: appmenu.c:420 menu.c:257 toolbar.c:158
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
-msgstr "Помощь"
+msgstr "п÷п╬п╪п╬я┴я▄"
 
-#: bookmarks.c:148
-msgid "Path"
-msgstr "Путь"
-
-#: bookmarks.c:156
+#: bookmarks.c:268
 msgid "Title"
-msgstr "Название"
+msgstr "п²п╟п╥п╡п╟п╫п╦п╣"
 
-#: bookmarks.c:305
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "п÷я┐я┌я▄"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
-msgstr "Не могу занести в закладки не локальный ресурс \"%s\"\n"
+msgstr "п²п╣ п╪п╬пЁя┐ п╥п╟п╫п╣я│я┌п╦ п╡ п╥п╟п╨п╩п╟п╢п╨п╦ п╫п╣ п╩п╬п╨п╟п╩я▄п╫я▀п╧ я─п╣я│я┐я─я│ \"%s\"\n"
 
-#: bookmarks.c:313 bookmarks.c:631
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
-msgstr "\"%s\" не каталог"
+msgstr "\"%s\" п╫п╣ п╨п╟я┌п╟п╩п╬пЁ"
 
-#: bookmarks.c:519
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
-msgstr "Сначала вы должны выбрать несколько строк для удаления"
+msgstr "п║п╫п╟я┤п╟п╩п╟ п╡я▀ п╢п╬п╩п╤п╫я▀ п╡я▀п╠я─п╟я┌я▄ п╫п╣я│п╨п╬п╩я▄п╨п╬ я│я┌я─п╬п╨ п╢п╩я▐ я┐п╢п╟п╩п╣п╫п╦я▐"
 
-#: bookmarks.c:543
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
-msgstr "Поместите курсор на элемент списка для его перемещения"
+msgstr "п÷п╬п╪п╣я│я┌п╦я┌п╣ п╨я┐я─я│п╬я─ п╫п╟ я█п╩п╣п╪п╣п╫я┌ я│п©п╦я│п╨п╟ п╢п╩я▐ п╣пЁп╬ п©п╣я─п╣п╪п╣я┴п╣п╫п╦я▐"
 
-#: bookmarks.c:563
+#: bookmarks.c:755
 msgid "This item is already at the end"
-msgstr "Этот элемент уже последний в списке"
+msgstr "п╜я┌п╬я┌ я█п╩п╣п╪п╣п╫я┌ я┐п╤п╣ п©п╬я│п╩п╣п╢п╫п╦п╧ п╡ я│п©п╦я│п╨п╣"
 
-#: bookmarks.c:637
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
-msgstr "Не могу занести в закладки не локальные каталоги, такие как \"%s\""
+msgstr "п²п╣ п╪п╬пЁя┐ п╥п╟п╫п╣я│я┌п╦ п╡ п╥п╟п╨п╩п╟п╢п╨п╦ п╫п╣ п╩п╬п╨п╟п╩я▄п╫я▀п╣ п╨п╟я┌п╟п╩п╬пЁп╦, я┌п╟п╨п╦п╣ п╨п╟п╨ \"%s\""
 
-#: bookmarks.c:779
+#: bookmarks.c:998
 msgid "Add New Bookmark"
-msgstr "Добавить закладку"
+msgstr "п■п╬п╠п╟п╡п╦я┌я▄ п╥п╟п╨п╩п╟п╢п╨я┐"
 
-#: bookmarks.c:786
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
-msgstr "Редактировать закладки"
+msgstr "п═п╣п╢п╟п╨я┌п╦я─п╬п╡п╟я┌я▄ п╥п╟п╨п╩п╟п╢п╨п╦"
 
-#: bookmarks.c:791
+#: bookmarks.c:1010
 msgid "Recently Visited"
-msgstr "Недавние"
-
-#: bulk_rename.c:66
-msgid "Bulk rename files"
-msgstr "Групповое переименование файлов"
+msgstr "п²п╣п╢п╟п╡п╫п╦п╣"
 
 #: bulk_rename.c:69
+msgid "Bulk rename files"
+msgstr "п⌠я─я┐п©п©п╬п╡п╬п╣ п©п╣я─п╣п╦п╪п╣п╫п╬п╡п╟п╫п╦п╣ я└п╟п╧п╩п╬п╡"
+
+#: bulk_rename.c:72
 msgid "Reset"
-msgstr "Сброс"
+msgstr "п║п╠я─п╬я│"
 
-#: bulk_rename.c:74
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
-msgstr "Сделать колонку \"Новое имя\" копией колонки \"Старое имя\""
+msgstr "п║п╢п╣п╩п╟я┌я▄ п╨п╬п╩п╬п╫п╨я┐ \"п²п╬п╡п╬п╣ п╦п╪я▐\" п╨п╬п©п╦п╣п╧ п╨п╬п╩п╬п╫п╨п╦ \"п║я┌п╟я─п╬п╣ п╦п╪я▐\""
 
-#: bulk_rename.c:79
+#: bulk_rename.c:82
 msgid "_Rename"
-msgstr "Что переименовать?"
+msgstr "п╖я┌п╬ п©п╣я─п╣п╦п╪п╣п╫п╬п╡п╟я┌я▄?"
 
-#: bulk_rename.c:92
+#: bulk_rename.c:95
 msgid "Replace:"
-msgstr "Заменить:"
+msgstr "п≈п╟п╪п╣п╫п╦я┌я▄:"
 
-#: bulk_rename.c:99
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -827,104 +861,108 @@ msgid ""
 "\\. matches a dot\n"
 "\\.htm$ matches the '.htm' in 'index.htm', etc"
 msgstr ""
-"Вот шаблон для поиска:\n"
-"^ обозначает началу имени файла\n"
-"$ обозначает конец\n"
-"\\. обозначает точку\n"
-"\\.htm$ соответствует \".htm\" в \"index.html\", и т.д."
+"п▓п╬я┌ я┬п╟п╠п╩п╬п╫ п╢п╩я▐ п©п╬п╦я│п╨п╟:\n"
+"^ п╬п╠п╬п╥п╫п╟я┤п╟п╣я┌ п╫п╟я┤п╟п╩я┐ п╦п╪п╣п╫п╦ я└п╟п╧п╩п╟\n"
+"$ п╬п╠п╬п╥п╫п╟я┤п╟п╣я┌ п╨п╬п╫п╣я├\n"
+"\\. п╬п╠п╬п╥п╫п╟я┤п╟п╣я┌ я┌п╬я┤п╨я┐\n"
+"\\.htm$ я│п╬п╬я┌п╡п╣я┌я│я┌п╡я┐п╣я┌ \".htm\" п╡ \"index.html\", п╦ я┌.п╢."
 
-#: bulk_rename.c:107
+#: bulk_rename.c:109
 msgid "With:"
-msgstr "На:"
+msgstr "п²п╟:"
 
-#: bulk_rename.c:114
+#: bulk_rename.c:116
+#, fuzzy
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
-"Первый подходящий фрагмент в имени каждого файла будет заменён этой строкой. "
-"В ней нет специальных символов."
+"п÷п╣я─п╡я▀п╧ п©п╬п╢я┘п╬п╢я▐я┴п╦п╧ я└я─п╟пЁп╪п╣п╫я┌ п╡ п╦п╪п╣п╫п╦ п╨п╟п╤п╢п╬пЁп╬ я└п╟п╧п╩п╟ п╠я┐п╢п╣я┌ п╥п╟п╪п╣п╫я▒п╫ я█я┌п╬п╧ я│я┌я─п╬п╨п╬п╧. "
+"п▓ п╫п╣п╧ п╫п╣я┌ я│п©п╣я├п╦п╟п╩я▄п╫я▀я┘ я│п╦п╪п╡п╬п╩п╬п╡."
 
-#: bulk_rename.c:118
+#: bulk_rename.c:122
 msgid "Apply"
-msgstr "Применить"
+msgstr "п÷я─п╦п╪п╣п╫п╦я┌я▄"
 
-#: bulk_rename.c:121
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
 msgstr ""
-"Произвести поиск и замену в колонке \"Новое имя\". Изменения не вступят в "
-"силу, пока вы не нажмёте кнопку \"Переименовать\"."
+"п÷я─п╬п╦п╥п╡п╣я│я┌п╦ п©п╬п╦я│п╨ п╦ п╥п╟п╪п╣п╫я┐ п╡ п╨п╬п╩п╬п╫п╨п╣ \"п²п╬п╡п╬п╣ п╦п╪я▐\". п≤п╥п╪п╣п╫п╣п╫п╦я▐ п╫п╣ п╡я│я┌я┐п©я▐я┌ п╡ "
+"я│п╦п╩я┐, п©п╬п╨п╟ п╡я▀ п╫п╣ п╫п╟п╤п╪я▒я┌п╣ п╨п╫п╬п©п╨я┐ \"п÷п╣я─п╣п╦п╪п╣п╫п╬п╡п╟я┌я▄\"."
 
-#: bulk_rename.c:140
+#: bulk_rename.c:144
 msgid "Old name"
-msgstr "Старое имя"
+msgstr "п║я┌п╟я─п╬п╣ п╦п╪я▐"
 
-#: bulk_rename.c:149
+#: bulk_rename.c:153
 msgid "New name"
-msgstr "Новое имя"
+msgstr "п²п╬п╡п╬п╣ п╦п╪я▐"
 
-#: bulk_rename.c:257
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
-msgstr "Ни одна строка в колонке \"Новое имя\" не совпала с шаблоном."
+msgstr "п²п╦ п╬п╢п╫п╟ я│я┌я─п╬п╨п╟ п╡ п╨п╬п╩п╬п╫п╨п╣ \"п²п╬п╡п╬п╣ п╦п╪я▐\" п╫п╣ я│п╬п╡п©п╟п╩п╟ я│ я┬п╟п╠п╩п╬п╫п╬п╪."
 
-#: bulk_rename.c:262
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
-msgstr "Найдено одно имя, но в результате переименования оно не изменится"
+msgstr "п²п╟п╧п╢п╣п╫п╬ п╬п╢п╫п╬ п╦п╪я▐, п╫п╬ п╡ я─п╣п╥я┐п╩я▄я┌п╟я┌п╣ п©п╣я─п╣п╦п╪п╣п╫п╬п╡п╟п╫п╦я▐ п╬п╫п╬ п╫п╣ п╦п╥п╪п╣п╫п╦я┌я│я▐"
 
-#: bulk_rename.c:265
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
-msgstr "%d имён совпало с шаблоном, но в результате они не изменятся"
+msgstr "%d п╦п╪я▒п╫ я│п╬п╡п©п╟п╩п╬ я│ я┬п╟п╠п╩п╬п╫п╬п╪, п╫п╬ п╡ я─п╣п╥я┐п╩я▄я┌п╟я┌п╣ п╬п╫п╦ п╫п╣ п╦п╥п╪п╣п╫я▐я┌я│я▐"
 
-#: bulk_rename.c:291
-msgid "Specify a regular expression to match, and a string to replace matches with."
-msgstr "Укажите шаблон для поиска и строку для замены найденных совпадений."
+#: bulk_rename.c:330
+msgid ""
+"Specify a regular expression to match, and a string to replace matches with."
+msgstr "пёп╨п╟п╤п╦я┌п╣ я┬п╟п╠п╩п╬п╫ п╢п╩я▐ п©п╬п╦я│п╨п╟ п╦ я│я┌я─п╬п╨я┐ п╢п╩я▐ п╥п╟п╪п╣п╫я▀ п╫п╟п╧п╢п╣п╫п╫я▀я┘ я│п╬п╡п©п╟п╢п╣п╫п╦п╧."
 
-#: bulk_rename.c:308
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
-msgstr "%s (для \"%s\")"
+msgstr "%s (п╢п╩я▐ \"%s\")"
 
-#: bulk_rename.c:341
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
-msgstr "Файл с именем \"%s\" уже существует. Групповое переименование остановлено."
+msgstr ""
+"п╓п╟п╧п╩ я│ п╦п╪п╣п╫п╣п╪ \"%s\" я┐п╤п╣ я│я┐я┴п╣я│я┌п╡я┐п╣я┌. п⌠я─я┐п©п©п╬п╡п╬п╣ п©п╣я─п╣п╦п╪п╣п╫п╬п╡п╟п╫п╦п╣ п╬я│я┌п╟п╫п╬п╡п╩п╣п╫п╬."
 
-#: bulk_rename.c:346
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
 "%s\n"
 "Aborting bulk rename."
 msgstr ""
-"Не удалось переименовать \"%s\" в \"%s\":\n"
+"п²п╣ я┐п╢п╟п╩п╬я│я▄ п©п╣я─п╣п╦п╪п╣п╫п╬п╡п╟я┌я▄ \"%s\" п╡ \"%s\":\n"
 "%s\n"
-"Групповое переименование остановлено."
+"п⌠я─я┐п©п©п╬п╡п╬п╣ п©п╣я─п╣п╦п╪п╣п╫п╬п╡п╟п╫п╦п╣ п╬я│я┌п╟п╫п╬п╡п╩п╣п╫п╬."
 
-#: bulk_rename.c:408
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
-msgstr "Файл \"%s\" уже существует"
+msgstr "п╓п╟п╧п╩ \"%s\" я┐п╤п╣ я│я┐я┴п╣я│я┌п╡я┐п╣я┌"
 
-#: bulk_rename.c:419
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
 "files to end up in different directories. Continue?"
 msgstr ""
-"Некоторые строки колонки \"Новое имя\" содержат слэш (например, \"%s\"). Из-"
-"за этого они попадут после переименования в другие каталоги. Продолжить?"
+"п²п╣п╨п╬я┌п╬я─я▀п╣ я│я┌я─п╬п╨п╦ п╨п╬п╩п╬п╫п╨п╦ \"п²п╬п╡п╬п╣ п╦п╪я▐\" я│п╬п╢п╣я─п╤п╟я┌ я│п╩я█я┬ (п╫п╟п©я─п╦п╪п╣я─, \"%s\"). п≤п╥-"
+"п╥п╟ я█я┌п╬пЁп╬ п╬п╫п╦ п©п╬п©п╟п╢я┐я┌ п©п╬я│п╩п╣ п©п╣я─п╣п╦п╪п╣п╫п╬п╡п╟п╫п╦я▐ п╡ п╢я─я┐пЁп╦п╣ п╨п╟я┌п╟п╩п╬пЁп╦. п÷я─п╬п╢п╬п╩п╤п╦я┌я▄?"
 
-#: bulk_rename.c:434
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
-msgstr "Ни одно имя не было изменено. Мне нечего делать!"
+msgstr "п²п╦ п╬п╢п╫п╬ п╦п╪я▐ п╫п╣ п╠я▀п╩п╬ п╦п╥п╪п╣п╫п╣п╫п╬. п°п╫п╣ п╫п╣я┤п╣пЁп╬ п╢п╣п╩п╟я┌я▄!"
 
 #: choices.c:434
 #, c-format
 msgid "%d directories could not be migrated"
-msgstr "%d каталогов переместить не удалось"
+msgstr "%d п╨п╟я┌п╟п╩п╬пЁп╬п╡ п©п╣я─п╣п╪п╣я│я┌п╦я┌я▄ п╫п╣ я┐п╢п╟п╩п╬я│я▄"
 
 #: choices.c:436
 #, c-format
@@ -935,64 +973,86 @@ msgid ""
 "%s\n"
 "%s"
 msgstr ""
-"Настройки были перемещены из\n"
+"п²п╟я│я┌я─п╬п╧п╨п╦ п╠я▀п╩п╦ п©п╣я─п╣п╪п╣я┴п╣п╫я▀ п╦п╥\n"
 "%s\n"
-"в новый каталог\n"
+"п╡ п╫п╬п╡я▀п╧ п╨п╟я┌п╟п╩п╬пЁ\n"
 "%s\n"
 "%s"
 
-#: dir.c:980
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
-msgstr "Не могу получить сведения о каталоге %s"
+msgstr "п²п╣ п╪п╬пЁя┐ п©п╬п╩я┐я┤п╦я┌я▄ я│п╡п╣п╢п╣п╫п╦я▐ п╬ п╨п╟я┌п╟п╩п╬пЁп╣ %s"
 
-#: dir.c:989
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
-msgstr "Не могу открыть каталог %s"
+msgstr "п²п╣ п╪п╬пЁя┐ п╬я┌п╨я─я▀я┌я▄ п╨п╟я┌п╟п╩п╬пЁ %s"
 
-#: display.c:629
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "п═п╟п╥п╪п╣я─"
+
+#: display.c:705
+msgid "Б■╓"
+msgstr ""
+
+#: display.c:706
+msgid "Б■░"
+msgstr ""
+
+#: display.c:707
+msgid "Б■≤"
+msgstr ""
+
+#: display.c:709
+msgid "Б■°"
+msgstr ""
+
+#: display.c:709
+msgid "Б■▄"
+msgstr ""
+
+#: display.c:710
+msgid "Б■╪"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
-msgstr "lstat(2) не удался: %s"
+msgstr "lstat(2) п╫п╣ я┐п╢п╟п╩я│я▐: %s"
 
-#: dnd.c:124
-msgid "Link (relative)"
-msgstr "Ссылка (относительная)"
-
-#: dnd.c:125
-msgid "Link (absolute)"
-msgstr "Ссылка (абсолютная)"
-
-#: dnd.c:424
+#: dnd.c:423
 msgid "Internal error - bad info type"
-msgstr "Внутренняя ошибка - неверный тип информации"
+msgstr "п▓п╫я┐я┌я─п╣п╫п╫я▐я▐ п╬я┬п╦п╠п╨п╟ - п╫п╣п╡п╣я─п╫я▀п╧ я┌п╦п© п╦п╫я└п╬я─п╪п╟я├п╦п╦"
 
-#: dnd.c:563
+#: dnd.c:565
 msgid "Drag a directory here to bookmark it."
-msgstr "Перетащите каталог сюда для занесения его в закладки."
+msgstr "п÷п╣я─п╣я┌п╟я┴п╦я┌п╣ п╨п╟я┌п╟п╩п╬пЁ я│я▌п╢п╟ п╢п╩я▐ п╥п╟п╫п╣я│п╣п╫п╦я▐ п╣пЁп╬ п╡ п╥п╟п╨п╩п╟п╢п╨п╦."
 
-#: dnd.c:578
+#: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
-msgstr "Ошибка протокола XDS: имя не может содержать \"/\"\n"
+msgstr "п·я┬п╦п╠п╨п╟ п©я─п╬я┌п╬п╨п╬п╩п╟ XDS: п╦п╪я▐ п╫п╣ п╪п╬п╤п╣я┌ я│п╬п╢п╣я─п╤п╟я┌я▄ \"/\"\n"
 
-#: dnd.c:603
+#: dnd.c:605
 msgid ""
 "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
 "plain) did not contain a leafname\n"
 msgstr ""
-"XdndDirectSave0 цель предоставлена, но атом XdndDirectSave0 (тип text/plain) "
-"не содержит leafname\n"
+"XdndDirectSave0 я├п╣п╩я▄ п©я─п╣п╢п╬я│я┌п╟п╡п╩п╣п╫п╟, п╫п╬ п╟я┌п╬п╪ XdndDirectSave0 (я┌п╦п© text/plain) "
+"п╫п╣ я│п╬п╢п╣я─п╤п╦я┌ leafname\n"
 
-#: dnd.c:616
+#: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
-msgstr "Внимание: требуется целевой тип text/uri-list или XdndDirectSave0."
+msgstr "п▓п╫п╦п╪п╟п╫п╦п╣: я┌я─п╣п╠я┐п╣я┌я│я▐ я├п╣п╩п╣п╡п╬п╧ я┌п╦п© text/uri-list п╦п╩п╦ XdndDirectSave0."
 
-#: dnd.c:619
-msgid "Sorry - I require a target type of text/uri-list or application/octet-stream."
-msgstr "Внимание: требуется целевой тип text/uri-list или application/octet-stream."
+#: dnd.c:621
+msgid ""
+"Sorry - I require a target type of text/uri-list or application/octet-stream."
+msgstr ""
+"п▓п╫п╦п╪п╟п╫п╦п╣: я┌я─п╣п╠я┐п╣я┌я│я▐ я├п╣п╩п╣п╡п╬п╧ я┌п╦п© text/uri-list п╦п╩п╦ application/octet-stream."
 
-#: dnd.c:689
+#: dnd.c:691
 #, c-format
 msgid ""
 "Failed to add some items to the pinboard, because they are on a remote "
@@ -1000,99 +1060,122 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
-"Не удалось добавить некоторые элементы на витрину, так как они находятся на "
-"удалённой машине. Например:\n"
+"п²п╣ я┐п╢п╟п╩п╬я│я▄ п╢п╬п╠п╟п╡п╦я┌я▄ п╫п╣п╨п╬я┌п╬я─я▀п╣ я█п╩п╣п╪п╣п╫я┌я▀ п╫п╟ п╡п╦я┌я─п╦п╫я┐, я┌п╟п╨ п╨п╟п╨ п╬п╫п╦ п╫п╟я┘п╬п╢я▐я┌я│я▐ п╫п╟ "
+"я┐п╢п╟п╩я▒п╫п╫п╬п╧ п╪п╟я┬п╦п╫п╣. п²п╟п©я─п╦п╪п╣я─:\n"
 "\n"
 "%s"
 
-#: dnd.c:764
+#: dnd.c:766
 msgid "Unknown target"
-msgstr "Неизвестная цель"
+msgstr "п²п╣п╦п╥п╡п╣я│я┌п╫п╟я▐ я├п╣п╩я▄"
 
-#: dnd.c:797
+#: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
-msgstr "Удаленная программа не может или отказывается передавать данные - извините"
+msgstr ""
+"пёп╢п╟п╩п╣п╫п╫п╟я▐ п©я─п╬пЁя─п╟п╪п╪п╟ п╫п╣ п╪п╬п╤п╣я┌ п╦п╩п╦ п╬я┌п╨п╟п╥я▀п╡п╟п╣я┌я│я▐ п©п╣я─п╣п╢п╟п╡п╟я┌я▄ п╢п╟п╫п╫я▀п╣ - п╦п╥п╡п╦п╫п╦я┌п╣"
 
-#: dnd.c:810
+#: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
-msgstr "Ошибка протокола XDS: код возврата должен быть 'S', 'F' или 'E'\n"
+msgstr "п·я┬п╦п╠п╨п╟ п©я─п╬я┌п╬п╨п╬п╩п╟ XDS: п╨п╬п╢ п╡п╬п╥п╡я─п╟я┌п╟ п╢п╬п╩п╤п╣п╫ п╠я▀я┌я▄ 'S', 'F' п╦п╩п╦ 'E'\n"
 
-#: dnd.c:843
+#: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
 msgstr ""
-"Внимание, невозможно отобразить меню действий для  удаленного файла / "
-"неструктурированных данных"
+"п▓п╫п╦п╪п╟п╫п╦п╣, п╫п╣п╡п╬п╥п╪п╬п╤п╫п╬ п╬я┌п╬п╠я─п╟п╥п╦я┌я▄ п╪п╣п╫я▌ п╢п╣п╧я│я┌п╡п╦п╧ п╢п╩я▐  я┐п╢п╟п╩п╣п╫п╫п╬пЁп╬ я└п╟п╧п╩п╟ / "
+"п╫п╣я│я┌я─я┐п╨я┌я┐я─п╦я─п╬п╡п╟п╫п╫я▀я┘ п╢п╟п╫п╫я▀я┘"
 
-#: dnd.c:859
+#: dnd.c:861
 msgid "UntitledData"
-msgstr "ДанныеБезИмени"
+msgstr "п■п╟п╫п╫я▀п╣п▒п╣п╥п≤п╪п╣п╫п╦"
 
-#: dnd.c:886
+#: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
-msgstr "Ошибка при сохранении файла: %s"
+msgstr "п·я┬п╦п╠п╨п╟ п©я─п╦ я│п╬я┘я─п╟п╫п╣п╫п╦п╦ я└п╟п╧п╩п╟: %s"
 
-#: dnd.c:959
+#: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
-msgstr "Нет URI в text/uri-list (нечего делать!)"
+msgstr "п²п╣я┌ URI п╡ text/uri-list (п╫п╣я┤п╣пЁп╬ п╢п╣п╩п╟я┌я▄!)"
 
-#: dnd.c:991
-msgid "Can't get data from remote machine (application/octet-stream not provided)"
+#: dnd.c:993
+msgid ""
+"Can't get data from remote machine (application/octet-stream not provided)"
 msgstr ""
-"Невозможно получить данные от удаленной машины (application/octet-stream не "
-"передан)"
+"п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ п©п╬п╩я┐я┤п╦я┌я▄ п╢п╟п╫п╫я▀п╣ п╬я┌ я┐п╢п╟п╩п╣п╫п╫п╬п╧ п╪п╟я┬п╦п╫я▀ (application/octet-stream п╫п╣ "
+"п©п╣я─п╣п╢п╟п╫)"
 
-#: dnd.c:1014
-msgid "Some of these files are on a different machine - they will be ignored - sorry"
+#: dnd.c:1015 menu.c:2406
+msgid ""
+"Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
-"Некоторые из этих файлов находятся на другой машине - они будут пропущены - "
-"извините"
+"п²п╣п╨п╬я┌п╬я─я▀п╣ п╦п╥ я█я┌п╦я┘ я└п╟п╧п╩п╬п╡ п╫п╟я┘п╬п╢я▐я┌я│я▐ п╫п╟ п╢я─я┐пЁп╬п╧ п╪п╟я┬п╦п╫п╣ - п╬п╫п╦ п╠я┐п╢я┐я┌ п©я─п╬п©я┐я┴п╣п╫я▀ - "
+"п╦п╥п╡п╦п╫п╦я┌п╣"
 
-#: dnd.c:1021
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
 msgstr ""
-"Ни один из этих файлов не находится на локальной машине - невозможно "
-"совершать операции над множеством удаленных файлов - извините"
+"п²п╦ п╬п╢п╦п╫ п╦п╥ я█я┌п╦я┘ я└п╟п╧п╩п╬п╡ п╫п╣ п╫п╟я┘п╬п╢п╦я┌я│я▐ п╫п╟ п╩п╬п╨п╟п╩я▄п╫п╬п╧ п╪п╟я┬п╦п╫п╣ - п╫п╣п╡п╬п╥п╪п╬п╤п╫п╬ "
+"я│п╬п╡п╣я─я┬п╟я┌я▄ п╬п©п╣я─п╟я├п╦п╦ п╫п╟п╢ п╪п╫п╬п╤п╣я│я┌п╡п╬п╪ я┐п╢п╟п╩п╣п╫п╫я▀я┘ я└п╟п╧п╩п╬п╡ - п╦п╥п╡п╦п╫п╦я┌п╣"
 
-#: dnd.c:1034
+#: dnd.c:1040
 msgid "Unknown action requested"
-msgstr "Запрошено неизвестное действие"
+msgstr "п≈п╟п©я─п╬я┬п╣п╫п╬ п╫п╣п╦п╥п╡п╣я│я┌п╫п╬п╣ п╢п╣п╧я│я┌п╡п╦п╣"
 
-#: dnd.c:1042
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
-msgstr "Ошибка при получении списка файлов: %s"
+msgstr "п·я┬п╦п╠п╨п╟ п©я─п╦ п©п╬п╩я┐я┤п╣п╫п╦п╦ я│п©п╦я│п╨п╟ я└п╟п╧п╩п╬п╡: %s"
+
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "п║я│я▀п╩п╨п╟ (п╬я┌п╫п╬я│п╦я┌п╣п╩я▄п╫п╟я▐)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "п║я│я▀п╩п╨п╟ (п╟п╠я│п╬п╩я▌я┌п╫п╟я▐)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "п║я│я▀п╩п╨п╟ (п╬я┌п╫п╬я│п╦я┌п╣п╩я▄п╫п╟я▐)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "п║я│я▀п╩п╨п╟ (п╟п╠я│п╬п╩я▌я┌п╫п╟я▐)"
 
 #: dropbox.c:112
 msgid "Show"
-msgstr "Показать"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄"
 
 #: dropbox.c:118
 msgid "Show the current choice in a filer window"
-msgstr "Показывать текущий выбор в окнах файлового менеджера"
+msgstr "п÷п╬п╨п╟п╥я▀п╡п╟я┌я▄ я┌п╣п╨я┐я┴п╦п╧ п╡я▀п╠п╬я─ п╡ п╬п╨п╫п╟я┘ я└п╟п╧п╩п╬п╡п╬пЁп╬ п╪п╣п╫п╣п╢п╤п╣я─п╟"
 
 #: dropbox.c:172
 msgid "<nothing>"
-msgstr "<ничего>"
+msgstr "<п╫п╦я┤п╣пЁп╬>"
 
 #: dropbox.c:237
 msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
 msgstr ""
-"Не могу показать текущий установленный элемент, потому что ничего пока не "
-"установлено. Перетащите на меня что-нибудь!"
+"п²п╣ п╪п╬пЁя┐ п©п╬п╨п╟п╥п╟я┌я▄ я┌п╣п╨я┐я┴п╦п╧ я┐я│я┌п╟п╫п╬п╡п╩п╣п╫п╫я▀п╧ я█п╩п╣п╪п╣п╫я┌, п©п╬я┌п╬п╪я┐ я┤я┌п╬ п╫п╦я┤п╣пЁп╬ п©п╬п╨п╟ п╫п╣ "
+"я┐я│я┌п╟п╫п╬п╡п╩п╣п╫п╬. п÷п╣я─п╣я┌п╟я┴п╦я┌п╣ п╫п╟ п╪п╣п╫я▐ я┤я┌п╬-п╫п╦п╠я┐п╢я▄!"
 
 #: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
-msgstr "Извините, но перетаскивать файлы в целевую область можно только по одному."
+msgstr ""
+"п≤п╥п╡п╦п╫п╦я┌п╣, п╫п╬ п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟я┌я▄ я└п╟п╧п╩я▀ п╡ я├п╣п╩п╣п╡я┐я▌ п╬п╠п╩п╟я│я┌я▄ п╪п╬п╤п╫п╬ я┌п╬п╩я▄п╨п╬ п©п╬ п╬п╢п╫п╬п╪я┐."
 
 #: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
-msgstr "Извините, Я не могу использовать \"%s\" потому что это не локальный файл."
+msgstr ""
+"п≤п╥п╡п╦п╫п╦я┌п╣, п╞ п╫п╣ п╪п╬пЁя┐ п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ \"%s\" п©п╬я┌п╬п╪я┐ я┤я┌п╬ я█я┌п╬ п╫п╣ п╩п╬п╨п╟п╩я▄п╫я▀п╧ я└п╟п╧п╩."
 
 #: dropbox.c:278 pinboard.c:932
 #, c-format
@@ -1100,163 +1183,193 @@ msgid ""
 "Can't access '%s':\n"
 "%s"
 msgstr ""
-"Нет доступа к %s:\n"
+"п²п╣я┌ п╢п╬я│я┌я┐п©п╟ п╨ %s:\n"
 "%s"
 
-#: filer.c:456
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
 "%s\n"
 msgstr ""
-"Ошибка просмотра \"%s\":\n"
+"п·я┬п╦п╠п╨п╟ п©я─п╬я│п╪п╬я┌я─п╟ \"%s\":\n"
 "%s\n"
 
-#: filer.c:460
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Ошибка просмотра \"%s\":\n"
-"%s"
-
-#: filer.c:576
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
 "Unmounting a device makes it safe to remove the disk."
 msgstr ""
-"Вы хотите отсоединить это устройство?\n"
+"п▓я▀ я┘п╬я┌п╦я┌п╣ п╬я┌я│п╬п╣п╢п╦п╫п╦я┌я▄ я█я┌п╬ я┐я│я┌я─п╬п╧я│я┌п╡п╬?\n"
 "\n"
-"Отсоединив устройство, вы можете безопасно извлечь из него диск."
+"п·я┌я│п╬п╣п╢п╦п╫п╦п╡ я┐я│я┌я─п╬п╧я│я┌п╡п╬, п╡я▀ п╪п╬п╤п╣я┌п╣ п╠п╣п╥п╬п©п╟я│п╫п╬ п╦п╥п╡п╩п╣я┤я▄ п╦п╥ п╫п╣пЁп╬ п╢п╦я│п╨."
 
-#: filer.c:580
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 msgid "No change"
-msgstr "Без изменений"
+msgstr "п▒п╣п╥ п╦п╥п╪п╣п╫п╣п╫п╦п╧"
 
-#: filer.c:586 menu.c:872
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
-msgstr "Отсоединить"
+msgstr "п·я┌я│п╬п╣п╢п╦п╫п╦я┌я▄"
 
-#: filer.c:690
-msgid "Directory missing/deleted"
-msgstr "Каталог отсутствует или удален"
-
-#: filer.c:1054
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
 "Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"Группа %s не установлена. Выберите несколько файлов и нажмите Ctrl+%s для "
-"установки группы. Нажмите %s для того, чтобы перевыбрать файлы позже. \n"
-"Убедитесь, что numlock включен, если вы используете цифровую  клавиатуру "
-"справа (keypad)."
+"п⌠я─я┐п©п©п╟ %s п╫п╣ я┐я│я┌п╟п╫п╬п╡п╩п╣п╫п╟. п▓я▀п╠п╣я─п╦я┌п╣ п╫п╣я│п╨п╬п╩я▄п╨п╬ я└п╟п╧п╩п╬п╡ п╦ п╫п╟п╤п╪п╦я┌п╣ Ctrl+%s п╢п╩я▐ "
+"я┐я│я┌п╟п╫п╬п╡п╨п╦ пЁя─я┐п©п©я▀. п²п╟п╤п╪п╦я┌п╣ %s п╢п╩я▐ я┌п╬пЁп╬, я┤я┌п╬п╠я▀ п©п╣я─п╣п╡я▀п╠я─п╟я┌я▄ я└п╟п╧п╩я▀ п©п╬п╥п╤п╣. \n"
+"пёп╠п╣п╢п╦я┌п╣я│я▄, я┤я┌п╬ numlock п╡п╨п╩я▌я┤п╣п╫, п╣я│п╩п╦ п╡я▀ п╦я│п©п╬п╩я▄п╥я┐п╣я┌п╣ я├п╦я└я─п╬п╡я┐я▌  п╨п╩п╟п╡п╦п╟я┌я┐я─я┐ "
+"я│п©я─п╟п╡п╟ (keypad)."
 
-#: filer.c:1290
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Каталог \"%s\" недоступен"
-
-#: filer.c:1442
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Каталог \"%s\" не найден"
-
-#: filer.c:1742
-msgid "Cancel"
-msgstr "Отменить"
-
-#: filer.c:2023
+#: filer.c:2655
 msgid "A"
-msgstr "А"
+msgstr "п░"
 
-#: filer.c:2025 find.c:923
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr "G"
 
-#: filer.c:2030
+#: filer.c:2664
 msgid "S"
 msgstr "S"
 
-#: filer.c:2032
+#: filer.c:2669
 msgid "T"
 msgstr "T"
 
-#: filer.c:2042
-msgid "All, "
-msgstr "Все, "
+#: filer.c:2670
+msgid "D"
+msgstr ""
 
-#: filer.c:2045
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
-msgstr "Раскрыть регулярное выражение (%s), "
+msgstr "п═п╟я│п╨я─я▀я┌я▄ я─п╣пЁя┐п╩я▐я─п╫п╬п╣ п╡я▀я─п╟п╤п╣п╫п╦п╣ (%s), "
 
-#: filer.c:2053
+#: filer.c:2694
 msgid "Scanning, "
-msgstr "Сканирование, "
+msgstr "п║п╨п╟п╫п╦я─п╬п╡п╟п╫п╦п╣, "
 
-#: filer.c:2055
+#: filer.c:2697
 msgid "Thumbs, "
-msgstr "Миниатюры, "
+msgstr "п°п╦п╫п╦п╟я┌я▌я─я▀, "
 
-#: filer.c:2331
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "п°п╦п╫п╦п╟я┌я▌я─я▀, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
-msgstr "Символическая ссылка на "
+msgstr "п║п╦п╪п╡п╬п╩п╦я┤п╣я│п╨п╟я▐ я│я│я▀п╩п╨п╟ п╫п╟ "
 
-#: filer.c:2373
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
-msgstr "Имя файла не соответствует кодировке UTF-8. Вам лучше его переименовать.\n"
+msgstr ""
+"п≤п╪я▐ я└п╟п╧п╩п╟ п╫п╣ я│п╬п╬я┌п╡п╣я┌я│я┌п╡я┐п╣я┌ п╨п╬п╢п╦я─п╬п╡п╨п╣ UTF-8. п▓п╟п╪ п╩я┐я┤я┬п╣ п╣пЁп╬ п©п╣я─п╣п╦п╪п╣п╫п╬п╡п╟я┌я▄.\n"
 
-#: filer.c:2684 menu.c:2008
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
-msgstr "Объект не существует!"
+msgstr "п·п╠я┼п╣п╨я┌ п╫п╣ я│я┐я┴п╣я│я┌п╡я┐п╣я┌!"
 
-#: filer.c:3411
+#: filer.c:4451
+msgid "Б√╪"
+msgstr ""
+
+#: filer.c:4451
+msgid "Б√╫"
+msgstr ""
+
+#: filer.c:4462
+msgid "Б√╥"
+msgstr ""
+
+#: filer.c:4462
+msgid "Б√╤"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
-msgstr "Выберите, какие параметры отображения сохранить."
+msgstr "п▓я▀п╠п╣я─п╦я┌п╣, п╨п╟п╨п╦п╣ п©п╟я─п╟п╪п╣я┌я─я▀ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐ я│п╬я┘я─п╟п╫п╦я┌я▄."
 
-#: filer.c:3415
+#: filer.c:4712
+#, fuzzy
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr "<b>п║п╬я┘я─п╟п╫п╦я┌я▄ п╫п╟я│я┌я─п╬п╧п╨п╦ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐ п╢п╩я▐ п╨п╟я┌п╟п╩п╬пЁп╟</b>"
+
+#: filer.c:4713
 msgid "<b>Save display settings for directory</b>"
-msgstr "<b>Сохранить настройки отображения для каталога</b>"
+msgstr "<b>п║п╬я┘я─п╟п╫п╦я┌я▄ п╫п╟я│я┌я─п╬п╧п╨п╦ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐ п╢п╩я▐ п╨п╟я┌п╟п╩п╬пЁп╟</b>"
 
-#: filer.c:3422
+#: filer.c:4720
 msgid "Select settings to save"
-msgstr "Выберите, какие параметры отображения сохранить"
+msgstr "п▓я▀п╠п╣я─п╦я┌п╣, п╨п╟п╨п╦п╣ п©п╟я─п╟п╪п╣я┌я─я▀ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐ я│п╬я┘я─п╟п╫п╦я┌я▄"
 
-#: filer.c:3429
+#: filer.c:4727
 msgid "Position"
-msgstr "Местоположение"
+msgstr "п°п╣я│я┌п╬п©п╬п╩п╬п╤п╣п╫п╦п╣"
 
-#: filer.c:3434 toolbar.c:133 toolbar.c:137 tips:39
-msgid "Size"
-msgstr "Размер"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "п·п╨п╫п╬"
 
-#: filer.c:3439
+#: filer.c:4737
 msgid "Show hidden"
-msgstr "Показать скрытые"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ я│п╨я─я▀я┌я▀п╣"
 
-#: filer.c:3445
-msgid "Display style"
-msgstr "Отображать как"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
+msgstr "п·я┌п╬п╠я─п╟п╤п╟я┌я▄ п╨п╟п╨"
 
-#: filer.c:3451
+#: filer.c:4749
 msgid "Sort type and order"
-msgstr "Тип и порядок сортировки"
+msgstr "п╒п╦п© п╦ п©п╬я─я▐п╢п╬п╨ я│п╬я─я┌п╦я─п╬п╡п╨п╦"
 
-#: filer.c:3456 toolbar.c:141
+#: filer.c:4754
 msgid "Details"
-msgstr "Подробности"
+msgstr "п÷п╬п╢я─п╬п╠п╫п╬я│я┌п╦"
 
-#: filer.c:3461 tips:92 tips:93
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
-msgstr "Миниатюры"
+msgstr "п°п╦п╫п╦п╟я┌я▌я─я▀"
 
-#: filer.c:3467
+#: filer.c:4765
 msgid "Filter"
-msgstr "Фильтр"
+msgstr "п╓п╦п╩я▄я┌я─"
 
 #: find.c:485
 msgid "And"
@@ -1476,29 +1589,29 @@ msgstr "blocks"
 
 #: gtksavebox.c:249
 msgid "Save As:"
-msgstr "Сохранить как:"
+msgstr "п║п╬я┘я─п╟п╫п╦я┌я▄ п╨п╟п╨:"
 
-#: gtksavebox.c:395
+#: gtksavebox.c:401
 msgid "Unnamed"
-msgstr "Без Имени"
+msgstr "п▒п╣п╥ п≤п╪п╣п╫п╦"
 
-#: gtksavebox.c:471
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
 msgstr ""
-"Удаленное приложение требует использовать прямую запись, однако невозможно "
-"прочитать XdndDirectSave0 (тип text/plain).\n"
+"пёп╢п╟п╩п╣п╫п╫п╬п╣ п©я─п╦п╩п╬п╤п╣п╫п╦п╣ я┌я─п╣п╠я┐п╣я┌ п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п©я─я▐п╪я┐я▌ п╥п╟п©п╦я│я▄, п╬п╢п╫п╟п╨п╬ п╫п╣п╡п╬п╥п╪п╬п╤п╫п╬ "
+"п©я─п╬я┤п╦я┌п╟я┌я▄ XdndDirectSave0 (я┌п╦п© text/plain).\n"
 
-#: gtksavebox.c:596
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
 msgstr ""
-"Перетащите пиктограмму в просматриваемый каталог\n"
-"(или введите полное имя файла)"
+"п÷п╣я─п╣я┌п╟я┴п╦я┌п╣ п©п╦п╨я┌п╬пЁя─п╟п╪п╪я┐ п╡ п©я─п╬я│п╪п╟я┌я─п╦п╡п╟п╣п╪я▀п╧ п╨п╟я┌п╟п╩п╬пЁ\n"
+"(п╦п╩п╦ п╡п╡п╣п╢п╦я┌п╣ п©п╬п╩п╫п╬п╣ п╦п╪я▐ я└п╟п╧п╩п╟)"
 
-#: gui_support.c:329
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1506,12 +1619,13 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:398
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
-msgstr "Попытка прочесть XML файл как текстовый. Файл \"%s\", возможно, поврежден"
+msgstr ""
+"п÷п╬п©я▀я┌п╨п╟ п©я─п╬я┤п╣я│я┌я▄ XML я└п╟п╧п╩ п╨п╟п╨ я┌п╣п╨я│я┌п╬п╡я▀п╧. п╓п╟п╧п╩ \"%s\", п╡п╬п╥п╪п╬п╤п╫п╬, п©п╬п╡я─п╣п╤п╢п╣п╫"
 
-#: gui_support.c:415
+#: gui_support.c:542
 #, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
@@ -1521,30 +1635,32 @@ msgid ""
 "the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
-"Ошибка в файле \"%s\" в строке %d: \n"
+"п·я┬п╦п╠п╨п╟ п╡ я└п╟п╧п╩п╣ \"%s\" п╡ я│я┌я─п╬п╨п╣ %d: \n"
 "\"%s\"\n"
-"Это могло произойти в результата обновления предыдущей версии ROX-Filer. "
-"Откройте окно настроек и попробуйте что-либо изменить, а затем вернуть их в "
-"исходное состояние (в результате чего файл будет сохранён заново).\n"
-"В дальнейшем ошибки будут игнорироваться."
+"п╜я┌п╬ п╪п╬пЁп╩п╬ п©я─п╬п╦п╥п╬п╧я┌п╦ п╡ я─п╣п╥я┐п╩я▄я┌п╟я┌п╟ п╬п╠п╫п╬п╡п╩п╣п╫п╦я▐ п©я─п╣п╢я▀п╢я┐я┴п╣п╧ п╡п╣я─я│п╦п╦ ROX-Filer. "
+"п·я┌п╨я─п╬п╧я┌п╣ п╬п╨п╫п╬ п╫п╟я│я┌я─п╬п╣п╨ п╦ п©п╬п©я─п╬п╠я┐п╧я┌п╣ я┤я┌п╬-п╩п╦п╠п╬ п╦п╥п╪п╣п╫п╦я┌я▄, п╟ п╥п╟я┌п╣п╪ п╡п╣я─п╫я┐я┌я▄ п╦я┘ п╡ "
+"п╦я│я┘п╬п╢п╫п╬п╣ я│п╬я│я┌п╬я▐п╫п╦п╣ (п╡ я─п╣п╥я┐п╩я▄я┌п╟я┌п╣ я┤п╣пЁп╬ я└п╟п╧п╩ п╠я┐п╢п╣я┌ я│п╬я┘я─п╟п╫я▒п╫ п╥п╟п╫п╬п╡п╬).\n"
+"п▓ п╢п╟п╩я▄п╫п╣п╧я┬п╣п╪ п╬я┬п╦п╠п╨п╦ п╠я┐п╢я┐я┌ п╦пЁп╫п╬я─п╦я─п╬п╡п╟я┌я▄я│я▐."
 
-#: gui_support.c:1007
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
-msgstr "Отсутствует или неверно задан разрыв строки в данных типа text/uri-list"
+msgstr ""
+"п·я┌я│я┐я┌я│я┌п╡я┐п╣я┌ п╦п╩п╦ п╫п╣п╡п╣я─п╫п╬ п╥п╟п╢п╟п╫ я─п╟п╥я─я▀п╡ я│я┌я─п╬п╨п╦ п╡ п╢п╟п╫п╫я▀я┘ я┌п╦п©п╟ text/uri-list"
 
-#: gui_support.c:1339
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
-msgstr "Невозможно открыть файл \"%s\": %s"
+msgstr "п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ п╬я┌п╨я─я▀я┌я▄ я└п╟п╧п╩ \"%s\": %s"
 
-#: gui_support.c:1383
+#: gui_support.c:1517
 #, c-format
-msgid "Failed to load image '%s': reason not known, probably a corrupt image file"
+msgid ""
+"Failed to load image '%s': reason not known, probably a corrupt image file"
 msgstr ""
-"Не получилось загрузить изображение \"%s\": причина неизвестна, вероятно - "
-"файл изображения испорчен."
+"п²п╣ п©п╬п╩я┐я┤п╦п╩п╬я│я▄ п╥п╟пЁя─я┐п╥п╦я┌я▄ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣ \"%s\": п©я─п╦я┤п╦п╫п╟ п╫п╣п╦п╥п╡п╣я│я┌п╫п╟, п╡п╣я─п╬я▐я┌п╫п╬ - "
+"я└п╟п╧п╩ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦я▐ п╦я│п©п╬я─я┤п╣п╫."
 
-#: gui_support.c:1434
+#: gui_support.c:1583
 #, c-format
 msgid ""
 "This program (%s) cannot be run, as the 0launch command is not available. It "
@@ -1552,8 +1668,8 @@ msgid ""
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
-"Эта программа (%s) не может быть запущена, так как команда 0launch "
-"недоступна. Скачать её можно отсюда:\n"
+"п╜я┌п╟ п©я─п╬пЁя─п╟п╪п╪п╟ (%s) п╫п╣ п╪п╬п╤п╣я┌ п╠я▀я┌я▄ п╥п╟п©я┐я┴п╣п╫п╟, я┌п╟п╨ п╨п╟п╨ п╨п╬п╪п╟п╫п╢п╟ 0launch "
+"п╫п╣п╢п╬я│я┌я┐п©п╫п╟. п║п╨п╟я┤п╟я┌я▄ п╣я▒ п╪п╬п╤п╫п╬ п╬я┌я│я▌п╢п╟:\n"
 "\n"
 "http://0install.net/injector.html"
 
@@ -1562,357 +1678,386 @@ msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
 msgstr ""
-"Вы должны сохранить настройки и перезагрузить программу, чтобы выбор языка "
-"вступил в силу."
+"п▓я▀ п╢п╬п╩п╤п╫я▀ я│п╬я┘я─п╟п╫п╦я┌я▄ п╫п╟я│я┌я─п╬п╧п╨п╦ п╦ п©п╣я─п╣п╥п╟пЁя─я┐п╥п╦я┌я▄ п©я─п╬пЁя─п╟п╪п╪я┐, я┤я┌п╬п╠я▀ п╡я▀п╠п╬я─ я▐п╥я▀п╨п╟ "
+"п╡я│я┌я┐п©п╦п╩ п╡ я│п╦п╩я┐."
 
-#: icon.c:76
+#: icon.c:77
 msgid "(click to set)"
-msgstr "(щелкните для установки)"
+msgstr "(я┴п╣п╩п╨п╫п╦я┌п╣ п╢п╩я▐ я┐я│я┌п╟п╫п╬п╡п╨п╦)"
 
-#: icon.c:131
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:132 menu.c:258
-msgid "About ROX-Filer..."
-msgstr "О программе..."
-
-#: icon.c:133 menu.c:259
-msgid "Show Help Files"
-msgstr "Показать файлы помощи"
-
-#: icon.c:134 menu.c:260
-msgid "Manual"
-msgstr "Руководство"
-
-#: icon.c:136 menu.c:235
-msgid "Options..."
-msgstr "Настройки..."
-
-#: icon.c:137 menu.c:244
-msgid "Home Directory"
-msgstr "Домашний каталог"
-
-#: icon.c:138 icon.c:1410 menu.c:212 type.c:223
-msgid "File"
-msgstr "Файл"
-
-#: icon.c:139 menu.c:218 menu.c:885
-msgid "Shift Open"
-msgstr "Открыть (принудительно)"
-
-#: icon.c:140 menu.c:223
-msgid "Properties"
-msgstr "Свойства"
-
-#: icon.c:141 menu.c:221
-msgid "Set Run Action..."
-msgstr "Установить действие"
-
-#: icon.c:142 menu.c:222
-msgid "Set Icon..."
-msgstr "Установить значок"
-
-#: icon.c:143 icon.c:867
-msgid "Edit Item"
-msgstr "Редактировать"
-
-#: icon.c:144
-msgid "Show Location"
-msgstr "Показать путь"
-
-#: icon.c:145
-msgid "Remove Item(s)"
-msgstr "Удалить объект(ы)"
-
-#: icon.c:318 log.c:110 menu.c:774
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s \"%s\""
 
-#: icon.c:331
+#: icon.c:311
 msgid "Nothing"
-msgstr "<ничего>"
+msgstr "<п╫п╦я┤п╣пЁп╬>"
 
-#: icon.c:592
+#: icon.c:576
 msgid "The location must contain at least one character!"
-msgstr "Место расположения должно содержать хотя бы один символ!"
+msgstr "п°п╣я│я┌п╬ я─п╟я│п©п╬п╩п╬п╤п╣п╫п╦я▐ п╢п╬п╩п╤п╫п╬ я│п╬п╢п╣я─п╤п╟я┌я▄ я┘п╬я┌я▐ п╠я▀ п╬п╢п╦п╫ я│п╦п╪п╡п╬п╩!"
 
-#: icon.c:657
+#: icon.c:641
 #, c-format
 msgid "You must unlock '%s' before removing it"
-msgstr "Вы должны разблокировать '%s' перед удалением"
+msgstr "п▓я▀ п╢п╬п╩п╤п╫я▀ я─п╟п╥п╠п╩п╬п╨п╦я─п╬п╡п╟я┌я▄ '%s' п©п╣я─п╣п╢ я┐п╢п╟п╩п╣п╫п╦п╣п╪"
 
-#: icon.c:667
+#: icon.c:651
 msgid "You must first select some items to remove"
-msgstr "Сначала вы должны выбрать несколько объектов для удаления"
+msgstr "п║п╫п╟я┤п╟п╩п╟ п╡я▀ п╢п╬п╩п╤п╫я▀ п╡я▀п╠я─п╟я┌я▄ п╫п╣я│п╨п╬п╩я▄п╨п╬ п╬п╠я┼п╣п╨я┌п╬п╡ п╢п╩я▐ я┐п╢п╟п╩п╣п╫п╦я▐"
 
-#: icon.c:673
+#: icon.c:657
 msgid "An item must be unlocked before it can be removed."
 msgstr ""
-"Выбранный элемент должен быть разблокирован прежде чем его можно будет "
-"удалить."
+"п▓я▀п╠я─п╟п╫п╫я▀п╧ я█п╩п╣п╪п╣п╫я┌ п╢п╬п╩п╤п╣п╫ п╠я▀я┌я▄ я─п╟п╥п╠п╩п╬п╨п╦я─п╬п╡п╟п╫ п©я─п╣п╤п╢п╣ я┤п╣п╪ п╣пЁп╬ п╪п╬п╤п╫п╬ п╠я┐п╢п╣я┌ "
+"я┐п╢п╟п╩п╦я┌я▄."
 
-#: icon.c:687
+#: icon.c:671
 msgid "You must open the menu over an item"
-msgstr "Вы должны открыть меню над объектом"
+msgstr "п▓я▀ п╢п╬п╩п╤п╫я▀ п╬я┌п╨я─я▀я┌я▄ п╪п╣п╫я▌ п╫п╟п╢ п╬п╠я┼п╣п╨я┌п╬п╪"
 
-#: icon.c:712 menu.c:1281
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
-msgstr "Вы можете устанавливать действия только для обычных файлов"
+msgstr "п▓я▀ п╪п╬п╤п╣я┌п╣ я┐я│я┌п╟п╫п╟п╡п╩п╦п╡п╟я┌я▄ п╢п╣п╧я│я┌п╡п╦я▐ я┌п╬п╩я▄п╨п╬ п╢п╩я▐ п╬п╠я▀я┤п╫я▀я┘ я└п╟п╧п╩п╬п╡"
 
-#: icon.c:798
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
-msgstr "Нажмите желаемое сочетание клавиш (к примеру, Control+F1)"
+msgstr "п²п╟п╤п╪п╦я┌п╣ п╤п╣п╩п╟п╣п╪п╬п╣ я│п╬я┤п╣я┌п╟п╫п╦п╣ п╨п╩п╟п╡п╦я┬ (п╨ п©я─п╦п╪п╣я─я┐, Control+F1)"
 
-#: icon.c:820
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
-msgstr "Отследить нажатие клавиш не удалось!"
+msgstr "п·я┌я│п╩п╣п╢п╦я┌я▄ п╫п╟п╤п╟я┌п╦п╣ п╨п╩п╟п╡п╦я┬ п╫п╣ я┐п╢п╟п╩п╬я│я▄!"
 
-#: icon.c:870
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "п═п╣п╢п╟п╨я┌п╦я─п╬п╡п╟я┌я▄"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
-msgstr "Щелчок по значку открывает:"
+msgstr "п╘п╣п╩я┤п╬п╨ п©п╬ п╥п╫п╟я┤п╨я┐ п╬я┌п╨я─я▀п╡п╟п╣я┌:"
 
-#: icon.c:880
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
-msgstr "Аргументы для передачи в качестве параметров (для исполняемых файлов):"
+msgstr "п░я─пЁя┐п╪п╣п╫я┌я▀ п╢п╩я▐ п©п╣я─п╣п╢п╟я┤п╦ п╡ п╨п╟я┤п╣я│я┌п╡п╣ п©п╟я─п╟п╪п╣я┌я─п╬п╡ (п╢п╩я▐ п╦я│п©п╬п╩п╫я▐п╣п╪я▀я┘ я└п╟п╧п╩п╬п╡):"
 
-#: icon.c:894
+#: icon.c:877
 msgid "The text displayed under the icon is:"
-msgstr "Текст, отображаемый под значком:"
+msgstr "п╒п╣п╨я│я┌, п╬я┌п╬п╠я─п╟п╤п╟п╣п╪я▀п╧ п©п╬п╢ п╥п╫п╟я┤п╨п╬п╪:"
 
-#: icon.c:907
+#: icon.c:890
 msgid "The keyboard shortcut is:"
-msgstr "Горячая клавиша:"
+msgstr "п⌠п╬я─я▐я┤п╟я▐ п╨п╩п╟п╡п╦я┬п╟:"
 
-#: icon.c:927
+#: icon.c:910
 msgid "Locked"
-msgstr "Заблокировано"
+msgstr "п≈п╟п╠п╩п╬п╨п╦я─п╬п╡п╟п╫п╬"
 
-#: icon.c:932
+#: icon.c:915
 msgid "Locking an item prevents it from being accidentally removed"
-msgstr "Блокирование объекта делает невозможным его случайное удаление."
+msgstr "п▒п╩п╬п╨п╦я─п╬п╡п╟п╫п╦п╣ п╬п╠я┼п╣п╨я┌п╟ п╢п╣п╩п╟п╣я┌ п╫п╣п╡п╬п╥п╪п╬п╤п╫я▀п╪ п╣пЁп╬ я│п╩я┐я┤п╟п╧п╫п╬п╣ я┐п╢п╟п╩п╣п╫п╦п╣."
 
-#: infobox.c:111
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "п· п©я─п╬пЁя─п╟п╪п╪п╣..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ я└п╟п╧п╩я▀ п©п╬п╪п╬я┴п╦"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "п═я┐п╨п╬п╡п╬п╢я│я┌п╡п╬"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "п²п╟я│я┌я─п╬п╧п╨п╦..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "п■п╬п╪п╟я┬п╫п╦п╧ п╨п╟я┌п╟п╩п╬пЁ"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "п╓п╟п╧п╩"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "п·я┌п╨я─я▀я┌я▄ (п©я─п╦п╫я┐п╢п╦я┌п╣п╩я▄п╫п╬)"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "п║п╡п╬п╧я│я┌п╡п╟"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ п╢п╣п╧я│я┌п╡п╦п╣"
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ п╥п╫п╟я┤п╬п╨"
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ п©я┐я┌я▄"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "пёп╢п╟п╩п╦я┌я▄ п╬п╠я┼п╣п╨я┌(я▀)"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
-msgstr "Вы уверены, что хотите открыть %d окон?"
+msgstr "п▓я▀ я┐п╡п╣я─п╣п╫я▀, я┤я┌п╬ я┘п╬я┌п╦я┌п╣ п╬я┌п╨я─я▀я┌я▄ %d п╬п╨п╬п╫?"
 
-#: infobox.c:112
+#: infobox.c:114
 msgid "Show Info"
-msgstr "Показать сведения"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ я│п╡п╣п╢п╣п╫п╦я▐"
 
-#: infobox.c:134 menu.c:779
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
-msgstr "(не соответствует utf-8)"
+msgstr "(п╫п╣ я│п╬п╬я┌п╡п╣я┌я│я┌п╡я┐п╣я┌ utf-8)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
-msgstr "Показать файлы помощи"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ я└п╟п╧п╩я▀ п©п╬п╪п╬я┴п╦"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
-msgstr "<b>Права доступа</b>"
+msgstr "<b>п÷я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟</b>"
 
-#: infobox.c:290
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
-msgstr "<b>Содержимое указывает...</b>"
+msgstr "<b>п║п╬п╢п╣я─п╤п╦п╪п╬п╣ я┐п╨п╟п╥я▀п╡п╟п╣я┌...</b>"
 
-#: infobox.c:427 infobox.c:568 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "п÷я─п╦ п╨п╬п©п╦я─п╬п╡п╟п╫п╦п╦ я┌п╬п╩я▄п╨п╬ п©я─п╬я┌п╬п╨п╬п╩п╦я─п╬п╡п╟я┌я▄ п╨п╟я┌п╟п╩п╬пЁп╦"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
-msgstr "байт"
+msgstr "п╠п╟п╧я┌"
 
-#: infobox.c:450
+#: infobox.c:480
 msgid "Failed to read size"
-msgstr "Невозможно определить размер"
+msgstr "п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ п╬п©я─п╣п╢п╣п╩п╦я┌я▄ я─п╟п╥п╪п╣я─"
 
-#: infobox.c:511
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
-msgstr "!\"%s\" это больше не символическая ссылка"
+msgstr "!\"%s\" я█я┌п╬ п╠п╬п╩я▄я┬п╣ п╫п╣ я│п╦п╪п╡п╬п╩п╦я┤п╣я│п╨п╟я▐ я│я│я▀п╩п╨п╟"
 
-#: infobox.c:518
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
 "%s"
 msgstr ""
-"Невозможно удалить ссылку \"%s\":\n"
+"п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ я┐п╢п╟п╩п╦я┌я▄ я│я│я▀п╩п╨я┐ \"%s\":\n"
 "%s"
 
-#: infobox.c:523
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
 "%s\n"
 "(note: old link has been deleted)"
 msgstr ""
-"Невозможно создать символическую ссылку \"%s\":\n"
+"п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ я│п╬п╥п╢п╟я┌я▄ я│п╦п╪п╡п╬п╩п╦я┤п╣я│п╨я┐я▌ я│я│я▀п╩п╨я┐ \"%s\":\n"
 "%s\n"
-"(примечание: старая ссылка была удалена)"
+"(п©я─п╦п╪п╣я┤п╟п╫п╦п╣: я│я┌п╟я─п╟я▐ я│я│я▀п╩п╨п╟ п╠я▀п╩п╟ я┐п╢п╟п╩п╣п╫п╟)"
 
-#: infobox.c:547 tips:242
+#: infobox.c:579 tips:321
 msgid "Error:"
-msgstr "Ошибка:"
+msgstr "п·я┬п╦п╠п╨п╟:"
 
-#: infobox.c:554
+#: infobox.c:586
 msgid "Real directory:"
-msgstr "Настоящий каталог:"
-
-#: infobox.c:557
-msgid "Owner, Group:"
-msgstr "Владелец, группа:"
-
-#: infobox.c:564 infobox.c:579 infobox.c:588
-msgid "Size:"
-msgstr "Размер:"
+msgstr "п²п╟я│я┌п╬я▐я┴п╦п╧ п╨п╟я┌п╟п╩п╬пЁ:"
 
 #: infobox.c:589
-msgid "Scanning"
-msgstr "Сканирование"
+msgid "Owner, Group:"
+msgstr "п▓п╩п╟п╢п╣п╩п╣я├, пЁя─я┐п©п©п╟:"
 
-#: infobox.c:614
-msgid "Failed to scan"
-msgstr "Невозможно сканировать"
+#: infobox.c:596 infobox.c:611 infobox.c:620
+msgid "Size:"
+msgstr "п═п╟п╥п╪п╣я─:"
 
 #: infobox.c:621
+msgid "Scanning"
+msgstr "п║п╨п╟п╫п╦я─п╬п╡п╟п╫п╦п╣"
+
+#: infobox.c:646
+msgid "Failed to scan"
+msgstr "п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ я│п╨п╟п╫п╦я─п╬п╡п╟я┌я▄"
+
+#: infobox.c:653
 msgid "Change time:"
-msgstr "Время изменения:"
+msgstr "п▓я─п╣п╪я▐ п╦п╥п╪п╣п╫п╣п╫п╦я▐:"
 
-#: infobox.c:623
+#: infobox.c:655
 msgid "Modify time:"
-msgstr "Время модификации:"
+msgstr "п▓я─п╣п╪я▐ п╪п╬п╢п╦я└п╦п╨п╟я├п╦п╦:"
 
-#: infobox.c:625
+#: infobox.c:657
 msgid "Access time:"
-msgstr "Время доступа:"
+msgstr "п▓я─п╣п╪я▐ п╢п╬я│я┌я┐п©п╟:"
 
-#: infobox.c:633
+#: infobox.c:665
 msgid "Extended attributes:"
-msgstr "Расширенные атрибуты:"
+msgstr "п═п╟я│я┬п╦я─п╣п╫п╫я▀п╣ п╟я┌я─п╦п╠я┐я┌я▀:"
 
-#: infobox.c:635
+#: infobox.c:667
 msgid "Present"
-msgstr "Текущий"
+msgstr "п╒п╣п╨я┐я┴п╦п╧"
 
-#: infobox.c:636
+#: infobox.c:668
 msgid "None"
-msgstr "Нет"
+msgstr "п²п╣я┌"
 
-#: infobox.c:637
+#: infobox.c:669
 msgid "Not supported"
-msgstr "Неподдерживаемый"
+msgstr "п²п╣п©п╬п╢п╢п╣я─п╤п╦п╡п╟п╣п╪я▀п╧"
 
-#: infobox.c:649
+#: infobox.c:681
 msgid "Link target:"
-msgstr "Ссылка указывает на:"
+msgstr "п║я│я▀п╩п╨п╟ я┐п╨п╟п╥я▀п╡п╟п╣я┌ п╫п╟:"
 
-#: infobox.c:661 infobox.c:664
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
-msgstr "Установить ассоциацию:"
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ п╟я│я│п╬я├п╦п╟я├п╦я▌:"
 
-#: infobox.c:661
+#: infobox.c:693
 msgid "Execute file"
-msgstr "Запустить файл"
+msgstr "п≈п╟п©я┐я│я┌п╦я┌я▄ я└п╟п╧п╩"
 
-#: infobox.c:773
+#: infobox.c:805
 msgid "Comment"
-msgstr "Комментарий"
+msgstr "п п╬п╪п╪п╣п╫я┌п╟я─п╦п╧"
 
-#: infobox.c:775
+#: infobox.c:807
 msgid "Execute"
-msgstr "Запустить файл "
+msgstr "п≈п╟п©я┐я│я┌п╦я┌я▄ я└п╟п╧п╩ "
 
-#: infobox.c:789
+#: infobox.c:822
 msgid "<nothing yet>"
-msgstr "<пока ничего>"
+msgstr "<п©п╬п╨п╟ п╫п╦я┤п╣пЁп╬>"
 
-#: infobox.c:860
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
-msgstr "file(1) говорит... %s"
+msgstr "file(1) пЁп╬п╡п╬я─п╦я┌... %s"
 
-#: infobox.c:917
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
-msgstr "Невозможно изменить права доступа: %s"
+msgstr "п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ п╦п╥п╪п╣п╫п╦я┌я▄ п©я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟: %s"
 
-#: infobox.c:935
+#: infobox.c:970 tips:120
 msgid "Owner"
-msgstr "Владелец"
+msgstr "п▓п╩п╟п╢п╣п╩п╣я├"
 
-#: infobox.c:937
+#: infobox.c:972 tips:122
 msgid "Group"
-msgstr "Группа"
+msgstr "п⌠я─я┐п©п©п╟"
 
-#: infobox.c:939
+#: infobox.c:974
 msgid "World"
-msgstr "Все"
+msgstr "п▓я│п╣"
 
-#: infobox.c:942
+#: infobox.c:977
 msgid "Read"
-msgstr "Читать"
+msgstr "п╖п╦я┌п╟я┌я▄"
 
-#: infobox.c:944
+#: infobox.c:980
 msgid "Write"
-msgstr "Писать"
+msgstr "п÷п╦я│п╟я┌я▄"
 
-#: infobox.c:946
+#: infobox.c:983
 msgid "Exec"
-msgstr "Выполнять"
+msgstr "п▓я▀п©п╬п╩п╫я▐я┌я▄"
 
-#: infobox.c:963
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:970
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:977
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky"
 
-#: infobox.c:999
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<п╫п╦я┤п╣пЁп╬>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
-msgstr "Символическая ссылка"
+msgstr "п║п╦п╪п╡п╬п╩п╦я┤п╣я│п╨п╟я▐ я│я│я▀п╩п╨п╟"
 
-#: infobox.c:1002
+#: infobox.c:1092
 msgid "ROX application"
-msgstr "Программа ROX"
+msgstr "п÷я─п╬пЁя─п╟п╪п╪п╟ ROX"
 
-#: infobox.c:1010
+#: infobox.c:1100
 msgid "mounted"
-msgstr "подключено"
+msgstr "п©п╬п╢п╨п╩я▌я┤п╣п╫п╬"
 
-#: infobox.c:1010
+#: infobox.c:1100
 msgid "unmounted"
-msgstr "отключено"
+msgstr "п╬я┌п╨п╩я▌я┤п╣п╫п╬"
 
-#: infobox.c:1014
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
-msgstr "Точка монтирования для %s (%s)"
+msgstr "п╒п╬я┤п╨п╟ п╪п╬п╫я┌п╦я─п╬п╡п╟п╫п╦я▐ п╢п╩я▐ %s (%s)"
 
-#: infobox.c:1017
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
-msgstr "Точка монтирования (%s)"
+msgstr "п╒п╬я┤п╨п╟ п╪п╬п╫я┌п╦я─п╬п╡п╟п╫п╦я▐ (%s)"
 
-#: log.c:55
+#: log.c:54
 msgid "ROX-Filer started"
-msgstr "ROX-Filer запущен"
+msgstr "ROX-Filer п╥п╟п©я┐я┴п╣п╫"
 
-#: log.c:112
+#: log.c:115
 #, c-format
 msgid "%s on %d items"
-msgstr "%s на %d объектов"
+msgstr "%s п╫п╟ %d п╬п╠я┼п╣п╨я┌п╬п╡"
 
-#: log.c:125
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "п п╬п©п╦я─п╬п╡п╟я┌я▄..."
+
+#: log.c:139
 msgid "Item"
-msgstr "Объект"
+msgstr "п·п╠я┼п╣п╨я┌"
 
-#: main.c:94
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "п▓я─п╣п╪я▐"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "п²п╟я│я┌я─п╬п╧п╨п╦"
+
+#: main.c:95
 msgid ""
 "Copyright (C) 2005 Thomas Leonard.\n"
 "ROX-Filer comes with ABSOLUTELY NO WARRANTY,\n"
@@ -1922,32 +2067,33 @@ msgid ""
 "For more information about these matters, see the file named COPYING.\n"
 msgstr ""
 "Copyright (C) 2005 Thomas Leonard.\n"
-"ROX-Filer поставляется АБСОЛЮТНО БЕЗ ГАРАНТИЙ в той мере,\n"
-"какая допустима соответствующим законодательством.\n"
-"Вы можете распространять копии  ROX-Filer\n"
-"на условиях универсальной общественной лицензии GPL.\n"
-"Для получения более подробной информации, откройте файл под названием "
+"ROX-Filer п©п╬я│я┌п╟п╡п╩я▐п╣я┌я│я▐ п░п▒п║п·п⌡п╝п╒п²п· п▒п∙п≈ п⌠п░п═п░п²п╒п≤п≥ п╡ я┌п╬п╧ п╪п╣я─п╣,\n"
+"п╨п╟п╨п╟я▐ п╢п╬п©я┐я│я┌п╦п╪п╟ я│п╬п╬я┌п╡п╣я┌я│я┌п╡я┐я▌я┴п╦п╪ п╥п╟п╨п╬п╫п╬п╢п╟я┌п╣п╩я▄я│я┌п╡п╬п╪.\n"
+"п▓я▀ п╪п╬п╤п╣я┌п╣ я─п╟я│п©я─п╬я│я┌я─п╟п╫я▐я┌я▄ п╨п╬п©п╦п╦  ROX-Filer\n"
+"п╫п╟ я┐я│п╩п╬п╡п╦я▐я┘ я┐п╫п╦п╡п╣я─я│п╟п╩я▄п╫п╬п╧ п╬п╠я┴п╣я│я┌п╡п╣п╫п╫п╬п╧ п╩п╦я├п╣п╫п╥п╦п╦ GPL.\n"
+"п■п╩я▐ п©п╬п╩я┐я┤п╣п╫п╦я▐ п╠п╬п╩п╣п╣ п©п╬п╢я─п╬п╠п╫п╬п╧ п╦п╫я└п╬я─п╪п╟я├п╦п╦, п╬я┌п╨я─п╬п╧я┌п╣ я└п╟п╧п╩ п©п╬п╢ п╫п╟п╥п╡п╟п╫п╦п╣п╪ "
 "COPYING.\n"
 
-#: main.c:103
+#: main.c:104
 msgid "Try `ROX-Filer/AppRun --help' for more information.\n"
-msgstr "Попробуйте \"ROX-Filer/AppRun --help\" для более подробной информации.\n"
+msgstr ""
+"п÷п╬п©я─п╬п╠я┐п╧я┌п╣ \"ROX-Filer/AppRun --help\" п╢п╩я▐ п╠п╬п╩п╣п╣ п©п╬п╢я─п╬п╠п╫п╬п╧ п╦п╫я└п╬я─п╪п╟я├п╦п╦.\n"
 
-#: main.c:106
+#: main.c:107
 msgid "Try `ROX-Filer/AppRun -h' for more information.\n"
-msgstr "Попробуйте \"ROX-Filer/AppRun -h\" для более подробной информации.\n"
+msgstr "п÷п╬п©я─п╬п╠я┐п╧я┌п╣ \"ROX-Filer/AppRun -h\" п╢п╩я▐ п╠п╬п╩п╣п╣ п©п╬п╢я─п╬п╠п╫п╬п╧ п╦п╫я└п╬я─п╪п╟я├п╦п╦.\n"
 
-#: main.c:108
+#: main.c:109
 msgid ""
 "NOTE: Your system does not support long options - \n"
 "you must use the short versions instead.\n"
 "\n"
 msgstr ""
-"NB: ваша система не поддерживает длинные параметры - \n"
-"вам следует использовать короткую запись параметров.\n"
+"NB: п╡п╟я┬п╟ я│п╦я│я┌п╣п╪п╟ п╫п╣ п©п╬п╢п╢п╣я─п╤п╦п╡п╟п╣я┌ п╢п╩п╦п╫п╫я▀п╣ п©п╟я─п╟п╪п╣я┌я─я▀ - \n"
+"п╡п╟п╪ я│п╩п╣п╢я┐п╣я┌ п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п╨п╬я─п╬я┌п╨я┐я▌ п╥п╟п©п╦я│я▄ п©п╟я─п╟п╪п╣я┌я─п╬п╡.\n"
 "\n"
 
-#: main.c:114
+#: main.c:115
 #, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
@@ -1977,340 +2123,422 @@ msgid ""
 "Report bugs to %s.\n"
 "Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
-"Использование: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
-"Будет открыта каждый указанный каталог или файл;\n"
-"без аргументов будет открыт текущий рабочий каталог.\n"
+"п≤я│п©п╬п╩я▄п╥п╬п╡п╟п╫п╦п╣: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
+"п▒я┐п╢п╣я┌ п╬я┌п╨я─я▀я┌п╟ п╨п╟п╤п╢я▀п╧ я┐п╨п╟п╥п╟п╫п╫я▀п╧ п╨п╟я┌п╟п╩п╬пЁ п╦п╩п╦ я└п╟п╧п╩;\n"
+"п╠п╣п╥ п╟я─пЁя┐п╪п╣п╫я┌п╬п╡ п╠я┐п╢п╣я┌ п╬я┌п╨я─я▀я┌ я┌п╣п╨я┐я┴п╦п╧ я─п╟п╠п╬я┤п╦п╧ п╨п╟я┌п╟п╩п╬пЁ.\n"
 "\n"
-"  -b, --border=PANEL\tоткрыть PANEL как пограничную панель\n"
-"  -B, --bottom=PANEL\tоткрыть PANEL как нижнюю панель\n"
-"  -c, --client-id=ID\tиспользуется для управления сессиями\n"
-"  -d, --dir=DIR\t\tоткрыть DIR как каталог (а не приложение)\n"
-"  -D, --close=DIR\tзакрыть DIR и все подкаталоги\n"
-"  -h, --help\t\tвывести эту справку и выйти\n"
-"  -l, --left=PANEL\tоткрыть PANEL как левую панель\n"
-"  -m, --mime-type=FILE\tвывести тип MIME файла FILE и выйти\n"
-"  -n, --new\t\tзапустить новую копию программы; используется для отладки\n"
-"  -p, --pinboard=PIN\tиспользовать витрину PIN\n"
-"  -r, --right=PANEL\tоткрыть PANEL как правую панель\n"
-"  -R, --RPC\t\tзадействовать ввод из stdin\n"
-"  -s, --show=FILE\tоткрыть каталог, содержащий FILE\n"
-"  -S, --rox-session\tиспользовать настройки по умолчанию для панели и "
-"витрины + \"-n\"\n"
-"  -t, --top=PANEL\tоткрыть PANEL как верхнюю панель\n"
-"  -u, --user\t\tотображать имя пользователя в каждом окне \n"
-"  -v, --version\t\tвывести информацию о версии программы и выйти\n"
-"  -x, --examine=FILE\tFILE был изменён - проверить его снова\n"
+"  -b, --border=PANEL\tп╬я┌п╨я─я▀я┌я▄ PANEL п╨п╟п╨ п©п╬пЁя─п╟п╫п╦я┤п╫я┐я▌ п©п╟п╫п╣п╩я▄\n"
+"  -B, --bottom=PANEL\tп╬я┌п╨я─я▀я┌я▄ PANEL п╨п╟п╨ п╫п╦п╤п╫я▌я▌ п©п╟п╫п╣п╩я▄\n"
+"  -c, --client-id=ID\tп╦я│п©п╬п╩я▄п╥я┐п╣я┌я│я▐ п╢п╩я▐ я┐п©я─п╟п╡п╩п╣п╫п╦я▐ я│п╣я│я│п╦я▐п╪п╦\n"
+"  -d, --dir=DIR\t\tп╬я┌п╨я─я▀я┌я▄ DIR п╨п╟п╨ п╨п╟я┌п╟п╩п╬пЁ (п╟ п╫п╣ п©я─п╦п╩п╬п╤п╣п╫п╦п╣)\n"
+"  -D, --close=DIR\tп╥п╟п╨я─я▀я┌я▄ DIR п╦ п╡я│п╣ п©п╬п╢п╨п╟я┌п╟п╩п╬пЁп╦\n"
+"  -h, --help\t\tп╡я▀п╡п╣я│я┌п╦ я█я┌я┐ я│п©я─п╟п╡п╨я┐ п╦ п╡я▀п╧я┌п╦\n"
+"  -l, --left=PANEL\tп╬я┌п╨я─я▀я┌я▄ PANEL п╨п╟п╨ п╩п╣п╡я┐я▌ п©п╟п╫п╣п╩я▄\n"
+"  -m, --mime-type=FILE\tп╡я▀п╡п╣я│я┌п╦ я┌п╦п© MIME я└п╟п╧п╩п╟ FILE п╦ п╡я▀п╧я┌п╦\n"
+"  -n, --new\t\tп╥п╟п©я┐я│я┌п╦я┌я▄ п╫п╬п╡я┐я▌ п╨п╬п©п╦я▌ п©я─п╬пЁя─п╟п╪п╪я▀; п╦я│п©п╬п╩я▄п╥я┐п╣я┌я│я▐ п╢п╩я▐ п╬я┌п╩п╟п╢п╨п╦\n"
+"  -p, --pinboard=PIN\tп╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п╡п╦я┌я─п╦п╫я┐ PIN\n"
+"  -r, --right=PANEL\tп╬я┌п╨я─я▀я┌я▄ PANEL п╨п╟п╨ п©я─п╟п╡я┐я▌ п©п╟п╫п╣п╩я▄\n"
+"  -R, --RPC\t\tп╥п╟п╢п╣п╧я│я┌п╡п╬п╡п╟я┌я▄ п╡п╡п╬п╢ п╦п╥ stdin\n"
+"  -s, --show=FILE\tп╬я┌п╨я─я▀я┌я▄ п╨п╟я┌п╟п╩п╬пЁ, я│п╬п╢п╣я─п╤п╟я┴п╦п╧ FILE\n"
+"  -S, --rox-session\tп╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п╫п╟я│я┌я─п╬п╧п╨п╦ п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌ п╢п╩я▐ п©п╟п╫п╣п╩п╦ п╦ "
+"п╡п╦я┌я─п╦п╫я▀ + \"-n\"\n"
+"  -t, --top=PANEL\tп╬я┌п╨я─я▀я┌я▄ PANEL п╨п╟п╨ п╡п╣я─я┘п╫я▌я▌ п©п╟п╫п╣п╩я▄\n"
+"  -u, --user\t\tп╬я┌п╬п╠я─п╟п╤п╟я┌я▄ п╦п╪я▐ п©п╬п╩я▄п╥п╬п╡п╟я┌п╣п╩я▐ п╡ п╨п╟п╤п╢п╬п╪ п╬п╨п╫п╣ \n"
+"  -v, --version\t\tп╡я▀п╡п╣я│я┌п╦ п╦п╫я└п╬я─п╪п╟я├п╦я▌ п╬ п╡п╣я─я│п╦п╦ п©я─п╬пЁя─п╟п╪п╪я▀ п╦ п╡я▀п╧я┌п╦\n"
+"  -x, --examine=FILE\tFILE п╠я▀п╩ п╦п╥п╪п╣п╫я▒п╫ - п©я─п╬п╡п╣я─п╦я┌я▄ п╣пЁп╬ я│п╫п╬п╡п╟\n"
 "\n"
-"Об ошибках сообщайте %s.\n"
-"Домашняя страница (и новые версии):http://rox.sourceforge.net/\n"
+"п·п╠ п╬я┬п╦п╠п╨п╟я┘ я│п╬п╬п╠я┴п╟п╧я┌п╣ %s.\n"
+"п■п╬п╪п╟я┬п╫я▐я▐ я│я┌я─п╟п╫п╦я├п╟ (п╦ п╫п╬п╡я▀п╣ п╡п╣я─я│п╦п╦):http://rox.sourceforge.net/\n"
 
-#: main.c:236
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Trying to continue..."
 msgstr ""
-"X server возвратил ошибку BadWindow. Возможно, это произошло из-за ошибки в "
-"GTK (во время перетаскивания?):\n"
+"X server п╡п╬п╥п╡я─п╟я┌п╦п╩ п╬я┬п╦п╠п╨я┐ BadWindow. п▓п╬п╥п╪п╬п╤п╫п╬, я█я┌п╬ п©я─п╬п╦п╥п╬я┬п╩п╬ п╦п╥-п╥п╟ п╬я┬п╦п╠п╨п╦ п╡ "
+"GTK (п╡п╬ п╡я─п╣п╪я▐ п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟п╫п╦я▐?):\n"
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
-"Попытаюсь продолжить..."
+"п÷п╬п©я▀я┌п╟я▌я│я▄ п©я─п╬п╢п╬п╩п╤п╦я┌я▄..."
 
-#: main.c:395
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
 msgstr ""
-"Аргумент -o больше не используется. Вы можете вместо этого использовать "
-"соответствующую опцию в диалоге настроек."
+"п░я─пЁя┐п╪п╣п╫я┌ -o п╠п╬п╩я▄я┬п╣ п╫п╣ п╦я│п©п╬п╩я▄п╥я┐п╣я┌я│я▐. п▓я▀ п╪п╬п╤п╣я┌п╣ п╡п╪п╣я│я┌п╬ я█я┌п╬пЁп╬ п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ "
+"я│п╬п╬я┌п╡п╣я┌я│я┌п╡я┐я▌я┴я┐я▌ п╬п©я├п╦я▌ п╡ п╢п╦п╟п╩п╬пЁп╣ п╫п╟я│я┌я─п╬п╣п╨."
 
-#: main.c:524
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
-msgstr "Запускается от пользователя \"%s\""
+msgstr "п≈п╟п©я┐я│п╨п╟п╣я┌я│я▐ п╬я┌ п©п╬п╩я▄п╥п╬п╡п╟я┌п╣п╩я▐ \"%s\""
 
-#: main.c:685
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
-msgstr "Собрано с версией GTK %s\n"
+msgstr "п║п╬п╠я─п╟п╫п╬ я│ п╡п╣я─я│п╦п╣п╧ GTK %s\n"
 
-#: main.c:686
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
-msgstr "Выполняется с версией GTK %d.%d.%d\n"
+msgstr "п▓я▀п©п╬п╩п╫я▐п╣я┌я│я▐ я│ п╡п╣я─я│п╦п╣п╧ GTK %d.%d.%d\n"
 
-#: main.c:690
+#: main.c:693
 msgid "features set at compile time"
-msgstr "параметры, установленные при компиляции"
+msgstr "п©п╟я─п╟п╪п╣я┌я─я▀, я┐я│я┌п╟п╫п╬п╡п╩п╣п╫п╫я▀п╣ п©я─п╦ п╨п╬п╪п©п╦п╩я▐я├п╦п╦"
 
-#: main.c:691
+#: main.c:694
 msgid "Large File Support"
-msgstr "Поддержка больших файлов"
+msgstr "п÷п╬п╢п╢п╣я─п╤п╨п╟ п╠п╬п╩я▄я┬п╦я┘ я└п╟п╧п╩п╬п╡"
 
-#: main.c:698
-msgid "Dnotify support"
-msgstr "Поддержка Dnotify"
-
-#: main.c:705
+#: main.c:701
 msgid "Binary compatibility"
-msgstr "Бинарная совместимость"
+msgstr "п▒п╦п╫п╟я─п╫п╟я▐ я│п╬п╡п╪п╣я│я┌п╦п╪п╬я│я┌я▄"
 
-#: main.c:707
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Yes (can run with older glibc versions)"
 
-#: main.c:709
+#: main.c:705
 msgid "No (apsymbols.h not found)"
-msgstr "Нет (apsymbols.h не найден)"
+msgstr "п²п╣я┌ (apsymbols.h п╫п╣ п╫п╟п╧п╢п╣п╫)"
 
-#: main.c:713
+#: main.c:709
 msgid "Extended attribute support"
-msgstr "Поддержка Расширенных атрибутов"
+msgstr "п÷п╬п╢п╢п╣я─п╤п╨п╟ п═п╟я│я┬п╦я─п╣п╫п╫я▀я┘ п╟я┌я─п╦п╠я┐я┌п╬п╡"
 
-#: main.c:864
+#: main.c:856
 #, c-format
 msgid "Unable to read '%s': %s"
-msgstr "Невозможно прочитать \"%s\": %s"
+msgstr "п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ п©я─п╬я┤п╦я┌п╟я┌я▄ \"%s\": %s"
 
-#: main.c:900
+#: main.c:895
 #, c-format
 msgid ""
 "Left-click to run %s.\n"
 "Right-click for a list of versions."
 msgstr ""
-"Левая кнопка мыши запустит %s.\n"
-"Правая выведет список версий."
+"п⌡п╣п╡п╟я▐ п╨п╫п╬п©п╨п╟ п╪я▀я┬п╦ п╥п╟п©я┐я│я┌п╦я┌ %s.\n"
+"п÷я─п╟п╡п╟я▐ п╡я▀п╡п╣п╢п╣я┌ я│п©п╦я│п╬п╨ п╡п╣я─я│п╦п╧."
 
-#: menu.c:185 tips:28
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "п·я┬п╦п╠п╨п╟ п©я─п╦ я│п╬п╥п╢п╟п╫п╦п╦ \"%s\": %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "п║п╬я┘я─п╟п╫п╦я┌я▄ п╨п╟п╨:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
-msgstr "Показать"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄"
 
-#: menu.c:186 tips:33
+#: menu.c:641 tips:49
 msgid "Icons View"
-msgstr "Значки"
+msgstr "п≈п╫п╟я┤п╨п╦"
 
-#: menu.c:187
-msgid "Icons, With..."
-msgstr "Значки, указывая..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
+msgstr "п≈п╫п╟я┤п╨п╦, я┐п╨п╟п╥я▀п╡п╟я▐..."
 
-#: menu.c:188 tips:52
-msgid "Sizes"
-msgstr "Размер"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "п╒п╣п╪п╟ п╥п╫п╟я┤п╨п╬п╡"
 
-#: menu.c:190 tips:226
-msgid "Types"
-msgstr "Тип"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "п÷я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟"
 
-#: menu.c:191 tips:55
-msgid "Times"
-msgstr "Время"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "п≈п╫п╟я┤п╨п╦, я┐п╨п╟п╥я▀п╡п╟я▐..."
 
-#: menu.c:192 tips:34 tips:70
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
-msgstr "Список"
+msgstr "п║п©п╦я│п╬п╨"
 
-#: menu.c:194
+#: menu.c:651
 msgid "Bigger Icons"
-msgstr "Большие значки"
+msgstr "п▒п╬п╩я▄я┬п╦п╣ п╥п╫п╟я┤п╨п╦"
 
-#: menu.c:195
+#: menu.c:653
 msgid "Smaller Icons"
-msgstr "Маленькие значки"
+msgstr "п°п╟п╩п╣п╫я▄п╨п╦п╣ п╥п╫п╟я┤п╨п╦"
 
-#: menu.c:196 tips:49
+#: menu.c:655 tips:71
 msgid "Automatic"
-msgstr "Автоматически"
+msgstr "п░п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╦"
 
-#: menu.c:198
+#: menu.c:661
 msgid "Sort by Name"
-msgstr "Сортировка по имени"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ п╦п╪п╣п╫п╦"
 
-#: menu.c:199
+#: menu.c:662
 msgid "Sort by Type"
-msgstr "Сортировка по типу"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ я┌п╦п©я┐"
 
-#: menu.c:200
-msgid "Sort by Date"
-msgstr "Сортировка по дате"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ п╢п╟я┌п╣"
 
-#: menu.c:201
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ п╢п╟я┌п╣"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ п╢п╟я┌п╣"
+
+#: menu.c:666
 msgid "Sort by Size"
-msgstr "Сортировка по размеру"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ я─п╟п╥п╪п╣я─я┐"
 
-#: menu.c:202
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "п÷я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟"
+
+#: menu.c:668
 msgid "Sort by Owner"
-msgstr "Сортировка по владельцу"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ п╡п╩п╟п╢п╣п╩я▄я├я┐"
 
-#: menu.c:203
+#: menu.c:669
 msgid "Sort by Group"
-msgstr "Сортировка по группе"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ пЁя─я┐п©п©п╣"
 
-#: menu.c:204
+#: menu.c:671
 msgid "Reversed"
-msgstr "В обратном порядке"
+msgstr "п▓ п╬п╠я─п╟я┌п╫п╬п╪ п©п╬я─я▐п╢п╨п╣"
 
-#: menu.c:206
+#: menu.c:675
 msgid "Show Hidden"
-msgstr "Показать спрятанные"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ я│п©я─я▐я┌п╟п╫п╫я▀п╣"
 
-#: menu.c:207
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ я└п╟п╧п╩я▀ п©п╬п╪п╬я┴п╦"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "п╫п╣я┌ п╨п╟я┌п╟п╩п╬пЁп╬п╡)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
-msgstr "Профильтровать файлы..."
+msgstr "п÷я─п╬я└п╦п╩я▄я┌я─п╬п╡п╟я┌я▄ я└п╟п╧п╩я▀..."
 
-#: menu.c:208
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "п÷я─п╬я└п╦п╩я▄я┌я─п╬п╡п╟я┌я▄ я└п╟п╧п╩я▀..."
+
+#: menu.c:681
 msgid "Filter Directories With Files"
-msgstr "Фильтровать каталоги с файлами"
+msgstr "п╓п╦п╩я▄я┌я─п╬п╡п╟я┌я▄ п╨п╟я┌п╟п╩п╬пЁп╦ я│ я└п╟п╧п╩п╟п╪п╦"
 
-#: menu.c:209
+#: menu.c:682
 msgid "Show Thumbnails"
-msgstr "Показать миниатюры"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ п╪п╦п╫п╦п╟я┌я▌я─я▀"
 
-#: menu.c:210
+#: menu.c:683
 msgid "Refresh"
-msgstr "Обновить"
+msgstr "п·п╠п╫п╬п╡п╦я┌я▄"
 
-#: menu.c:211
-msgid "Save Current Display Settings..."
-msgstr "Сохранить текущие настройки отображения..."
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "п·п╠п╫п╬п╡п╦я┌я▄"
 
-#: menu.c:213
-msgid "Copy..."
-msgstr "Копировать..."
+#: menu.c:686
+#, fuzzy
+msgid "Save Display Settings..."
+msgstr "п║п╬я┘я─п╟п╫п╦я┌я▄ я┌п╣п╨я┐я┴п╦п╣ п╫п╟я│я┌я─п╬п╧п╨п╦ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐..."
 
-#: menu.c:214
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "п║п╬я┘я─п╟п╫п╦я┌я▄ я┌п╣п╨я┐я┴п╦п╣ п╫п╟я│я┌я─п╬п╧п╨п╦ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐..."
+
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "п÷п╬я│я┤п╦я┌п╟я┌я▄"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
-msgstr "Переименовать..."
+msgstr "п÷п╣я─п╣п╦п╪п╣п╫п╬п╡п╟я┌я▄..."
 
-#: menu.c:215
+#: menu.c:700
 msgid "Link..."
-msgstr "Ссылка..."
+msgstr "п║я│я▀п╩п╨п╟..."
 
-#: menu.c:219
+#: menu.c:708
 msgid "Send To..."
-msgstr "Отправить в..."
+msgstr "п·я┌п©я─п╟п╡п╦я┌я▄ п╡..."
 
-#: menu.c:224
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "п═п╟я│я┬п╦я─п╣п╫п╫я▀п╣ п╟я┌я─п╦п╠я┐я┌я▀"
+
+#: menu.c:721
 msgid "Count"
-msgstr "Посчитать"
+msgstr "п÷п╬я│я┤п╦я┌п╟я┌я▄"
 
-#: menu.c:225
+#: menu.c:723
 msgid "Set Type..."
-msgstr "Установить тип..."
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ я┌п╦п©..."
 
-#: menu.c:229 toolbar.c:154
+#: menu.c:731 toolbar.c:179
 msgid "Select"
-msgstr "Выбрать"
+msgstr "п▓я▀п╠я─п╟я┌я▄"
 
-#: menu.c:230
+#: menu.c:733
 msgid "Select All"
-msgstr "Выбрать все"
+msgstr "п▓я▀п╠я─п╟я┌я▄ п╡я│п╣"
 
-#: menu.c:231
+#: menu.c:735
 msgid "Clear Selection"
-msgstr "Снять выбор"
+msgstr "п║п╫я▐я┌я▄ п╡я▀п╠п╬я─"
 
-#: menu.c:232
+#: menu.c:736
 msgid "Invert Selection"
-msgstr "Инвертировать выбор"
+msgstr "п≤п╫п╡п╣я─я┌п╦я─п╬п╡п╟я┌я▄ п╡я▀п╠п╬я─"
 
-#: menu.c:233
+#: menu.c:737
 msgid "Select by Name..."
-msgstr "Выбирать по имени..."
+msgstr "п▓я▀п╠п╦я─п╟я┌я▄ п©п╬ п╦п╪п╣п╫п╦..."
 
-#: menu.c:234
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "п▓я▀п╠я─п╟я┌я▄ п╣я│п╩п╦..."
+
+#: menu.c:741
 msgid "Select If..."
-msgstr "Выбрать если..."
+msgstr "п▓я▀п╠я─п╟я┌я▄ п╣я│п╩п╦..."
 
-#: menu.c:236
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
-msgstr "Новый"
+msgstr "п²п╬п╡я▀п╧"
 
-#: menu.c:238
+#: menu.c:752
 msgid "Blank file"
-msgstr "Пустой файл"
+msgstr "п÷я┐я│я┌п╬п╧ я└п╟п╧п╩"
 
-#: menu.c:240 tasklist.c:306
+#: menu.c:756 tasklist.c:305
 msgid "Window"
-msgstr "Окно"
+msgstr "п·п╨п╫п╬"
 
-#: menu.c:241
+#: menu.c:758
 msgid "Parent, New Window"
-msgstr "На уровень выше, новое окно"
+msgstr "п²п╟ я┐я─п╬п╡п╣п╫я▄ п╡я▀я┬п╣, п╫п╬п╡п╬п╣ п╬п╨п╫п╬"
 
-#: menu.c:242
+#: menu.c:759
 msgid "Parent, Same Window"
-msgstr "На уровень выше, то же окно"
+msgstr "п²п╟ я┐я─п╬п╡п╣п╫я▄ п╡я▀я┬п╣, я┌п╬ п╤п╣ п╬п╨п╫п╬"
 
-#: menu.c:243
+#: menu.c:761 tips:44
 msgid "New Window"
-msgstr "Новое окно"
-
-#: menu.c:245
-msgid "Show Bookmarks"
-msgstr "Показать закладки"
-
-#: menu.c:246
-msgid "Show Log"
-msgstr "Показать сведения"
-
-#: menu.c:247
-msgid "Follow Symbolic Links"
-msgstr "Следовать по символическим ссылкам"
-
-#: menu.c:248
-msgid "Resize Window"
-msgstr "Изменить размер окна"
-
-#: menu.c:251
-msgid "Close Window"
-msgstr "Закрыть oкно"
-
-#: menu.c:253
-msgid "Enter Path..."
-msgstr "Ввести путь..."
-
-#: menu.c:254
-msgid "Shell Command..."
-msgstr "Команда оболочки..."
-
-#: menu.c:255
-msgid "Terminal Here"
-msgstr "Открыть терминал здесь"
-
-#: menu.c:256
-msgid "Switch to Terminal"
-msgstr "Переключиться в терминал"
-
-#: menu.c:725
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "Откройте \"Меню\" мышью, удерживая Shift, чтобы отправить файл куда-либо"
+msgstr "п²п╬п╡п╬п╣ п╬п╨п╫п╬"
 
 #: menu.c:764
-msgid "Next Click"
-msgstr "Следующий щелчок"
+msgid "Show Bookmarks"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ п╥п╟п╨п╩п╟п╢п╨п╦"
 
-#: menu.c:786
+#: menu.c:766
+msgid "Show Log"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ я│п╡п╣п╢п╣п╫п╦я▐"
+
+#: menu.c:768
+msgid "Follow Symbolic Links"
+msgstr "п║п╩п╣п╢п╬п╡п╟я┌я▄ п©п╬ я│п╦п╪п╡п╬п╩п╦я┤п╣я│п╨п╦п╪ я│я│я▀п╩п╨п╟п╪"
+
+#: menu.c:769
+msgid "Resize Window"
+msgstr "п≤п╥п╪п╣п╫п╦я┌я▄ я─п╟п╥п╪п╣я─ п╬п╨п╫п╟"
+
+#: menu.c:771
+msgid "Close Window"
+msgstr "п≈п╟п╨я─я▀я┌я▄ oп╨п╫п╬"
+
+#: menu.c:776
+msgid "Enter Path..."
+msgstr "п▓п╡п╣я│я┌п╦ п©я┐я┌я▄..."
+
+#: menu.c:778
+msgid "Shell Command..."
+msgstr "п п╬п╪п╟п╫п╢п╟ п╬п╠п╬п╩п╬я┤п╨п╦..."
+
+#: menu.c:780
+msgid "Terminal Here"
+msgstr "п·я┌п╨я─я▀я┌я▄ я┌п╣я─п╪п╦п╫п╟п╩ п╥п╢п╣я│я▄"
+
+#: menu.c:782
+msgid "Switch to Terminal"
+msgstr "п÷п╣я─п╣п╨п╩я▌я┤п╦я┌я▄я│я▐ п╡ я┌п╣я─п╪п╦п╫п╟п╩"
+
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "п■п╬п©п╬п╩п╫п╦я┌я▄ п╪п╣п╫я▌..."
+
+#: menu.c:976
+msgid "Next Click"
+msgstr "п║п╩п╣п╢я┐я▌я┴п╦п╧ я┴п╣п╩я┤п╬п╨"
+
+#: menu.c:998
 #, c-format
 msgid "%d items"
-msgstr "%d объектов"
+msgstr "%d п╬п╠я┼п╣п╨я┌п╬п╡"
 
-#: menu.c:874
+#: menu.c:1094
 msgid "Open unmounted"
-msgstr "Открыть неподключенным"
+msgstr "п·я┌п╨я─я▀я┌я▄ п╫п╣п©п╬п╢п╨п╩я▌я┤п╣п╫п╫я▀п╪"
 
-#: menu.c:877
+#: menu.c:1097
 msgid "Show Target"
-msgstr "Показать цель"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ я├п╣п╩я▄"
 
-#: menu.c:879
+#: menu.c:1099
 msgid "Look Inside"
-msgstr "Посмотреть внутрь"
+msgstr "п÷п╬я│п╪п╬я┌я─п╣я┌я▄ п╡п╫я┐я┌я─я▄"
 
-#: menu.c:881
+#: menu.c:1101
 msgid "Open As Text"
-msgstr "Открыть как текст"
+msgstr "п·я┌п╨я─я▀я┌я▄ п╨п╟п╨ я┌п╣п╨я│я┌"
 
-#: menu.c:1052
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2318,73 +2546,86 @@ msgid ""
 "it may simply be that the filesystem needs to be mounted with the right "
 "mount option ('user_xattr' on Linux)."
 msgstr ""
-"Расширенные атрибуты, используемые для хранения типов, не поддерживаются для "
-"этого файла (этих файлов).\n"
-"Возможно, это из-за недостаточной функциональности файловой системы, "
-"библиотеки С или при подключении файловой системы были указаны неверные "
-"параметры('user_xattr' в Linux)."
+"п═п╟я│я┬п╦я─п╣п╫п╫я▀п╣ п╟я┌я─п╦п╠я┐я┌я▀, п╦я│п©п╬п╩я▄п╥я┐п╣п╪я▀п╣ п╢п╩я▐ я┘я─п╟п╫п╣п╫п╦я▐ я┌п╦п©п╬п╡, п╫п╣ п©п╬п╢п╢п╣я─п╤п╦п╡п╟я▌я┌я│я▐ п╢п╩я▐ "
+"я█я┌п╬пЁп╬ я└п╟п╧п╩п╟ (я█я┌п╦я┘ я└п╟п╧п╩п╬п╡).\n"
+"п▓п╬п╥п╪п╬п╤п╫п╬, я█я┌п╬ п╦п╥-п╥п╟ п╫п╣п╢п╬я│я┌п╟я┌п╬я┤п╫п╬п╧ я└я┐п╫п╨я├п╦п╬п╫п╟п╩я▄п╫п╬я│я┌п╦ я└п╟п╧п╩п╬п╡п╬п╧ я│п╦я│я┌п╣п╪я▀, "
+"п╠п╦п╠п╩п╦п╬я┌п╣п╨п╦ п║ п╦п╩п╦ п©я─п╦ п©п╬п╢п╨п╩я▌я┤п╣п╫п╦п╦ я└п╟п╧п╩п╬п╡п╬п╧ я│п╦я│я┌п╣п╪я▀ п╠я▀п╩п╦ я┐п╨п╟п╥п╟п╫я▀ п╫п╣п╡п╣я─п╫я▀п╣ "
+"п©п╟я─п╟п╪п╣я┌я─я▀('user_xattr' п╡ Linux)."
 
-#: menu.c:1058
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
-msgstr "Для некоторых из этих файлов установка типа не поддерживается"
+msgstr "п■п╩я▐ п╫п╣п╨п╬я┌п╬я─я▀я┘ п╦п╥ я█я┌п╦я┘ я└п╟п╧п╩п╬п╡ я┐я│я┌п╟п╫п╬п╡п╨п╟ я┌п╦п©п╟ п╫п╣ п©п╬п╢п╢п╣я─п╤п╦п╡п╟п╣я┌я│я▐"
 
-#: menu.c:1093
+#: menu.c:1364
 msgid "_Relative link"
-msgstr "Относительная ссылка"
+msgstr "п·я┌п╫п╬я│п╦я┌п╣п╩я▄п╫п╟я▐ я│я│я▀п╩п╨п╟"
 
-#: menu.c:1099
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
 "If off, the path from the root directory is stored - use this if the symlink "
 "may move but the target will stay put."
 msgstr ""
-"Если включено, то ссылки будут содержать относительный путь от ссылки к "
-"целевому файлу. Используйте эту возможность, когда ссылка и целевой файл "
-"будут перемещены вместе.\n"
-"Если выключено, то будет сохранен путь от корневого каталога - это будет "
-"кстати, если ссылка будет перемещена, а целевой файл останется на прежнем "
-"месте."
+"п∙я│п╩п╦ п╡п╨п╩я▌я┤п╣п╫п╬, я┌п╬ я│я│я▀п╩п╨п╦ п╠я┐п╢я┐я┌ я│п╬п╢п╣я─п╤п╟я┌я▄ п╬я┌п╫п╬я│п╦я┌п╣п╩я▄п╫я▀п╧ п©я┐я┌я▄ п╬я┌ я│я│я▀п╩п╨п╦ п╨ "
+"я├п╣п╩п╣п╡п╬п╪я┐ я└п╟п╧п╩я┐. п≤я│п©п╬п╩я▄п╥я┐п╧я┌п╣ я█я┌я┐ п╡п╬п╥п╪п╬п╤п╫п╬я│я┌я▄, п╨п╬пЁп╢п╟ я│я│я▀п╩п╨п╟ п╦ я├п╣п╩п╣п╡п╬п╧ я└п╟п╧п╩ "
+"п╠я┐п╢я┐я┌ п©п╣я─п╣п╪п╣я┴п╣п╫я▀ п╡п╪п╣я│я┌п╣.\n"
+"п∙я│п╩п╦ п╡я▀п╨п╩я▌я┤п╣п╫п╬, я┌п╬ п╠я┐п╢п╣я┌ я│п╬я┘я─п╟п╫п╣п╫ п©я┐я┌я▄ п╬я┌ п╨п╬я─п╫п╣п╡п╬пЁп╬ п╨п╟я┌п╟п╩п╬пЁп╟ - я█я┌п╬ п╠я┐п╢п╣я┌ "
+"п╨я│я┌п╟я┌п╦, п╣я│п╩п╦ я│я│я▀п╩п╨п╟ п╠я┐п╢п╣я┌ п©п╣я─п╣п╪п╣я┴п╣п╫п╟, п╟ я├п╣п╩п╣п╡п╬п╧ я└п╟п╧п╩ п╬я│я┌п╟п╫п╣я┌я│я▐ п╫п╟ п©я─п╣п╤п╫п╣п╪ "
+"п╪п╣я│я┌п╣."
 
-#: menu.c:1169
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
-msgstr "Новый путь не абсолютный"
+msgstr "п²п╬п╡я▀п╧ п©я┐я┌я▄ п╫п╣ п╟п╠я│п╬п╩я▌я┌п╫я▀п╧"
 
-#: menu.c:1235
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr ""
-"Символическая ссылка из \"%s\" уже существует. Заменить его ссылкой на \"%s"
+"п║п╦п╪п╡п╬п╩п╦я┤п╣я│п╨п╟я▐ я│я│я▀п╩п╨п╟ п╦п╥ \"%s\" я┐п╤п╣ я│я┐я┴п╣я│я┌п╡я┐п╣я┌. п≈п╟п╪п╣п╫п╦я┌я▄ п╣пЁп╬ я│я│я▀п╩п╨п╬п╧ п╫п╟ \"%s"
 "\"?"
 
-#: menu.c:1241
+#: menu.c:1546
 msgid "_Replace"
-msgstr "_Заменить"
+msgstr "_п≈п╟п╪п╣п╫п╦я┌я▄"
 
-#: menu.c:1361 menu.c:1402 menu.c:1462
-msgid "Create"
-msgstr "Создать"
-
-#: menu.c:1362
+#: menu.c:1704
 msgid "NewDir"
-msgstr "Новый каталог"
+msgstr "п²п╬п╡я▀п╧ п╨п╟я┌п╟п╩п╬пЁ"
 
-#: menu.c:1376 menu.c:1382
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Ошибка при создании \"%s\": %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "п║п╬п╥п╢п╟я┌я▄"
 
-#: menu.c:1403
+#: menu.c:1755
 msgid "NewFile"
-msgstr "Новый файл"
+msgstr "п²п╬п╡я▀п╧ я└п╟п╧п╩"
 
-#: menu.c:1421
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
-msgstr "Ошибка при создании файла: невозможно найти шаблон для %s"
+msgstr "п·я┬п╦п╠п╨п╟ п©я─п╦ я│п╬п╥п╢п╟п╫п╦п╦ я└п╟п╧п╩п╟: п╫п╣п╡п╬п╥п╪п╬п╤п╫п╬ п╫п╟п╧я┌п╦ я┬п╟п╠п╩п╬п╫ п╢п╩я▐ %s"
 
-#: menu.c:1492
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"п║п╬п╥п╢п╟п╧я┌п╣ п╡ я█я┌п╬п╪ п╨п╟я┌п╟п╩п╬пЁп╣ я│п╦п╪п╡п╬п╩п╦я┤п╣я│п╨я┐я▌ я│я│я▀п╩п╨я┐ п╫п╟ п╩я▌п╠я┐я▌ п©я─п╬пЁя─п╟п╪п╪я┐ - п╦ п╬п╫п╟ "
+"п╠я┐п╢п╣я┌ п©п╬я▐п╡п╩я▐я┌я▄я│я▐ п╡ п╪п╣п╫я▌ п╢п╩я▐ п╡я│п╣я┘ я└п╟п╧п╩п╬п╡ я█я┌п╬пЁп╬ я┌п╦п©п╟ (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2396,33 +2637,38 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
-"Меню \"Отправить в...\" предоставляет быстрый способ для отправки файлов в "
-"определенные приложения. Приложения, предлагаемые в этом меню, находятся в "
-"следующих каталогах:\n"
+"п°п╣п╫я▌ \"п·я┌п©я─п╟п╡п╦я┌я▄ п╡...\" п©я─п╣п╢п╬я│я┌п╟п╡п╩я▐п╣я┌ п╠я▀я│я┌я─я▀п╧ я│п©п╬я│п╬п╠ п╢п╩я▐ п╬я┌п©я─п╟п╡п╨п╦ я└п╟п╧п╩п╬п╡ п╡ "
+"п╬п©я─п╣п╢п╣п╩п╣п╫п╫я▀п╣ п©я─п╦п╩п╬п╤п╣п╫п╦я▐. п÷я─п╦п╩п╬п╤п╣п╫п╦я▐, п©я─п╣п╢п╩п╟пЁп╟п╣п╪я▀п╣ п╡ я█я┌п╬п╪ п╪п╣п╫я▌, п╫п╟я┘п╬п╢я▐я┌я│я▐ п╡ "
+"я│п╩п╣п╢я┐я▌я┴п╦я┘ п╨п╟я┌п╟п╩п╬пЁп╟я┘:\n"
 " \n"
 "%s\n"
 "%s\n"
-"Меню \"Отправить в...\" может быть открыто щелчком по файлу как для \"Меню\", но с зажатой клавишей Shift.\n"
+"п°п╣п╫я▌ \"п·я┌п©я─п╟п╡п╦я┌я▄ п╡...\" п╪п╬п╤п╣я┌ п╠я▀я┌я▄ п╬я┌п╨я─я▀я┌п╬ я┴п╣п╩я┤п╨п╬п╪ п©п╬ я└п╟п╧п╩я┐ п╨п╟п╨ п╢п╩я▐ \"п°п╣п╫я▌"
+"\", п╫п╬ я│ п╥п╟п╤п╟я┌п╬п╧ п╨п╩п╟п╡п╦я┬п╣п╧ Shift.\n"
 "\n"
-"Расширенное использование:\n"
-"Вы можете создать также подкаталоги под названием \".text_html\", \".text\", "
-"и т.д. которые буду показаны только для файлов этих типов. \".group\" будет "
-"показан только если будут выделены сразу несколько файлов."
+"п═п╟я│я┬п╦я─п╣п╫п╫п╬п╣ п╦я│п©п╬п╩я▄п╥п╬п╡п╟п╫п╦п╣:\n"
+"п▓я▀ п╪п╬п╤п╣я┌п╣ я│п╬п╥п╢п╟я┌я▄ я┌п╟п╨п╤п╣ п©п╬п╢п╨п╟я┌п╟п╩п╬пЁп╦ п©п╬п╢ п╫п╟п╥п╡п╟п╫п╦п╣п╪ \".text_html\", \".text\", "
+"п╦ я┌.п╢. п╨п╬я┌п╬я─я▀п╣ п╠я┐п╢я┐ п©п╬п╨п╟п╥п╟п╫я▀ я┌п╬п╩я▄п╨п╬ п╢п╩я▐ я└п╟п╧п╩п╬п╡ я█я┌п╦я┘ я┌п╦п©п╬п╡. \".group\" п╠я┐п╢п╣я┌ "
+"п©п╬п╨п╟п╥п╟п╫ я┌п╬п╩я▄п╨п╬ п╣я│п╩п╦ п╠я┐п╢я┐я┌ п╡я▀п╢п╣п╩п╣п╫я▀ я│я─п╟п╥я┐ п╫п╣я│п╨п╬п╩я▄п╨п╬ я└п╟п╧п╩п╬п╡."
 
-#: menu.c:1503
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
-msgstr "Сейчас будет открыт ваш каталог \"Отправить в...\", вы можете сделать ссылку(Ctrl+Shift перетаскивание) на любое приложение, которое захотите сюда добавить."
+msgstr ""
+"п║п╣п╧я┤п╟я│ п╠я┐п╢п╣я┌ п╬я┌п╨я─я▀я┌ п╡п╟я┬ п╨п╟я┌п╟п╩п╬пЁ \"п·я┌п©я─п╟п╡п╦я┌я▄ п╡...\", п╡я▀ п╪п╬п╤п╣я┌п╣ я│п╢п╣п╩п╟я┌я▄ "
+"я│я│я▀п╩п╨я┐(Ctrl+Shift п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟п╫п╦п╣) п╫п╟ п╩я▌п╠п╬п╣ п©я─п╦п╩п╬п╤п╣п╫п╦п╣, п╨п╬я┌п╬я─п╬п╣ п╥п╟я┘п╬я┌п╦я┌п╣ я│я▌п╢п╟ "
+"п╢п╬п╠п╟п╡п╦я┌я▄."
 
-#: menu.c:1506 menu.c:1546
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
-msgstr "Установки переменной CHOICESPATH запрещают изменения - извините."
+msgstr "пёя│я┌п╟п╫п╬п╡п╨п╦ п©п╣я─п╣п╪п╣п╫п╫п╬п╧ CHOICESPATH п╥п╟п©я─п╣я┴п╟я▌я┌ п╦п╥п╪п╣п╫п╣п╫п╦я▐ - п╦п╥п╡п╦п╫п╦я┌п╣."
 
-#: menu.c:1539
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2433,103 +2679,141 @@ msgid ""
 "%s\n"
 "%s\n"
 msgstr ""
-"Все файлы, помещённые в каталоги \"Шаблоны\" появятся в меню \"Новый\" "
-"Выбрав любой из них вы создадите его копию в качестве нового файла.\n"
+"п▓я│п╣ я└п╟п╧п╩я▀, п©п╬п╪п╣я┴я▒п╫п╫я▀п╣ п╡ п╨п╟я┌п╟п╩п╬пЁп╦ \"п╗п╟п╠п╩п╬п╫я▀\" п©п╬я▐п╡я▐я┌я│я▐ п╡ п╪п╣п╫я▌ \"п²п╬п╡я▀п╧\" "
+"п▓я▀п╠я─п╟п╡ п╩я▌п╠п╬п╧ п╦п╥ п╫п╦я┘ п╡я▀ я│п╬п╥п╢п╟п╢п╦я┌п╣ п╣пЁп╬ п╨п╬п©п╦я▌ п╡ п╨п╟я┤п╣я│я┌п╡п╣ п╫п╬п╡п╬пЁп╬ я└п╟п╧п╩п╟.\n"
 "\n"
-"Шаблоны содержатся в следующих каталогах:\n"
+"п╗п╟п╠п╩п╬п╫я▀ я│п╬п╢п╣я─п╤п╟я┌я│я▐ п╡ я│п╩п╣п╢я┐я▌я┴п╦я┘ п╨п╟я┌п╟п╩п╬пЁп╟я┘:\n"
 "\n"
 "%s\n"
 "%s\n"
 
-#: menu.c:1544
+#: menu.c:1936
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
 msgstr ""
-"Сейчас будет открыт ваш каталог \"Шаблоны\"; в него вы можете поместить "
-"любые файлы, которые будете использовать в качестве шаблонов."
+"п║п╣п╧я┤п╟я│ п╠я┐п╢п╣я┌ п╬я┌п╨я─я▀я┌ п╡п╟я┬ п╨п╟я┌п╟п╩п╬пЁ \"п╗п╟п╠п╩п╬п╫я▀\"; п╡ п╫п╣пЁп╬ п╡я▀ п╪п╬п╤п╣я┌п╣ п©п╬п╪п╣я│я┌п╦я┌я▄ "
+"п╩я▌п╠я▀п╣ я└п╟п╧п╩я▀, п╨п╬я┌п╬я─я▀п╣ п╠я┐п╢п╣я┌п╣ п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п╡ п╨п╟я┤п╣я│я┌п╡п╣ я┬п╟п╠п╩п╬п╫п╬п╡."
 
-#: menu.c:1661
-msgid "Customise"
-msgstr "Настроить"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
+msgstr "п²п╟я│я┌я─п╬п╦я┌я▄"
 
-#: menu.c:1734
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "п■п╬п©п╬п╩п╫п╦я┌я▄ п╪п╣п╫я▌..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
-msgstr "Это уже каноническое имя для данного каталога."
+msgstr "п╜я┌п╬ я┐п╤п╣ п╨п╟п╫п╬п╫п╦я┤п╣я│п╨п╬п╣ п╦п╪я▐ п╢п╩я▐ п╢п╟п╫п╫п╬пЁп╬ п╨п╟я┌п╟п╩п╬пЁп╟."
 
-#: menu.c:1765
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
 msgstr ""
-"Вы не можете открыть второе окно просмотра этого каталога, так как включена "
-"опция \"Уникальные окна\"."
+"п▓я▀ п╫п╣ п╪п╬п╤п╣я┌п╣ п╬я┌п╨я─я▀я┌я▄ п╡я┌п╬я─п╬п╣ п╬п╨п╫п╬ п©я─п╬я│п╪п╬я┌я─п╟ я█я┌п╬пЁп╬ п╨п╟я┌п╟п╩п╬пЁп╟, я┌п╟п╨ п╨п╟п╨ п╡п╨п╩я▌я┤п╣п╫п╟ "
+"п╬п©я├п╦я▐ \"пёп╫п╦п╨п╟п╩я▄п╫я▀п╣ п╬п╨п╫п╟\"."
 
-#: menu.c:1891
-msgid "Copy ... ?"
-msgstr "Что копировать?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1894
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?п п╬п©п╦я─п╬п╡п╟я┌я▄ %s п╡ %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?п п╬п©п╦я─п╬п╡п╟я┌я▄ %s п╡ %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
-msgstr "Что переименовать?"
+msgstr "п╖я┌п╬ п©п╣я─п╣п╦п╪п╣п╫п╬п╡п╟я┌я▄?"
 
-#: menu.c:1897
+#: menu.c:2462
 msgid "Symlink ... ?"
-msgstr "На что сделать ссылку?"
+msgstr "п²п╟ я┤я┌п╬ я│п╢п╣п╩п╟я┌я▄ я│я│я▀п╩п╨я┐?"
 
-#: menu.c:1900
+#: menu.c:2465
 msgid "Shift Open ... ?"
-msgstr "Что открыть принудительно?"
+msgstr "п╖я┌п╬ п╬я┌п╨я─я▀я┌я▄ п©я─п╦п╫я┐п╢п╦я┌п╣п╩я▄п╫п╬?"
 
-#: menu.c:1903
+#: menu.c:2468
 msgid "Properties of ... ?"
-msgstr "Свойства файла ...?"
+msgstr "п║п╡п╬п╧я│я┌п╡п╟ я└п╟п╧п╩п╟ ...?"
 
-#: menu.c:1906
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "п═п╟я│я┬п╦я─п╣п╫п╫я▀п╣ п╟я┌я─п╦п╠я┐я┌я▀"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
-msgstr "Установить тип файла ...?"
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ я┌п╦п© я└п╟п╧п╩п╟ ...?"
 
-#: menu.c:1909
+#: menu.c:2479
 msgid "Set run action for ... ?"
-msgstr "Установить ассоциацию для ...?"
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ п╟я│я│п╬я├п╦п╟я├п╦я▌ п╢п╩я▐ ...?"
 
-#: menu.c:1912
+#: menu.c:2482
 msgid "Set icon for ... ?"
-msgstr "Выбрать значок для ...?"
+msgstr "п▓я▀п╠я─п╟я┌я▄ п╥п╫п╟я┤п╬п╨ п╢п╩я▐ ...?"
 
-#: menu.c:1915
+#: menu.c:2485
 msgid "Send ... to ... ?"
-msgstr "Отправить ... в ...?"
+msgstr "п·я┌п©я─п╟п╡п╦я┌я▄ ... п╡ ...?"
 
-#: menu.c:1918
+#: menu.c:2488
 msgid "DELETE ... ?"
-msgstr "Что удалить?"
+msgstr "п╖я┌п╬ я┐п╢п╟п╩п╦я┌я▄?"
 
-#: menu.c:1921
+#: menu.c:2491
 msgid "Count the size of ... ?"
-msgstr "Подсчитать размер ...?"
+msgstr "п÷п╬п╢я│я┤п╦я┌п╟я┌я▄ я─п╟п╥п╪п╣я─ ...?"
 
-#: menu.c:1924
+#: menu.c:2494
 msgid "Set permissions on ... ?"
-msgstr "Установить права для ...?"
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ п©я─п╟п╡п╟ п╢п╩я▐ ...?"
 
-#: menu.c:1927
+#: menu.c:2497
 msgid "Search inside ... ?"
-msgstr "Искать внутри чего?"
+msgstr "п≤я│п╨п╟я┌я▄ п╡п╫я┐я┌я─п╦ я┤п╣пЁп╬?"
 
-#: menu.c:1991
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "п╖я┌п╬ п╨п╬п©п╦я─п╬п╡п╟я┌я▄?"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
-msgstr "Вы не можете делать это более чем с одним объектом сразу"
+msgstr "п▓я▀ п╫п╣ п╪п╬п╤п╣я┌п╣ п╢п╣п╩п╟я┌я▄ я█я┌п╬ п╠п╬п╩п╣п╣ я┤п╣п╪ я│ п╬п╢п╫п╦п╪ п╬п╠я┼п╣п╨я┌п╬п╪ я│я─п╟п╥я┐"
 
-#: menu.c:2023
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
-msgstr "Переименовать"
+msgstr "п÷п╣я─п╣п╦п╪п╣п╫п╬п╡п╟я┌я▄"
 
-#: menu.c:2028
+#: menu.c:2619
 msgid "Symlink"
-msgstr "Символическая ссылка"
+msgstr "п║п╦п╪п╡п╬п╩п╦я┤п╣я│п╨п╟я▐ я│я│я▀п╩п╨п╟"
 
-#: menu.c:2057
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2541,17 +2825,17 @@ msgid ""
 "\tgtk-can-change-accels = 1\n"
 "\t(this only works if NOT using XSETTINGS)"
 msgstr ""
-"Назначаемые пользователем горячие клавиши по умолчанию выключены в Gtk2, и "
-"вы их ещё не включили. Вы можете включить эту возможность следующим "
-"образом:\n"
-"1) используя XSettings менеджер, такой как ROX-Session или gnome-settings-"
+"п²п╟п╥п╫п╟я┤п╟п╣п╪я▀п╣ п©п╬п╩я▄п╥п╬п╡п╟я┌п╣п╩п╣п╪ пЁп╬я─я▐я┤п╦п╣ п╨п╩п╟п╡п╦я┬п╦ п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌ п╡я▀п╨п╩я▌я┤п╣п╫я▀ п╡ Gtk2, п╦ "
+"п╡я▀ п╦я┘ п╣я┴я▒ п╫п╣ п╡п╨п╩я▌я┤п╦п╩п╦. п▓я▀ п╪п╬п╤п╣я┌п╣ п╡п╨п╩я▌я┤п╦я┌я▄ я█я┌я┐ п╡п╬п╥п╪п╬п╤п╫п╬я│я┌я▄ я│п╩п╣п╢я┐я▌я┴п╦п╪ "
+"п╬п╠я─п╟п╥п╬п╪:\n"
+"1) п╦я│п©п╬п╩я▄п╥я┐я▐ XSettings п╪п╣п╫п╣п╢п╤п╣я─, я┌п╟п╨п╬п╧ п╨п╟п╨ ROX-Session п╦п╩п╦ gnome-settings-"
 "daemon\n"
-"или\n"
-"2) добавив следующую строку в ~/.gtkrc-2.0:\n"
+"п╦п╩п╦\n"
+"2) п╢п╬п╠п╟п╡п╦п╡ я│п╩п╣п╢я┐я▌я┴я┐я▌ я│я┌я─п╬п╨я┐ п╡ ~/.gtkrc-2.0:\n"
 "\tgtk-can-change-accels = 1\n"
-"\t(это сработает только если вы НЕ используете XSETTINGS)"
+"\t(я█я┌п╬ я│я─п╟п╠п╬я┌п╟п╣я┌ я┌п╬п╩я▄п╨п╬ п╣я│п╩п╦ п╡я▀ п²п∙ п╦я│п©п╬п╩я▄п╥я┐п╣я┌п╣ XSETTINGS)"
 
-#: menu.c:2068
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2562,55 +2846,85 @@ msgid ""
 "The key will appear next to the menu item and you can just press that key "
 "without opening the menu in future."
 msgstr ""
-"Для установки горячей клавиши для элемента меню:\n"
+"п■п╩я▐ я┐я│я┌п╟п╫п╬п╡п╨п╦ пЁп╬я─я▐я┤п╣п╧ п╨п╩п╟п╡п╦я┬п╦ п╢п╩я▐ я█п╩п╣п╪п╣п╫я┌п╟ п╪п╣п╫я▌:\n"
 "\n"
-"- Откройте меню в окне файлового менеджера;\n"
-"- Наведите курсор на элемент, который вы хотите использовать;\n"
-"- Нажмите клавишу, которую хотите назначить горячей;\n"
+"- п·я┌п╨я─п╬п╧я┌п╣ п╪п╣п╫я▌ п╡ п╬п╨п╫п╣ я└п╟п╧п╩п╬п╡п╬пЁп╬ п╪п╣п╫п╣п╢п╤п╣я─п╟;\n"
+"- п²п╟п╡п╣п╢п╦я┌п╣ п╨я┐я─я│п╬я─ п╫п╟ я█п╩п╣п╪п╣п╫я┌, п╨п╬я┌п╬я─я▀п╧ п╡я▀ я┘п╬я┌п╦я┌п╣ п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄;\n"
+"- п²п╟п╤п╪п╦я┌п╣ п╨п╩п╟п╡п╦я┬я┐, п╨п╬я┌п╬я─я┐я▌ я┘п╬я┌п╦я┌п╣ п╫п╟п╥п╫п╟я┤п╦я┌я▄ пЁп╬я─я▐я┤п╣п╧;\n"
 "\n"
-"Эта клавиша будет отображена рядом с элементом меню и теперь вам достаточно "
-"будет просто нажать эту клавишу для активизации элемента без открытия самого "
-"меню."
+"п╜я┌п╟ п╨п╩п╟п╡п╦я┬п╟ п╠я┐п╢п╣я┌ п╬я┌п╬п╠я─п╟п╤п╣п╫п╟ я─я▐п╢п╬п╪ я│ я█п╩п╣п╪п╣п╫я┌п╬п╪ п╪п╣п╫я▌ п╦ я┌п╣п©п╣я─я▄ п╡п╟п╪ п╢п╬я│я┌п╟я┌п╬я┤п╫п╬ "
+"п╠я┐п╢п╣я┌ п©я─п╬я│я┌п╬ п╫п╟п╤п╟я┌я▄ я█я┌я┐ п╨п╩п╟п╡п╦я┬я┐ п╢п╩я▐ п╟п╨я┌п╦п╡п╦п╥п╟я├п╦п╦ я█п╩п╣п╪п╣п╫я┌п╟ п╠п╣п╥ п╬я┌п╨я─я▀я┌п╦я▐ я│п╟п╪п╬пЁп╬ "
+"п╪п╣п╫я▌."
 
-#: menu.c:2083
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
-msgstr "Установить горячие клавиши"
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ пЁп╬я─я▐я┤п╦п╣ п╨п╩п╟п╡п╦я┬п╦"
 
-#: minibuffer.c:129
+#: minibuffer.c:140
 msgid "Goto:"
-msgstr "Идти в:"
+msgstr "п≤п╢я┌п╦ п╡:"
 
-#: minibuffer.c:130
+#: minibuffer.c:141
 msgid "Shell:"
-msgstr "Оболочка:"
+msgstr "п·п╠п╬п╩п╬я┤п╨п╟:"
 
-#: minibuffer.c:131
+#: minibuffer.c:142
 msgid "Select If:"
-msgstr "Выбрать если:"
+msgstr "п▓я▀п╠я─п╟я┌я▄ п╣я│п╩п╦:"
 
-#: minibuffer.c:132
+#: minibuffer.c:143
 msgid "Select Named:"
-msgstr "Выбрать названные:"
+msgstr "п▓я▀п╠я─п╟я┌я▄ п╫п╟п╥п╡п╟п╫п╫я▀п╣:"
 
-#: minibuffer.c:133
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "п▓я▀п╠я─п╟я┌я▄ п╣я│п╩п╦:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
-msgstr "Шаблон:"
+msgstr "п╗п╟п╠п╩п╬п╫:"
 
-#: minibuffer.c:265
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
 msgstr ""
-"Введите имя файла для отображения. Нажмите Tab для автодополнения имени, "
-"Escape для закрытия строки ввода."
+"п▓п╡п╣п╢п╦я┌п╣ п╦п╪я▐ я└п╟п╧п╩п╟ п╢п╩я▐ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐. п²п╟п╤п╪п╦я┌п╣ Tab п╢п╩я▐ п╟п╡я┌п╬п╢п╬п©п╬п╩п╫п╣п╫п╦я▐ п╦п╪п╣п╫п╦, "
+"Escape п╢п╩я▐ п╥п╟п╨я─я▀я┌п╦я▐ я│я┌я─п╬п╨п╦ п╡п╡п╬п╢п╟."
 
-#: minibuffer.c:271
-msgid "Enter a shell command to execute. Click on a file to add it to the buffer."
+#: minibuffer.c:326
+msgid ""
+"Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
-"Введите команду оболочки для выполнения. Щелкните по файлу для добавления "
-"его имени в строку ввода."
+"п▓п╡п╣п╢п╦я┌п╣ п╨п╬п╪п╟п╫п╢я┐ п╬п╠п╬п╩п╬я┤п╨п╦ п╢п╩я▐ п╡я▀п©п╬п╩п╫п╣п╫п╦я▐. п╘п╣п╩п╨п╫п╦я┌п╣ п©п╬ я└п╟п╧п╩я┐ п╢п╩я▐ п╢п╬п╠п╟п╡п╩п╣п╫п╦я▐ "
+"п╣пЁп╬ п╦п╪п╣п╫п╦ п╡ я│я┌я─п╬п╨я┐ п╡п╡п╬п╢п╟."
 
-#: minibuffer.c:276
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"п▓п╡п╣п╢п╦я┌п╣ я┬п╟п╠п╩п╬п╫ п╢п╩я▐ п╡я▀п╠п╬я─п╟ п©п╬п╢я┘п╬п╢я▐я┴п╦я┘ п╦п╪я▒п╫ я└п╟п╧п╩п╬п╡:\n"
+"\n"
+"? п╬п╠п╬п╥п╫п╟я┤п╟п╣я┌ п╩я▌п╠п╬п╧ п╬п╢п╦п╫п╬я┤п╫я▀п╧ я│п╦п╪п╡п╬п╩\n"
+"* п╬п╠п╬п╥п╫п╟я┤п╟п╣я┌ п╫п╦ п╬п╢п╫п╬пЁп╬ п╦п╩п╦ п╩я▌п╠п╬п╣ п╨п╬п╩п╦я┤п╣я│я┌п╡п╬ я│п╦п╪п╡п╬п╩п╬п╡\n"
+"[aA] п╥п╫п╟я┤п╦я┌ 'a' п╦п╩п╦ 'A'\n"
+"[a-z] п╬п╠п╬п╥п╫п╟я┤п╟п╣я┌ п╡я│п╣ п╠я┐п╨п╡я▀ п╬я┌ a п╢п╬ z (п╫п╦п╤п╫п╦п╧ я─п╣пЁп╦я│я┌я─)\n"
+"*.png п╬п╠п╬п╥п╫п╟я┤п╟п╣я┌ п╡я│п╣ п╦п╪п╣п╫п╟, п╬п╨п╟п╫я┤п╦п╡п╟я▌я┴п╦п╣я│я▐ п╫п╟ '.png'"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2620,173 +2934,186 @@ msgid ""
 "[a-z] means any character from a to z (lowercase)\n"
 "*.png means any name ending in '.png'"
 msgstr ""
-"Введите шаблон для выбора подходящих имён файлов:\n"
+"п▓п╡п╣п╢п╦я┌п╣ я┬п╟п╠п╩п╬п╫ п╢п╩я▐ п╡я▀п╠п╬я─п╟ п©п╬п╢я┘п╬п╢я▐я┴п╦я┘ п╦п╪я▒п╫ я└п╟п╧п╩п╬п╡:\n"
 "\n"
-"? обозначает любой одиночный символ\n"
-"* обозначает ни одного или любое количество символов\n"
-"[aA] значит 'a' или 'A'\n"
-"[a-z] обозначает все буквы от a до z (нижний регистр)\n"
-"*.png обозначает все имена, оканчивающиеся на '.png'"
+"? п╬п╠п╬п╥п╫п╟я┤п╟п╣я┌ п╩я▌п╠п╬п╧ п╬п╢п╦п╫п╬я┤п╫я▀п╧ я│п╦п╪п╡п╬п╩\n"
+"* п╬п╠п╬п╥п╫п╟я┤п╟п╣я┌ п╫п╦ п╬п╢п╫п╬пЁп╬ п╦п╩п╦ п╩я▌п╠п╬п╣ п╨п╬п╩п╦я┤п╣я│я┌п╡п╬ я│п╦п╪п╡п╬п╩п╬п╡\n"
+"[aA] п╥п╫п╟я┤п╦я┌ 'a' п╦п╩п╦ 'A'\n"
+"[a-z] п╬п╠п╬п╥п╫п╟я┤п╟п╣я┌ п╡я│п╣ п╠я┐п╨п╡я▀ п╬я┌ a п╢п╬ z (п╫п╦п╤п╫п╦п╧ я─п╣пЁп╦я│я┌я─)\n"
+"*.png п╬п╠п╬п╥п╫п╟я┤п╟п╣я┌ п╡я│п╣ п╦п╪п╣п╫п╟, п╬п╨п╟п╫я┤п╦п╡п╟я▌я┴п╦п╣я│я▐ п╫п╟ '.png'"
 
-#: minibuffer.c:288
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
 msgstr ""
-"Введите шаблон для фильтрации отображаемых файлов. Ввод пустого шаблона "
-"отключит фильтрацию."
+"п▓п╡п╣п╢п╦я┌п╣ я┬п╟п╠п╩п╬п╫ п╢п╩я▐ я└п╦п╩я▄я┌я─п╟я├п╦п╦ п╬я┌п╬п╠я─п╟п╤п╟п╣п╪я▀я┘ я└п╟п╧п╩п╬п╡. п▓п╡п╬п╢ п©я┐я│я┌п╬пЁп╬ я┬п╟п╠п╩п╬п╫п╟ "
+"п╬я┌п╨п╩я▌я┤п╦я┌ я└п╦п╩я▄я┌я─п╟я├п╦я▌."
 
-#: minibuffer.c:908
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"п▓п╡п╣п╢п╦я┌п╣ я┬п╟п╠п╩п╬п╫ п╢п╩я▐ я└п╦п╩я▄я┌я─п╟я├п╦п╦ п╬я┌п╬п╠я─п╟п╤п╟п╣п╪я▀я┘ я└п╟п╧п╩п╬п╡. п▓п╡п╬п╢ п©я┐я│я┌п╬пЁп╬ я┬п╟п╠п╩п╬п╫п╟ "
+"п╬я┌п╨п╩я▌я┤п╦я┌ я└п╦п╩я▄я┌я─п╟я├п╦я▌."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
-msgstr "Неправильные условия поиска"
+msgstr "п²п╣п©я─п╟п╡п╦п╩я▄п╫я▀п╣ я┐я│п╩п╬п╡п╦я▐ п©п╬п╦я│п╨п╟"
 
 #: mount.c:103
 #, c-format
 msgid "File system table \"%s\" not found, cannot monitor system mounts"
-msgstr "Данные о файловых системах \"%s\" не найдены, невозможно отслеживать подключения файловых систем"
+msgstr ""
+"п■п╟п╫п╫я▀п╣ п╬ я└п╟п╧п╩п╬п╡я▀я┘ я│п╦я│я┌п╣п╪п╟я┘ \"%s\" п╫п╣ п╫п╟п╧п╢п╣п╫я▀, п╫п╣п╡п╬п╥п╪п╬п╤п╫п╬ п╬я┌я│п╩п╣п╤п╦п╡п╟я┌я▄ "
+"п©п╬п╢п╨п╩я▌я┤п╣п╫п╦я▐ я└п╟п╧п╩п╬п╡я▀я┘ я│п╦я│я┌п╣п╪"
 
 #: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
-msgstr "%s всего, %s использовано %s свободно (%.1f %%)"
+msgstr "%s п╡я│п╣пЁп╬, %s п╦я│п©п╬п╩я▄п╥п╬п╡п╟п╫п╬ %s я│п╡п╬п╠п╬п╢п╫п╬ (%.1f %%)"
 
-#: options.c:275
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
-msgstr "Старый файл с настройками программы был сконвертирован в новый XML формат."
+msgstr ""
+"п║я┌п╟я─я▀п╧ я└п╟п╧п╩ я│ п╫п╟я│я┌я─п╬п╧п╨п╟п╪п╦ п©я─п╬пЁя─п╟п╪п╪я▀ п╠я▀п╩ я│п╨п╬п╫п╡п╣я─я┌п╦я─п╬п╡п╟п╫ п╡ п╫п╬п╡я▀п╧ XML я└п╬я─п╪п╟я┌."
 
-#: options.c:535 options.c:1256
+#: options.c:560 options.c:1250
 msgid "(use default)"
-msgstr "(использовать умолчания)"
+msgstr "(п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ я┐п╪п╬п╩я┤п╟п╫п╦я▐)"
 
-#: options.c:805
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
-msgstr "Внутренняя ошибка: нельзя прочесть %s"
+msgstr "п▓п╫я┐я┌я─п╣п╫п╫я▐я▐ п╬я┬п╦п╠п╨п╟: п╫п╣п╩я▄п╥я▐ п©я─п╬я┤п╣я│я┌я▄ %s"
 
-#: options.c:914
+#: options.c:929
 msgid "Options"
-msgstr "Настройки"
+msgstr "п²п╟я│я┌я─п╬п╧п╨п╦"
 
-#: options.c:959
+#: options.c:974
 msgid "_Revert"
-msgstr "_Откат"
+msgstr "_п·я┌п╨п╟я┌"
 
-#: options.c:965
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr ""
-"Вернуть все изменившиеся настройки в положение, когда окно настроек был "
-"только что открыто."
+"п▓п╣я─п╫я┐я┌я▄ п╡я│п╣ п╦п╥п╪п╣п╫п╦п╡я┬п╦п╣я│я▐ п╫п╟я│я┌я─п╬п╧п╨п╦ п╡ п©п╬п╩п╬п╤п╣п╫п╦п╣, п╨п╬пЁп╢п╟ п╬п╨п╫п╬ п╫п╟я│я┌я─п╬п╣п╨ п╠я▀п╩ "
+"я┌п╬п╩я▄п╨п╬ я┤я┌п╬ п╬я┌п╨я─я▀я┌п╬."
 
-#: options.c:980
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
 "%s"
 msgstr ""
-"Настройки будут сохранены в:\n"
+"п²п╟я│я┌я─п╬п╧п╨п╦ п╠я┐п╢я┐я┌ я│п╬я┘я─п╟п╫п╣п╫я▀ п╡:\n"
 "%s"
 
-#: options.c:988
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
-msgstr "Сохранение запрещено переменной окружения CHOICESPATH"
+msgstr "п║п╬я┘я─п╟п╫п╣п╫п╦п╣ п╥п╟п©я─п╣я┴п╣п╫п╬ п©п╣я─п╣п╪п╣п╫п╫п╬п╧ п╬п╨я─я┐п╤п╣п╫п╦я▐ CHOICESPATH"
 
-#: options.c:1161 usericons.c:452
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
-msgstr "Ошибка при сохранении %s: %s"
+msgstr "п·я┬п╦п╠п╨п╟ п©я─п╦ я│п╬я┘я─п╟п╫п╣п╫п╦п╦ %s: %s"
 
-#: options.c:1793
+#: options.c:1813
 msgid "Missing '='"
-msgstr "Пропущен символ \"=\""
+msgstr "п÷я─п╬п©я┐я┴п╣п╫ я│п╦п╪п╡п╬п╩ \"=\""
 
-#: panel.c:319
+#: panel.c:326
 #, c-format
 msgid "Unable to replace '%s'"
-msgstr "Невозможно заменить \"%s\""
+msgstr "п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ п╥п╟п╪п╣п╫п╦я┌я▄ \"%s\""
 
-#: panel.c:323
+#: panel.c:330
 #, c-format
 msgid "Unable to save '%s'"
-msgstr "Невозможно сохранить \"%s\""
+msgstr "п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ я│п╬я┘я─п╟п╫п╦я┌я▄ \"%s\""
 
-#: panel.c:526
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
-msgstr "Ваш старый файл с настройками панели был сконвертирован в новый XML формат."
+msgstr ""
+"п▓п╟я┬ я│я┌п╟я─я▀п╧ я└п╟п╧п╩ я│ п╫п╟я│я┌я─п╬п╧п╨п╟п╪п╦ п©п╟п╫п╣п╩п╦ п╠я▀п╩ я│п╨п╬п╫п╡п╣я─я┌п╦я─п╬п╡п╟п╫ п╡ п╫п╬п╡я▀п╧ XML я└п╬я─п╪п╟я┌."
 
-#: panel.c:634
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
 msgstr ""
-"Вы пытались закрыть панель через оконный менеджер. Как правило, это "
-"случайное действие. Действительно закрыть?"
+"п▓я▀ п©я▀я┌п╟п╩п╦я│я▄ п╥п╟п╨я─я▀я┌я▄ п©п╟п╫п╣п╩я▄ я┤п╣я─п╣п╥ п╬п╨п╬п╫п╫я▀п╧ п╪п╣п╫п╣п╢п╤п╣я─. п п╟п╨ п©я─п╟п╡п╦п╩п╬, я█я┌п╬ "
+"я│п╩я┐я┤п╟п╧п╫п╬п╣ п╢п╣п╧я│я┌п╡п╦п╣. п■п╣п╧я│я┌п╡п╦я┌п╣п╩я▄п╫п╬ п╥п╟п╨я─я▀я┌я▄?"
 
-#: panel.c:735
+#: panel.c:771
 msgid "Missing < or > in panel config file"
-msgstr "Отсутствуют \"<\" или \">\" в файле с настройками панели"
+msgstr "п·я┌я│я┐я┌я│я┌п╡я┐я▌я┌ \"<\" п╦п╩п╦ \">\" п╡ я└п╟п╧п╩п╣ я│ п╫п╟я│я┌я─п╬п╧п╨п╟п╪п╦ п©п╟п╫п╣п╩п╦"
 
-#: panel.c:1618
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
-msgstr "Ошибка при сохранении панели %s: %s"
+msgstr "п·я┬п╦п╠п╨п╟ п©я─п╦ я│п╬я┘я─п╟п╫п╣п╫п╦п╦ п©п╟п╫п╣п╩п╦ %s: %s"
 
-#: panel.c:1934
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
-msgstr "Апплет завершился без отображения информации на экран!"
+msgstr "п░п©п©п╩п╣я┌ п╥п╟п╡п╣я─я┬п╦п╩я│я▐ п╠п╣п╥ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐ п╦п╫я└п╬я─п╪п╟я├п╦п╦ п╫п╟ я█п╨я─п╟п╫!"
 
-#: panel.c:2030
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
 "%s"
 msgstr ""
-"Ошибка выполнения апплета:\n"
+"п·я┬п╦п╠п╨п╟ п╡я▀п©п╬п╩п╫п╣п╫п╦я▐ п╟п©п©п╩п╣я┌п╟:\n"
 "%s"
 
-#: panel.c:2655
+#: panel.c:2751
 msgid "Are you sure you want to remove this panel from the desktop?"
-msgstr "Вы уверены, что хотите убрать эту панель с рабочего стола?"
+msgstr "п▓я▀ я┐п╡п╣я─п╣п╫я▀, я┤я┌п╬ я┘п╬я┌п╦я┌п╣ я┐п╠я─п╟я┌я▄ я█я┌я┐ п©п╟п╫п╣п╩я▄ я│ я─п╟п╠п╬я┤п╣пЁп╬ я│я┌п╬п╩п╟?"
 
-#: panel.c:2658 panel.c:2685
+#: panel.c:2754 panel.c:2781
 msgid "Remove Panel"
-msgstr "Удалить панель"
+msgstr "пёп╢п╟п╩п╦я┌я▄ п©п╟п╫п╣п╩я▄"
 
-#: panel.c:2681
+#: panel.c:2777
 msgid "Panel Options..."
-msgstr "Настройки панели..."
+msgstr "п²п╟я│я┌я─п╬п╧п╨п╦ п©п╟п╫п╣п╩п╦..."
 
-#: panel.c:2767
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
-msgstr "Монитор Xinerama %d недоступен"
+msgstr "п°п╬п╫п╦я┌п╬я─ Xinerama %d п╫п╣п╢п╬я│я┌я┐п©п╣п╫"
 
-#: panel.c:2797
+#: panel.c:2897
 msgid "Top"
-msgstr "Сверху"
+msgstr "п║п╡п╣я─я┘я┐"
 
-#: panel.c:2799
+#: panel.c:2899
 msgid "Bottom"
-msgstr "Снизу"
+msgstr "п║п╫п╦п╥я┐"
 
-#: panel.c:2801
+#: panel.c:2901
 msgid "Left"
-msgstr "Слева"
+msgstr "п║п╩п╣п╡п╟"
 
-#: panel.c:2803
+#: panel.c:2903
 msgid "Right"
-msgstr "Справа"
+msgstr "п║п©я─п╟п╡п╟"
 
-#: panel.c:2805
+#: panel.c:2905
 msgid "Default"
-msgstr "По умолчанию"
+msgstr "п÷п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌"
 
-#: panel.c:2809
+#: panel.c:2909
 msgid "Unknown side"
-msgstr "Неизвестная сторона"
+msgstr "п²п╣п╦п╥п╡п╣я│я┌п╫п╟я▐ я│я┌п╬я─п╬п╫п╟"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
-msgstr "Ваша старая витрина была сконвертирована в новый XML формат."
+msgstr "п▓п╟я┬п╟ я│я┌п╟я─п╟я▐ п╡п╦я┌я─п╦п╫п╟ п╠я▀п╩п╟ я│п╨п╬п╫п╡п╣я─я┌п╦я─п╬п╡п╟п╫п╟ п╡ п╫п╬п╡я▀п╧ XML я└п╬я─п╪п╟я┌."
 
 #: pinboard.c:711
 msgid ""
@@ -2794,9 +3121,9 @@ msgid ""
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
 "the SOAP SetBackdropApp method."
 msgstr ""
-"Фон должен управляться каталогом с приложением. Перетащите каталог с "
-"программой в окно \"Установить Фон\" - или (для программистов) передайте его "
-"методу SOAP SetBackdropApp."
+"п╓п╬п╫ п╢п╬п╩п╤п╣п╫ я┐п©я─п╟п╡п╩я▐я┌я▄я│я▐ п╨п╟я┌п╟п╩п╬пЁп╬п╪ я│ п©я─п╦п╩п╬п╤п╣п╫п╦п╣п╪. п÷п╣я─п╣я┌п╟я┴п╦я┌п╣ п╨п╟я┌п╟п╩п╬пЁ я│ "
+"п©я─п╬пЁя─п╟п╪п╪п╬п╧ п╡ п╬п╨п╫п╬ \"пёя│я┌п╟п╫п╬п╡п╦я┌я▄ п╓п╬п╫\" - п╦п╩п╦ (п╢п╩я▐ п©я─п╬пЁя─п╟п╪п╪п╦я│я┌п╬п╡) п©п╣я─п╣п╢п╟п╧я┌п╣ п╣пЁп╬ "
+"п╪п╣я┌п╬п╢я┐ SOAP SetBackdropApp."
 
 #: pinboard.c:730
 msgid ""
@@ -2806,226 +3133,170 @@ msgid ""
 "Programmers: the application's AppInfo.xml must contain the CanSetBackdrop "
 "element, as described in ROX-Filer's manual."
 msgstr ""
-"Вы можете указать в качестве фона только изображение или программу, которая "
-"знает, как управлять фоном.\n"
+"п▓я▀ п╪п╬п╤п╣я┌п╣ я┐п╨п╟п╥п╟я┌я▄ п╡ п╨п╟я┤п╣я│я┌п╡п╣ я└п╬п╫п╟ я┌п╬п╩я▄п╨п╬ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣ п╦п╩п╦ п©я─п╬пЁя─п╟п╪п╪я┐, п╨п╬я┌п╬я─п╟я▐ "
+"п╥п╫п╟п╣я┌, п╨п╟п╨ я┐п©я─п╟п╡п╩я▐я┌я▄ я└п╬п╫п╬п╪.\n"
 "\n"
-"Программисты: файл приложения AppInfo.xml должен содержать элемент "
-"CanSetBackdrop, как это описано в руководстве программы ROX-Filer."
+"п÷я─п╬пЁя─п╟п╪п╪п╦я│я┌я▀: я└п╟п╧п╩ п©я─п╦п╩п╬п╤п╣п╫п╦я▐ AppInfo.xml п╢п╬п╩п╤п╣п╫ я│п╬п╢п╣я─п╤п╟я┌я▄ я█п╩п╣п╪п╣п╫я┌ "
+"CanSetBackdrop, п╨п╟п╨ я█я┌п╬ п╬п©п╦я│п╟п╫п╬ п╡ я─я┐п╨п╬п╡п╬п╢я│я┌п╡п╣ п©я─п╬пЁя─п╟п╪п╪я▀ ROX-Filer."
 
 #: pinboard.c:750
 msgid "Set backdrop"
-msgstr "Установить фон"
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ я└п╬п╫"
 
 #: pinboard.c:761
 msgid "Choose a style and drag an image in:"
-msgstr "Выберите стиль и затем перетащите изображение в:"
+msgstr "п▓я▀п╠п╣я─п╦я┌п╣ я│я┌п╦п╩я▄ п╦ п╥п╟я┌п╣п╪ п©п╣я─п╣я┌п╟я┴п╦я┌п╣ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣ п╡:"
 
 #: pinboard.c:774
 msgid "Centre the image without scaling it"
-msgstr "Помещать изображение в центре без масштабирования."
+msgstr "п÷п╬п╪п╣я┴п╟я┌я▄ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣ п╡ я├п╣п╫я┌я─п╣ п╠п╣п╥ п╪п╟я│я┬я┌п╟п╠п╦я─п╬п╡п╟п╫п╦я▐."
 
 #: pinboard.c:775
 msgid "Centre"
-msgstr "По центру"
+msgstr "п÷п╬ я├п╣п╫я┌я─я┐"
 
 #: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
-msgstr "Масштабировать изображение без искажения соотношений сторон"
+msgstr "п°п╟я│я┬я┌п╟п╠п╦я─п╬п╡п╟я┌я▄ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣ п╠п╣п╥ п╦я│п╨п╟п╤п╣п╫п╦я▐ я│п╬п╬я┌п╫п╬я┬п╣п╫п╦п╧ я│я┌п╬я─п╬п╫"
 
 #: pinboard.c:778
 msgid "Scale"
-msgstr "Масштабировать"
+msgstr "п°п╟я│я┬я┌п╟п╠п╦я─п╬п╡п╟я┌я▄"
 
 #: pinboard.c:779
 msgid ""
 "Scale the image to fit the backdrop area, regardless of image dimensions - "
 "overscale"
-msgstr "Масштабировать изображение так, чтобы заполнить область фона, безотносительно его размеров."
+msgstr ""
+"п°п╟я│я┬я┌п╟п╠п╦я─п╬п╡п╟я┌я▄ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣ я┌п╟п╨, я┤я┌п╬п╠я▀ п╥п╟п©п╬п╩п╫п╦я┌я▄ п╬п╠п╩п╟я│я┌я▄ я└п╬п╫п╟, "
+"п╠п╣п╥п╬я┌п╫п╬я│п╦я┌п╣п╩я▄п╫п╬ п╣пЁп╬ я─п╟п╥п╪п╣я─п╬п╡."
 
 #: pinboard.c:781
 msgid "Fit"
-msgstr "Подогнать по размеру"
+msgstr "п÷п╬п╢п╬пЁп╫п╟я┌я▄ п©п╬ я─п╟п╥п╪п╣я─я┐"
 
 #: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
-msgstr "Масштабировать изображение"
+msgstr "п°п╟я│я┬я┌п╟п╠п╦я─п╬п╡п╟я┌я▄ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣"
 
 #: pinboard.c:783
 msgid "Stretch"
-msgstr "Растянуть"
+msgstr "п═п╟я│я┌я▐п╫я┐я┌я▄"
 
 #: pinboard.c:784
 msgid "Tile the image over the backdrop area"
-msgstr "Настелить изображение черепицей на рабочем столе"
+msgstr "п²п╟я│я┌п╣п╩п╦я┌я▄ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣ я┤п╣я─п╣п©п╦я├п╣п╧ п╫п╟ я─п╟п╠п╬я┤п╣п╪ я│я┌п╬п╩п╣"
 
 #: pinboard.c:785
 msgid "Tile"
-msgstr "Черепицей"
+msgstr "п╖п╣я─п╣п©п╦я├п╣п╧"
 
 #: pinboard.c:790
 msgid "Drop an image here"
-msgstr "Бросьте изображение сюда"
+msgstr "п▒я─п╬я│я▄я┌п╣ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣ я│я▌п╢п╟"
 
 #: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
 msgstr ""
-"Витрина не использовалась... Была выбрана витрина по умолчанию. Используйте "
-"'rox -p=Default' чтобы включить эту витрину в будущем."
+"п▓п╦я┌я─п╦п╫п╟ п╫п╣ п╦я│п©п╬п╩я▄п╥п╬п╡п╟п╩п╟я│я▄... п▒я▀п╩п╟ п╡я▀п╠я─п╟п╫п╟ п╡п╦я┌я─п╦п╫п╟ п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌. п≤я│п©п╬п╩я▄п╥я┐п╧я┌п╣ "
+"'rox -p=Default' я┤я┌п╬п╠я▀ п╡п╨п╩я▌я┤п╦я┌я▄ я█я┌я┐ п╡п╦я┌я─п╦п╫я┐ п╡ п╠я┐п╢я┐я┴п╣п╪."
 
 #: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
 msgstr ""
-"Только файлы (и определённые приложения) могут быть использованы для "
-"установки фона."
+"п╒п╬п╩я▄п╨п╬ я└п╟п╧п╩я▀ (п╦ п╬п©я─п╣п╢п╣п╩я▒п╫п╫я▀п╣ п©я─п╦п╩п╬п╤п╣п╫п╦я▐) п╪п╬пЁя┐я┌ п╠я▀я┌я▄ п╦я│п©п╬п╩я▄п╥п╬п╡п╟п╫я▀ п╢п╩я▐ "
+"я┐я│я┌п╟п╫п╬п╡п╨п╦ я└п╬п╫п╟."
 
-#: pinboard.c:1570
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
-msgstr "Отсутствует \">\" в метке"
+msgstr "п·я┌я│я┐я┌я│я┌п╡я┐п╣я┌ \">\" п╡ п╪п╣я┌п╨п╣"
 
-#: pinboard.c:1579
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
-msgstr "Отсутствует \",\" после метки"
+msgstr "п·я┌я│я┐я┌я│я┌п╡я┐п╣я┌ \",\" п©п╬я│п╩п╣ п╪п╣я┌п╨п╦"
 
-#: pinboard.c:1667
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
-msgstr "Ошибка сохранения витрины %s: %s"
+msgstr "п·я┬п╦п╠п╨п╟ я│п╬я┘я─п╟п╫п╣п╫п╦я▐ п╡п╦я┌я─п╦п╫я▀ %s: %s"
 
-#: pinboard.c:2212
+#: pinboard.c:2247
 msgid "Backdrop..."
-msgstr "Фон..."
+msgstr "п╓п╬п╫..."
 
-#: pinboard.c:2215
+#: pinboard.c:2250
 msgid "Add Panel"
-msgstr "Добавить панель"
+msgstr "п■п╬п╠п╟п╡п╦я┌я▄ п©п╟п╫п╣п╩я▄"
 
-#: pinboard.c:2309
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
 "%s\n"
 "Backdrop removed."
 msgstr ""
-"Ошибка загрузки фонового изображения:\n"
+"п·я┬п╦п╠п╨п╟ п╥п╟пЁя─я┐п╥п╨п╦ я└п╬п╫п╬п╡п╬пЁп╬ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦я▐:\n"
 "%s\n"
-"Фон убран."
+"п╓п╬п╫ я┐п╠я─п╟п╫."
 
-#: pixmaps.c:976
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
 "%s"
 msgstr ""
-"Не могу удалить миниатюры в %s:\n"
+"п²п╣ п╪п╬пЁя┐ я┐п╢п╟п╩п╦я┌я▄ п╪п╦п╫п╦п╟я┌я▌я─я▀ п╡ %s:\n"
 "%s"
 
-#: pixmaps.c:997
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
-msgstr "Нет миниатюр для удаления"
+msgstr "п²п╣я┌ п╪п╦п╫п╦п╟я┌я▌я─ п╢п╩я▐ я┐п╢п╟п╩п╣п╫п╦я▐"
 
-#: pixmaps.c:1010
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
-msgstr "Очистить кеш миниатюр на диске"
+msgstr "п·я┤п╦я│я┌п╦я┌я▄ п╨п╣я┬ п╪п╦п╫п╦п╟я┌я▌я─ п╫п╟ п╢п╦я│п╨п╣"
 
-#: remote.c:722
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
-msgstr "Неизвестный стиль \"%s\""
+msgstr "п²п╣п╦п╥п╡п╣я│я┌п╫я▀п╧ я│я┌п╦п╩я▄ \"%s\""
 
-#: remote.c:744
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
-msgstr "Неизвестный тип подробностей \"%s\""
+msgstr "п²п╣п╦п╥п╡п╣я│я┌п╫я▀п╧ я┌п╦п© п©п╬п╢я─п╬п╠п╫п╬я│я┌п╣п╧ \"%s\""
 
-#: remote.c:772
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
-msgstr "Неизвестный тип сортировки \"%s\""
+msgstr "п²п╣п╦п╥п╡п╣я│я┌п╫я▀п╧ я┌п╦п© я│п╬я─я┌п╦я─п╬п╡п╨п╦ \"%s\""
 
-#: remote.c:1247
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
-msgstr "Попытка вызвать неизвестный SOAP метод \"%s\""
+msgstr "п÷п╬п©я▀я┌п╨п╟ п╡я▀п╥п╡п╟я┌я▄ п╫п╣п╦п╥п╡п╣я│я┌п╫я▀п╧ SOAP п╪п╣я┌п╬п╢ \"%s\""
 
-#: run.c:99 run.c:152
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
-msgstr "Программа %s не найдена. Она была удалена?"
+msgstr "п÷я─п╬пЁя─п╟п╪п╪п╟ %s п╫п╣ п╫п╟п╧п╢п╣п╫п╟. п·п╫п╟ п╠я▀п╩п╟ я┐п╢п╟п╩п╣п╫п╟?"
 
-#: run.c:302
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "Файл не существует или нет доступа: %s"
-
-#: run.c:307
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "Не знаю, как открыть\"%s\""
-
-#: run.c:338
-#, c-format
-msgid "'%s' is not a valid URI"
-msgstr "\"%s\" не является корректным URI"
-
-#: run.c:349
-#, c-format
-msgid "%s not accessable"
-msgstr "\"%s\" недоступен"
-
-#: run.c:357
-#, c-format
-msgid "Non-local URL %s"
-msgstr "Не локальный URL %s"
-
-#: run.c:374
-#, c-format
-msgid "%s: no handler for %s"
-msgstr "%s: нет обработчика для %s"
-
-#: run.c:394
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"Приложение:\n"
-"Это каталог приложения - вы можете запустить его как программу или открыть "
-"для просмотра содержимого (щелкните по значку удерживая Shift). Большинство "
-"приложений предлагают свою подсказку, однако у этого приложения подсказки "
-"нет."
-
-#: run.c:478
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "Не получается отправить данные в программу: %s"
-
-#: run.c:508
-#, c-format
-msgid "Could not read link: %s"
-msgstr "Не могу прочитать ссылку: %s"
-
-#: run.c:536
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr "Битая ссылка (или же у вас нет прав следовать по ней): %s"
-
-#: run.c:573
+#: run.c:359
 #, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
 "action by choosing `Set Run Action' from the File menu, or you can just drag "
 "the file to an application.%s"
 msgstr ""
-"Не установлены ассоциации запуска для файлов этого типа (%s/%s) - вы можете "
-"установить ассоциации выбрав \"Установить ассоциации\" из меню \"Файл\" или "
-"вы можете перетащить этот файл на нужную программу. %s"
+"п²п╣ я┐я│я┌п╟п╫п╬п╡п╩п╣п╫я▀ п╟я│я│п╬я├п╦п╟я├п╦п╦ п╥п╟п©я┐я│п╨п╟ п╢п╩я▐ я└п╟п╧п╩п╬п╡ я█я┌п╬пЁп╬ я┌п╦п©п╟ (%s/%s) - п╡я▀ п╪п╬п╤п╣я┌п╣ "
+"я┐я│я┌п╟п╫п╬п╡п╦я┌я▄ п╟я│я│п╬я├п╦п╟я├п╦п╦ п╡я▀п╠я─п╟п╡ \"пёя│я┌п╟п╫п╬п╡п╦я┌я▄ п╟я│я│п╬я├п╦п╟я├п╦п╦\" п╦п╥ п╪п╣п╫я▌ \"п╓п╟п╧п╩\" п╦п╩п╦ "
+"п╡я▀ п╪п╬п╤п╣я┌п╣ п©п╣я─п╣я┌п╟я┴п╦я┌я▄ я█я┌п╬я┌ я└п╟п╧п╩ п╫п╟ п╫я┐п╤п╫я┐я▌ п©я─п╬пЁя─п╟п╪п╪я┐. %s"
 
-#: run.c:579
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -3034,10 +3305,68 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"NB: Если вы хотели запустить программу, то вам следует установить бит "
-"\"исполняемый\" в диалоге \"Права доступа\" меню \"Файл\"."
+"NB: п∙я│п╩п╦ п╡я▀ я┘п╬я┌п╣п╩п╦ п╥п╟п©я┐я│я┌п╦я┌я▄ п©я─п╬пЁя─п╟п╪п╪я┐, я┌п╬ п╡п╟п╪ я│п╩п╣п╢я┐п╣я┌ я┐я│я┌п╟п╫п╬п╡п╦я┌я▄ п╠п╦я┌ "
+"\"п╦я│п©п╬п╩п╫я▐п╣п╪я▀п╧\" п╡ п╢п╦п╟п╩п╬пЁп╣ \"п÷я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟\" п╪п╣п╫я▌ \"п╓п╟п╧п╩\"."
 
-#: run.c:746
+#: run.c:373
+#, c-format
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "п╓п╟п╧п╩ п╫п╣ я│я┐я┴п╣я│я┌п╡я┐п╣я┌ п╦п╩п╦ п╫п╣я┌ п╢п╬я│я┌я┐п©п╟: %s"
+
+#: run.c:378
+#, c-format
+msgid "I don't know how to open '%s'"
+msgstr "п²п╣ п╥п╫п╟я▌, п╨п╟п╨ п╬я┌п╨я─я▀я┌я▄\"%s\""
+
+#: run.c:409
+#, c-format
+msgid "'%s' is not a valid URI"
+msgstr "\"%s\" п╫п╣ я▐п╡п╩я▐п╣я┌я│я▐ п╨п╬я─я─п╣п╨я┌п╫я▀п╪ URI"
+
+#: run.c:420
+#, c-format
+msgid "%s not accessable"
+msgstr "\"%s\" п╫п╣п╢п╬я│я┌я┐п©п╣п╫"
+
+#: run.c:428
+#, c-format
+msgid "Non-local URL %s"
+msgstr "п²п╣ п╩п╬п╨п╟п╩я▄п╫я▀п╧ URL %s"
+
+#: run.c:445
+#, c-format
+msgid "%s: no handler for %s"
+msgstr "%s: п╫п╣я┌ п╬п╠я─п╟п╠п╬я┌я┤п╦п╨п╟ п╢п╩я▐ %s"
+
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
+msgstr ""
+"п÷я─п╦п╩п╬п╤п╣п╫п╦п╣:\n"
+"п╜я┌п╬ п╨п╟я┌п╟п╩п╬пЁ п©я─п╦п╩п╬п╤п╣п╫п╦я▐ - п╡я▀ п╪п╬п╤п╣я┌п╣ п╥п╟п©я┐я│я┌п╦я┌я▄ п╣пЁп╬ п╨п╟п╨ п©я─п╬пЁя─п╟п╪п╪я┐ п╦п╩п╦ п╬я┌п╨я─я▀я┌я▄ "
+"п╢п╩я▐ п©я─п╬я│п╪п╬я┌я─п╟ я│п╬п╢п╣я─п╤п╦п╪п╬пЁп╬ (я┴п╣п╩п╨п╫п╦я┌п╣ п©п╬ п╥п╫п╟я┤п╨я┐ я┐п╢п╣я─п╤п╦п╡п╟я▐ Shift). п▒п╬п╩я▄я┬п╦п╫я│я┌п╡п╬ "
+"п©я─п╦п╩п╬п╤п╣п╫п╦п╧ п©я─п╣п╢п╩п╟пЁп╟я▌я┌ я│п╡п╬я▌ п©п╬п╢я│п╨п╟п╥п╨я┐, п╬п╢п╫п╟п╨п╬ я┐ я█я┌п╬пЁп╬ п©я─п╦п╩п╬п╤п╣п╫п╦я▐ п©п╬п╢я│п╨п╟п╥п╨п╦ "
+"п╫п╣я┌."
+
+#: run.c:549
+#, c-format
+msgid "Could not send data to program: %s"
+msgstr "п²п╣ п©п╬п╩я┐я┤п╟п╣я┌я│я▐ п╬я┌п©я─п╟п╡п╦я┌я▄ п╢п╟п╫п╫я▀п╣ п╡ п©я─п╬пЁя─п╟п╪п╪я┐: %s"
+
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "п²п╣ п╪п╬пЁя┐ п©я─п╬я┤п╦я┌п╟я┌я▄ я│я│я▀п╩п╨я┐: %s"
+
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
+msgstr "п▒п╦я┌п╟я▐ я│я│я▀п╩п╨п╟ (п╦п╩п╦ п╤п╣ я┐ п╡п╟я│ п╫п╣я┌ п©я─п╟п╡ я│п╩п╣п╢п╬п╡п╟я┌я▄ п©п╬ п╫п╣п╧): %s"
+
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3051,495 +3380,597 @@ msgid ""
 "Otherwise, you should check, or even just delete, all the existing run "
 "actions."
 msgstr ""
-"Исполняемый файл \"%s\" открыт для записи всем! Я не буду его запускать. "
-"Пожалуйста, измените права доступа к этому файлу (возможно, такая ситуация "
-"сложилась из-за ошибки в более ранней версии программы).\n"
+"п≤я│п©п╬п╩п╫я▐п╣п╪я▀п╧ я└п╟п╧п╩ \"%s\" п╬я┌п╨я─я▀я┌ п╢п╩я▐ п╥п╟п©п╦я│п╦ п╡я│п╣п╪! п╞ п╫п╣ п╠я┐п╢я┐ п╣пЁп╬ п╥п╟п©я┐я│п╨п╟я┌я▄. "
+"п÷п╬п╤п╟п╩я┐п╧я│я┌п╟, п╦п╥п╪п╣п╫п╦я┌п╣ п©я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟ п╨ я█я┌п╬п╪я┐ я└п╟п╧п╩я┐ (п╡п╬п╥п╪п╬п╤п╫п╬, я┌п╟п╨п╟я▐ я│п╦я┌я┐п╟я├п╦я▐ "
+"я│п╩п╬п╤п╦п╩п╟я│я▄ п╦п╥-п╥п╟ п╬я┬п╦п╠п╨п╦ п╡ п╠п╬п╩п╣п╣ я─п╟п╫п╫п╣п╧ п╡п╣я─я│п╦п╦ п©я─п╬пЁя─п╟п╪п╪я▀).\n"
 "\n"
-"Если для установки действий вы используете файл, открытый на запись всем (не "
-"символические ссылки), то это значит, что любой, кто садится за ваш "
-"компьютер, может злонамеренно заменить ваши настройки своими. \n"
+"п∙я│п╩п╦ п╢п╩я▐ я┐я│я┌п╟п╫п╬п╡п╨п╦ п╢п╣п╧я│я┌п╡п╦п╧ п╡я▀ п╦я│п©п╬п╩я▄п╥я┐п╣я┌п╣ я└п╟п╧п╩, п╬я┌п╨я─я▀я┌я▀п╧ п╫п╟ п╥п╟п©п╦я│я▄ п╡я│п╣п╪ (п╫п╣ "
+"я│п╦п╪п╡п╬п╩п╦я┤п╣я│п╨п╦п╣ я│я│я▀п╩п╨п╦), я┌п╬ я█я┌п╬ п╥п╫п╟я┤п╦я┌, я┤я┌п╬ п╩я▌п╠п╬п╧, п╨я┌п╬ я│п╟п╢п╦я┌я│я▐ п╥п╟ п╡п╟я┬ "
+"п╨п╬п╪п©я▄я▌я┌п╣я─, п╪п╬п╤п╣я┌ п╥п╩п╬п╫п╟п╪п╣я─п╣п╫п╫п╬ п╥п╟п╪п╣п╫п╦я┌я▄ п╡п╟я┬п╦ п╫п╟я│я┌я─п╬п╧п╨п╦ я│п╡п╬п╦п╪п╦. \n"
 "\n"
-"Если вы доверяете всем пользователем вашего компьютера, беспокоиться не "
-"стоит. В ином случае следует проверить (или даже просто удалить) "
-"существующие настройки."
+"п∙я│п╩п╦ п╡я▀ п╢п╬п╡п╣я─я▐п╣я┌п╣ п╡я│п╣п╪ п©п╬п╩я▄п╥п╬п╡п╟я┌п╣п╩п╣п╪ п╡п╟я┬п╣пЁп╬ п╨п╬п╪п©я▄я▌я┌п╣я─п╟, п╠п╣я│п©п╬п╨п╬п╦я┌я▄я│я▐ п╫п╣ "
+"я│я┌п╬п╦я┌. п▓ п╦п╫п╬п╪ я│п╩я┐я┤п╟п╣ я│п╩п╣п╢я┐п╣я┌ п©я─п╬п╡п╣я─п╦я┌я▄ (п╦п╩п╦ п╢п╟п╤п╣ п©я─п╬я│я┌п╬ я┐п╢п╟п╩п╦я┌я▄) "
+"я│я┐я┴п╣я│я┌п╡я┐я▌я┴п╦п╣ п╫п╟я│я┌я─п╬п╧п╨п╦."
 
-#: run.c:759
+#: run.c:798
 msgid "go-w (Fix security problem)"
-msgstr "go-w (Исправление проблем с безопасностью)"
+msgstr "go-w (п≤я│п©я─п╟п╡п╩п╣п╫п╦п╣ п©я─п╬п╠п╩п╣п╪ я│ п╠п╣п╥п╬п©п╟я│п╫п╬я│я┌я▄я▌)"
 
-#: support.c:272
-msgid "B"
-msgstr "Б"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:351
+#: support.c:381
 msgid "byte"
-msgstr "байт"
+msgstr "п╠п╟п╧я┌"
 
-#: support.c:1589 support.c:1643
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
-msgstr "Невозможно открыть файл \"%s\": %s"
+msgstr "п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ п╬я┌п╨я─я▀я┌я▄ я└п╟п╧п╩ \"%s\": %s"
 
-#: support.c:1600 support.c:1654
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
-msgstr "Невозможно выполнить mmap для \"%s\": %s"
+msgstr "п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ п╡я▀п©п╬п╩п╫п╦я┌я▄ mmap п╢п╩я▐ \"%s\": %s"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close"
-msgstr "Закрыть"
+msgstr "п≈п╟п╨я─я▀я┌я▄"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close filer window"
-msgstr "Закрыть окно"
+msgstr "п≈п╟п╨я─я▀я┌я▄ п╬п╨п╫п╬"
 
-#: toolbar.c:117
+#: toolbar.c:120
 msgid "Up"
-msgstr "Вверх"
+msgstr "п▓п╡п╣я─я┘"
 
-#: toolbar.c:117
-msgid "Change to parent directory"
-msgstr "Уйти в родительский каталог"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:121
+#: toolbar.c:126
 msgid "Home"
-msgstr "Домашний каталог"
+msgstr "п■п╬п╪п╟я┬п╫п╦п╧ п╨п╟я┌п╟п╩п╬пЁ"
 
-#: toolbar.c:121
-msgid "Change to home directory"
-msgstr "Перейти в домашний каталог"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks"
-msgstr "Закладки"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks menu"
-msgstr "Меню закладок"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:129
+#: toolbar.c:138
 msgid "Scan"
-msgstr "Сканировать"
+msgstr "п║п╨п╟п╫п╦я─п╬п╡п╟я┌я▄"
 
-#: toolbar.c:129
-msgid "Rescan directory contents"
-msgstr "Перечитать содержимое каталога"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:133
-msgid "Change icon size"
-msgstr "Изменить размер значков"
+#: toolbar.c:143
+#, fuzzy
+msgid "SizeБ■╪"
+msgstr "п═п╟п╥п╪п╣я─"
 
-#: toolbar.c:137
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  Б■≤ : Huge\n"
+"  Б■╓ : Large\n"
+"  Б■░ : Small\n"
+"  Б■▄, Б■° : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "п░п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╦"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
-msgstr "Автоматически"
+msgstr "п░п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╦"
 
-#: toolbar.c:141
-msgid "Show extra details"
-msgstr "Показать дополнительные подробности"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "п║п©п╦я│п╬п╨"
 
-#: toolbar.c:145
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
-msgstr "Сортировка"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟"
 
-#: toolbar.c:145
+#: toolbar.c:165
 msgid "Change sort criteria"
-msgstr "Изменить критерий сортировки"
+msgstr "п≤п╥п╪п╣п╫п╦я┌я▄ п╨я─п╦я┌п╣я─п╦п╧ я│п╬я─я┌п╦я─п╬п╡п╨п╦"
 
-#: toolbar.c:149
-msgid "Hidden"
-msgstr "Скрытые"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:149
+#: toolbar.c:169
 msgid ""
 "Left: Show/hide hidden files\n"
 "Right: Show/hide thumbnails"
 msgstr ""
-"Левая кнопка: показать/спрятать скрытые файлы\n"
-"Правая кнопка: показать/спрятать миниатюры"
+"п⌡п╣п╡п╟я▐ п╨п╫п╬п©п╨п╟: п©п╬п╨п╟п╥п╟я┌я▄/я│п©я─я▐я┌п╟я┌я▄ я│п╨я─я▀я┌я▀п╣ я└п╟п╧п╩я▀\n"
+"п÷я─п╟п╡п╟я▐ п╨п╫п╬п©п╨п╟: п©п╬п╨п╟п╥п╟я┌я▄/я│п©я─я▐я┌п╟я┌я▄ п╪п╦п╫п╦п╟я┌я▌я─я▀"
 
-#: toolbar.c:154
-msgid "Select all/invert selection"
-msgstr "Выбрать все/инвертировать выбор"
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
 
-#: toolbar.c:158
+#: toolbar.c:174
+#, fuzzy
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+"п⌡п╣п╡п╟я▐ п╨п╫п╬п©п╨п╟: п©п╬п╨п╟п╥п╟я┌я▄/я│п©я─я▐я┌п╟я┌я▄ я│п╨я─я▀я┌я▀п╣ я└п╟п╧п╩я▀\n"
+"п÷я─п╟п╡п╟я▐ п╨п╫п╬п©п╨п╟: п©п╬п╨п╟п╥п╟я┌я▄/я│п©я─я▐я┌п╟я┌я▄ п╪п╦п╫п╦п╟я┌я▌я─я▀"
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "п▓я▀п╠я─п╟я┌я▄ п╡я│п╣/п╦п╫п╡п╣я─я┌п╦я─п╬п╡п╟я┌я▄ п╡я▀п╠п╬я─"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "Б≈▀"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  Б√╫: No settings\n"
+"  Б√╪: Own settings\n"
+"  Б√╤: Parent settings\n"
+"  Б√╥: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
-msgstr "Показать помощь ROX-Filer'a"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ п©п╬п╪п╬я┴я▄ ROX-Filer'a"
 
-#: toolbar.c:221
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
-msgstr " (%u скрыто)"
+msgstr " (%u я│п╨я─я▀я┌п╬)"
 
-#: toolbar.c:229 tips:58
+#: toolbar.c:276 tips:79
 msgid "items"
-msgstr "объектов"
+msgstr "п╬п╠я┼п╣п╨я┌п╬п╡"
 
-#: toolbar.c:229
+#: toolbar.c:276
 msgid "item"
-msgstr "объект"
+msgstr "п╬п╠я┼п╣п╨я┌"
 
-#: toolbar.c:232
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
-msgstr "Нет объектов %s"
+msgstr "п²п╣я┌ п╬п╠я┼п╣п╨я┌п╬п╡ %s"
 
-#: toolbar.c:251
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
-msgstr "%u выбрано (%s)"
+msgstr "%u п╡я▀п╠я─п╟п╫п╬ (%s)"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by name"
-msgstr "Сортировка по имени"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ п╦п╪п╣п╫п╦"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by type"
-msgstr "Сортировка по типу"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ я┌п╦п©я┐"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by date"
-msgstr "Сортировка по дате"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ п╢п╟я┌п╣"
 
-#: toolbar.c:446
+#: toolbar.c:535
 msgid "Sort by size"
-msgstr "Сортировка по размеру"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ я─п╟п╥п╪п╣я─я┐"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by owner"
-msgstr "Сортировка по владельцу"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ п╡п╩п╟п╢п╣п╩я▄я├я┐"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by group"
-msgstr "Сортировка по группе"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟ п©п╬ пЁя─я┐п©п©п╣"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "ascending"
-msgstr "по нарастанию"
+msgstr "п©п╬ п╫п╟я─п╟я│я┌п╟п╫п╦я▌"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "descending"
-msgstr "по убыванию"
+msgstr "п©п╬ я┐п╠я▀п╡п╟п╫п╦я▌"
 
-#: type.c:214
+#: toolbar.c:891
+#, fuzzy
+msgid "_N_Items_"
+msgstr "п·п╠я┼п╣п╨я┌"
+
+#: type.c:221
 msgid "Sym link"
-msgstr "Символическая ссылка"
+msgstr "п║п╦п╪п╡п╬п╩п╦я┤п╣я│п╨п╟я▐ я│я│я▀п╩п╨п╟"
 
-#: type.c:216
+#: type.c:223
 msgid "Mount point"
-msgstr "Точка монтирования"
-
-#: type.c:218
-msgid "App dir"
-msgstr "Каталог программы"
+msgstr "п╒п╬я┤п╨п╟ п╪п╬п╫я┌п╦я─п╬п╡п╟п╫п╦я▐"
 
 #: type.c:225
+msgid "App dir"
+msgstr "п п╟я┌п╟п╩п╬пЁ п©я─п╬пЁя─п╟п╪п╪я▀"
+
+#: type.c:232
 msgid "Dir"
-msgstr "Каталог"
+msgstr "п п╟я┌п╟п╩п╬пЁ"
 
-#: type.c:227
+#: type.c:234
 msgid "Char dev"
-msgstr "Символьное устройство"
+msgstr "п║п╦п╪п╡п╬п╩я▄п╫п╬п╣ я┐я│я┌я─п╬п╧я│я┌п╡п╬"
 
-#: type.c:229
+#: type.c:236
 msgid "Block dev"
-msgstr "Блочное устройство"
-
-#: type.c:231
-msgid "Pipe"
-msgstr "Поток"
-
-#: type.c:233
-msgid "Socket"
-msgstr "Сокет"
-
-#: type.c:235
-msgid "Door"
-msgstr "Дверь"
+msgstr "п▒п╩п╬я┤п╫п╬п╣ я┐я│я┌я─п╬п╧я│я┌п╡п╬"
 
 #: type.c:238
-msgid "Unknown"
-msgstr "Неизвестно"
+msgid "Pipe"
+msgstr "п÷п╬я┌п╬п╨"
 
-#: type.c:556
+#: type.c:240
+msgid "Socket"
+msgstr "п║п╬п╨п╣я┌"
+
+#: type.c:242
+msgid "Door"
+msgstr "п■п╡п╣я─я▄"
+
+#: type.c:245
+msgid "Unknown"
+msgstr "п²п╣п╦п╥п╡п╣я│я┌п╫п╬"
+
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
 "gimp \"$@\""
 msgstr ""
-"Введите команду оболочки, которая загрузит \"$@\" в подходящую программу. "
-"Пример:\n"
+"п▓п╡п╣п╢п╦я┌п╣ п╨п╬п╪п╟п╫п╢я┐ п╬п╠п╬п╩п╬я┤п╨п╦, п╨п╬я┌п╬я─п╟я▐ п╥п╟пЁя─я┐п╥п╦я┌ \"$@\" п╡ п©п╬п╢я┘п╬п╢я▐я┴я┐я▌ п©я─п╬пЁя─п╟п╪п╪я┐. "
+"п÷я─п╦п╪п╣я─:\n"
 "\n"
 "gimp \"$@\""
 
-#: type.c:737
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
-msgstr "Это была не программа! Вам следует задать программу!"
+msgstr "п╜я┌п╬ п╠я▀п╩п╟ п╫п╣ п©я─п╬пЁя─п╟п╪п╪п╟! п▓п╟п╪ я│п╩п╣п╢я┐п╣я┌ п╥п╟п╢п╟я┌я▄ п©я─п╬пЁя─п╟п╪п╪я┐!"
 
-#: type.c:797
+#: type.c:839
 msgid "No run action defined"
-msgstr "Не установлена ассоциация"
+msgstr "п²п╣ я┐я│я┌п╟п╫п╬п╡п╩п╣п╫п╟ п╟я│я│п╬я├п╦п╟я├п╦я▐"
 
-#: type.c:801
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
-msgstr "Ошибка в обработчике %s: %s"
+msgstr "п·я┬п╦п╠п╨п╟ п╡ п╬п╠я─п╟п╠п╬я┌я┤п╦п╨п╣ %s: %s"
 
-#: type.c:816
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
-msgstr "Неправильное приложение %s (некорректный AppRun)"
+msgstr "п²п╣п©я─п╟п╡п╦п╩я▄п╫п╬п╣ п©я─п╦п╩п╬п╤п╣п╫п╦п╣ %s (п╫п╣п╨п╬я─я─п╣п╨я┌п╫я▀п╧ AppRun)"
 
-#: type.c:827
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
-msgstr "Неисполняемый файл %s"
-
-#: type.c:860
-msgid "Set run action"
-msgstr "Установить ассоциацию"
-
-#: type.c:866
-msgid "If a handler for the specific type isn't set up, use this as the default."
-msgstr ""
-"Если обработчик какого-то типа не определён, использовать по умолчанию "
-"данный."
-
-#: type.c:868
-#, c-format
-msgid "Set default for all `%s/<anything>'"
-msgstr "Установить ассоциацию для всех \"%s/<что угодно>\""
-
-#: type.c:872
-msgid "Use this application for all files with this MIME type."
-msgstr "Использовать это приложение для всех файлов данного типа MIME."
-
-#: type.c:874
-#, c-format
-msgid "Only for the type `%s' (%s/%s)"
-msgstr "Только для типа \"%s\"(%s/%s)"
-
-#: type.c:880
-msgid "Drop a suitable application here"
-msgstr "Бросьте подходящую программу сюда"
-
-#: type.c:895
-msgid "OR"
-msgstr "или"
+msgstr "п²п╣п╦я│п©п╬п╩п╫я▐п╣п╪я▀п╧ я└п╟п╧п╩ %s"
 
 #: type.c:902
+msgid "Set run action"
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ п╟я│я│п╬я├п╦п╟я├п╦я▌"
+
+#: type.c:908
+msgid ""
+"If a handler for the specific type isn't set up, use this as the default."
+msgstr ""
+"п∙я│п╩п╦ п╬п╠я─п╟п╠п╬я┌я┤п╦п╨ п╨п╟п╨п╬пЁп╬-я┌п╬ я┌п╦п©п╟ п╫п╣ п╬п©я─п╣п╢п╣п╩я▒п╫, п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌ "
+"п╢п╟п╫п╫я▀п╧."
+
+#: type.c:910
+#, c-format
+msgid "Set default for all `%s/<anything>'"
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ п╟я│я│п╬я├п╦п╟я├п╦я▌ п╢п╩я▐ п╡я│п╣я┘ \"%s/<я┤я┌п╬ я┐пЁп╬п╢п╫п╬>\""
+
+#: type.c:914
+msgid "Use this application for all files with this MIME type."
+msgstr "п≤я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ я█я┌п╬ п©я─п╦п╩п╬п╤п╣п╫п╦п╣ п╢п╩я▐ п╡я│п╣я┘ я└п╟п╧п╩п╬п╡ п╢п╟п╫п╫п╬пЁп╬ я┌п╦п©п╟ MIME."
+
+#: type.c:916
+#, c-format
+msgid "Only for the type `%s' (%s/%s)"
+msgstr "п╒п╬п╩я▄п╨п╬ п╢п╩я▐ я┌п╦п©п╟ \"%s\"(%s/%s)"
+
+#: type.c:922
+msgid "Drop a suitable application here"
+msgstr "п▒я─п╬я│я▄я┌п╣ п©п╬п╢я┘п╬п╢я▐я┴я┐я▌ п©я─п╬пЁя─п╟п╪п╪я┐ я│я▌п╢п╟"
+
+#: type.c:963
+msgid "OR"
+msgstr "п╦п╩п╦"
+
+#: type.c:971
 msgid "Enter a shell command:"
-msgstr "Введите команду оболочки:"
+msgstr "п▓п╡п╣п╢п╦я┌п╣ п╨п╬п╪п╟п╫п╢я┐ п╬п╠п╬п╩п╬я┤п╨п╦:"
 
-#: type.c:931
+#: type.c:1000
 msgid "_Use Command"
-msgstr "Использовать команду"
+msgstr "п≤я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п╨п╬п╪п╟п╫п╢я┐"
 
-#: type.c:961
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
 msgstr ""
-"Ассоциированное приложение уже существует и имеет значительный размер - вы "
-"уверены что хотите удалить его?"
+"п░я│я│п╬я├п╦п╦я─п╬п╡п╟п╫п╫п╬п╣ п©я─п╦п╩п╬п╤п╣п╫п╦п╣ я┐п╤п╣ я│я┐я┴п╣я│я┌п╡я┐п╣я┌ п╦ п╦п╪п╣п╣я┌ п╥п╫п╟я┤п╦я┌п╣п╩я▄п╫я▀п╧ я─п╟п╥п╪п╣я─ - п╡я▀ "
+"я┐п╡п╣я─п╣п╫я▀ я┤я┌п╬ я┘п╬я┌п╦я┌п╣ я┐п╢п╟п╩п╦я┌я▄ п╣пЁп╬?"
 
-#: type.c:972
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
-msgstr "Не могу удалить %s: %s"
+msgstr "п²п╣ п╪п╬пЁя┐ я┐п╢п╟п╩п╦я┌я▄ %s: %s"
 
-#: type.c:1009
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
-msgstr "Сохранение настроек запрещено переменной окружения CHOICESPATH"
+msgstr "п║п╬я┘я─п╟п╫п╣п╫п╦п╣ п╫п╟я│я┌я─п╬п╣п╨ п╥п╟п©я─п╣я┴п╣п╫п╬ п©п╣я─п╣п╪п╣п╫п╫п╬п╧ п╬п╨я─я┐п╤п╣п╫п╦я▐ CHOICESPATH"
 
-#: type.c:1311
+#: type.c:1395
 #, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
 "%s"
 msgstr ""
-"Невозможно создать символическую ссылку \"%s\":\n"
+"п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ я│п╬п╥п╢п╟я┌я▄ я│п╦п╪п╡п╬п╩п╦я┤п╣я│п╨я┐я▌ я│я│я▀п╩п╨я┐ \"%s\":\n"
 "%s"
 
-#: usericons.c:179
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
-msgstr "Введенный путь не существует. Значок не изменён."
+msgstr "п▓п╡п╣п╢п╣п╫п╫я▀п╧ п©я┐я┌я▄ п╫п╣ я│я┐я┴п╣я│я┌п╡я┐п╣я┌. п≈п╫п╟я┤п╬п╨ п╫п╣ п╦п╥п╪п╣п╫я▒п╫."
 
-#: usericons.c:189 usericons.c:618
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
 "The icon has not been changed."
 msgstr ""
-"Невозможно загрузить файл с изображением -- возможно, задан неизвестный "
-"формат или нет права на чтение файла.\n"
-"Значок не была изменён."
+"п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ п╥п╟пЁя─я┐п╥п╦я┌я▄ я└п╟п╧п╩ я│ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣п╪ -- п╡п╬п╥п╪п╬п╤п╫п╬, п╥п╟п╢п╟п╫ п╫п╣п╦п╥п╡п╣я│я┌п╫я▀п╧ "
+"я└п╬я─п╪п╟я┌ п╦п╩п╦ п╫п╣я┌ п©я─п╟п╡п╟ п╫п╟ я┤я┌п╣п╫п╦п╣ я└п╟п╧п╩п╟.\n"
+"п≈п╫п╟я┤п╬п╨ п╫п╣ п╠я▀п╩п╟ п╦п╥п╪п╣п╫я▒п╫."
 
-#: usericons.c:235
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
-msgstr "В самом деле удалить значок \"%s\"?"
+msgstr "п▓ я│п╟п╪п╬п╪ п╢п╣п╩п╣ я┐п╢п╟п╩п╦я┌я▄ п╥п╫п╟я┤п╬п╨ \"%s\"?"
 
-#: usericons.c:239
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
 "%s"
 msgstr ""
-"Невозможно удалить \"%s\":\n"
+"п²п╣п╡п╬п╥п╪п╬п╤п╫п╬ я┐п╢п╟п╩п╦я┌я▄ \"%s\":\n"
 "%s"
 
-#: usericons.c:272
-msgid "Set icon"
-msgstr "Установить значок"
-
 #: usericons.c:281
-msgid "Use a copy of the image as the default for all files of these MIME types."
-msgstr "Использовать копию изображения по умолчанию для всех файлов данных MIME типов"
-
-#: usericons.c:283
-#, c-format
-msgid "Set icon for all `%s/<anything>'"
-msgstr "Установить значок для всех \"%s/<что угодно>\""
-
-#: usericons.c:288
-msgid "Use a copy of the image for all files of this MIME type."
-msgstr "Использовать копию изображения для всех файлов данного MIME типа"
+msgid "Set icon"
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ п╥п╫п╟я┤п╬п╨"
 
 #: usericons.c:290
+msgid ""
+"Use a copy of the image as the default for all files of these MIME types."
+msgstr ""
+"п≤я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п╨п╬п©п╦я▌ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦я▐ п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌ п╢п╩я▐ п╡я│п╣я┘ я└п╟п╧п╩п╬п╡ п╢п╟п╫п╫я▀я┘ MIME я┌п╦п©п╬п╡"
+
+#: usericons.c:292
+#, c-format
+msgid "Set icon for all `%s/<anything>'"
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ п╥п╫п╟я┤п╬п╨ п╢п╩я▐ п╡я│п╣я┘ \"%s/<я┤я┌п╬ я┐пЁп╬п╢п╫п╬>\""
+
+#: usericons.c:297
+msgid "Use a copy of the image for all files of this MIME type."
+msgstr "п≤я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п╨п╬п©п╦я▌ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦я▐ п╢п╩я▐ п╡я│п╣я┘ я└п╟п╧п╩п╬п╡ п╢п╟п╫п╫п╬пЁп╬ MIME я┌п╦п©п╟"
+
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
-msgstr "Только для типа \"%s\"(%s/%s)"
+msgstr "п╒п╬п╩я▄п╨п╬ п╢п╩я▐ я┌п╦п©п╟ \"%s\"(%s/%s)"
 
-#: usericons.c:296
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
 msgstr ""
-"Добавьте имена файлов и изображений в ваш личный список. Эта настройка будет "
-"потеряна, если файл или изображение будут перемещены."
+"п■п╬п╠п╟п╡я▄я┌п╣ п╦п╪п╣п╫п╟ я└п╟п╧п╩п╬п╡ п╦ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╧ п╡ п╡п╟я┬ п╩п╦я┤п╫я▀п╧ я│п©п╦я│п╬п╨. п╜я┌п╟ п╫п╟я│я┌я─п╬п╧п╨п╟ п╠я┐п╢п╣я┌ "
+"п©п╬я┌п╣я─я▐п╫п╟, п╣я│п╩п╦ я└п╟п╧п╩ п╦п╩п╦ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣ п╠я┐п╢я┐я┌ п©п╣я─п╣п╪п╣я┴п╣п╫я▀."
 
-#: usericons.c:299
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
-msgstr "Только для файла \"%s\""
+msgstr "п╒п╬п╩я▄п╨п╬ п╢п╩я▐ я└п╟п╧п╩п╟ \"%s\""
 
-#: usericons.c:307
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
 "This is usually the best option if you can write to the directory."
 msgstr ""
-"Скопируйте изображение в каталог как скрытый файл \".DirIcon\". Все "
-"пользователи будут видеть этот значок, и вы можете безопасно перемещать "
-"каталог. Возможно, это лучшее решение, если вы имеете права на запись в "
-"данный каталог."
+"п║п╨п╬п©п╦я─я┐п╧я┌п╣ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣ п╡ п╨п╟я┌п╟п╩п╬пЁ п╨п╟п╨ я│п╨я─я▀я┌я▀п╧ я└п╟п╧п╩ \".DirIcon\". п▓я│п╣ "
+"п©п╬п╩я▄п╥п╬п╡п╟я┌п╣п╩п╦ п╠я┐п╢я┐я┌ п╡п╦п╢п╣я┌я▄ я█я┌п╬я┌ п╥п╫п╟я┤п╬п╨, п╦ п╡я▀ п╪п╬п╤п╣я┌п╣ п╠п╣п╥п╬п©п╟я│п╫п╬ п©п╣я─п╣п╪п╣я┴п╟я┌я▄ "
+"п╨п╟я┌п╟п╩п╬пЁ. п▓п╬п╥п╪п╬п╤п╫п╬, я█я┌п╬ п╩я┐я┤я┬п╣п╣ я─п╣я┬п╣п╫п╦п╣, п╣я│п╩п╦ п╡я▀ п╦п╪п╣п╣я┌п╣ п©я─п╟п╡п╟ п╫п╟ п╥п╟п©п╦я│я▄ п╡ "
+"п╢п╟п╫п╫я▀п╧ п╨п╟я┌п╟п╩п╬пЁ."
 
-#: usericons.c:313
+#: usericons.c:322
 msgid "Copy image into directory"
-msgstr "Скопировать изображение в каталог"
+msgstr "п║п╨п╬п©п╦я─п╬п╡п╟я┌я▄ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣ п╡ п╨п╟я┌п╟п╩п╬пЁ"
 
-#: usericons.c:319
+#: usericons.c:328
 msgid "Drop an icon file here"
-msgstr "Бросьте значок сюда"
+msgstr "п▒я─п╬я│я▄я┌п╣ п╥п╫п╟я┤п╬п╨ я│я▌п╢п╟"
 
-#: usericons.c:589
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
-msgstr "Установка значка запрещена переменной окружения CHOICESPATH"
+msgstr "пёя│я┌п╟п╫п╬п╡п╨п╟ п╥п╫п╟я┤п╨п╟ п╥п╟п©я─п╣я┴п╣п╫п╟ п©п╣я─п╣п╪п╣п╫п╫п╬п╧ п╬п╨я─я┐п╤п╣п╫п╦я▐ CHOICESPATH"
 
-#: usericons.c:633
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
 "%s"
 msgstr ""
-"Ошибка при создании изображения \"%s\":\n"
+"п·я┬п╦п╠п╨п╟ п©я─п╦ я│п╬п╥п╢п╟п╫п╦п╦ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦я▐ \"%s\":\n"
 "%s"
 
-#: view_details.c:957
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
 msgid "Mono font"
-msgstr "Моноширинный шрифт"
+msgstr "п°п╬п╫п╬я┬п╦я─п╦п╫п╫я▀п╧ я┬я─п╦я└я┌"
 
-#: view_details.c:958
+#: view_details.c:1019
 msgid "Font for displaying mono-spaced text"
-msgstr "Шрифт для отображения моноширинного текста"
+msgstr "п╗я─п╦я└я┌ п╢п╩я▐ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐ п╪п╬п╫п╬я┬п╦я─п╦п╫п╫п╬пЁп╬ я┌п╣п╨я│я┌п╟"
 
-#: view_details.c:1059
+#: view_details.c:1233
 msgid "_Name"
-msgstr "_Имя"
+msgstr "_п≤п╪я▐"
 
-#: view_details.c:1062
+#: view_details.c:1236
 msgid "_Type"
-msgstr "_Тип"
+msgstr "_п╒п╦п©"
 
-#: view_details.c:1065
-msgid "_Permissions"
-msgstr "_Права доступа"
-
-#: view_details.c:1070
-msgid "_Owner"
-msgstr "_Владелец"
-
-#: view_details.c:1072
-msgid "_Group"
-msgstr "_Группа"
-
-#: view_details.c:1074
+#: view_details.c:1238
 msgid "_Size"
-msgstr "_Размер"
+msgstr "_п═п╟п╥п╪п╣я─"
 
-#: view_details.c:1080
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_п÷я─п╟п╡п╟ п╢п╬я│я┌я┐п©п╟"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_п▓п╩п╟п╢п╣п╩п╣я├"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_п⌠я─я┐п©п©п╟"
+
+#: view_details.c:1254
 msgid "Last _Modified"
-msgstr "_Был изменен"
+msgstr "_п▒я▀п╩ п╦п╥п╪п╣п╫п╣п╫"
+
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "п═п╟я│я┬п╦я─п╣п╫п╫я▀п╣ п╟я┌я─п╦п╠я┐я┌я▀"
 
 #: tips:1
 msgid "Filer windows"
-msgstr "Параметры окон файл-менеджера"
+msgstr "п÷п╟я─п╟п╪п╣я┌я─я▀ п╬п╨п╬п╫ я└п╟п╧п╩-п╪п╣п╫п╣п╢п╤п╣я─п╟"
 
 #: tips:2
 msgid "Auto-resize filer windows"
-msgstr "Автоматическое изменение размера окна"
+msgstr "п░п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╬п╣ п╦п╥п╪п╣п╫п╣п╫п╦п╣ я─п╟п╥п╪п╣я─п╟ п╬п╨п╫п╟"
 
 #: tips:3
 msgid "Never automatically resize"
-msgstr "Никогда не изменять размер окна"
+msgstr "п²п╦п╨п╬пЁп╢п╟ п╫п╣ п╦п╥п╪п╣п╫я▐я┌я▄ я─п╟п╥п╪п╣я─ п╬п╨п╫п╟"
 
 #: tips:4
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
 msgstr ""
-"Размер окна меняется вручную - с помощью оконного менеджера, меню \"Размер "
-"окна\" или двойным щелчком на фоне окна."
+"п═п╟п╥п╪п╣я─ п╬п╨п╫п╟ п╪п╣п╫я▐п╣я┌я│я▐ п╡я─я┐я┤п╫я┐я▌ - я│ п©п╬п╪п╬я┴я▄я▌ п╬п╨п╬п╫п╫п╬пЁп╬ п╪п╣п╫п╣п╢п╤п╣я─п╟, п╪п╣п╫я▌ \"п═п╟п╥п╪п╣я─ "
+"п╬п╨п╫п╟\" п╦п╩п╦ п╢п╡п╬п╧п╫я▀п╪ я┴п╣п╩я┤п╨п╬п╪ п╫п╟ я└п╬п╫п╣ п╬п╨п╫п╟."
 
 #: tips:5
 msgid "Resize when changing the display style"
-msgstr "Подбирать размер, когда меняется стиль отображения"
+msgstr "п÷п╬п╢п╠п╦я─п╟я┌я▄ я─п╟п╥п╪п╣я─, п╨п╬пЁп╢п╟ п╪п╣п╫я▐п╣я┌я│я▐ я│я┌п╦п╩я▄ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐"
 
 #: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
 msgstr ""
-"При смене размера значков или количестве отображаемых подробностей  размер "
-"окна меняется автоматически."
+"п÷я─п╦ я│п╪п╣п╫п╣ я─п╟п╥п╪п╣я─п╟ п╥п╫п╟я┤п╨п╬п╡ п╦п╩п╦ п╨п╬п╩п╦я┤п╣я│я┌п╡п╣ п╬я┌п╬п╠я─п╟п╤п╟п╣п╪я▀я┘ п©п╬п╢я─п╬п╠п╫п╬я│я┌п╣п╧  я─п╟п╥п╪п╣я─ "
+"п╬п╨п╫п╟ п╪п╣п╫я▐п╣я┌я│я▐ п╟п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╦."
 
 #: tips:7
 msgid "Always resize"
-msgstr "Всегда подбирать размер"
+msgstr "п▓я│п╣пЁп╢п╟ п©п╬п╢п╠п╦я─п╟я┌я▄ я─п╟п╥п╪п╣я─"
 
 #: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
 msgstr ""
-"Размер окна меняется всегда, когда это кажется полезным (при смене каталога "
-"или стиля отображения)."
+"п═п╟п╥п╪п╣я─ п╬п╨п╫п╟ п╪п╣п╫я▐п╣я┌я│я▐ п╡я│п╣пЁп╢п╟, п╨п╬пЁп╢п╟ я█я┌п╬ п╨п╟п╤п╣я┌я│я▐ п©п╬п╩п╣п╥п╫я▀п╪ (п©я─п╦ я│п╪п╣п╫п╣ п╨п╟я┌п╟п╩п╬пЁп╟ "
+"п╦п╩п╦ я│я┌п╦п╩я▐ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐)."
 
 #: tips:9
 msgid "Largest window size:"
-msgstr "Наибольший размер окна:"
+msgstr "п²п╟п╦п╠п╬п╩я▄я┬п╦п╧ я─п╟п╥п╪п╣я─ п╬п╨п╫п╟:"
 
-#: tips:10
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
@@ -3548,1055 +3979,1424 @@ msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
 msgstr ""
-"Самый большой размер, в процентах от размера экрана, на который окно может "
-"изменить размер автоматически."
+"п║п╟п╪я▀п╧ п╠п╬п╩я▄я┬п╬п╧ я─п╟п╥п╪п╣я─, п╡ п©я─п╬я├п╣п╫я┌п╟я┘ п╬я┌ я─п╟п╥п╪п╣я─п╟ я█п╨я─п╟п╫п╟, п╫п╟ п╨п╬я┌п╬я─я▀п╧ п╬п╨п╫п╬ п╪п╬п╤п╣я┌ "
+"п╦п╥п╪п╣п╫п╦я┌я▄ я─п╟п╥п╪п╣я─ п╟п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╦."
 
 #: tips:12
-msgid "Window behaviour"
-msgstr "Поведение окна"
-
-#: tips:13
-msgid "Short titlebar flags"
-msgstr "Короткие флаги в заголовке"
+#, fuzzy
+msgid "Largest window width:"
+msgstr "п²п╟п╦п╠п╬п╩я▄я┬п╦п╧ я─п╟п╥п╪п╣я─ п╬п╨п╫п╟:"
 
 #: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"п║п╟п╪я▀п╧ п╠п╬п╩я▄я┬п╬п╧ я─п╟п╥п╪п╣я─, п╡ п©я─п╬я├п╣п╫я┌п╟я┘ п╬я┌ я─п╟п╥п╪п╣я─п╟ я█п╨я─п╟п╫п╟, п╫п╟ п╨п╬я┌п╬я─я▀п╧ п╬п╨п╫п╬ п╪п╬п╤п╣я┌ "
+"п╦п╥п╪п╣п╫п╦я┌я▄ я─п╟п╥п╪п╣я─ п╟п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╦."
+
+#: tips:15
+msgid "Window behaviour"
+msgstr "п÷п╬п╡п╣п╢п╣п╫п╦п╣ п╬п╨п╫п╟"
+
+#: tips:16
+msgid "Short titlebar flags"
+msgstr "п п╬я─п╬я┌п╨п╦п╣ я└п╩п╟пЁп╦ п╡ п╥п╟пЁп╬п╩п╬п╡п╨п╣"
+
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
 msgstr ""
-"Использовать начальные буквы, а не слова, для индикаторов Сканирования, Всех "
-"и Миниатюр в заголовке окна."
+"п≤я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п╫п╟я┤п╟п╩я▄п╫я▀п╣ п╠я┐п╨п╡я▀, п╟ п╫п╣ я│п╩п╬п╡п╟, п╢п╩я▐ п╦п╫п╢п╦п╨п╟я┌п╬я─п╬п╡ п║п╨п╟п╫п╦я─п╬п╡п╟п╫п╦я▐, п▓я│п╣я┘ "
+"п╦ п°п╦п╫п╦п╟я┌я▌я─ п╡ п╥п╟пЁп╬п╩п╬п╡п╨п╣ п╬п╨п╫п╟."
 
-#: tips:15
+#: tips:18
 msgid "Unique windows"
-msgstr "Уникальные окна"
+msgstr "пёп╫п╦п╨п╟п╩я▄п╫я▀п╣ п╬п╨п╫п╟"
 
-#: tips:16
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
 msgstr ""
-"Если вы откроете каталог и этот же каталог уже отображается в другом окне, "
-"то второе окно будет закрыто."
+"п∙я│п╩п╦ п╡я▀ п╬я┌п╨я─п╬п╣я┌п╣ п╨п╟я┌п╟п╩п╬пЁ п╦ я█я┌п╬я┌ п╤п╣ п╨п╟я┌п╟п╩п╬пЁ я┐п╤п╣ п╬я┌п╬п╠я─п╟п╤п╟п╣я┌я│я▐ п╡ п╢я─я┐пЁп╬п╪ п╬п╨п╫п╣, "
+"я┌п╬ п╡я┌п╬я─п╬п╣ п╬п╨п╫п╬ п╠я┐п╢п╣я┌ п╥п╟п╨я─я▀я┌п╬."
 
-#: tips:17
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "п·п╨п╫п╬"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
-msgstr "Новое окно по нажатию кнопки 1"
+msgstr "п²п╬п╡п╬п╣ п╬п╨п╫п╬ п©п╬ п╫п╟п╤п╟я┌п╦я▌ п╨п╫п╬п©п╨п╦ 1"
 
-#: tips:18
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
 "reuse the current window."
 msgstr ""
-"При нажатии первой кнопки мыши (обычно левая кнопка) открывается каталог в "
-"новом окне. При нажатии кнопки 2 (средней) для открытия каталога будет "
-"использовано текущее окно."
+"п÷я─п╦ п╫п╟п╤п╟я┌п╦п╦ п©п╣я─п╡п╬п╧ п╨п╫п╬п©п╨п╦ п╪я▀я┬п╦ (п╬п╠я▀я┤п╫п╬ п╩п╣п╡п╟я▐ п╨п╫п╬п©п╨п╟) п╬я┌п╨я─я▀п╡п╟п╣я┌я│я▐ п╨п╟я┌п╟п╩п╬пЁ п╡ "
+"п╫п╬п╡п╬п╪ п╬п╨п╫п╣. п÷я─п╦ п╫п╟п╤п╟я┌п╦п╦ п╨п╫п╬п©п╨п╦ 2 (я│я─п╣п╢п╫п╣п╧) п╢п╩я▐ п╬я┌п╨я─я▀я┌п╦я▐ п╨п╟я┌п╟п╩п╬пЁп╟ п╠я┐п╢п╣я┌ "
+"п╦я│п©п╬п╩я▄п╥п╬п╡п╟п╫п╬ я┌п╣п╨я┐я┴п╣п╣ п╬п╨п╫п╬."
 
-#: tips:19
+#: tips:26
 msgid "Single-click navigation"
-msgstr "Навигация одним щелчком"
+msgstr "п²п╟п╡п╦пЁп╟я├п╦я▐ п╬п╢п╫п╦п╪ я┴п╣п╩я┤п╨п╬п╪"
 
-#: tips:20 tips:116
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
 "things."
 msgstr ""
-"Одиночный щелчок по объекту открывает его. Удерживайте Control для выбора "
-"объектов. Если выключено, один щелчок выбирает объект; двойной щелчок "
-"открывает его."
+"п·п╢п╦п╫п╬я┤п╫я▀п╧ я┴п╣п╩я┤п╬п╨ п©п╬ п╬п╠я┼п╣п╨я┌я┐ п╬я┌п╨я─я▀п╡п╟п╣я┌ п╣пЁп╬. пёп╢п╣я─п╤п╦п╡п╟п╧я┌п╣ Control п╢п╩я▐ п╡я▀п╠п╬я─п╟ "
+"п╬п╠я┼п╣п╨я┌п╬п╡. п∙я│п╩п╦ п╡я▀п╨п╩я▌я┤п╣п╫п╬, п╬п╢п╦п╫ я┴п╣п╩я┤п╬п╨ п╡я▀п╠п╦я─п╟п╣я┌ п╬п╠я┼п╣п╨я┌; п╢п╡п╬п╧п╫п╬п╧ я┴п╣п╩я┤п╬п╨ "
+"п╬я┌п╨я─я▀п╡п╟п╣я┌ п╣пЁп╬."
 
-#: tips:21
+#: tips:28
 msgid "Double-click on background resizes"
-msgstr "Двойной щелчок на фоне изменяет размер окна"
+msgstr "п■п╡п╬п╧п╫п╬п╧ я┴п╣п╩я┤п╬п╨ п╫п╟ я└п╬п╫п╣ п╦п╥п╪п╣п╫я▐п╣я┌ я─п╟п╥п╪п╣я─ п╬п╨п╫п╟"
 
-#: tips:22
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
 msgstr ""
-"Двойной клик на фоне окна изменяет его размер, точно так же, как нажатие "
-"кнопки \"Автоматически устанавливать размер\" на панели инструментов"
+"п■п╡п╬п╧п╫п╬п╧ п╨п╩п╦п╨ п╫п╟ я└п╬п╫п╣ п╬п╨п╫п╟ п╦п╥п╪п╣п╫я▐п╣я┌ п╣пЁп╬ я─п╟п╥п╪п╣я─, я┌п╬я┤п╫п╬ я┌п╟п╨ п╤п╣, п╨п╟п╨ п╫п╟п╤п╟я┌п╦п╣ "
+"п╨п╫п╬п©п╨п╦ \"п░п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╦ я┐я│я┌п╟п╫п╟п╡п╩п╦п╡п╟я┌я▄ я─п╟п╥п╪п╣я─\" п╫п╟ п©п╟п╫п╣п╩п╦ п╦п╫я│я┌я─я┐п╪п╣п╫я┌п╬п╡"
 
-#: tips:23
+#: tips:30
 msgid "Sorting"
-msgstr "Сортировка"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╨п╟"
 
-#: tips:24
+#: tips:31
 msgid "Directories come first (for sort by name)"
-msgstr "Сначала каталоги (для сортировки по имени)"
+msgstr "п║п╫п╟я┤п╟п╩п╟ п╨п╟я┌п╟п╩п╬пЁп╦ (п╢п╩я▐ я│п╬я─я┌п╦я─п╬п╡п╨п╦ п©п╬ п╦п╪п╣п╫п╦)"
 
-#: tips:25
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
 msgstr ""
-"Если опция включена, каталоги отображаются перед всем остальным при выборе "
-"сортировки по имени."
+"п∙я│п╩п╦ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, п╨п╟я┌п╟п╩п╬пЁп╦ п╬я┌п╬п╠я─п╟п╤п╟я▌я┌я│я▐ п©п╣я─п╣п╢ п╡я│п╣п╪ п╬я│я┌п╟п╩я▄п╫я▀п╪ п©я─п╦ п╡я▀п╠п╬я─п╣ "
+"я│п╬я─я┌п╦я─п╬п╡п╨п╦ п©п╬ п╦п╪п╣п╫п╦."
 
-#: tips:26
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
-msgstr "Сначала имена в верхнем регистре (для сортировки по имени)"
+msgstr "п║п╫п╟я┤п╟п╩п╟ п╦п╪п╣п╫п╟ п╡ п╡п╣я─я┘п╫п╣п╪ я─п╣пЁп╦я│я┌я─п╣ (п╢п╩я▐ я│п╬я─я┌п╦я─п╬п╡п╨п╦ п©п╬ п╦п╪п╣п╫п╦)"
 
-#: tips:27
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
 msgstr ""
-"Если включено, все имена файлов, начинающиеся с заглавных букв будут идти "
-"перед именами файлов в нижнем регистре."
+"п∙я│п╩п╦ п╡п╨п╩я▌я┤п╣п╫п╬, п╡я│п╣ п╦п╪п╣п╫п╟ я└п╟п╧п╩п╬п╡, п╫п╟я┤п╦п╫п╟я▌я┴п╦п╣я│я▐ я│ п╥п╟пЁп╩п╟п╡п╫я▀я┘ п╠я┐п╨п╡ п╠я┐п╢я┐я┌ п╦п╢я┌п╦ "
+"п©п╣я─п╣п╢ п╦п╪п╣п╫п╟п╪п╦ я└п╟п╧п╩п╬п╡ п╡ п╫п╦п╤п╫п╣п╪ я─п╣пЁп╦я│я┌я─п╣."
 
-#: tips:29
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "п║п╫п╟я┤п╟п╩п╟ п╨п╟я┌п╟п╩п╬пЁп╦ (п╢п╩я▐ я│п╬я─я┌п╦я─п╬п╡п╨п╦ п©п╬ п╦п╪п╣п╫п╦)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sec"
+
+#: tips:38
+msgid "Show extended attribute indicator"
+msgstr "п÷п╬п╨п╟п╥я▀п╡п╟я┌я▄ п╦п╫п╢п╦п╨п╟я┌п╬я─ я─п╟я│я┬п╦я─п╣п╫п╫я▀я┘ п╟я┌я─п╦п╠я┐я┌п╬п╡"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+"п∙я│п╩п╦ я█я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, я┌п╬ я└п╟п╧п╩я▀, п╢п╩я▐ п╨п╬я┌п╬я─я▀я┘ я┐я│я┌п╟п╫п╬п╡п╩п╣п╫ я┘п╬я┌я▐ п╠я▀ п╬п╢п╦п╫ "
+"я─п╟я│я┬п╦я─п╣п╫п╫я▀п╧ п╟я┌я─п╦п╠я┐я┌, п╠я┐п╢я┐я┌ п©п╬п╪п╣я┤п╣п╫я▀ я│п©п╣я├п╦п╟п╩я▄п╫я▀п╪ п╥п╫п╟я┤п╨п╬п╪."
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
-msgstr "Установки по умолчанию для нового окна"
+msgstr "пёя│я┌п╟п╫п╬п╡п╨п╦ п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌ п╢п╩я▐ п╫п╬п╡п╬пЁп╬ п╬п╨п╫п╟"
 
-#: tips:30
+#: tips:46
 msgid "Inherit options from source window"
-msgstr "Наследовать установки из исходного окна"
+msgstr "п²п╟я│п╩п╣п╢п╬п╡п╟я┌я▄ я┐я│я┌п╟п╫п╬п╡п╨п╦ п╦п╥ п╦я│я┘п╬п╢п╫п╬пЁп╬ п╬п╨п╫п╟"
 
-#: tips:31
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
 msgstr ""
-"Если эта опция включена, тогда установки для нового окна будут унаследованы "
-"из исходного окна, когда это возможно, иначе они устанавливаются в значения "
-"по умолчанию."
+"п∙я│п╩п╦ я█я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, я┌п╬пЁп╢п╟ я┐я│я┌п╟п╫п╬п╡п╨п╦ п╢п╩я▐ п╫п╬п╡п╬пЁп╬ п╬п╨п╫п╟ п╠я┐п╢я┐я┌ я┐п╫п╟я│п╩п╣п╢п╬п╡п╟п╫я▀ "
+"п╦п╥ п╦я│я┘п╬п╢п╫п╬пЁп╬ п╬п╨п╫п╟, п╨п╬пЁп╢п╟ я█я┌п╬ п╡п╬п╥п╪п╬п╤п╫п╬, п╦п╫п╟я┤п╣ п╬п╫п╦ я┐я│я┌п╟п╫п╟п╡п╩п╦п╡п╟я▌я┌я│я▐ п╡ п╥п╫п╟я┤п╣п╫п╦я▐ "
+"п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌."
 
-#: tips:32
+#: tips:48
 msgid "View type:"
-msgstr "Тип просмотра:"
+msgstr "п╒п╦п© п©я─п╬я│п╪п╬я┌я─п╟:"
 
-#: tips:35
+#: tips:51
 msgid "Sort by:"
-msgstr "Сортировать по:"
+msgstr "п║п╬я─я┌п╦я─п╬п╡п╟я┌я▄ п©п╬:"
 
-#: tips:37 tips:54
+#: tips:53 tips:76 tips:114
 msgid "Type"
-msgstr "Тип"
+msgstr "п╒п╦п©"
 
-#: tips:38
-msgid "Date"
-msgstr "Дата"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
+msgstr "п■п╟я┌п╟"
 
-#: tips:40
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "п■п╟я┌п╟"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "п■п╟я┌п╟"
+
+#: tips:58
 msgid "Show hidden files"
-msgstr "Показать скрытые файлы"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ я│п╨я─я▀я┌я▀п╣ я└п╟п╧п╩я▀"
 
-#: tips:41
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
 msgstr ""
-"Если эта опция включена, файлы, имена которых начинаются с точки, тоже "
-"показываются, в противном случае они спрятаны."
+"п∙я│п╩п╦ я█я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, я└п╟п╧п╩я▀, п╦п╪п╣п╫п╟ п╨п╬я┌п╬я─я▀я┘ п╫п╟я┤п╦п╫п╟я▌я┌я│я▐ я│ я┌п╬я┤п╨п╦, я┌п╬п╤п╣ "
+"п©п╬п╨п╟п╥я▀п╡п╟я▌я┌я│я▐, п╡ п©я─п╬я┌п╦п╡п╫п╬п╪ я│п╩я┐я┤п╟п╣ п╬п╫п╦ я│п©я─я▐я┌п╟п╫я▀."
 
-#: tips:42
-msgid "Show extended attribute indicator"
-msgstr "Показывать индикатор расширенных атрибутов"
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ я│п╨я─я▀я┌я▀п╣ я└п╟п╧п╩я▀"
 
-#: tips:43
+#: tips:61
+#, fuzzy
 msgid ""
-"If this is on then files which have one or more extended attributes set will "
-"have an emblem added to indicate this."
-msgstr "Если эта опция включена, то файлы, для которых установлен хотя бы один расширенный атрибут, будут помечены специальным значком."
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"п∙я│п╩п╦ я█я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, я└п╟п╧п╩я▀, п╦п╪п╣п╫п╟ п╨п╬я┌п╬я─я▀я┘ п╫п╟я┤п╦п╫п╟я▌я┌я│я▐ я│ я┌п╬я┤п╨п╦, я┌п╬п╤п╣ "
+"п©п╬п╨п╟п╥я▀п╡п╟я▌я┌я│я▐, п╡ п©я─п╬я┌п╦п╡п╫п╬п╪ я│п╩я┐я┤п╟п╣ п╬п╫п╦ я│п©я─я▐я┌п╟п╫я▀."
 
-#: tips:44
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "п·пЁя─п╬п╪п╫я▀п╣ п╥п╫п╟я┤п╨п╦"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "п©п╦п╨я│п╣п╩п╣п╧"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
-msgstr "Значки"
+msgstr "п≈п╫п╟я┤п╨п╦"
 
-#: tips:45
+#: tips:67
 msgid "Default size:"
-msgstr "Размер по умолчанию:"
+msgstr "п═п╟п╥п╪п╣я─ п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌:"
 
-#: tips:46
+#: tips:68
 msgid "Huge Icons"
-msgstr "Огромные значки"
+msgstr "п·пЁя─п╬п╪п╫я▀п╣ п╥п╫п╟я┤п╨п╦"
 
-#: tips:47 tips:217
+#: tips:69 tips:296
 msgid "Large Icons"
-msgstr "Большие значки"
+msgstr "п▒п╬п╩я▄я┬п╦п╣ п╥п╫п╟я┤п╨п╦"
 
-#: tips:48 tips:216
+#: tips:70 tips:295
 msgid "Small Icons"
-msgstr "Маленькие значки"
+msgstr "п°п╟п╩п╣п╫я▄п╨п╦п╣ п╥п╫п╟я┤п╨п╦"
 
-#: tips:50
+#: tips:72
 msgid "Default details:"
-msgstr "Подробности по умолчанию:"
+msgstr "п÷п╬п╢я─п╬п╠п╫п╬я│я┌п╦ п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌:"
 
-#: tips:51
+#: tips:73
 msgid "No details"
-msgstr "Без подробностей"
+msgstr "п▒п╣п╥ п©п╬п╢я─п╬п╠п╫п╬я│я┌п╣п╧"
 
-#: tips:56
-msgid "Automatic small icons:"
-msgstr "Автоматически переключать на маленькие значки:"
+#: tips:74
+msgid "Sizes"
+msgstr "п═п╟п╥п╪п╣я─"
 
-#: tips:57
-msgid "Change at:"
-msgstr "Начиная с:"
+#: tips:77
+msgid "Times"
+msgstr "п▓я─п╣п╪я▐"
 
-#: tips:59
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
+msgstr "п░п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╦ п©п╣я─п╣п╨п╩я▌я┤п╟я┌я▄ п╫п╟ п╪п╟п╩п╣п╫я▄п╨п╦п╣ п╥п╫п╟я┤п╨п╦:"
+
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
 "used."
 msgstr ""
-"В случае автоматического выбор размера значков, если каталог содержит "
-"множество элементов, будут использоваться маленькие значки.В противном "
-"случае будут использованы большие значки."
+"п▓ я│п╩я┐я┤п╟п╣ п╟п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╬пЁп╬ п╡я▀п╠п╬я─ я─п╟п╥п╪п╣я─п╟ п╥п╫п╟я┤п╨п╬п╡, п╣я│п╩п╦ п╨п╟я┌п╟п╩п╬пЁ я│п╬п╢п╣я─п╤п╦я┌ "
+"п╪п╫п╬п╤п╣я│я┌п╡п╬ я█п╩п╣п╪п╣п╫я┌п╬п╡, п╠я┐п╢я┐я┌ п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄я│я▐ п╪п╟п╩п╣п╫я▄п╨п╦п╣ п╥п╫п╟я┤п╨п╦.п▓ п©я─п╬я┌п╦п╡п╫п╬п╪ "
+"я│п╩я┐я┤п╟п╣ п╠я┐п╢я┐я┌ п╦я│п©п╬п╩я▄п╥п╬п╡п╟п╫я▀ п╠п╬п╩я▄я┬п╦п╣ п╥п╫п╟я┤п╨п╦."
 
-#: tips:60
-msgid "Max width (Large icons):"
-msgstr "Наибольшая ширина (большие значки):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "п▒п╬п╩я▄я┬п╦п╣ п╥п╫п╟я┤п╨п╦"
 
-#: tips:61 tips:64
-msgid "pixels"
-msgstr "пикселей"
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
+msgstr ""
+"п╒п╣п╨я│я┌ я┬п╦я─п╣ я┐п╨п╟п╥п╟п╫п╫п╬пЁп╬ п╥п╫п╟я┤п╣п╫п╦я▐ п╠я┐п╢п╣я┌ я─п╟п╥п╠п╦я┌ п╫п╟ п╢п╡п╣ я│я┌я─п╬п╨п╦ п╡ я─п╣п╤п╦п╪п╣ п©п╬п╨п╟п╥п╟ "
+"п╠п╬п╩я▄я┬п╦я┘ п╥п╫п╟я┤п╨п╬п╡. п▓ я─п╣п╤п╦п╪п╣ п╬пЁя─п╬п╪п╫я▀я┘ п╥п╫п╟я┤п╨п╬п╡ я┌п╣п╨я│я┌ п©п╣я─п╣п╫п╬я│п╦я┌я│я▐ п╫п╟ п╫п╬п╡я┐я▌ "
+"я│я┌я─п╬п╨я┐, п╨п╬пЁп╢п╟ п╬п╫ п╫п╟ 50% я┬п╦я─п╣ я█я┌п╬пЁп╬ п╥п╫п╟я┤п╣п╫п╦я▐."
 
-#: tips:62
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
 msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
 msgstr ""
-"Текст шире указанного значения будет разбит на две строки в режиме показа "
-"больших значков. В режиме огромных значков текст переносится на новую "
-"строку, когда он на 50% шире этого значения."
 
-#: tips:63
-msgid "(Small Icons):"
-msgstr "(Маленькие значки):"
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
 
-#: tips:65
+#: tips:88
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr ""
+"п∙я│п╩п╦ я█я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, п╠п╬п╩я▄я┬п╦п╣ п╦п╨п╬п╫п╨п╦ п╠я┐п╢я┐я┌ п╡я▀я│я┌я─п╟п╦п╡п╟я┌я▄я│я▐ п╡п╣я─я┌п╦п╨п╟п╩я▄п╫п╬, п╟ "
+"п╫п╣ пЁп╬я─п╦п╥п╬п╫я┌п╟п╩я▄п╫п╬."
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "(п°п╟п╩п╣п╫я▄п╨п╦п╣ п╥п╫п╟я┤п╨п╦):"
+
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
-msgstr "Максимальный размер текстового поля под маленькими значками."
+msgstr "п°п╟п╨я│п╦п╪п╟п╩я▄п╫я▀п╧ я─п╟п╥п╪п╣я─ я┌п╣п╨я│я┌п╬п╡п╬пЁп╬ п©п╬п╩я▐ п©п╬п╢ п╪п╟п╩п╣п╫я▄п╨п╦п╪п╦ п╥п╫п╟я┤п╨п╟п╪п╦."
 
-#: tips:66
+#: tips:92
 msgid "Order small icons vertically"
-msgstr "Располагать маленькие иконки вертикально"
+msgstr "п═п╟я│п©п╬п╩п╟пЁп╟я┌я▄ п╪п╟п╩п╣п╫я▄п╨п╦п╣ п╦п╨п╬п╫п╨п╦ п╡п╣я─я┌п╦п╨п╟п╩я▄п╫п╬"
 
-#: tips:67
-msgid "If this option is on, then small icons are arranged in columns, not rows."
+#: tips:93
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
 msgstr ""
-"Если эта опция включена, маленькие иконки будут выстраиваться вертикально, а "
-"не горизонтально."
+"п∙я│п╩п╦ я█я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, п╪п╟п╩п╣п╫я▄п╨п╦п╣ п╦п╨п╬п╫п╨п╦ п╠я┐п╢я┐я┌ п╡я▀я│я┌я─п╟п╦п╡п╟я┌я▄я│я▐ п╡п╣я─я┌п╦п╨п╟п╩я▄п╫п╬, п╟ "
+"п╫п╣ пЁп╬я─п╦п╥п╬п╫я┌п╟п╩я▄п╫п╬."
 
-#: tips:68
+#: tips:94
 msgid "Order large icons vertically"
-msgstr "Располагать большие иконки вертикально"
+msgstr "п═п╟я│п©п╬п╩п╟пЁп╟я┌я▄ п╠п╬п╩я▄я┬п╦п╣ п╦п╨п╬п╫п╨п╦ п╡п╣я─я┌п╦п╨п╟п╩я▄п╫п╬"
 
-#: tips:69
-msgid "If this option is on, then large icons are arranged in columns, not rows."
+#: tips:95
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
 msgstr ""
-"Если эта опция включена, большие иконки будут выстраиваться вертикально, а "
-"не горизонтально."
+"п∙я│п╩п╦ я█я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, п╠п╬п╩я▄я┬п╦п╣ п╦п╨п╬п╫п╨п╦ п╠я┐п╢я┐я┌ п╡я▀я│я┌я─п╟п╦п╡п╟я┌я▄я│я▐ п╡п╣я─я┌п╦п╨п╟п╩я▄п╫п╬, п╟ "
+"п╫п╣ пЁп╬я─п╦п╥п╬п╫я┌п╟п╩я▄п╫п╬."
 
-#: tips:71
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
-msgstr "Показать заголовки столбцов"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ п╥п╟пЁп╬п╩п╬п╡п╨п╦ я│я┌п╬п╩п╠я├п╬п╡"
 
-#: tips:72
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
-msgstr "Если включено, то заголовки столбцов будут показаны в режиме списка."
+msgstr "п∙я│п╩п╦ п╡п╨п╩я▌я┤п╣п╫п╬, я┌п╬ п╥п╟пЁп╬п╩п╬п╡п╨п╦ я│я┌п╬п╩п╠я├п╬п╡ п╠я┐п╢я┐я┌ п©п╬п╨п╟п╥п╟п╫я▀ п╡ я─п╣п╤п╦п╪п╣ я│п©п╦я│п╨п╟."
 
-#: tips:73
+#: tips:102
 msgid "Show full type"
-msgstr "Показывать тип полностью"
+msgstr "п÷п╬п╨п╟п╥я▀п╡п╟я┌я▄ я┌п╦п© п©п╬п╩п╫п╬я│я┌я▄я▌"
 
-#: tips:74
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr ""
-"Если эта опция включена, вместо краткого указания сведений о файле будет "
-"показываться полное описание объекта."
+"п∙я│п╩п╦ я█я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, п╡п╪п╣я│я┌п╬ п╨я─п╟я┌п╨п╬пЁп╬ я┐п╨п╟п╥п╟п╫п╦я▐ я│п╡п╣п╢п╣п╫п╦п╧ п╬ я└п╟п╧п╩п╣ п╠я┐п╢п╣я┌ "
+"п©п╬п╨п╟п╥я▀п╡п╟я┌я▄я│я▐ п©п╬п╩п╫п╬п╣ п╬п©п╦я│п╟п╫п╦п╣ п╬п╠я┼п╣п╨я┌п╟."
 
-#: tips:75
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "п°п╟п╨я│п╦п╪п╟п╩я▄п╫я▀п╧ я─п╟п╥п╪п╣я─ я┌п╣п╨я│я┌п╬п╡п╬пЁп╬ п©п╬п╩я▐ п©п╬п╢ п╪п╟п╩п╣п╫я▄п╨п╦п╪п╦ п╥п╫п╟я┤п╨п╟п╪п╦."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ п╥п╟пЁп╬п╩п╬п╡п╨п╦ я│я┌п╬п╩п╠я├п╬п╡"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr "п∙я│п╩п╦ п╡п╨п╩я▌я┤п╣п╫п╬, я┌п╬ п╥п╟пЁп╬п╩п╬п╡п╨п╦ я│я┌п╬п╩п╠я├п╬п╡ п╠я┐п╢я┐я┌ п©п╬п╨п╟п╥п╟п╫я▀ п╡ я─п╣п╤п╦п╪п╣ я│п©п╦я│п╨п╟."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr "п∙я│п╩п╦ п╡п╨п╩я▌я┤п╣п╫п╬, я┌п╬ п╥п╟пЁп╬п╩п╬п╡п╨п╦ я│я┌п╬п╩п╠я├п╬п╡ п╠я┐п╢я┐я┌ п©п╬п╨п╟п╥п╟п╫я▀ п╡ я─п╣п╤п╦п╪п╣ я│п©п╦я│п╨п╟."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr "п∙я│п╩п╦ п╡п╨п╩я▌я┤п╣п╫п╬, я┌п╬ п╥п╟пЁп╬п╩п╬п╡п╨п╦ я│я┌п╬п╩п╠я├п╬п╡ п╠я┐п╢я┐я┌ п©п╬п╨п╟п╥п╟п╫я▀ п╡ я─п╣п╤п╦п╪п╣ я│п©п╦я│п╨п╟."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr "п∙я│п╩п╦ п╡п╨п╩я▌я┤п╣п╫п╬, я┌п╬ п╥п╟пЁп╬п╩п╬п╡п╨п╦ я│я┌п╬п╩п╠я├п╬п╡ п╠я┐п╢я┐я┌ п©п╬п╨п╟п╥п╟п╫я▀ п╡ я─п╣п╤п╦п╪п╣ я│п©п╦я│п╨п╟."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr "п∙я│п╩п╦ п╡п╨п╩я▌я┤п╣п╫п╬, я┌п╬ п╥п╟пЁп╬п╩п╬п╡п╨п╦ я│я┌п╬п╩п╠я├п╬п╡ п╠я┐п╢я┐я┌ п©п╬п╨п╟п╥п╟п╫я▀ п╡ я─п╣п╤п╦п╪п╣ я│п©п╦я│п╨п╟."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr "п∙я│п╩п╦ п╡п╨п╩я▌я┤п╣п╫п╬, я┌п╬ п╥п╟пЁп╬п╩п╬п╡п╨п╦ я│я┌п╬п╩п╠я├п╬п╡ п╠я┐п╢я┐я┌ п©п╬п╨п╟п╥п╟п╫я▀ п╡ я─п╣п╤п╦п╪п╣ я│п©п╦я│п╨п╟."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "_п▒я▀п╩ п╦п╥п╪п╣п╫п╣п╫"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr "п∙я│п╩п╦ п╡п╨п╩я▌я┤п╣п╫п╬, я┌п╬ п╥п╟пЁп╬п╩п╬п╡п╨п╦ я│я┌п╬п╩п╠я├п╬п╡ п╠я┐п╢я┐я┌ п©п╬п╨п╟п╥п╟п╫я▀ п╡ я─п╣п╤п╦п╪п╣ я│п©п╦я│п╨п╟."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr "п∙я│п╩п╦ п╡п╨п╩я▌я┤п╣п╫п╬, я┌п╬ п╥п╟пЁп╬п╩п╬п╡п╨п╦ я│я┌п╬п╩п╠я├п╬п╡ п╠я┐п╢я┐я┌ п©п╬п╨п╟п╥п╟п╫я▀ п╡ я─п╣п╤п╦п╪п╣ я│п©п╦я│п╨п╟."
+
+#: tips:128
+#, fuzzy
+msgid "Last Accessed"
+msgstr "\"%s\" п╫п╣п╢п╬я│я┌я┐п©п╣п╫"
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr "п∙я│п╩п╦ п╡п╨п╩я▌я┤п╣п╫п╬, я┌п╬ п╥п╟пЁп╬п╩п╬п╡п╨п╦ я│я┌п╬п╩п╠я├п╬п╡ п╠я┐п╢я┐я┌ п©п╬п╨п╟п╥п╟п╫я▀ п╡ я─п╣п╤п╦п╪п╣ я│п©п╦я│п╨п╟."
+
+#: tips:130
 msgid "Tools/Minibuffer"
-msgstr "Инструменты/Минибуфер"
+msgstr "п≤п╫я│я┌я─я┐п╪п╣п╫я┌я▀/п°п╦п╫п╦п╠я┐я└п╣я─"
 
-#: tips:76
+#: tips:131
 msgid "Toolbar"
-msgstr "Панель инструментов"
+msgstr "п÷п╟п╫п╣п╩я▄ п╦п╫я│я┌я─я┐п╪п╣п╫я┌п╬п╡"
 
-#: tips:77
+#: tips:132
 msgid "Toolbar type:"
-msgstr "Тип панели инструментов:"
+msgstr "п╒п╦п© п©п╟п╫п╣п╩п╦ п╦п╫я│я┌я─я┐п╪п╣п╫я┌п╬п╡:"
 
-#: tips:78
+#: tips:133
 msgid "No toolbar"
-msgstr "Без панели инструментов"
+msgstr "п▒п╣п╥ п©п╟п╫п╣п╩п╦ п╦п╫я│я┌я─я┐п╪п╣п╫я┌п╬п╡"
 
-#: tips:79
+#: tips:134
 msgid "Icons only"
-msgstr "Только значки"
+msgstr "п╒п╬п╩я▄п╨п╬ п╥п╫п╟я┤п╨п╦"
 
-#: tips:80
+#: tips:135
 msgid "Text under icons"
-msgstr "Текст под значками"
+msgstr "п╒п╣п╨я│я┌ п©п╬п╢ п╥п╫п╟я┤п╨п╟п╪п╦"
 
-#: tips:81
+#: tips:136
 msgid "Text beside icons"
-msgstr "Текст рядом со значками"
+msgstr "п╒п╣п╨я│я┌ я─я▐п╢п╬п╪ я│п╬ п╥п╫п╟я┤п╨п╟п╪п╦"
 
-#: tips:82
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "п╒п╬п╩я▄п╨п╬ п©п╟п╫п╣п╩я▄"
+
+#: tips:138
 msgid "Show totals of items"
-msgstr "Показывать общее количество объектов"
+msgstr "п÷п╬п╨п╟п╥я▀п╡п╟я┌я▄ п╬п╠я┴п╣п╣ п╨п╬п╩п╦я┤п╣я│я┌п╡п╬ п╬п╠я┼п╣п╨я┌п╬п╡"
 
-#: tips:83
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
 "selected items and their combined size."
 msgstr ""
-"Показывать количество объектов, отображаемых в окне менеджера, так же как и "
-"количество скрытых объектов (если они есть). Когда что-либо выбрано, "
-"показывать количество выбранных объектов и их общий размер."
+"п÷п╬п╨п╟п╥я▀п╡п╟я┌я▄ п╨п╬п╩п╦я┤п╣я│я┌п╡п╬ п╬п╠я┼п╣п╨я┌п╬п╡, п╬я┌п╬п╠я─п╟п╤п╟п╣п╪я▀я┘ п╡ п╬п╨п╫п╣ п╪п╣п╫п╣п╢п╤п╣я─п╟, я┌п╟п╨ п╤п╣ п╨п╟п╨ п╦ "
+"п╨п╬п╩п╦я┤п╣я│я┌п╡п╬ я│п╨я─я▀я┌я▀я┘ п╬п╠я┼п╣п╨я┌п╬п╡ (п╣я│п╩п╦ п╬п╫п╦ п╣я│я┌я▄). п п╬пЁп╢п╟ я┤я┌п╬-п╩п╦п╠п╬ п╡я▀п╠я─п╟п╫п╬, "
+"п©п╬п╨п╟п╥я▀п╡п╟я┌я▄ п╨п╬п╩п╦я┤п╣я│я┌п╡п╬ п╡я▀п╠я─п╟п╫п╫я▀я┘ п╬п╠я┼п╣п╨я┌п╬п╡ п╦ п╦я┘ п╬п╠я┴п╦п╧ я─п╟п╥п╪п╣я─."
 
-#: tips:84
+#: tips:140
 msgid "Select the buttons you want on the bar:"
-msgstr "Отметьте кнопки, которые вы хотите видеть на панели:"
+msgstr "п·я┌п╪п╣я┌я▄я┌п╣ п╨п╫п╬п©п╨п╦, п╨п╬я┌п╬я─я▀п╣ п╡я▀ я┘п╬я┌п╦я┌п╣ п╡п╦п╢п╣я┌я▄ п╫п╟ п©п╟п╫п╣п╩п╦:"
 
-#: tips:85
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
-msgstr "Ширина панели инструментов определяет минимальную ширину окна"
+msgstr "п╗п╦я─п╦п╫п╟ п©п╟п╫п╣п╩п╦ п╦п╫я│я┌я─я┐п╪п╣п╫я┌п╬п╡ п╬п©я─п╣п╢п╣п╩я▐п╣я┌ п╪п╦п╫п╦п╪п╟п╩я▄п╫я┐я▌ я┬п╦я─п╦п╫я┐ п╬п╨п╫п╟"
 
-#: tips:86
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
 msgstr ""
-"Каждое окно обязательно будет настолько широким, чтобы показать панель "
-"инструментов целиком"
+"п п╟п╤п╢п╬п╣ п╬п╨п╫п╬ п╬п╠я▐п╥п╟я┌п╣п╩я▄п╫п╬ п╠я┐п╢п╣я┌ п╫п╟я│я┌п╬п╩я▄п╨п╬ я┬п╦я─п╬п╨п╦п╪, я┤я┌п╬п╠я▀ п©п╬п╨п╟п╥п╟я┌я▄ п©п╟п╫п╣п╩я▄ "
+"п╦п╫я│я┌я─я┐п╪п╣п╫я┌п╬п╡ я├п╣п╩п╦п╨п╬п╪"
 
-#: tips:87
+#: tips:143
 msgid "Minibuffer"
-msgstr "Минибуфер"
+msgstr "п°п╦п╫п╦п╠я┐я└п╣я─"
 
-#: tips:88
+#: tips:144
 msgid "Beep if Tab-completion fails"
-msgstr "Сигнал при неудачном Tab-дополнении"
+msgstr "п║п╦пЁп╫п╟п╩ п©я─п╦ п╫п╣я┐п╢п╟я┤п╫п╬п╪ Tab-п╢п╬п©п╬п╩п╫п╣п╫п╦п╦"
 
-#: tips:89
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
 "letter varies)."
 msgstr ""
-"Когда используется строка \"Введите путь...\" и был нажат Tab, сигнал "
-"прозвучит, если ничего не произошло (например, существует несколько "
-"возможных вариантов дополнения)."
+"п п╬пЁп╢п╟ п╦я│п©п╬п╩я▄п╥я┐п╣я┌я│я▐ я│я┌я─п╬п╨п╟ \"п▓п╡п╣п╢п╦я┌п╣ п©я┐я┌я▄...\" п╦ п╠я▀п╩ п╫п╟п╤п╟я┌ Tab, я│п╦пЁп╫п╟п╩ "
+"п©я─п╬п╥п╡я┐я┤п╦я┌, п╣я│п╩п╦ п╫п╦я┤п╣пЁп╬ п╫п╣ п©я─п╬п╦п╥п╬я┬п╩п╬ (п╫п╟п©я─п╦п╪п╣я─, я│я┐я┴п╣я│я┌п╡я┐п╣я┌ п╫п╣я│п╨п╬п╩я▄п╨п╬ "
+"п╡п╬п╥п╪п╬п╤п╫я▀я┘ п╡п╟я─п╦п╟п╫я┌п╬п╡ п╢п╬п©п╬п╩п╫п╣п╫п╦я▐)."
 
-#: tips:90
+#: tips:146
 msgid "Beep if there are several matches"
-msgstr "Сигнал при нескольких совпадениях"
+msgstr "п║п╦пЁп╫п╟п╩ п©я─п╦ п╫п╣я│п╨п╬п╩я▄п╨п╦я┘ я│п╬п╡п©п╟п╢п╣п╫п╦я▐я┘"
 
-#: tips:91
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
 msgstr ""
-"Когда используется строка \"Введите путь...\" и был нажат Tab, сигнал "
-"прозвучит, когда существует более одного подходящего файла, даже если "
-"несколько символов уже было добавлено."
+"п п╬пЁп╢п╟ п╦я│п©п╬п╩я▄п╥я┐п╣я┌я│я▐ я│я┌я─п╬п╨п╟ \"п▓п╡п╣п╢п╦я┌п╣ п©я┐я┌я▄...\" п╦ п╠я▀п╩ п╫п╟п╤п╟я┌ Tab, я│п╦пЁп╫п╟п╩ "
+"п©я─п╬п╥п╡я┐я┤п╦я┌, п╨п╬пЁп╢п╟ я│я┐я┴п╣я│я┌п╡я┐п╣я┌ п╠п╬п╩п╣п╣ п╬п╢п╫п╬пЁп╬ п©п╬п╢я┘п╬п╢я▐я┴п╣пЁп╬ я└п╟п╧п╩п╟, п╢п╟п╤п╣ п╣я│п╩п╦ "
+"п╫п╣я│п╨п╬п╩я▄п╨п╬ я│п╦п╪п╡п╬п╩п╬п╡ я┐п╤п╣ п╠я▀п╩п╬ п╢п╬п╠п╟п╡п╩п╣п╫п╬."
 
-#: tips:94
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "п÷я─п╬пЁя─п╟п╪п╪п╟ п╢п╩я▐ я│п╨п╟я┤п╦п╡п╟п╫п╦я▐"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "п·я┬п╦п╠п╨п╟ п╡ п╬п╠я─п╟п╠п╬я┌я┤п╦п╨п╣ %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
 msgstr ""
-"Когда миниатюры включены, для каждого файла с изображением показывается  его "
-"уменьшенный вариант."
+"п п╬пЁп╢п╟ п╪п╦п╫п╦п╟я┌я▌я─я▀ п╡п╨п╩я▌я┤п╣п╫я▀, п╢п╩я▐ п╨п╟п╤п╢п╬пЁп╬ я└п╟п╧п╩п╟ я│ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╣п╪ п©п╬п╨п╟п╥я▀п╡п╟п╣я┌я│я▐  п╣пЁп╬ "
+"я┐п╪п╣п╫я▄я┬п╣п╫п╫я▀п╧ п╡п╟я─п╦п╟п╫я┌."
 
-#: tips:95
+#: tips:155
 msgid "Show image thumbnails"
-msgstr "Показывать миниатюры картинок"
+msgstr "п÷п╬п╨п╟п╥я▀п╡п╟я┌я▄ п╪п╦п╫п╦п╟я┌я▌я─я▀ п╨п╟я─я┌п╦п╫п╬п╨"
 
-#: tips:96
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
 msgstr ""
-"Это установки по умолчанию для новых окон. Используйте меню \"Отображение\" "
-"для включения и отключения миниатюр для отдельных окон"
+"п╜я┌п╬ я┐я│я┌п╟п╫п╬п╡п╨п╦ п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌ п╢п╩я▐ п╫п╬п╡я▀я┘ п╬п╨п╬п╫. п≤я│п©п╬п╩я▄п╥я┐п╧я┌п╣ п╪п╣п╫я▌ \"п·я┌п╬п╠я─п╟п╤п╣п╫п╦п╣\" "
+"п╢п╩я▐ п╡п╨п╩я▌я┤п╣п╫п╦я▐ п╦ п╬я┌п╨п╩я▌я┤п╣п╫п╦я▐ п╪п╦п╫п╦п╟я┌я▌я─ п╢п╩я▐ п╬я┌п╢п╣п╩я▄п╫я▀я┘ п╬п╨п╬п╫"
 
-#: tips:97
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "п÷п╬п╨п╟п╥я▀п╡п╟я┌я▄ п╪п╦п╫п╦п╟я┌я▌я─я▀ п╨п╟я─я┌п╦п╫п╬п╨"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
-msgstr "Миниатюры для видео"
+msgstr "п°п╦п╫п╦п╟я┌я▌я─я▀ п╢п╩я▐ п╡п╦п╢п╣п╬"
 
-#: tips:98
+#: tips:160
 msgid "Thumbnails cache"
-msgstr "Кеш миниатюр"
+msgstr "п п╣я┬ п╪п╦п╫п╦п╟я┌я▌я─"
 
-#: tips:99
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
-"Для увеличения скорости, созданные миниатюры изображений сохраняются в "
-"скрытом каталоге ~/.thumbails. Щелкните здесь для удаления всех уже "
-"созданных миниатюр. Миниатюры будут создаваться заново по мере необходимости."
+"п■п╩я▐ я┐п╡п╣п╩п╦я┤п╣п╫п╦я▐ я│п╨п╬я─п╬я│я┌п╦, я│п╬п╥п╢п╟п╫п╫я▀п╣ п╪п╦п╫п╦п╟я┌я▌я─я▀ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╧ я│п╬я┘я─п╟п╫я▐я▌я┌я│я▐ п╡ "
+"я│п╨я─я▀я┌п╬п╪ п╨п╟я┌п╟п╩п╬пЁп╣ ~/.thumbails. п╘п╣п╩п╨п╫п╦я┌п╣ п╥п╢п╣я│я▄ п╢п╩я▐ я┐п╢п╟п╩п╣п╫п╦я▐ п╡я│п╣я┘ я┐п╤п╣ "
+"я│п╬п╥п╢п╟п╫п╫я▀я┘ п╪п╦п╫п╦п╟я┌я▌я─. п°п╦п╫п╦п╟я┌я▌я─я▀ п╠я┐п╢я┐я┌ я│п╬п╥п╢п╟п╡п╟я┌я▄я│я▐ п╥п╟п╫п╬п╡п╬ п©п╬ п╪п╣я─п╣ п╫п╣п╬п╠я┘п╬п╢п╦п╪п╬я│я┌п╦."
 
-#: tips:100
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
 msgid "Manage thumbnails"
-msgstr "Управление миниатюрами"
+msgstr "пёп©я─п╟п╡п╩п╣п╫п╦п╣ п╪п╦п╫п╦п╟я┌я▌я─п╟п╪п╦"
 
-#: tips:101 tips:158
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "п°п╦п╫п╦п╟я┌я▌я─я▀ п╢п╩я▐ п╡п╦п╢п╣п╬"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sec"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
-msgstr "Витрина"
+msgstr "п▓п╦я┌я─п╦п╫п╟"
 
-#: tips:102
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
 msgstr ""
-"Когда вы используете витрину, то можете перетаскивать файлы и приложения на "
-"рабочий стол для создания ярлыков к ним."
+"п п╬пЁп╢п╟ п╡я▀ п╦я│п©п╬п╩я▄п╥я┐п╣я┌п╣ п╡п╦я┌я─п╦п╫я┐, я┌п╬ п╪п╬п╤п╣я┌п╣ п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟я┌я▄ я└п╟п╧п╩я▀ п╦ п©я─п╦п╩п╬п╤п╣п╫п╦я▐ п╫п╟ "
+"я─п╟п╠п╬я┤п╦п╧ я│я┌п╬п╩ п╢п╩я▐ я│п╬п╥п╢п╟п╫п╦я▐ я▐я─п╩я▀п╨п╬п╡ п╨ п╫п╦п╪."
 
-#: tips:103 tips:213
+#: tips:178 tips:292
 msgid "Appearance"
-msgstr "Внешний вид"
+msgstr "п▓п╫п╣я┬п╫п╦п╧ п╡п╦п╢"
 
-#: tips:104
+#: tips:179
 msgid "Foreground:"
-msgstr "Передний план:"
+msgstr "п÷п╣я─п╣п╢п╫п╦п╧ п©п╩п╟п╫:"
 
-#: tips:105
+#: tips:180
 msgid "Text shadow:"
-msgstr "Тень текста:"
+msgstr "п╒п╣п╫я▄ я┌п╣п╨я│я┌п╟:"
 
-#: tips:106
+#: tips:181
 msgid "Background:"
-msgstr "Фон:"
+msgstr "п╓п╬п╫:"
 
-#: tips:107
+#: tips:182
 msgid "No shadow"
-msgstr "Без тени"
+msgstr "п▒п╣п╥ я┌п╣п╫п╦"
 
-#: tips:108
+#: tips:183
 msgid "Thin"
-msgstr "Слабая тень"
+msgstr "п║п╩п╟п╠п╟я▐ я┌п╣п╫я▄"
 
-#: tips:109
+#: tips:184
 msgid "Thick"
-msgstr "Резкая тень"
+msgstr "п═п╣п╥п╨п╟я▐ я┌п╣п╫я▄"
 
-#: tips:110
+#: tips:185
 msgid "Use custom font:"
-msgstr "Использовать пользовательский шрифт:"
+msgstr "п≤я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п©п╬п╩я▄п╥п╬п╡п╟я┌п╣п╩я▄я│п╨п╦п╧ я┬я─п╦я└я┌:"
 
-#: tips:111
+#: tips:186
 msgid "The font used for the text displayed under the icons"
-msgstr "Шрифт, который используется для отображения текста под значками"
+msgstr "п╗я─п╦я└я┌, п╨п╬я┌п╬я─я▀п╧ п╦я│п©п╬п╩я▄п╥я┐п╣я┌я│я▐ п╢п╩я▐ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐ я┌п╣п╨я│я┌п╟ п©п╬п╢ п╥п╫п╟я┤п╨п╟п╪п╦"
 
-#: tips:112
+#: tips:187
 msgid "Fast scaling of images"
-msgstr "Быстрое масштабирование изображений"
+msgstr "п▒я▀я│я┌я─п╬п╣ п╪п╟я│я┬я┌п╟п╠п╦я─п╬п╡п╟п╫п╦п╣ п╦п╥п╬п╠я─п╟п╤п╣п╫п╦п╧"
 
-#: tips:113
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
 msgstr ""
-"Выберите быстрый или медленный алгоритм масштабирования фонового "
-"изображения. Медленный алгоритм может давать лучший результат."
+"п▓я▀п╠п╣я─п╦я┌п╣ п╠я▀я│я┌я─я▀п╧ п╦п╩п╦ п╪п╣п╢п╩п╣п╫п╫я▀п╧ п╟п╩пЁп╬я─п╦я┌п╪ п╪п╟я│я┬я┌п╟п╠п╦я─п╬п╡п╟п╫п╦я▐ я└п╬п╫п╬п╡п╬пЁп╬ "
+"п╦п╥п╬п╠я─п╟п╤п╣п╫п╦я▐. п°п╣п╢п╩п╣п╫п╫я▀п╧ п╟п╩пЁп╬я─п╦я┌п╪ п╪п╬п╤п╣я┌ п╢п╟п╡п╟я┌я▄ п╩я┐я┤я┬п╦п╧ я─п╣п╥я┐п╩я▄я┌п╟я┌."
 
-#: tips:114
+#: tips:189
 msgid "Pinboard behaviour"
-msgstr "Поведение витрины"
+msgstr "п÷п╬п╡п╣п╢п╣п╫п╦п╣ п╡п╦я┌я─п╦п╫я▀"
 
-#: tips:115
+#: tips:190
 msgid "Single-click to open"
-msgstr "Навигация одним щелчком"
+msgstr "п²п╟п╡п╦пЁп╟я├п╦я▐ п╬п╢п╫п╦п╪ я┴п╣п╩я┤п╨п╬п╪"
 
-#: tips:117
+#: tips:192
 msgid "Keep icons within screen limits"
-msgstr "Удерживать значки в границах экрана"
+msgstr "пёп╢п╣я─п╤п╦п╡п╟я┌я▄ п╥п╫п╟я┤п╨п╦ п╡ пЁя─п╟п╫п╦я├п╟я┘ я█п╨я─п╟п╫п╟"
 
-#: tips:118
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
 msgstr ""
-"Если эта опция включена, значки на витрине всегда будут внутри экрана, "
-"включая подпись."
+"п∙я│п╩п╦ я█я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, п╥п╫п╟я┤п╨п╦ п╫п╟ п╡п╦я┌я─п╦п╫п╣ п╡я│п╣пЁп╢п╟ п╠я┐п╢я┐я┌ п╡п╫я┐я┌я─п╦ я█п╨я─п╟п╫п╟, "
+"п╡п╨п╩я▌я┤п╟я▐ п©п╬п╢п©п╦я│я▄."
 
-#: tips:119
+#: tips:194
 msgid "Icon grid step:"
-msgstr "Размер шага сетки:"
+msgstr "п═п╟п╥п╪п╣я─ я┬п╟пЁп╟ я│п╣я┌п╨п╦:"
 
-#: tips:120
+#: tips:195
 msgid "Fine"
-msgstr "Точный"
+msgstr "п╒п╬я┤п╫я▀п╧"
 
-#: tips:121
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
-msgstr "Для размещения значков на рабочем столе используется 2-х пиксельная сетка."
+msgstr ""
+"п■п╩я▐ я─п╟п╥п╪п╣я┴п╣п╫п╦я▐ п╥п╫п╟я┤п╨п╬п╡ п╫п╟ я─п╟п╠п╬я┤п╣п╪ я│я┌п╬п╩п╣ п╦я│п©п╬п╩я▄п╥я┐п╣я┌я│я▐ 2-я┘ п©п╦п╨я│п╣п╩я▄п╫п╟я▐ я│п╣я┌п╨п╟."
 
-#: tips:122
+#: tips:197
 msgid "Medium"
-msgstr "Средний"
+msgstr "п║я─п╣п╢п╫п╦п╧"
 
-#: tips:123
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
-msgstr "Для размещения значков на рабочем столе используется 16-ти пиксельная сетка."
+msgstr ""
+"п■п╩я▐ я─п╟п╥п╪п╣я┴п╣п╫п╦я▐ п╥п╫п╟я┤п╨п╬п╡ п╫п╟ я─п╟п╠п╬я┤п╣п╪ я│я┌п╬п╩п╣ п╦я│п©п╬п╩я▄п╥я┐п╣я┌я│я▐ 16-я┌п╦ п©п╦п╨я│п╣п╩я▄п╫п╟я▐ я│п╣я┌п╨п╟."
 
-#: tips:124
+#: tips:199
 msgid "Coarse"
-msgstr "Грубый"
+msgstr "п⌠я─я┐п╠я▀п╧"
 
-#: tips:125
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
-msgstr "Для размещения значков на рабочем столе используется 32-х пиксельная сетка."
+msgstr ""
+"п■п╩я▐ я─п╟п╥п╪п╣я┴п╣п╫п╦я▐ п╥п╫п╟я┤п╨п╬п╡ п╫п╟ я─п╟п╠п╬я┤п╣п╪ я│я┌п╬п╩п╣ п╦я│п©п╬п╩я▄п╥я┐п╣я┌я│я▐ 32-я┘ п©п╦п╨я│п╣п╩я▄п╫п╟я▐ я│п╣я┌п╨п╟."
 
-#: tips:126 tips:128
+#: tips:201 tips:203
 msgid "Iconified windows"
-msgstr "Свернутые окна"
+msgstr "п║п╡п╣я─п╫я┐я┌я▀п╣ п╬п╨п╫п╟"
 
-#: tips:127
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
 "windows."
 msgstr ""
-"Многие оконные менеджеры предоставляют возможность сворачивать (или "
-"\"минимизировать\") окна и многие программы, включая ROX-Filer, могут "
-"использоваться для отображения свернутых окон."
+"п°п╫п╬пЁп╦п╣ п╬п╨п╬п╫п╫я▀п╣ п╪п╣п╫п╣п╢п╤п╣я─я▀ п©я─п╣п╢п╬я│я┌п╟п╡п╩я▐я▌я┌ п╡п╬п╥п╪п╬п╤п╫п╬я│я┌я▄ я│п╡п╬я─п╟я┤п╦п╡п╟я┌я▄ (п╦п╩п╦ "
+"\"п╪п╦п╫п╦п╪п╦п╥п╦я─п╬п╡п╟я┌я▄\") п╬п╨п╫п╟ п╦ п╪п╫п╬пЁп╦п╣ п©я─п╬пЁя─п╟п╪п╪я▀, п╡п╨п╩я▌я┤п╟я▐ ROX-Filer, п╪п╬пЁя┐я┌ "
+"п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄я│я▐ п╢п╩я▐ п╬я┌п╬п╠я─п╟п╤п╣п╫п╦я▐ я│п╡п╣я─п╫я┐я┌я▀я┘ п╬п╨п╬п╫."
 
-#: tips:129
+#: tips:204
 msgid "Show iconified windows"
-msgstr "Показывать свернутые окна"
+msgstr "п÷п╬п╨п╟п╥я▀п╡п╟я┌я▄ я│п╡п╣я─п╫я┐я┌я▀п╣ п╬п╨п╫п╟"
 
-#: tips:130
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
 "pinboard must be in use."
 msgstr ""
-"Если эта опция включена, ROX-Filer будет показывать каждое свернутое окно "
-"как небольшую кнопку на витрине. Для этого требуется использовать "
-"совместимый оконный менеджер и задействовать витрину."
+"п∙я│п╩п╦ я█я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, ROX-Filer п╠я┐п╢п╣я┌ п©п╬п╨п╟п╥я▀п╡п╟я┌я▄ п╨п╟п╤п╢п╬п╣ я│п╡п╣я─п╫я┐я┌п╬п╣ п╬п╨п╫п╬ "
+"п╨п╟п╨ п╫п╣п╠п╬п╩я▄я┬я┐я▌ п╨п╫п╬п©п╨я┐ п╫п╟ п╡п╦я┌я─п╦п╫п╣. п■п╩я▐ я█я┌п╬пЁп╬ я┌я─п╣п╠я┐п╣я┌я│я▐ п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ "
+"я│п╬п╡п╪п╣я│я┌п╦п╪я▀п╧ п╬п╨п╬п╫п╫я▀п╧ п╪п╣п╫п╣п╢п╤п╣я─ п╦ п╥п╟п╢п╣п╧я│я┌п╡п╬п╡п╟я┌я▄ п╡п╦я┌я─п╦п╫я┐."
 
-#: tips:131
+#: tips:206
 msgid "Show per workspace"
-msgstr "Показывать для каждого рабочего места"
+msgstr "п÷п╬п╨п╟п╥я▀п╡п╟я┌я▄ п╢п╩я▐ п╨п╟п╤п╢п╬пЁп╬ я─п╟п╠п╬я┤п╣пЁп╬ п╪п╣я│я┌п╟"
 
-#: tips:132
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
 msgstr ""
-"Если эта опция включена, ROX будет показывать только те свёрнутые окна, "
-"которые располагаются на текущем рабочем месте."
+"п∙я│п╩п╦ я█я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, ROX п╠я┐п╢п╣я┌ п©п╬п╨п╟п╥я▀п╡п╟я┌я▄ я┌п╬п╩я▄п╨п╬ я┌п╣ я│п╡я▒я─п╫я┐я┌я▀п╣ п╬п╨п╫п╟, "
+"п╨п╬я┌п╬я─я▀п╣ я─п╟я│п©п╬п╩п╟пЁп╟я▌я┌я│я▐ п╫п╟ я┌п╣п╨я┐я┴п╣п╪ я─п╟п╠п╬я┤п╣п╪ п╪п╣я│я┌п╣."
 
-#: tips:133
+#: tips:208
 msgid "Iconify to the"
-msgstr "Размещать свёрнутые окна"
+msgstr "п═п╟п╥п╪п╣я┴п╟я┌я▄ я│п╡я▒я─п╫я┐я┌я▀п╣ п╬п╨п╫п╟"
 
-#: tips:134
+#: tips:209
 msgid "top-left"
-msgstr "сверху-слева"
+msgstr "я│п╡п╣я─я┘я┐-я│п╩п╣п╡п╟"
 
-#: tips:135
+#: tips:210
 msgid "top-right"
-msgstr "сверху-справа"
+msgstr "я│п╡п╣я─я┘я┐-я│п©я─п╟п╡п╟"
 
-#: tips:136
+#: tips:211
 msgid "bottom-left"
-msgstr "внизу-слева"
+msgstr "п╡п╫п╦п╥я┐-я│п╩п╣п╡п╟"
 
-#: tips:137
+#: tips:212
 msgid "bottom-right"
-msgstr "внизу-справа"
+msgstr "п╡п╫п╦п╥я┐-я│п©я─п╟п╡п╟"
 
-#: tips:138
+#: tips:213
 msgid ", going"
-msgstr ", выстраивать"
+msgstr ", п╡я▀я│я┌я─п╟п╦п╡п╟я┌я▄"
 
-#: tips:139
+#: tips:214
 msgid "horizontally"
-msgstr "горизонтально"
+msgstr "пЁп╬я─п╦п╥п╬п╫я┌п╟п╩я▄п╫п╬"
 
-#: tips:140
+#: tips:215
 msgid "vertically"
-msgstr "вертикально"
+msgstr "п╡п╣я─я┌п╦п╨п╟п╩я▄п╫п╬"
 
-#: tips:141
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
 "or bottom margin to avoid placing the icons there. The filer already knows "
 "about its own panel."
 msgstr ""
-"Иногда файловый менеджер не знает о дополнительных элементах на вашем "
-"рабочем столе и располагает свёрнутые окна под, например, панелью Gnome. Вы "
-"можете задать верхнее или нижнее поле, чтобы избежать попадание свёрнутых "
-"окон в эту область. ROX уже знает о местоположении собственной панели."
+"п≤п╫п╬пЁп╢п╟ я└п╟п╧п╩п╬п╡я▀п╧ п╪п╣п╫п╣п╢п╤п╣я─ п╫п╣ п╥п╫п╟п╣я┌ п╬ п╢п╬п©п╬п╩п╫п╦я┌п╣п╩я▄п╫я▀я┘ я█п╩п╣п╪п╣п╫я┌п╟я┘ п╫п╟ п╡п╟я┬п╣п╪ "
+"я─п╟п╠п╬я┤п╣п╪ я│я┌п╬п╩п╣ п╦ я─п╟я│п©п╬п╩п╟пЁп╟п╣я┌ я│п╡я▒я─п╫я┐я┌я▀п╣ п╬п╨п╫п╟ п©п╬п╢, п╫п╟п©я─п╦п╪п╣я─, п©п╟п╫п╣п╩я▄я▌ Gnome. п▓я▀ "
+"п╪п╬п╤п╣я┌п╣ п╥п╟п╢п╟я┌я▄ п╡п╣я─я┘п╫п╣п╣ п╦п╩п╦ п╫п╦п╤п╫п╣п╣ п©п╬п╩п╣, я┤я┌п╬п╠я▀ п╦п╥п╠п╣п╤п╟я┌я▄ п©п╬п©п╟п╢п╟п╫п╦п╣ я│п╡я▒я─п╫я┐я┌я▀я┘ "
+"п╬п╨п╬п╫ п╡ я█я┌я┐ п╬п╠п╩п╟я│я┌я▄. ROX я┐п╤п╣ п╥п╫п╟п╣я┌ п╬ п╪п╣я│я┌п╬п©п╬п╩п╬п╤п╣п╫п╦п╦ я│п╬п╠я│я┌п╡п╣п╫п╫п╬п╧ п©п╟п╫п╣п╩п╦."
 
-#: tips:142
+#: tips:217
 msgid "Top margin"
-msgstr "Верхнее поле"
+msgstr "п▓п╣я─я┘п╫п╣п╣ п©п╬п╩п╣"
 
-#: tips:143
+#: tips:218
 msgid "Height of no-go area at top of screen."
-msgstr "Высота неиспользуемого пространства вверху экрана"
+msgstr "п▓я▀я│п╬я┌п╟ п╫п╣п╦я│п©п╬п╩я▄п╥я┐п╣п╪п╬пЁп╬ п©я─п╬я│я┌я─п╟п╫я│я┌п╡п╟ п╡п╡п╣я─я┘я┐ я█п╨я─п╟п╫п╟"
 
-#: tips:144
+#: tips:219
 msgid "Bottom margin"
-msgstr "Нижнее поле"
+msgstr "п²п╦п╤п╫п╣п╣ п©п╬п╩п╣"
 
-#: tips:145
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
-msgstr "Высота неиспользуемого пространства внизу экрана"
+msgstr "п▓я▀я│п╬я┌п╟ п╫п╣п╦я│п©п╬п╩я▄п╥я┐п╣п╪п╬пЁп╬ п©я─п╬я│я┌я─п╟п╫я│я┌п╡п╟ п╡п╫п╦п╥я┐ я█п╨я─п╟п╫п╟"
 
-#: tips:146
+#: tips:221
 msgid "Left margin"
-msgstr "Левое поле"
+msgstr "п⌡п╣п╡п╬п╣ п©п╬п╩п╣"
 
-#: tips:147
+#: tips:222
 msgid "Width of no-go area at left of screen."
-msgstr "Высота неиспользуемого пространства слева экрана"
+msgstr "п▓я▀я│п╬я┌п╟ п╫п╣п╦я│п©п╬п╩я▄п╥я┐п╣п╪п╬пЁп╬ п©я─п╬я│я┌я─п╟п╫я│я┌п╡п╟ я│п╩п╣п╡п╟ я█п╨я─п╟п╫п╟"
 
-#: tips:148
+#: tips:223
 msgid "Right margin"
-msgstr "Правое поле"
+msgstr "п÷я─п╟п╡п╬п╣ п©п╬п╩п╣"
 
-#: tips:149
+#: tips:224
 msgid "Width of no-go area at right of screen."
-msgstr "Высота неиспользуемого пространства справа экрана"
+msgstr "п▓я▀я│п╬я┌п╟ п╫п╣п╦я│п©п╬п╩я▄п╥я┐п╣п╪п╬пЁп╬ п©я─п╬я│я┌я─п╟п╫я│я┌п╡п╟ я│п©я─п╟п╡п╟ я█п╨я─п╟п╫п╟"
 
-#: tips:150
+#: tips:225
 msgid "Desktop"
-msgstr "Рабочий стол"
+msgstr "п═п╟п╠п╬я┤п╦п╧ я│я┌п╬п╩"
 
-#: tips:151
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
 msgstr ""
-"Если ROX запускается менеджером сессий (например, ROX-Session), он может "
-"создавать панель и/или витрину. Здесь вы можете определить, что именно будет "
-"создаваться."
+"п∙я│п╩п╦ ROX п╥п╟п©я┐я│п╨п╟п╣я┌я│я▐ п╪п╣п╫п╣п╢п╤п╣я─п╬п╪ я│п╣я│я│п╦п╧ (п╫п╟п©я─п╦п╪п╣я─, ROX-Session), п╬п╫ п╪п╬п╤п╣я┌ "
+"я│п╬п╥п╢п╟п╡п╟я┌я▄ п©п╟п╫п╣п╩я▄ п╦/п╦п╩п╦ п╡п╦я┌я─п╦п╫я┐. п≈п╢п╣я│я▄ п╡я▀ п╪п╬п╤п╣я┌п╣ п╬п©я─п╣п╢п╣п╩п╦я┌я▄, я┤я┌п╬ п╦п╪п╣п╫п╫п╬ п╠я┐п╢п╣я┌ "
+"я│п╬п╥п╢п╟п╡п╟я┌я▄я│я▐."
 
-#: tips:152
+#: tips:227
 msgid "Panel only"
-msgstr "Только панель"
+msgstr "п╒п╬п╩я▄п╨п╬ п©п╟п╫п╣п╩я▄"
 
-#: tips:153
+#: tips:228
 msgid "Only a panel is shown."
-msgstr "Показывается только панель."
+msgstr "п÷п╬п╨п╟п╥я▀п╡п╟п╣я┌я│я▐ я┌п╬п╩я▄п╨п╬ п©п╟п╫п╣п╩я▄."
 
-#: tips:154
+#: tips:229
 msgid "Pinboard only"
-msgstr "Только витрина"
+msgstr "п╒п╬п╩я▄п╨п╬ п╡п╦я┌я─п╦п╫п╟"
 
-#: tips:155
+#: tips:230
 msgid "Only the pinboard is shown."
-msgstr "Показывается только витрина."
+msgstr "п÷п╬п╨п╟п╥я▀п╡п╟п╣я┌я│я▐ я┌п╬п╩я▄п╨п╬ п╡п╦я┌я─п╦п╫п╟."
 
-#: tips:156
+#: tips:231
 msgid "Panel and pinboard"
-msgstr "Панель и витрина"
+msgstr "п÷п╟п╫п╣п╩я▄ п╦ п╡п╦я┌я─п╦п╫п╟"
 
-#: tips:157
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
-msgstr "Показываются и панель, и витрина."
+msgstr "п÷п╬п╨п╟п╥я▀п╡п╟я▌я┌я│я▐ п╦ п©п╟п╫п╣п╩я▄, п╦ п╡п╦я┌я─п╦п╫п╟."
 
-#: tips:159
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
-msgstr "Укажите имя витрины, которая будет отображаться."
+msgstr "пёп╨п╟п╤п╦я┌п╣ п╦п╪я▐ п╡п╦я┌я─п╦п╫я▀, п╨п╬я┌п╬я─п╟я▐ п╠я┐п╢п╣я┌ п╬я┌п╬п╠я─п╟п╤п╟я┌я▄я│я▐."
 
-#: tips:160
-msgid "Panel (obsolete)"
-msgstr "Панель (устаревшая опция)"
-
-#: tips:161
-msgid ""
-"Enter the name of the panel to show here. This option is now only used when "
-"upgrading from an old version."
-msgstr "Укажите имя витрины, которая будет отображаться. Теперь эта опция используется только при обновлении старой версии программы."
-
-#: tips:162
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
-msgstr "Изменения вступят в силу, когда вы запустите ROX снова."
+msgstr "п≤п╥п╪п╣п╫п╣п╫п╦я▐ п╡я│я┌я┐п©я▐я┌ п╡ я│п╦п╩я┐, п╨п╬пЁп╢п╟ п╡я▀ п╥п╟п©я┐я│я┌п╦я┌п╣ ROX я│п╫п╬п╡п╟."
 
-#: tips:163
+#: tips:236
+#, fuzzy
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
-msgstr "Менеджер сессий включает эту опцию используя параметр -S или --rox-session."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
+msgstr ""
+"п°п╣п╫п╣п╢п╤п╣я─ я│п╣я│я│п╦п╧ п╡п╨п╩я▌я┤п╟п╣я┌ я█я┌я┐ п╬п©я├п╦я▌ п╦я│п©п╬п╩я▄п╥я┐я▐ п©п╟я─п╟п╪п╣я┌я─ -S п╦п╩п╦ --rox-session."
 
-#: tips:164
+#: tips:237
 msgid "Action windows"
-msgstr "Окна действий"
+msgstr "п·п╨п╫п╟ п╢п╣п╧я│я┌п╡п╦п╧"
 
-#: tips:165
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
 msgstr ""
-"Окно действий появляется когда вы запускаете\n"
-"какую-либо фоновую операцию, например, копируете\n"
-"или удаляете файлы."
+"п·п╨п╫п╬ п╢п╣п╧я│я┌п╡п╦п╧ п©п╬я▐п╡п╩я▐п╣я┌я│я▐ п╨п╬пЁп╢п╟ п╡я▀ п╥п╟п©я┐я│п╨п╟п╣я┌п╣\n"
+"п╨п╟п╨я┐я▌-п╩п╦п╠п╬ я└п╬п╫п╬п╡я┐я▌ п╬п©п╣я─п╟я├п╦я▌, п╫п╟п©я─п╦п╪п╣я─, п╨п╬п©п╦я─я┐п╣я┌п╣\n"
+"п╦п╩п╦ я┐п╢п╟п╩я▐п╣я┌п╣ я└п╟п╧п╩я▀."
 
-#: tips:166
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
-msgstr "Выполнять без подтверждения (Молча) следующие действия:"
+msgstr "п▓я▀п©п╬п╩п╫я▐я┌я▄ п╠п╣п╥ п©п╬п╢я┌п╡п╣я─п╤п╢п╣п╫п╦я▐ (п°п╬п╩я┤п╟) я│п╩п╣п╢я┐я▌я┴п╦п╣ п╢п╣п╧я│я┌п╡п╦я▐:"
 
-#: tips:168
+#: tips:241
 msgid "Copy files without confirming first."
-msgstr "Копировать файлы без подтверждения."
+msgstr "п п╬п©п╦я─п╬п╡п╟я┌я▄ я└п╟п╧п╩я▀ п╠п╣п╥ п©п╬п╢я┌п╡п╣я─п╤п╢п╣п╫п╦я▐."
 
-#: tips:170
+#: tips:243
 msgid "Move files without confirming first."
-msgstr "Перемещать файлы без подтверждения."
+msgstr "п÷п╣я─п╣п╪п╣я┴п╟я┌я▄ я└п╟п╧п╩я▀ п╠п╣п╥ п©п╬п╢я┌п╡п╣я─п╤п╢п╣п╫п╦я▐."
 
-#: tips:172
+#: tips:245
 msgid "Create links to files without confirming first."
-msgstr "Создавать ссылки на файлы без подтверждения."
+msgstr "п║п╬п╥п╢п╟п╡п╟я┌я▄ я│я│я▀п╩п╨п╦ п╫п╟ я└п╟п╧п╩я▀ п╠п╣п╥ п©п╬п╢я┌п╡п╣я─п╤п╢п╣п╫п╦я▐."
 
-#: tips:174
+#: tips:247
 msgid "Delete files without confirming first."
-msgstr "Удалять файлы без подтверждения."
+msgstr "пёп╢п╟п╩я▐я┌я▄ я└п╟п╧п╩я▀ п╠п╣п╥ п©п╬п╢я┌п╡п╣я─п╤п╢п╣п╫п╦я▐."
 
-#: tips:175
+#: tips:248
 msgid "Mount"
-msgstr "Монтировать"
+msgstr "п°п╬п╫я┌п╦я─п╬п╡п╟я┌я▄"
 
-#: tips:176
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
-msgstr "Монтировать и отмонтировать файловые системы без подтверждения."
+msgstr "п°п╬п╫я┌п╦я─п╬п╡п╟я┌я▄ п╦ п╬я┌п╪п╬п╫я┌п╦я─п╬п╡п╟я┌я▄ я└п╟п╧п╩п╬п╡я▀п╣ я│п╦я│я┌п╣п╪я▀ п╠п╣п╥ п©п╬п╢я┌п╡п╣я─п╤п╢п╣п╫п╦я▐."
 
-#: tips:177
+#: tips:250
 msgid "Default settings"
-msgstr "Установки по умолчанию"
+msgstr "пёя│я┌п╟п╫п╬п╡п╨п╦ п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌"
 
-#: tips:179
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "п÷я─п╦п╫я┐п╢п╦я┌п╣п╩я▄п╫п╬"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
-msgstr "Не подтверждать удаление объектов, защищённых от записи."
+msgstr "п²п╣ п©п╬п╢я┌п╡п╣я─п╤п╢п╟я┌я▄ я┐п╢п╟п╩п╣п╫п╦п╣ п╬п╠я┼п╣п╨я┌п╬п╡, п╥п╟я┴п╦я┴я▒п╫п╫я▀я┘ п╬я┌ п╥п╟п©п╦я│п╦."
 
-#: tips:181
+#: tips:254
 msgid "Don't display so much information in the message area."
-msgstr "Не отображать лишней информации в поле сообщений."
+msgstr "п²п╣ п╬я┌п╬п╠я─п╟п╤п╟я┌я▄ п╩п╦я┬п╫п╣п╧ п╦п╫я└п╬я─п╪п╟я├п╦п╦ п╡ п©п╬п╩п╣ я│п╬п╬п╠я┴п╣п╫п╦п╧."
 
-#: tips:183
+#: tips:256
 msgid "Also change contents of subdirectories."
-msgstr "Также менять содержимое подкаталогов"
+msgstr "п╒п╟п╨п╤п╣ п╪п╣п╫я▐я┌я▄ я│п╬п╢п╣я─п╤п╦п╪п╬п╣ п©п╬п╢п╨п╟я┌п╟п╩п╬пЁп╬п╡"
 
-#: tips:186
+#: tips:263
 msgid "Mount commands"
-msgstr "Команды монтирования"
+msgstr "п п╬п╪п╟п╫п╢я▀ п╪п╬п╫я┌п╦я─п╬п╡п╟п╫п╦я▐"
 
-#: tips:187
+#: tips:264
 msgid "Mount command"
-msgstr "Команда монтирования"
+msgstr "п п╬п╪п╟п╫п╢п╟ п╪п╬п╫я┌п╦я─п╬п╡п╟п╫п╦я▐"
 
-#: tips:188
+#: tips:265
 msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
 msgstr ""
-"Команда, используемая для подсоединения файловой системы. Если вы не "
-"уверены, используйте \"mount\"."
+"п п╬п╪п╟п╫п╢п╟, п╦я│п©п╬п╩я▄п╥я┐п╣п╪п╟я▐ п╢п╩я▐ п©п╬п╢я│п╬п╣п╢п╦п╫п╣п╫п╦я▐ я└п╟п╧п╩п╬п╡п╬п╧ я│п╦я│я┌п╣п╪я▀. п∙я│п╩п╦ п╡я▀ п╫п╣ "
+"я┐п╡п╣я─п╣п╫я▀, п╦я│п©п╬п╩я▄п╥я┐п╧я┌п╣ \"mount\"."
 
-#: tips:189
+#: tips:266
 msgid "Unmount command"
-msgstr "Команда размонтирования"
+msgstr "п п╬п╪п╟п╫п╢п╟ я─п╟п╥п╪п╬п╫я┌п╦я─п╬п╡п╟п╫п╦я▐"
 
-#: tips:190
+#: tips:267
 msgid ""
 "The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
 "without the first \"n\")."
 msgstr ""
-"Команда, используемая для отсоединения файловой системы. Если вы не уверены, "
-"используйте \"umount\" (да, без буквы \"n\" в начале)."
+"п п╬п╪п╟п╫п╢п╟, п╦я│п©п╬п╩я▄п╥я┐п╣п╪п╟я▐ п╢п╩я▐ п╬я┌я│п╬п╣п╢п╦п╫п╣п╫п╦я▐ я└п╟п╧п╩п╬п╡п╬п╧ я│п╦я│я┌п╣п╪я▀. п∙я│п╩п╦ п╡я▀ п╫п╣ я┐п╡п╣я─п╣п╫я▀, "
+"п╦я│п©п╬п╩я▄п╥я┐п╧я┌п╣ \"umount\" (п╢п╟, п╠п╣п╥ п╠я┐п╨п╡я▀ \"n\" п╡ п╫п╟я┤п╟п╩п╣)."
 
-#: tips:191
+#: tips:268
 msgid "Eject command"
-msgstr "Команда извлечения диска"
+msgstr "п п╬п╪п╟п╫п╢п╟ п╦п╥п╡п╩п╣я┤п╣п╫п╦я▐ п╢п╦я│п╨п╟"
 
-#: tips:192
+#: tips:269
 msgid "The command used to eject removable media. If unsure, use \"eject\"."
-msgstr "Команда, используемая для выброса диска. Если вы не уверены, используйте \"eject\"."
+msgstr ""
+"п п╬п╪п╟п╫п╢п╟, п╦я│п©п╬п╩я▄п╥я┐п╣п╪п╟я▐ п╢п╩я▐ п╡я▀п╠я─п╬я│п╟ п╢п╦я│п╨п╟. п∙я│п╩п╦ п╡я▀ п╫п╣ я┐п╡п╣я─п╣п╫я▀, п╦я│п©п╬п╩я▄п╥я┐п╧я┌п╣ "
+"\"eject\"."
 
-#: tips:193
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
-msgstr "Параметры перетаскивания"
+msgstr "п÷п╟я─п╟п╪п╣я┌я─я▀ п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟п╫п╦я▐"
 
-#: tips:194
+#: tips:273
 msgid "Dragging to icons"
-msgstr "Перетаскивать на значки"
+msgstr "п÷п╣я─п╣я┌п╟я│п╨п╦п╡п╟я┌я▄ п╫п╟ п╥п╫п╟я┤п╨п╦"
 
-#: tips:195
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
-msgstr "Разрешить перетаскивание значки в окнах файлового менеджера"
+msgstr "п═п╟п╥я─п╣я┬п╦я┌я▄ п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟п╫п╦п╣ п╥п╫п╟я┤п╨п╦ п╡ п╬п╨п╫п╟я┘ я└п╟п╧п╩п╬п╡п╬пЁп╬ п╪п╣п╫п╣п╢п╤п╣я─п╟"
 
-#: tips:196
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
 "will put it into that directory, or load it into the program."
 msgstr ""
-"Когда эта опция включена, вы можете перетаскивать файлы в подкаталоги или "
-"программы в окне файлового менеджера. Объекты будут подсвечены, когда вы "
-"наведете курсор, а файл будет помещен в выбранный каталог или же загружен в "
-"программу."
+"п п╬пЁп╢п╟ я█я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╣п╫п╟, п╡я▀ п╪п╬п╤п╣я┌п╣ п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟я┌я▄ я└п╟п╧п╩я▀ п╡ п©п╬п╢п╨п╟я┌п╟п╩п╬пЁп╦ п╦п╩п╦ "
+"п©я─п╬пЁя─п╟п╪п╪я▀ п╡ п╬п╨п╫п╣ я└п╟п╧п╩п╬п╡п╬пЁп╬ п╪п╣п╫п╣п╢п╤п╣я─п╟. п·п╠я┼п╣п╨я┌я▀ п╠я┐п╢я┐я┌ п©п╬п╢я│п╡п╣я┤п╣п╫я▀, п╨п╬пЁп╢п╟ п╡я▀ "
+"п╫п╟п╡п╣п╢п╣я┌п╣ п╨я┐я─я│п╬я─, п╟ я└п╟п╧п╩ п╠я┐п╢п╣я┌ п©п╬п╪п╣я┴п╣п╫ п╡ п╡я▀п╠я─п╟п╫п╫я▀п╧ п╨п╟я┌п╟п╩п╬пЁ п╦п╩п╦ п╤п╣ п╥п╟пЁя─я┐п╤п╣п╫ п╡ "
+"п©я─п╬пЁя─п╟п╪п╪я┐."
 
-#: tips:197
+#: tips:276
 msgid "Directories spring open"
-msgstr "Открывать каталоги автоматически"
+msgstr "п·я┌п╨я─я▀п╡п╟я┌я▄ п╨п╟я┌п╟п╩п╬пЁп╦ п╟п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╦"
 
-#: tips:198
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
 "short while."
 msgstr ""
-"Эта опция требует включения предыдущей опции. Заставляет выбранный каталог "
-"автоматически открыться после того, как перетаскиваемый файл пробыл над ним "
-"какое-то время."
+"п╜я┌п╟ п╬п©я├п╦я▐ я┌я─п╣п╠я┐п╣я┌ п╡п╨п╩я▌я┤п╣п╫п╦я▐ п©я─п╣п╢я▀п╢я┐я┴п╣п╧ п╬п©я├п╦п╦. п≈п╟я│я┌п╟п╡п╩я▐п╣я┌ п╡я▀п╠я─п╟п╫п╫я▀п╧ п╨п╟я┌п╟п╩п╬пЁ "
+"п╟п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╦ п╬я┌п╨я─я▀я┌я▄я│я▐ п©п╬я│п╩п╣ я┌п╬пЁп╬, п╨п╟п╨ п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟п╣п╪я▀п╧ я└п╟п╧п╩ п©я─п╬п╠я▀п╩ п╫п╟п╢ п╫п╦п╪ "
+"п╨п╟п╨п╬п╣-я┌п╬ п╡я─п╣п╪я▐."
 
-#: tips:199
+#: tips:278
 msgid "Spring delay:"
-msgstr "Задержка открытия:"
+msgstr "п≈п╟п╢п╣я─п╤п╨п╟ п╬я┌п╨я─я▀я┌п╦я▐:"
 
-#: tips:200
+#: tips:279
 msgid "ms"
-msgstr "мс"
+msgstr "п╪я│"
 
-#: tips:201
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
 "have any effect."
 msgstr ""
-"Эта опция устанавливает задержку в миллисекундах, требующуюся для "
-"автоматического открытия каталога. Предыдущая опция должна быть включена."
+"п╜я┌п╟ п╬п©я├п╦я▐ я┐я│я┌п╟п╫п╟п╡п╩п╦п╡п╟п╣я┌ п╥п╟п╢п╣я─п╤п╨я┐ п╡ п╪п╦п╩п╩п╦я│п╣п╨я┐п╫п╢п╟я┘, я┌я─п╣п╠я┐я▌я┴я┐я▌я│я▐ п╢п╩я▐ "
+"п╟п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╬пЁп╬ п╬я┌п╨я─я▀я┌п╦я▐ п╨п╟я┌п╟п╩п╬пЁп╟. п÷я─п╣п╢я▀п╢я┐я┴п╟я▐ п╬п©я├п╦я▐ п╢п╬п╩п╤п╫п╟ п╠я▀я┌я▄ п╡п╨п╩я▌я┤п╣п╫п╟."
 
-#: tips:202
+#: tips:281
 msgid "When dragging files with the left mouse button"
-msgstr "При перетаскивании файлов левой кнопкой мыши"
+msgstr "п÷я─п╦ п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟п╫п╦п╦ я└п╟п╧п╩п╬п╡ п╩п╣п╡п╬п╧ п╨п╫п╬п©п╨п╬п╧ п╪я▀я┬п╦"
 
-#: tips:203 tips:207
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
-msgstr "Показывать меню возможных действий"
+msgstr "п÷п╬п╨п╟п╥я▀п╡п╟я┌я▄ п╪п╣п╫я▌ п╡п╬п╥п╪п╬п╤п╫я▀я┘ п╢п╣п╧я│я┌п╡п╦п╧"
 
-#: tips:204
+#: tips:283
 msgid "Copy the files"
-msgstr "Копировать файлы"
+msgstr "п п╬п©п╦я─п╬п╡п╟я┌я▄ я└п╟п╧п╩я▀"
 
-#: tips:205
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
 msgstr ""
-"Тем не менее, вы все равно можете использовать меню, перетаскивая файлы и "
-"удерживая клавишу Alt."
+"п╒п╣п╪ п╫п╣ п╪п╣п╫п╣п╣, п╡я▀ п╡я│п╣ я─п╟п╡п╫п╬ п╪п╬п╤п╣я┌п╣ п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п╪п╣п╫я▌, п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟я▐ я└п╟п╧п╩я▀ п╦ "
+"я┐п╢п╣я─п╤п╦п╡п╟я▐ п╨п╩п╟п╡п╦я┬я┐ Alt."
 
-#: tips:206
+#: tips:285
 msgid "When dragging files with the middle mouse button"
-msgstr "При перетаскивании файлов cредней кнопкой мыши"
+msgstr "п÷я─п╦ п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟п╫п╦п╦ я└п╟п╧п╩п╬п╡ cя─п╣п╢п╫п╣п╧ п╨п╫п╬п©п╨п╬п╧ п╪я▀я┬п╦"
 
-#: tips:208
+#: tips:287
 msgid "Move the files"
-msgstr "Перемещать файлы"
+msgstr "п÷п╣я─п╣п╪п╣я┴п╟я┌я▄ я└п╟п╧п╩я▀"
 
-#: tips:209
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
 msgstr ""
-"Тем не менее, вы все-равно можете использовать меню, перетаскивая файлы "
-"левой кнопкой мыши удерживая клавишу Alt."
+"п╒п╣п╪ п╫п╣ п╪п╣п╫п╣п╣, п╡я▀ п╡я│п╣-я─п╟п╡п╫п╬ п╪п╬п╤п╣я┌п╣ п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п╪п╣п╫я▌, п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟я▐ я└п╟п╧п╩я▀ "
+"п╩п╣п╡п╬п╧ п╨п╫п╬п©п╨п╬п╧ п╪я▀я┬п╦ я┐п╢п╣я─п╤п╦п╡п╟я▐ п╨п╩п╟п╡п╦я┬я┐ Alt."
 
-#: tips:210
+#: tips:289
 msgid "Download handler"
-msgstr "Программа для скачивания"
+msgstr "п÷я─п╬пЁя─п╟п╪п╪п╟ п╢п╩я▐ я│п╨п╟я┤п╦п╡п╟п╫п╦я▐"
 
-#: tips:211
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
 "current directory is the destination. Eg:\n"
 "xterm -e wget $1"
 msgstr ""
-"Когда вы перетаскиваете файл из окна броузера или другого удалённого "
-"источника, эта программа будет запущена, чтобы скачать данный файл. $1 это "
-"перетащенный в окно ROX URI, а текущий каталог будет целевым. Например:\n"
+"п п╬пЁп╢п╟ п╡я▀ п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟п╣я┌п╣ я└п╟п╧п╩ п╦п╥ п╬п╨п╫п╟ п╠я─п╬я┐п╥п╣я─п╟ п╦п╩п╦ п╢я─я┐пЁп╬пЁп╬ я┐п╢п╟п╩я▒п╫п╫п╬пЁп╬ "
+"п╦я│я┌п╬я┤п╫п╦п╨п╟, я█я┌п╟ п©я─п╬пЁя─п╟п╪п╪п╟ п╠я┐п╢п╣я┌ п╥п╟п©я┐я┴п╣п╫п╟, я┤я┌п╬п╠я▀ я│п╨п╟я┤п╟я┌я▄ п╢п╟п╫п╫я▀п╧ я└п╟п╧п╩. $1 я█я┌п╬ "
+"п©п╣я─п╣я┌п╟я┴п╣п╫п╫я▀п╧ п╡ п╬п╨п╫п╬ ROX URI, п╟ я┌п╣п╨я┐я┴п╦п╧ п╨п╟я┌п╟п╩п╬пЁ п╠я┐п╢п╣я┌ я├п╣п╩п╣п╡я▀п╪. п²п╟п©я─п╦п╪п╣я─:\n"
 "xterm -e wget $1"
 
-#: tips:212
+#: tips:291
 msgid "Menus"
-msgstr "Меню"
+msgstr "п°п╣п╫я▌"
 
-#: tips:214
+#: tips:293
 msgid "Size of icons in menus:"
-msgstr "Размер значков для меню:"
+msgstr "п═п╟п╥п╪п╣я─ п╥п╫п╟я┤п╨п╬п╡ п╢п╩я▐ п╪п╣п╫я▌:"
 
-#: tips:215
+#: tips:294
 msgid "No Icons"
-msgstr "Без значков"
+msgstr "п▒п╣п╥ п╥п╫п╟я┤п╨п╬п╡"
 
-#: tips:218
+#: tips:297
 msgid "Same as current window"
-msgstr "То же, что и текущее окно"
+msgstr "п╒п╬ п╤п╣, я┤я┌п╬ п╦ я┌п╣п╨я┐я┴п╣п╣ п╬п╨п╫п╬"
 
-#: tips:219
+#: tips:298
 msgid "Same as default"
-msgstr "То же, что и по умолчанию"
+msgstr "п╒п╬ п╤п╣, я┤я┌п╬ п╦ п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌"
 
-#: tips:220
+#: tips:299
 msgid "Behaviour"
-msgstr "Поведение"
+msgstr "п÷п╬п╡п╣п╢п╣п╫п╦п╣"
 
-#: tips:221
+#: tips:300
 msgid "File menu on right-click"
-msgstr "Контекстное меню \"Файл\" вызывается правым кликом"
+msgstr "п п╬п╫я┌п╣п╨я│я┌п╫п╬п╣ п╪п╣п╫я▌ \"п╓п╟п╧п╩\" п╡я▀п╥я▀п╡п╟п╣я┌я│я▐ п©я─п╟п╡я▀п╪ п╨п╩п╦п╨п╬п╪"
 
-#: tips:222
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
 msgstr ""
-"Показывать меню \"Файл\" вместо главного меню при щелчке правой кнопкой "
-"мыши  на выбранных файлах. Главное меню в таком случае становится доступным "
-"при удержании клавиши Control."
+"п÷п╬п╨п╟п╥я▀п╡п╟я┌я▄ п╪п╣п╫я▌ \"п╓п╟п╧п╩\" п╡п╪п╣я│я┌п╬ пЁп╩п╟п╡п╫п╬пЁп╬ п╪п╣п╫я▌ п©я─п╦ я┴п╣п╩я┤п╨п╣ п©я─п╟п╡п╬п╧ п╨п╫п╬п©п╨п╬п╧ "
+"п╪я▀я┬п╦  п╫п╟ п╡я▀п╠я─п╟п╫п╫я▀я┘ я└п╟п╧п╩п╟я┘. п⌠п╩п╟п╡п╫п╬п╣ п╪п╣п╫я▌ п╡ я┌п╟п╨п╬п╪ я│п╩я┐я┤п╟п╣ я│я┌п╟п╫п╬п╡п╦я┌я│я▐ п╢п╬я│я┌я┐п©п╫я▀п╪ "
+"п©я─п╦ я┐п╢п╣я─п╤п╟п╫п╦п╦ п╨п╩п╟п╡п╦я┬п╦ Control."
 
-#: tips:223
+#: tips:302
 msgid "Terminal emulator program"
-msgstr "Программа терминала"
+msgstr "п÷я─п╬пЁя─п╟п╪п╪п╟ я┌п╣я─п╪п╦п╫п╟п╩п╟"
 
-#: tips:224
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
-msgstr "Программа, запускаемая при выборе пункта меню \"Открыть терминал здесь\"."
+msgstr ""
+"п÷я─п╬пЁя─п╟п╪п╪п╟, п╥п╟п©я┐я│п╨п╟п╣п╪п╟я▐ п©я─п╦ п╡я▀п╠п╬я─п╣ п©я┐п╫п╨я┌п╟ п╪п╣п╫я▌ \"п·я┌п╨я─я▀я┌я▄ я┌п╣я─п╪п╦п╫п╟п╩ п╥п╢п╣я│я▄\"."
 
-#: tips:225
+#: tips:304
 msgid "Keyboard shortcuts"
-msgstr "Установить горячие клавиши"
+msgstr "пёя│я┌п╟п╫п╬п╡п╦я┌я▄ пЁп╬я─я▐я┤п╦п╣ п╨п╩п╟п╡п╦я┬п╦"
 
-#: tips:227
+#: tips:305
+msgid "Types"
+msgstr "п╒п╦п©"
+
+#: tips:306
 msgid "MIME types"
-msgstr "Типы MIME"
+msgstr "п╒п╦п©я▀ MIME"
 
-#: tips:228
+#: tips:307
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
 msgstr ""
-"Файловый менеджер использует набор правил, помогающих определить тип MIME "
-"для каждого файла, а затем подбирает для него подходящий значок."
+"п╓п╟п╧п╩п╬п╡я▀п╧ п╪п╣п╫п╣п╢п╤п╣я─ п╦я│п©п╬п╩я▄п╥я┐п╣я┌ п╫п╟п╠п╬я─ п©я─п╟п╡п╦п╩, п©п╬п╪п╬пЁп╟я▌я┴п╦я┘ п╬п©я─п╣п╢п╣п╩п╦я┌я▄ я┌п╦п© MIME "
+"п╢п╩я▐ п╨п╟п╤п╢п╬пЁп╬ я└п╟п╧п╩п╟, п╟ п╥п╟я┌п╣п╪ п©п╬п╢п╠п╦я─п╟п╣я┌ п╢п╩я▐ п╫п╣пЁп╬ п©п╬п╢я┘п╬п╢я▐я┴п╦п╧ п╥п╫п╟я┤п╬п╨."
 
-#: tips:229
+#: tips:308
 msgid "Edit MIME rules"
-msgstr "Редактировать типы MIME"
+msgstr "п═п╣п╢п╟п╨я┌п╦я─п╬п╡п╟я┌я▄ я┌п╦п©я▀ MIME"
 
-#: tips:230
+#: tips:309
 msgid "Themes"
-msgstr "Темы"
+msgstr "п╒п╣п╪я▀"
 
-#: tips:231
+#: tips:310
 msgid "Icon theme"
-msgstr "Тема значков"
+msgstr "п╒п╣п╪п╟ п╥п╫п╟я┤п╨п╬п╡"
 
-#: tips:232
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
-msgstr "Темы должны находится внутри каталога ~/.icons"
+msgstr "п╒п╣п╪я▀ п╢п╬п╩п╤п╫я▀ п╫п╟я┘п╬п╢п╦я┌я│я▐ п╡п╫я┐я┌я─п╦ п╨п╟я┌п╟п╩п╬пЁп╟ ~/.icons"
 
-#: tips:233
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
 msgstr ""
-"Используйте диалог \"Установить значок...\" для ассоциации значков с MIME "
-"типами. Заметьте, что установленные таким образом значки имеют приоритет над "
-"значками, заданными текущей темой."
+"п≤я│п©п╬п╩я▄п╥я┐п╧я┌п╣ п╢п╦п╟п╩п╬пЁ \"пёя│я┌п╟п╫п╬п╡п╦я┌я▄ п╥п╫п╟я┤п╬п╨...\" п╢п╩я▐ п╟я│я│п╬я├п╦п╟я├п╦п╦ п╥п╫п╟я┤п╨п╬п╡ я│ MIME "
+"я┌п╦п©п╟п╪п╦. п≈п╟п╪п╣я┌я▄я┌п╣, я┤я┌п╬ я┐я│я┌п╟п╫п╬п╡п╩п╣п╫п╫я▀п╣ я┌п╟п╨п╦п╪ п╬п╠я─п╟п╥п╬п╪ п╥п╫п╟я┤п╨п╦ п╦п╪п╣я▌я┌ п©я─п╦п╬я─п╦я┌п╣я┌ п╫п╟п╢ "
+"п╥п╫п╟я┤п╨п╟п╪п╦, п╥п╟п╢п╟п╫п╫я▀п╪п╦ я┌п╣п╨я┐я┴п╣п╧ я┌п╣п╪п╬п╧."
 
-#: tips:234
+#: tips:313
 msgid "Colours"
-msgstr "Цвета"
+msgstr "п╕п╡п╣я┌п╟"
 
-#: tips:235
+#: tips:314
 msgid "File type colours"
-msgstr "Расцветка типов файлов"
+msgstr "п═п╟я│я├п╡п╣я┌п╨п╟ я┌п╦п©п╬п╡ я└п╟п╧п╩п╬п╡"
 
-#: tips:236
+#: tips:315
 msgid "Colour files based on their types"
-msgstr "Раскрашивать файлы известных типов"
+msgstr "п═п╟я│п╨я─п╟я┬п╦п╡п╟я┌я▄ я└п╟п╧п╩я▀ п╦п╥п╡п╣я│я┌п╫я▀я┘ я┌п╦п©п╬п╡"
 
-#: tips:237
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
-msgstr "Имена файлов (и подробности) окрашиваются относительно их типа"
+msgstr "п≤п╪п╣п╫п╟ я└п╟п╧п╩п╬п╡ (п╦ п©п╬п╢я─п╬п╠п╫п╬я│я┌п╦) п╬п╨я─п╟я┬п╦п╡п╟я▌я┌я│я▐ п╬я┌п╫п╬я│п╦я┌п╣п╩я▄п╫п╬ п╦я┘ я┌п╦п©п╟"
 
-#: tips:238
+#: tips:317
 msgid "Directory:"
-msgstr "Каталог:"
+msgstr "п п╟я┌п╟п╩п╬пЁ:"
 
-#: tips:239
+#: tips:318
 msgid "Regular file:"
-msgstr "Обычный файл:"
+msgstr "п·п╠я▀я┤п╫я▀п╧ я└п╟п╧п╩:"
 
-#: tips:240
+#: tips:319
 msgid "Pipe:"
-msgstr "Канал:"
+msgstr "п п╟п╫п╟п╩:"
 
-#: tips:241
+#: tips:320
 msgid "Socket:"
-msgstr "Сокет:"
+msgstr "п║п╬п╨п╣я┌:"
 
-#: tips:243
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
 msgstr ""
-"Ошибка, к примеру, ссылка указывает не несуществующий файл или нет прав "
-"доступа к файлу."
+"п·я┬п╦п╠п╨п╟, п╨ п©я─п╦п╪п╣я─я┐, я│я│я▀п╩п╨п╟ я┐п╨п╟п╥я▀п╡п╟п╣я┌ п╫п╣ п╫п╣я│я┐я┴п╣я│я┌п╡я┐я▌я┴п╦п╧ я└п╟п╧п╩ п╦п╩п╦ п╫п╣я┌ п©я─п╟п╡ "
+"п╢п╬я│я┌я┐п©п╟ п╨ я└п╟п╧п╩я┐."
 
-#: tips:244
+#: tips:323
 msgid "Character device:"
-msgstr "Символьное устройство:"
+msgstr "п║п╦п╪п╡п╬п╩я▄п╫п╬п╣ я┐я│я┌я─п╬п╧я│я┌п╡п╬:"
 
-#: tips:245
+#: tips:324
 msgid "Block device:"
-msgstr "Блочное устройство:"
+msgstr "п▒п╩п╬я┤п╫п╬п╣ я┐я│я┌я─п╬п╧я│я┌п╡п╬:"
 
-#: tips:246
+#: tips:325
 msgid "Door:"
-msgstr "Дверь:"
+msgstr "п■п╡п╣я─я▄:"
 
-#: tips:247
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
 msgstr ""
-"Файлы-\"двери\" очень похожи на сокеты или каналы и существуют только в ОС "
-"Солярис."
+"п╓п╟п╧п╩я▀-\"п╢п╡п╣я─п╦\" п╬я┤п╣п╫я▄ п©п╬я┘п╬п╤п╦ п╫п╟ я│п╬п╨п╣я┌я▀ п╦п╩п╦ п╨п╟п╫п╟п╩я▀ п╦ я│я┐я┴п╣я│я┌п╡я┐я▌я┌ я┌п╬п╩я▄п╨п╬ п╡ п·п║ "
+"п║п╬п╩я▐я─п╦я│."
 
-#: tips:248
+#: tips:327
 msgid "Executable file:"
-msgstr "Исполняемый файл:"
+msgstr "п≤я│п©п╬п╩п╫я▐п╣п╪я▀п╧ я└п╟п╧п╩:"
 
-#: tips:249
+#: tips:328
 msgid "Application directory:"
-msgstr "Каталог приложения:"
+msgstr "п п╟я┌п╟п╩п╬пЁ п©я─п╦п╩п╬п╤п╣п╫п╦я▐:"
 
-#: tips:250
+#: tips:329
 msgid "Unknown type:"
-msgstr "Неизвестный тип:"
+msgstr "п²п╣п╦п╥п╡п╣я│я┌п╫я▀п╧ я┌п╦п©:"
 
-#: tips:251
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "п╓п╬п╫:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "п≤я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п©п╬п╩я▄п╥п╬п╡п╟я┌п╣п╩я▄я│п╨п╦п╧ я┬я─п╦я└я┌:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
-msgstr "Совместимость"
+msgstr "п║п╬п╡п╪п╣я│я┌п╦п╪п╬я│я┌я▄"
 
-#: tips:252
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
-msgstr "Проблемы с оконным менеджером"
+msgstr "п÷я─п╬п╠п╩п╣п╪я▀ я│ п╬п╨п╬п╫п╫я▀п╪ п╪п╣п╫п╣п╢п╤п╣я─п╬п╪"
 
-#: tips:253
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
-msgstr "Переназначать управление оконного менеджера для витрины и панелей"
+msgstr "п÷п╣я─п╣п╫п╟п╥п╫п╟я┤п╟я┌я▄ я┐п©я─п╟п╡п╩п╣п╫п╦п╣ п╬п╨п╬п╫п╫п╬пЁп╬ п╪п╣п╫п╣п╢п╤п╣я─п╟ п╢п╩я▐ п╡п╦я┌я─п╦п╫я▀ п╦ п©п╟п╫п╣п╩п╣п╧"
 
-#: tips:254
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4604,241 +5404,404 @@ msgid ""
 "on it, titlebars and other decorations appearing around windows, or having "
 "them appear in window-select lists."
 msgstr ""
-"Некоторые оконные менеджеры не поддерживают \"Extended Window Manager Hint "
-"system\" и показывают витрину и панели как обычные окна. Включите эту опцию "
-"для решения проблем, таких как: выход витрины на передний план, когда вы по "
-"ней щелкаете, наличие у неё заголовка и других оконных элементов оформления "
-"окна или её появление в списке окон"
+"п²п╣п╨п╬я┌п╬я─я▀п╣ п╬п╨п╬п╫п╫я▀п╣ п╪п╣п╫п╣п╢п╤п╣я─я▀ п╫п╣ п©п╬п╢п╢п╣я─п╤п╦п╡п╟я▌я┌ \"Extended Window Manager Hint "
+"system\" п╦ п©п╬п╨п╟п╥я▀п╡п╟я▌я┌ п╡п╦я┌я─п╦п╫я┐ п╦ п©п╟п╫п╣п╩п╦ п╨п╟п╨ п╬п╠я▀я┤п╫я▀п╣ п╬п╨п╫п╟. п▓п╨п╩я▌я┤п╦я┌п╣ я█я┌я┐ п╬п©я├п╦я▌ "
+"п╢п╩я▐ я─п╣я┬п╣п╫п╦я▐ п©я─п╬п╠п╩п╣п╪, я┌п╟п╨п╦я┘ п╨п╟п╨: п╡я▀я┘п╬п╢ п╡п╦я┌я─п╦п╫я▀ п╫п╟ п©п╣я─п╣п╢п╫п╦п╧ п©п╩п╟п╫, п╨п╬пЁп╢п╟ п╡я▀ п©п╬ "
+"п╫п╣п╧ я┴п╣п╩п╨п╟п╣я┌п╣, п╫п╟п╩п╦я┤п╦п╣ я┐ п╫п╣я▒ п╥п╟пЁп╬п╩п╬п╡п╨п╟ п╦ п╢я─я┐пЁп╦я┘ п╬п╨п╬п╫п╫я▀я┘ я█п╩п╣п╪п╣п╫я┌п╬п╡ п╬я└п╬я─п╪п╩п╣п╫п╦я▐ "
+"п╬п╨п╫п╟ п╦п╩п╦ п╣я▒ п©п╬я▐п╡п╩п╣п╫п╦п╣ п╡ я│п©п╦я│п╨п╣ п╬п╨п╬п╫"
 
-#: tips:255
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
-msgstr "Передавать все щелчки мышью по фону в оконный менеджер"
+msgstr "п÷п╣я─п╣п╢п╟п╡п╟я┌я▄ п╡я│п╣ я┴п╣п╩я┤п╨п╦ п╪я▀я┬я▄я▌ п©п╬ я└п╬п╫я┐ п╡ п╬п╨п╬п╫п╫я▀п╧ п╪п╣п╫п╣п╢п╤п╣я─"
 
-#: tips:256
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
 "events to your window manager instead. Clicks on icons will not be forwarded."
 msgstr ""
-"Обычно, правый щелчок по рабочему столу открывает меню витрины, а левый "
-"щелчок снимает выделение. Включите опцию, и вместо этого данные события "
-"будут передаваться в ваш оконный менеджер. Щелчки по значкам передаваться не "
-"будут."
+"п·п╠я▀я┤п╫п╬, п©я─п╟п╡я▀п╧ я┴п╣п╩я┤п╬п╨ п©п╬ я─п╟п╠п╬я┤п╣п╪я┐ я│я┌п╬п╩я┐ п╬я┌п╨я─я▀п╡п╟п╣я┌ п╪п╣п╫я▌ п╡п╦я┌я─п╦п╫я▀, п╟ п╩п╣п╡я▀п╧ "
+"я┴п╣п╩я┤п╬п╨ я│п╫п╦п╪п╟п╣я┌ п╡я▀п╢п╣п╩п╣п╫п╦п╣. п▓п╨п╩я▌я┤п╦я┌п╣ п╬п©я├п╦я▌, п╦ п╡п╪п╣я│я┌п╬ я█я┌п╬пЁп╬ п╢п╟п╫п╫я▀п╣ я│п╬п╠я▀я┌п╦я▐ "
+"п╠я┐п╢я┐я┌ п©п╣я─п╣п╢п╟п╡п╟я┌я▄я│я▐ п╡ п╡п╟я┬ п╬п╨п╬п╫п╫я▀п╧ п╪п╣п╫п╣п╢п╤п╣я─. п╘п╣п╩я┤п╨п╦ п©п╬ п╥п╫п╟я┤п╨п╟п╪ п©п╣я─п╣п╢п╟п╡п╟я┌я▄я│я▐ п╫п╣ "
+"п╠я┐п╢я┐я┌."
 
-#: tips:257
+#: tips:343
 msgid "Blackbox root menus hack"
-msgstr "Обработка меню blackbox"
+msgstr "п·п╠я─п╟п╠п╬я┌п╨п╟ п╪п╣п╫я▌ blackbox"
 
-#: tips:258
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
 "managers are expected to change their behaviour in new versions so that this "
 "isn't necessary."
 msgstr ""
-"Blackbox, Fluxbox и им подобные оконные менеджеры плохо сочетаются с "
-"витриной ROX. Эта опция включает некоторые обходные алгоритмы. Ожидается, "
-"что новые версии этих оконных менеджеров будут вести себя иначе, и эта "
-"функция в будущем больше не понадобится."
+"Blackbox, Fluxbox п╦ п╦п╪ п©п╬п╢п╬п╠п╫я▀п╣ п╬п╨п╬п╫п╫я▀п╣ п╪п╣п╫п╣п╢п╤п╣я─я▀ п©п╩п╬я┘п╬ я│п╬я┤п╣я┌п╟я▌я┌я│я▐ я│ "
+"п╡п╦я┌я─п╦п╫п╬п╧ ROX. п╜я┌п╟ п╬п©я├п╦я▐ п╡п╨п╩я▌я┤п╟п╣я┌ п╫п╣п╨п╬я┌п╬я─я▀п╣ п╬п╠я┘п╬п╢п╫я▀п╣ п╟п╩пЁп╬я─п╦я┌п╪я▀. п·п╤п╦п╢п╟п╣я┌я│я▐, "
+"я┤я┌п╬ п╫п╬п╡я▀п╣ п╡п╣я─я│п╦п╦ я█я┌п╦я┘ п╬п╨п╬п╫п╫я▀я┘ п╪п╣п╫п╣п╢п╤п╣я─п╬п╡ п╠я┐п╢я┐я┌ п╡п╣я│я┌п╦ я│п╣п╠я▐ п╦п╫п╟я┤п╣, п╦ я█я┌п╟ "
+"я└я┐п╫п╨я├п╦я▐ п╡ п╠я┐п╢я┐я┴п╣п╪ п╠п╬п╩я▄я┬п╣ п╫п╣ п©п╬п╫п╟п╢п╬п╠п╦я┌я│я▐."
 
-#: tips:259
+#: tips:345
 msgid "Panel is a 'dock'"
-msgstr "Панель работает как \"док\"."
+msgstr "п÷п╟п╫п╣п╩я▄ я─п╟п╠п╬я┌п╟п╣я┌ п╨п╟п╨ \"п╢п╬п╨\"."
 
-#: tips:260
+#: tips:346
+#, fuzzy
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
-"Отключите эту опцию, если панель остаётся поверх всех окон вопреки вашему "
-"желанию. Для вступления настройки в силу требуется перезапустить ROX."
+"п·я┌п╨п╩я▌я┤п╦я┌п╣ я█я┌я┐ п╬п©я├п╦я▌, п╣я│п╩п╦ п©п╟п╫п╣п╩я▄ п╬я│я┌п╟я▒я┌я│я▐ п©п╬п╡п╣я─я┘ п╡я│п╣я┘ п╬п╨п╬п╫ п╡п╬п©я─п╣п╨п╦ п╡п╟я┬п╣п╪я┐ "
+"п╤п╣п╩п╟п╫п╦я▌. п■п╩я▐ п╡я│я┌я┐п©п╩п╣п╫п╦я▐ п╫п╟я│я┌я─п╬п╧п╨п╦ п╡ я│п╦п╩я┐ я┌я─п╣п╠я┐п╣я┌я│я▐ п©п╣я─п╣п╥п╟п©я┐я│я┌п╦я┌я▄ ROX."
 
-#: tips:261
+#: tips:347
+msgid "Panel stays on top"
+msgstr ""
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
-msgstr "Перетаскивание"
+msgstr "п÷п╣я─п╣я┌п╟я│п╨п╦п╡п╟п╫п╦п╣"
 
-#: tips:262
+#: tips:352
 msgid "Don't use hostnames"
-msgstr "Не использовать имя хоста"
+msgstr "п²п╣ п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п╦п╪я▐ я┘п╬я│я┌п╟"
 
-#: tips:263
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
 "sign on the pointer but the drop doesn't work."
 msgstr ""
-"Некоторые старые программы, не поддерживающие XDND полностью, могут "
-"потребовать включить эту опцию. Используйте эту опцию, если при "
-"перетаскивании файлов в программу отображается значок + на курсоре, но "
-"перетаскивания не происходит."
+"п²п╣п╨п╬я┌п╬я─я▀п╣ я│я┌п╟я─я▀п╣ п©я─п╬пЁя─п╟п╪п╪я▀, п╫п╣ п©п╬п╢п╢п╣я─п╤п╦п╡п╟я▌я┴п╦п╣ XDND п©п╬п╩п╫п╬я│я┌я▄я▌, п╪п╬пЁя┐я┌ "
+"п©п╬я┌я─п╣п╠п╬п╡п╟я┌я▄ п╡п╨п╩я▌я┤п╦я┌я▄ я█я┌я┐ п╬п©я├п╦я▌. п≤я│п©п╬п╩я▄п╥я┐п╧я┌п╣ я█я┌я┐ п╬п©я├п╦я▌, п╣я│п╩п╦ п©я─п╦ "
+"п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟п╫п╦п╦ я└п╟п╧п╩п╬п╡ п╡ п©я─п╬пЁя─п╟п╪п╪я┐ п╬я┌п╬п╠я─п╟п╤п╟п╣я┌я│я▐ п╥п╫п╟я┤п╬п╨ + п╫п╟ п╨я┐я─я│п╬я─п╣, п╫п╬ "
+"п©п╣я─п╣я┌п╟я│п╨п╦п╡п╟п╫п╦я▐ п╫п╣ п©я─п╬п╦я│я┘п╬п╢п╦я┌."
 
-#: tips:264
-msgid "Extended attributes"
-msgstr "Расширенные атрибуты"
-
-#: tips:265
+#: tips:355
 msgid "Don't use extended attributes"
-msgstr "Не использовать расширенные атрибуты"
+msgstr "п²п╣ п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ я─п╟я│я┬п╦я─п╣п╫п╫я▀п╣ п╟я┌я─п╦п╠я┐я┌я▀"
 
-#: tips:266
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
 "disabled, the MIME type of the file is only derived from the file name and "
 "the properties window does not report extended attributes."
 msgstr ""
-"Опция отключает использование расширенных атрибутов, поддерживаемых "
-"современными ОС и файловыми системами. В таком случае становится недоступным "
-"пункт \"Установить тип\", тип MIME устанавливается только по имени файла, а "
-"окно \"Свойства\" не показывает данные о расширенных атрибутах."
+"п·п©я├п╦я▐ п╬я┌п╨п╩я▌я┤п╟п╣я┌ п╦я│п©п╬п╩я▄п╥п╬п╡п╟п╫п╦п╣ я─п╟я│я┬п╦я─п╣п╫п╫я▀я┘ п╟я┌я─п╦п╠я┐я┌п╬п╡, п©п╬п╢п╢п╣я─п╤п╦п╡п╟п╣п╪я▀я┘ "
+"я│п╬п╡я─п╣п╪п╣п╫п╫я▀п╪п╦ п·п║ п╦ я└п╟п╧п╩п╬п╡я▀п╪п╦ я│п╦я│я┌п╣п╪п╟п╪п╦. п▓ я┌п╟п╨п╬п╪ я│п╩я┐я┤п╟п╣ я│я┌п╟п╫п╬п╡п╦я┌я│я▐ п╫п╣п╢п╬я│я┌я┐п©п╫я▀п╪ "
+"п©я┐п╫п╨я┌ \"пёя│я┌п╟п╫п╬п╡п╦я┌я▄ я┌п╦п©\", я┌п╦п© MIME я┐я│я┌п╟п╫п╟п╡п╩п╦п╡п╟п╣я┌я│я▐ я┌п╬п╩я▄п╨п╬ п©п╬ п╦п╪п╣п╫п╦ я└п╟п╧п╩п╟, п╟ "
+"п╬п╨п╫п╬ \"п║п╡п╬п╧я│я┌п╡п╟\" п╫п╣ п©п╬п╨п╟п╥я▀п╡п╟п╣я┌ п╢п╟п╫п╫я▀п╣ п╬ я─п╟я│я┬п╦я─п╣п╫п╫я▀я┘ п╟я┌я─п╦п╠я┐я┌п╟я┘."
 
-#: ../Templates.glade:7
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "п║п╫п╦п╥я┐"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "п║п©я─п╟п╡п╟"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
 msgid "ROX-Filer log viewer"
-msgstr "Просмотреть логи ROX-Filer"
+msgstr "п÷я─п╬я│п╪п╬я┌я─п╣я┌я▄ п╩п╬пЁп╦ ROX-Filer"
 
-#: ../Templates.glade:22
+#: ../Templates.ui.h:2
 msgid "Recently performed actions..."
-msgstr "Самые недавние действия..."
+msgstr "п║п╟п╪я▀п╣ п╫п╣п╢п╟п╡п╫п╦п╣ п╢п╣п╧я│я┌п╡п╦я▐..."
 
-#: ../Templates.glade:77
+#: ../Templates.ui.h:3
 msgid "Open Directory"
-msgstr "Открыть каталог"
+msgstr "п·я┌п╨я─я▀я┌я▄ п╨п╟я┌п╟п╩п╬пЁ"
 
-#: ../Templates.glade:129
+#: ../Templates.ui.h:4
 msgid "Panel Options"
-msgstr "Настройки панели"
+msgstr "п²п╟я│я┌я─п╬п╧п╨п╦ п©п╟п╫п╣п╩п╦"
 
-#: ../Templates.glade:169
-msgid "Every icon on this panel is shown with an image and some text."
-msgstr "Каждый значок на панели отображается вместе с текстом."
-
-#: ../Templates.glade:170
+#: ../Templates.ui.h:5
 msgid "Image and Text"
-msgstr "Значок и текст"
+msgstr "п≈п╫п╟я┤п╬п╨ п╦ я┌п╣п╨я│я┌"
 
-#: ../Templates.glade:186
+#: ../Templates.ui.h:6
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "п п╟п╤п╢я▀п╧ п╥п╫п╟я┤п╬п╨ п╫п╟ п©п╟п╫п╣п╩п╦ п╬я┌п╬п╠я─п╟п╤п╟п╣я┌я│я▐ п╡п╪п╣я│я┌п╣ я│ я┌п╣п╨я│я┌п╬п╪."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "п≈п╫п╟я┤п╨п╦ я┌п╬п╩я▄п╨п╬ п╢п╩я▐ п©я─п╦п╩п╬п╤п╣п╫п╦п╧"
+
+#: ../Templates.ui.h:8
 msgid ""
 "Applications in this panel have just an image, everything else has both an "
 "image and text."
-msgstr "На этой панели только со значком будут приложения, остальное и со значком, и с текстом."
+msgstr ""
+"п²п╟ я█я┌п╬п╧ п©п╟п╫п╣п╩п╦ я┌п╬п╩я▄п╨п╬ я│п╬ п╥п╫п╟я┤п╨п╬п╪ п╠я┐п╢я┐я┌ п©я─п╦п╩п╬п╤п╣п╫п╦я▐, п╬я│я┌п╟п╩я▄п╫п╬п╣ п╦ я│п╬ п╥п╫п╟я┤п╨п╬п╪, п╦ "
+"я│ я┌п╣п╨я│я┌п╬п╪."
 
-#: ../Templates.glade:187
-msgid "Image only for applications"
-msgstr "Значки только для приложений"
-
-#: ../Templates.glade:205
-msgid "Only the image is shown for icons in this panel."
-msgstr "На этой панели показываются только значки"
-
-#: ../Templates.glade:206
+#: ../Templates.ui.h:9
 msgid "Image only"
-msgstr "Только значки"
+msgstr "п╒п╬п╩я▄п╨п╬ п╥п╫п╟я┤п╨п╦"
 
-#: ../Templates.glade:235
+#: ../Templates.ui.h:10
+msgid "Only the image is shown for icons in this panel."
+msgstr "п²п╟ я█я┌п╬п╧ п©п╟п╫п╣п╩п╦ п©п╬п╨п╟п╥я▀п╡п╟я▌я┌я│я▐ я┌п╬п╩я▄п╨п╬ п╥п╫п╟я┤п╨п╦"
+
+#: ../Templates.ui.h:11
 msgid "Panel width"
-msgstr "Ширина панели"
+msgstr "п╗п╦я─п╦п╫п╟ п©п╟п╫п╣п╩п╦"
 
-#: ../Templates.glade:247
+#: ../Templates.ui.h:12
 msgid "The size of this panel."
-msgstr "Размер панели"
+msgstr "п═п╟п╥п╪п╣я─ п©п╟п╫п╣п╩п╦"
 
-#: ../Templates.glade:259
+#: ../Templates.ui.h:13
 msgid "px"
-msgstr "пикс."
+msgstr "п©п╦п╨я│."
 
-#: ../Templates.glade:278
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "п÷п╣я─п╣п╡п╬п╢"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "п²п╣ п©п╣я─п╣п╨я─я▀п╡п╟я┌я▄ п©п╟п╫п╣п╩я▄"
+
+#: ../Templates.ui.h:19
 msgid ""
 "Ask the window manager not to cover this panel when maximising windows, "
 "otherwise leave just 2 pixels at the edge of the screen to allow auto-"
 "raising. Some window managers may not honour this setting."
 msgstr ""
-"Попросить оконный менеджер не закрывать панель при растягивании окон на весь "
-"экран. В противном случае будут оставлены только 2 пикселя у края "
-"экрана, чтобы работало автоматическое всплытие панели. Некоторые оконные менеджеры "
-"могут не поддерживать эту опцию."
+"п÷п╬п©я─п╬я│п╦я┌я▄ п╬п╨п╬п╫п╫я▀п╧ п╪п╣п╫п╣п╢п╤п╣я─ п╫п╣ п╥п╟п╨я─я▀п╡п╟я┌я▄ п©п╟п╫п╣п╩я▄ п©я─п╦ я─п╟я│я┌я▐пЁп╦п╡п╟п╫п╦п╦ п╬п╨п╬п╫ п╫п╟ п╡п╣я│я▄ "
+"я█п╨я─п╟п╫. п▓ п©я─п╬я┌п╦п╡п╫п╬п╪ я│п╩я┐я┤п╟п╣ п╠я┐п╢я┐я┌ п╬я│я┌п╟п╡п╩п╣п╫я▀ я┌п╬п╩я▄п╨п╬ 2 п©п╦п╨я│п╣п╩я▐ я┐ п╨я─п╟я▐ я█п╨я─п╟п╫п╟, "
+"я┤я┌п╬п╠я▀ я─п╟п╠п╬я┌п╟п╩п╬ п╟п╡я┌п╬п╪п╟я┌п╦я┤п╣я│п╨п╬п╣ п╡я│п©п╩я▀я┌п╦п╣ п©п╟п╫п╣п╩п╦. п²п╣п╨п╬я┌п╬я─я▀п╣ п╬п╨п╬п╫п╫я▀п╣ п╪п╣п╫п╣п╢п╤п╣я─я▀ "
+"п╪п╬пЁя┐я┌ п╫п╣ п©п╬п╢п╢п╣я─п╤п╦п╡п╟я┌я▄ я█я┌я┐ п╬п©я├п╦я▌."
 
-#: ../Templates.glade:279
-msgid "Do not cover panel"
-msgstr "Не перекрывать панель"
-
-#: ../Templates.glade:297
+#: ../Templates.ui.h:20
 msgid "<b>Panel style</b>"
-msgstr "<b>Стиль панели</b>"
+msgstr "<b>п║я┌п╦п╩я▄ п©п╟п╫п╣п╩п╦</b>"
 
-#: ../Templates.glade:331
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "п·пЁя─п╟п╫п╦я┤п╦я┌я▄ я█п╨я─п╟п╫п╬п╪ Xinerama"
+
+#: ../Templates.ui.h:22
 msgid ""
 "If you use multiple monitors with Xinerama, use this option to confine the "
 "panel to one monitor."
 msgstr ""
-"Если у вас многодисплейный экран Xinerama, используйте эту опцию, чтобы "
-"панели оставались только на одном экране."
+"п∙я│п╩п╦ я┐ п╡п╟я│ п╪п╫п╬пЁп╬п╢п╦я│п©п╩п╣п╧п╫я▀п╧ я█п╨я─п╟п╫ Xinerama, п╦я│п©п╬п╩я▄п╥я┐п╧я┌п╣ я█я┌я┐ п╬п©я├п╦я▌, я┤я┌п╬п╠я▀ "
+"п©п╟п╫п╣п╩п╦ п╬я│я┌п╟п╡п╟п╩п╦я│я▄ я┌п╬п╩я▄п╨п╬ п╫п╟ п╬п╢п╫п╬п╪ я█п╨я─п╟п╫п╣."
 
-#: ../Templates.glade:332
-msgid "Confine to Xinerama monitor"
-msgstr "Ограничить экраном Xinerama"
-
-#: ../Templates.glade:347
+#: ../Templates.ui.h:23
 msgid ""
 "The monitor this panel is confined to when using Xinerama. The numbering "
 "starts from zero."
-msgstr "Экран, на котором будут заперта панель в режиме Xinerama (начиная с 0)"
+msgstr "п╜п╨я─п╟п╫, п╫п╟ п╨п╬я┌п╬я─п╬п╪ п╠я┐п╢я┐я┌ п╥п╟п©п╣я─я┌п╟ п©п╟п╫п╣п╩я▄ п╡ я─п╣п╤п╦п╪п╣ Xinerama (п╫п╟я┤п╦п╫п╟я▐ я│ 0)"
 
-#: ../Templates.glade:372
+#: ../Templates.ui.h:24
 msgid "<b>Xinerama</b>"
 msgstr "<b>Xinerama</b>"
 
-#: ../Templates.glade:407
+#: ../Templates.ui.h:25
 msgid "Right edge"
-msgstr "Справа"
+msgstr "п║п©я─п╟п╡п╟"
 
-#: ../Templates.glade:426
+#: ../Templates.ui.h:26
 msgid "Left edge"
-msgstr "Слева"
+msgstr "п║п╩п╣п╡п╟"
 
-#: ../Templates.glade:443
+#: ../Templates.ui.h:27
 msgid "Bottom edge"
-msgstr "Снизу"
+msgstr "п║п╫п╦п╥я┐"
 
-#: ../Templates.glade:462
+#: ../Templates.ui.h:28
 msgid "Top edge"
-msgstr "Сверху"
+msgstr "п║п╡п╣я─я┘я┐"
 
-#: ../Templates.glade:496
+#: ../Templates.ui.h:29
 msgid "<b>Position</b>"
-msgstr "<b>Положение</b>"
+msgstr "<b>п÷п╬п╩п╬п╤п╣п╫п╦п╣</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<п╨п╟я┌п╟п╩п╬пЁ>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?\"%s\" я┐п╤п╣ я│я┐я┴п╣я│я┌п╡я┐п╣я┌ - п©п╣я─п╣п©п╦я│п╟я┌я▄?"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "п·я┬п╦п╠п╨п╟ п©я─п╬я│п╪п╬я┌я─п╟ \"%s\":\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "п п╟я┌п╟п╩п╬пЁ п╬я┌я│я┐я┌я│я┌п╡я┐п╣я┌ п╦п╩п╦ я┐п╢п╟п╩п╣п╫"
+
+#~ msgid "Directory '%s' is not accessible"
+#~ msgstr "п п╟я┌п╟п╩п╬пЁ \"%s\" п╫п╣п╢п╬я│я┌я┐п©п╣п╫"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "п п╟я┌п╟п╩п╬пЁ \"%s\" п╫п╣ п╫п╟п╧п╢п╣п╫"
+
+#~ msgid "Cancel"
+#~ msgstr "п·я┌п╪п╣п╫п╦я┌я▄"
+
+#~ msgid "All, "
+#~ msgstr "п▓я│п╣, "
+
+#~ msgid "Dnotify support"
+#~ msgstr "п÷п╬п╢п╢п╣я─п╤п╨п╟ Dnotify"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "п·я┌п╨я─п╬п╧я┌п╣ \"п°п╣п╫я▌\" п╪я▀я┬я▄я▌, я┐п╢п╣я─п╤п╦п╡п╟я▐ Shift, я┤я┌п╬п╠я▀ п╬я┌п©я─п╟п╡п╦я┌я▄ я└п╟п╧п╩ п╨я┐п╢п╟-п╩п╦п╠п╬"
+
+#~ msgid "B"
+#~ msgstr "п▒"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "пёп╧я┌п╦ п╡ я─п╬п╢п╦я┌п╣п╩я▄я│п╨п╦п╧ п╨п╟я┌п╟п╩п╬пЁ"
+
+#~ msgid "Change to home directory"
+#~ msgstr "п÷п╣я─п╣п╧я┌п╦ п╡ п╢п╬п╪п╟я┬п╫п╦п╧ п╨п╟я┌п╟п╩п╬пЁ"
+
+#~ msgid "Bookmarks"
+#~ msgstr "п≈п╟п╨п╩п╟п╢п╨п╦"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "п°п╣п╫я▌ п╥п╟п╨п╩п╟п╢п╬п╨"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "п÷п╣я─п╣я┤п╦я┌п╟я┌я▄ я│п╬п╢п╣я─п╤п╦п╪п╬п╣ п╨п╟я┌п╟п╩п╬пЁп╟"
+
+#~ msgid "Change icon size"
+#~ msgstr "п≤п╥п╪п╣п╫п╦я┌я▄ я─п╟п╥п╪п╣я─ п╥п╫п╟я┤п╨п╬п╡"
+
+#~ msgid "Show extra details"
+#~ msgstr "п÷п╬п╨п╟п╥п╟я┌я▄ п╢п╬п©п╬п╩п╫п╦я┌п╣п╩я▄п╫я▀п╣ п©п╬п╢я─п╬п╠п╫п╬я│я┌п╦"
+
+#~ msgid "Hidden"
+#~ msgstr "п║п╨я─я▀я┌я▀п╣"
+
+#~ msgid "Change at:"
+#~ msgstr "п²п╟я┤п╦п╫п╟я▐ я│:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "п²п╟п╦п╠п╬п╩я▄я┬п╟я▐ я┬п╦я─п╦п╫п╟ (п╠п╬п╩я▄я┬п╦п╣ п╥п╫п╟я┤п╨п╦):"
+
+#~ msgid "Panel (obsolete)"
+#~ msgstr "п÷п╟п╫п╣п╩я▄ (я┐я│я┌п╟я─п╣п╡я┬п╟я▐ п╬п©я├п╦я▐)"
+
+#~ msgid ""
+#~ "Enter the name of the panel to show here. This option is now only used "
+#~ "when upgrading from an old version."
+#~ msgstr ""
+#~ "пёп╨п╟п╤п╦я┌п╣ п╦п╪я▐ п╡п╦я┌я─п╦п╫я▀, п╨п╬я┌п╬я─п╟я▐ п╠я┐п╢п╣я┌ п╬я┌п╬п╠я─п╟п╤п╟я┌я▄я│я▐. п╒п╣п©п╣я─я▄ я█я┌п╟ п╬п©я├п╦я▐ "
+#~ "п╦я│п©п╬п╩я▄п╥я┐п╣я┌я│я▐ я┌п╬п╩я▄п╨п╬ п©я─п╦ п╬п╠п╫п╬п╡п╩п╣п╫п╦п╦ я│я┌п╟я─п╬п╧ п╡п╣я─я│п╦п╦ п©я─п╬пЁя─п╟п╪п╪я▀."
 
 #~ msgid "Panel: %s"
-#~ msgstr "Панель: %s"
+#~ msgstr "п÷п╟п╫п╣п╩я▄: %s"
 
 #~ msgid "Select the panel's position:"
-#~ msgstr "Выбeрите расположение панели:"
+#~ msgstr "п▓я▀п╠eя─п╦я┌п╣ я─п╟я│п©п╬п╩п╬п╤п╣п╫п╦п╣ п©п╟п╫п╣п╩п╦:"
 
 #~ msgid "Top-edge panel"
-#~ msgstr "Панель сверху"
+#~ msgstr "п÷п╟п╫п╣п╩я▄ я│п╡п╣я─я┘я┐"
 
 #~ msgid "Bottom edge panel"
-#~ msgstr "Панель снизу"
+#~ msgstr "п÷п╟п╫п╣п╩я▄ я│п╫п╦п╥я┐"
 
 #~ msgid "Left edge panel"
-#~ msgstr "Панель слева"
+#~ msgstr "п÷п╟п╫п╣п╩я▄ я│п╩п╣п╡п╟"
 
 #~ msgid "Right-edge panel"
-#~ msgstr "Панель справа"
+#~ msgstr "п÷п╟п╫п╣п╩я▄ я│п©я─п╟п╡п╟"
 
 #~ msgid "Invalid .gmo translation file (too short): %s"
-#~ msgstr "Неверный формат файла перевода .gmo (слишком короткий): %s"
+#~ msgstr "п²п╣п╡п╣я─п╫я▀п╧ я└п╬я─п╪п╟я┌ я└п╟п╧п╩п╟ п©п╣я─п╣п╡п╬п╢п╟ .gmo (я│п╩п╦я┬п╨п╬п╪ п╨п╬я─п╬я┌п╨п╦п╧): %s"
 
 #~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
 #~ msgstr ""
-#~ "Неверный формат файла перевода .gmo (\"волшебное\" число GNU не найдено): "
+#~ "п²п╣п╡п╣я─п╫я▀п╧ я└п╬я─п╪п╟я┌ я└п╟п╧п╩п╟ п©п╣я─п╣п╡п╬п╢п╟ .gmo (\"п╡п╬п╩я┬п╣п╠п╫п╬п╣\" я┤п╦я│п╩п╬ GNU п╫п╣ п╫п╟п╧п╢п╣п╫п╬): "
 #~ "%s"
 
 #~ msgid ""
 #~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
 #~ "instead."
 #~ msgstr ""
-#~ "Тема значков \"%s\" не содержит значков для типов MIME. Вместо неё будет "
-#~ "использоваться тема ROX по умолчанию."
+#~ "п╒п╣п╪п╟ п╥п╫п╟я┤п╨п╬п╡ \"%s\" п╫п╣ я│п╬п╢п╣я─п╤п╦я┌ п╥п╫п╟я┤п╨п╬п╡ п╢п╩я▐ я┌п╦п©п╬п╡ MIME. п▓п╪п╣я│я┌п╬ п╫п╣я▒ п╠я┐п╢п╣я┌ "
+#~ "п╦я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄я│я▐ я┌п╣п╪п╟ ROX п©п╬ я┐п╪п╬п╩я┤п╟п╫п╦я▌."
 
 #~ msgid ""
 #~ "Failed to create symlink '%s':\n"
@@ -4848,179 +5811,175 @@ msgstr "<b>Положение</b>"
 #~ "application:postscript' icon couldn't be loaded for some reason, or %s is "
 #~ "a link to an invalid directory; try deleting it)"
 #~ msgstr ""
-#~ "Создать символическую ссылку \"%s\" не удалось:\n"
+#~ "п║п╬п╥п╢п╟я┌я▄ я│п╦п╪п╡п╬п╩п╦я┤п╣я│п╨я┐я▌ я│я│я▀п╩п╨я┐ \"%s\" п╫п╣ я┐п╢п╟п╩п╬я│я▄:\n"
 #~ "%s\n"
 #~ "\n"
-#~ "(Это может означать, что тема для ROX уже находится там, но значок 'mime-"
-#~ "application:postscript' почему-то не может быть загружена - или %s "
-#~ "является символической ссылкой на несуществующий каталог, попробуйте её "
-#~ "удалить)"
-
-#~ msgid "Translation"
-#~ msgstr "Перевод"
+#~ "(п╜я┌п╬ п╪п╬п╤п╣я┌ п╬п╥п╫п╟я┤п╟я┌я▄, я┤я┌п╬ я┌п╣п╪п╟ п╢п╩я▐ ROX я┐п╤п╣ п╫п╟я┘п╬п╢п╦я┌я│я▐ я┌п╟п╪, п╫п╬ п╥п╫п╟я┤п╬п╨ 'mime-"
+#~ "application:postscript' п©п╬я┤п╣п╪я┐-я┌п╬ п╫п╣ п╪п╬п╤п╣я┌ п╠я▀я┌я▄ п╥п╟пЁя─я┐п╤п╣п╫п╟ - п╦п╩п╦ %s "
+#~ "я▐п╡п╩я▐п╣я┌я│я▐ я│п╦п╪п╡п╬п╩п╦я┤п╣я│п╨п╬п╧ я│я│я▀п╩п╨п╬п╧ п╫п╟ п╫п╣я│я┐я┴п╣я│я┌п╡я┐я▌я┴п╦п╧ п╨п╟я┌п╟п╩п╬пЁ, п©п╬п©я─п╬п╠я┐п╧я┌п╣ п╣я▒ "
+#~ "я┐п╢п╟п╩п╦я┌я▄)"
 
 #~ msgid "Language"
-#~ msgstr "Язык"
+#~ msgstr "п╞п╥я▀п╨"
 
 #~ msgid "Use the LANG environment variable"
-#~ msgstr "Использовать переменную окружения LANG"
+#~ msgstr "п≤я│п©п╬п╩я▄п╥п╬п╡п╟я┌я▄ п©п╣я─п╣п╪п╣п╫п╫я┐я▌ п╬п╨я─я┐п╤п╣п╫п╦я▐ LANG"
 
 #~ msgid "Basque"
-#~ msgstr "Баскский"
+#~ msgstr "п▒п╟я│п╨я│п╨п╦п╧"
 
 #~ msgid "Chinese (traditional)"
-#~ msgstr "Китайский (традиционный)"
+#~ msgstr "п п╦я┌п╟п╧я│п╨п╦п╧ (я┌я─п╟п╢п╦я├п╦п╬п╫п╫я▀п╧)"
 
 #~ msgid "Chinese (simplified)"
-#~ msgstr "Китайский (упрощённый)"
+#~ msgstr "п п╦я┌п╟п╧я│п╨п╦п╧ (я┐п©я─п╬я┴я▒п╫п╫я▀п╧)"
 
 #~ msgid "Czech"
-#~ msgstr "Чешский"
+#~ msgstr "п╖п╣я┬я│п╨п╦п╧"
 
 #~ msgid "Danish"
-#~ msgstr "Датский"
+#~ msgstr "п■п╟я┌я│п╨п╦п╧"
 
 #~ msgid "Dutch"
-#~ msgstr "Голландский"
+#~ msgstr "п⌠п╬п╩п╩п╟п╫п╢я│п╨п╦п╧"
 
 #~ msgid "English (no translation)"
-#~ msgstr "Английский (без перевода)"
+#~ msgstr "п░п╫пЁп╩п╦п╧я│п╨п╦п╧ (п╠п╣п╥ п©п╣я─п╣п╡п╬п╢п╟)"
 
 #~ msgid "Estonian"
-#~ msgstr "Эстонский"
+#~ msgstr "п╜я│я┌п╬п╫я│п╨п╦п╧"
 
 #~ msgid "Finnish"
-#~ msgstr "Финский"
+#~ msgstr "п╓п╦п╫я│п╨п╦п╧"
 
 #~ msgid "French"
-#~ msgstr "Французский"
+#~ msgstr "п╓я─п╟п╫я├я┐п╥я│п╨п╦п╧"
 
 #~ msgid "German"
-#~ msgstr "Немецкий"
+#~ msgstr "п²п╣п╪п╣я├п╨п╦п╧"
 
 #~ msgid "Hungarian"
-#~ msgstr "Венгерский"
+#~ msgstr "п▓п╣п╫пЁп╣я─я│п╨п╦п╧"
 
 #~ msgid "Japanese"
-#~ msgstr "Японский"
+#~ msgstr "п╞п©п╬п╫я│п╨п╦п╧"
 
 #~ msgid "Norwegian"
-#~ msgstr "Норвежский"
+#~ msgstr "п²п╬я─п╡п╣п╤я│п╨п╦п╧"
 
 #~ msgid "Italian"
-#~ msgstr "Итальянский"
+#~ msgstr "п≤я┌п╟п╩я▄я▐п╫я│п╨п╦п╧"
 
 #~ msgid "Polish"
-#~ msgstr "Польский"
+#~ msgstr "п÷п╬п╩я▄я│п╨п╦п╧"
 
 #~ msgid "Portuguese (Portugal)"
-#~ msgstr "Португальский (Португалия)"
+#~ msgstr "п÷п╬я─я┌я┐пЁп╟п╩я▄я│п╨п╦п╧ (п÷п╬я─я┌я┐пЁп╟п╩п╦я▐)"
 
 #~ msgid "Portuguese (Brasil)"
-#~ msgstr "Португальский (Бразилия)"
+#~ msgstr "п÷п╬я─я┌я┐пЁп╟п╩я▄я│п╨п╦п╧ (п▒я─п╟п╥п╦п╩п╦я▐)"
 
 #~ msgid "Romanian"
-#~ msgstr "Румынский"
+#~ msgstr "п═я┐п╪я▀п╫я│п╨п╦п╧"
 
 # tips
 #~ msgid "Russian"
-#~ msgstr "Русский"
+#~ msgstr "п═я┐я│я│п╨п╦п╧"
 
 #~ msgid "Spanish"
-#~ msgstr "Испанский"
+#~ msgstr "п≤я│п©п╟п╫я│п╨п╦п╧"
 
 #~ msgid "Swedish"
-#~ msgstr "Шведский"
+#~ msgstr "п╗п╡п╣п╢я│п╨п╦п╧"
 
 #~ msgid "Ukrainian"
-#~ msgstr "Украинский"
+#~ msgstr "пёп╨я─п╟п╦п╫я│п╨п╦п╧"
 
 #~ msgid "Vietnamese"
-#~ msgstr "Вьетнамский"
+#~ msgstr "п▓я▄п╣я┌п╫п╟п╪я│п╨п╦п╧"
 
 #~ msgid "Panels"
-#~ msgstr "Панели"
+#~ msgstr "п÷п╟п╫п╣п╩п╦"
 
 #~ msgid ""
 #~ "Panels are bars of icons that run along the side of the screen. See the "
 #~ "manual for information about using panels."
 #~ msgstr ""
-#~ "Панели это ряды иконок, располагающиеся вдоль границы экрана.\n"
-#~ "Смотрите документацию для подробной информации об использовании панелей."
+#~ "п÷п╟п╫п╣п╩п╦ я█я┌п╬ я─я▐п╢я▀ п╦п╨п╬п╫п╬п╨, я─п╟я│п©п╬п╩п╟пЁп╟я▌я┴п╦п╣я│я▐ п╡п╢п╬п╩я▄ пЁя─п╟п╫п╦я├я▀ я█п╨я─п╟п╫п╟.\n"
+#~ "п║п╪п╬я┌я─п╦я┌п╣ п╢п╬п╨я┐п╪п╣п╫я┌п╟я├п╦я▌ п╢п╩я▐ п©п╬п╢я─п╬п╠п╫п╬п╧ п╦п╫я└п╬я─п╪п╟я├п╦п╦ п╬п╠ п╦я│п©п╬п╩я▄п╥п╬п╡п╟п╫п╦п╦ п©п╟п╫п╣п╩п╣п╧."
 
 #~ msgid "(thick)"
-#~ msgstr "(широкая)"
+#~ msgstr "(я┬п╦я─п╬п╨п╟я▐)"
 
 #~ msgid "Enter the name of the panel to show here."
-#~ msgstr "Укажите имя панели, которая будет отображаться."
+#~ msgstr "пёп╨п╟п╤п╦я┌п╣ п╦п╪я▐ п©п╟п╫п╣п╩п╦, п╨п╬я┌п╬я─п╟я▐ п╠я┐п╢п╣я┌ п╬я┌п╬п╠я─п╟п╤п╟я┌я▄я│я▐."
 
 #~ msgid "Choices migration"
-#~ msgstr "Перемещение настроек"
+#~ msgstr "п÷п╣я─п╣п╪п╣я┴п╣п╫п╦п╣ п╫п╟я│я┌я─п╬п╣п╨"
 
 #~ msgid ""
 #~ ".\n"
 #~ "Home page (including updated versions): http://rox.sourceforge.net/\n"
 #~ msgstr ""
 #~ ".\n"
-#~ "Домашняя страница (включая обновления): http://rox.sourceforge.net/\n"
+#~ "п■п╬п╪п╟я┬п╫я▐я▐ я│я┌я─п╟п╫п╦я├п╟ (п╡п╨п╩я▌я┤п╟я▐ п╬п╠п╫п╬п╡п╩п╣п╫п╦я▐): http://rox.sourceforge.net/\n"
 
 #~ msgid "GNOME-VFS library"
-#~ msgstr "GNOME-VFS библиотека"
+#~ msgstr "GNOME-VFS п╠п╦п╠п╩п╦п╬я┌п╣п╨п╟"
 
 #~ msgid "No (need 2.8.0 or later)"
-#~ msgstr "Нет (нужна 2.8.0. или более поздняя)"
+#~ msgstr "п²п╣я┌ (п╫я┐п╤п╫п╟ 2.8.0. п╦п╩п╦ п╠п╬п╩п╣п╣ п©п╬п╥п╢п╫я▐я▐)"
 
 #~ msgid "Open AVFS"
-#~ msgstr "Открыть AVFS"
+#~ msgstr "п·я┌п╨я─я▀я┌я▄ AVFS"
 
 #
 #~ msgid "Look inside ... ?"
-#~ msgstr "Посмотреть внутрь чего?"
+#~ msgstr "п÷п╬я│п╪п╬я┌я─п╣я┌я▄ п╡п╫я┐я┌я─я▄ я┤п╣пЁп╬?"
 
 #~ msgid "Show/hide hidden files"
-#~ msgstr "Отображать или не отображать скрытые файлы"
+#~ msgstr "п·я┌п╬п╠я─п╟п╤п╟я┌я▄ п╦п╩п╦ п╫п╣ п╬я┌п╬п╠я─п╟п╤п╟я┌я▄ я│п╨я─я▀я┌я▀п╣ я└п╟п╧п╩я▀"
 
 #~ msgid ""
 #~ "Error loading MIME database:\n"
 #~ "%s"
 #~ msgstr ""
-#~ "Ошибка загрузки базы данных MIME:\n"
+#~ "п·я┬п╦п╠п╨п╟ п╥п╟пЁя─я┐п╥п╨п╦ п╠п╟п╥я▀ п╢п╟п╫п╫я▀я┘ MIME:\n"
 #~ "%s"
 
 #~ msgid "File '%s' corrupted!"
-#~ msgstr "Файл '%s' поврежден!"
+#~ msgstr "п╓п╟п╧п╩ '%s' п©п╬п╡я─п╣п╤п╢п╣п╫!"
 
 #~ msgid "Icon '%s' not present in theme"
-#~ msgstr "Пиктограммы '%s' нет в данной теме"
+#~ msgstr "п÷п╦п╨я┌п╬пЁя─п╟п╪п╪я▀ '%s' п╫п╣я┌ п╡ п╢п╟п╫п╫п╬п╧ я┌п╣п╪п╣"
 
 #~ msgid "Executable files"
-#~ msgstr "Запускаемые файлы"
+#~ msgstr "п≈п╟п©я┐я│п╨п╟п╣п╪я▀п╣ я└п╟п╧п╩я▀"
 
 #~ msgid "Ignore eXecutable bit for known extensions"
-#~ msgstr "Игнорировать запускаемый бит для известных расширений"
+#~ msgstr "п≤пЁп╫п╬я─п╦я─п╬п╡п╟я┌я▄ п╥п╟п©я┐я│п╨п╟п╣п╪я▀п╧ п╠п╦я┌ п╢п╩я▐ п╦п╥п╡п╣я│я┌п╫я▀я┘ я─п╟я│я┬п╦я─п╣п╫п╦п╧"
 
 #~ msgid ""
 #~ "If a file has a known extension (eg '.gif') then ignore the executable "
 #~ "bit. This is useful if you have files on a Windows-type filesystem which "
 #~ "are being shown as executable programs."
 #~ msgstr ""
-#~ "Если расширение файла известно (например '.gif'), тогда запускаемый бит "
-#~ "игнорируется. Это полезно, если у вас есть файлы на файловой системе "
-#~ "Windows, которыеотображаются как запускаемые программы."
+#~ "п∙я│п╩п╦ я─п╟я│я┬п╦я─п╣п╫п╦п╣ я└п╟п╧п╩п╟ п╦п╥п╡п╣я│я┌п╫п╬ (п╫п╟п©я─п╦п╪п╣я─ '.gif'), я┌п╬пЁп╢п╟ п╥п╟п©я┐я│п╨п╟п╣п╪я▀п╧ п╠п╦я┌ "
+#~ "п╦пЁп╫п╬я─п╦я─я┐п╣я┌я│я▐. п╜я┌п╬ п©п╬п╩п╣п╥п╫п╬, п╣я│п╩п╦ я┐ п╡п╟я│ п╣я│я┌я▄ я└п╟п╧п╩я▀ п╫п╟ я└п╟п╧п╩п╬п╡п╬п╧ я│п╦я│я┌п╣п╪п╣ "
+#~ "Windows, п╨п╬я┌п╬я─я▀п╣п╬я┌п╬п╠я─п╟п╤п╟я▌я┌я│я▐ п╨п╟п╨ п╥п╟п©я┐я│п╨п╟п╣п╪я▀п╣ п©я─п╬пЁя─п╟п╪п╪я▀."
 
 #, fuzzy
 #~ msgid "Umount"
-#~ msgstr "Отсоединить"
+#~ msgstr "п·я┌я│п╬п╣п╢п╦п╫п╦я┌я▄"
 
 #~ msgid "Symbolic link to %s"
-#~ msgstr "Символическая ссылка для %s"
+#~ msgstr "п║п╦п╪п╡п╬п╩п╦я┤п╣я│п╨п╟я▐ я│я│я▀п╩п╨п╟ п╢п╩я▐ %s"
 
 #~ msgid "No (gnome-vfs-config not found)"
-#~ msgstr "Нет (gnome-vfs-config not found)"
+#~ msgstr "п²п╣я┌ (gnome-vfs-config not found)"
 
 #~ msgid "Info"
-#~ msgstr "Информация"
+#~ msgstr "п≤п╫я└п╬я─п╪п╟я├п╦я▐"
 
 #~ msgid "Examine ... ?"
-#~ msgstr "Проверить что?"
-
+#~ msgstr "п÷я─п╬п╡п╣я─п╦я┌я▄ я┤я┌п╬?"

--- a/ROX-Filer/src/po/sv.po
+++ b/ROX-Filer/src/po/sv.po
@@ -6,62 +6,67 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-08-09 14:02+0100\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2002-09-15 19:25+0200\n"
 "Last-Translator: Marcys Lundblad <ml@update.uu.se>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: abox.c:127
-msgid "<dir>"
-msgstr "<katalog>"
+msgid "<src>"
+msgstr ""
 
-#: abox.c:219
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 #, fuzzy
 msgid "_Quiet"
 msgstr "_Tyst"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Quiet"
 msgstr "Tyst"
 
-#: abox.c:228
+#: abox.c:247
 msgid "Don't confirm every operation"
-msgstr "Bekr‰fta inte alla kommandon"
+msgstr "Bekr√§fta inte alla kommandon"
 
-#: abox.c:455 tips:60
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Namn"
 
-#: abox.c:461 menu.c:232
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Katalog"
 
-#: abox.c:550
+#: abox.c:546
 msgid "Expression:"
 msgstr "Uttryck:"
 
-#: action.c:58
+#: action.c:57
 #, fuzzy
 msgid "See the attr(5) man page for full details."
-msgstr "Se ROX-Filer-manualen fˆr detaljer."
+msgstr "Se ROX-Filer-manualen f√∂r detaljer."
 
-#: action.c:60
+#: action.c:59
 #, fuzzy
 msgid "See the fsattr(5) man page for full details."
-msgstr "Se ROX-Filer-manualen fˆr detaljer."
+msgstr "Se ROX-Filer-manualen f√∂r detaljer."
 
-#: action.c:62
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr ""
 
-#: action.c:188
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Find uttrycksreferens"
 
-#: action.c:199
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -100,12 +105,12 @@ msgid ""
 "<b>prune</b> (false, and prevents searching the contents of a directory)."
 msgstr ""
 
-#: action.c:246
+#: action.c:256
 #, fuzzy
 msgid "Change permissions reference"
 msgstr "Find uttrycksreferens"
 
-#: action.c:257
+#: action.c:267
 #, fuzzy
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
@@ -136,40 +141,40 @@ msgid ""
 "\n"
 "See the chmod(1) man page for full details."
 msgstr ""
-"Normalt kan du bara v‰lja ett kommando frÂn menyn (klicka pÂ \n"
-"pilen vid sidan av kommandorutan). Ibland, behˆvs det mer...\n"
+"Normalt kan du bara v√§lja ett kommando fr√•n menyn (klicka p√• \n"
+"pilen vid sidan av kommandorutan). Ibland, beh√∂vs det mer...\n"
 "\n"
-"Formatey fˆr ett kommando ‰r:\n"
-"ƒNDRING, ƒNDRING, ...\n"
-"D‰r ƒNDRING ‰r:\n"
-"VEM HUR RƒTTIGHETER\n"
-"VEM ‰r en kombination av u, g och o som best‰mmer huruvida\n"
-"r‰ttigheter fˆr ‰garen, grupen eller ˆvriga skall ‰ndras.\n"
-"HUR ‰r +, - eller = fˆr att l‰gga till, ta bort eller s‰tta "
-"dessar‰ttigheter.\n"
-"RƒTTIGHETER ‰r en kombination av bokst‰verna 'rwxXstugo'\n"
+"Formatey f√∂r ett kommando √§r:\n"
+"√ÑNDRING, √ÑNDRING, ...\n"
+"D√§r √ÑNDRING √§r:\n"
+"VEM HUR R√ÑTTIGHETER\n"
+"VEM √§r en kombination av u, g och o som best√§mmer huruvida\n"
+"r√§ttigheter f√∂r √§garen, grupen eller √∂vriga skall √§ndras.\n"
+"HUR √§r +, - eller = f√∂r att l√§gga till, ta bort eller s√§tta "
+"dessar√§ttigheter.\n"
+"R√ÑTTIGHETER √§r en kombination av bokst√§verna 'rwxXstugo'\n"
 "\n"
 "Text mellan { och } samt mellanrum saknar betydelse.\n"
 "\n"
 "Exempel:\n"
-"u+rw \t(filens ‰gare fÂr r‰ttighet att l‰sa och skriva)\n"
-"g=u\t(gruppens r‰ttigheter s‰tts till samma som fˆr filens ‰gare)\n"
-"o=u-w\t(ˆvriga fÂr samma r‰ttigheter som ‰garen, dock utanskrivr‰ttigheter)\n"
-"a+x\t(alla fÂr kˆr- och ˆppningsr‰ttigheter - det samma som 'ugo+x')\n"
-"a+X\t(kataloger blir tillg‰ngliga fˆr alla; filer som var\n"
-"kˆrbara fˆr nÂgon blir kˆrbara fˆr alla)\n"
-"u+rw, go+r\t(tvÂ kommandon pÂ en gÂng!)\n"
-"u+s\t(s‰tt SetUID-biten - har ofta ingen effekt pÂ skript-filer)\n"
-"755\t(s‰tt r‰ttigheter direkt)\n"
+"u+rw \t(filens √§gare f√•r r√§ttighet att l√§sa och skriva)\n"
+"g=u\t(gruppens r√§ttigheter s√§tts till samma som f√∂r filens √§gare)\n"
+"o=u-w\t(√∂vriga f√•r samma r√§ttigheter som √§garen, dock utanskrivr√§ttigheter)\n"
+"a+x\t(alla f√•r k√∂r- och √∂ppningsr√§ttigheter - det samma som 'ugo+x')\n"
+"a+X\t(kataloger blir tillg√§ngliga f√∂r alla; filer som var\n"
+"k√∂rbara f√∂r n√•gon blir k√∂rbara f√∂r alla)\n"
+"u+rw, go+r\t(tv√• kommandon p√• en g√•ng!)\n"
+"u+s\t(s√§tt SetUID-biten - har ofta ingen effekt p√• skript-filer)\n"
+"755\t(s√§tt r√§ttigheter direkt)\n"
 "\n"
-"Se manualsidan chmod(1) fˆr detaljer."
+"Se manualsidan chmod(1) f√∂r detaljer."
 
-#: action.c:298
+#: action.c:308
 #, fuzzy
 msgid "Set type reference"
 msgstr "Find uttrycksreferens"
 
-#: action.c:309
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -185,92 +190,98 @@ msgid ""
 "on certain file systems and where the OS implements them.\n"
 msgstr ""
 
-#: action.c:416
+#: action.c:459
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 
-#: action.c:432
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Det uppstod ett fel.\n"
 
-#: action.c:434
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Det uppstod %d fel.\n"
 
-#: action.c:458
+#: action.c:516
 msgid "ERROR reading"
-msgstr "FEL under l‰sning"
+msgstr "FEL under l√§sning"
 
-#: action.c:501
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Klar\n"
 
-#: action.c:557 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "FEL"
 
-#: action.c:711 main.c:674 main.c:681 main.c:688
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Ja"
 
-#: action.c:714 main.c:676 main.c:690
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Nej"
 
-#: action.c:732
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
 msgstr ""
 
-#: action.c:739
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
 msgstr ""
 
-#: action.c:892
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
-msgstr "?R‰kna innehÂllet i %s?"
+msgstr "?R√§kna inneh√•llet i %s?"
 
-#: action.c:928
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Radera %s'%s'?"
 
-#: action.c:929
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "SKRIVSKYDDAD "
 
-#: action.c:936
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'Raderar '%s'\n"
 
-#: action.c:949
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
-msgstr "'Katalogen '%s' ‰r raderad\n"
+msgstr "'Katalogen '%s' √§r raderad\n"
 
-#: action.c:982
+#: action.c:1104
 #, fuzzy, c-format
 msgid "?Eject '%s'?"
 msgstr "?Kontrollera '%s'?"
 
-#: action.c:989
+#: action.c:1111
 #, fuzzy, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Raderar '%s'\n"
 
-#: action.c:1008
+#: action.c:1130
 #, fuzzy, c-format
 msgid ""
 "!%s\n"
@@ -279,81 +290,96 @@ msgstr ""
 "!%s\n"
 "Montering misslyckades\n"
 
-#: action.c:1027 action.c:1046
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Kontrollera '%s'?"
 
-#: action.c:1043
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
-msgstr "!Ogiltiga sˆkparametrar - r‰tta dem och fˆrsˆk igen\n"
+msgstr "!Ogiltiga s√∂kparametrar - r√§tta dem och f√∂rs√∂k igen\n"
 
-#: action.c:1053
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(medan '%s' kontrolleras)\n"
 
-#: action.c:1127 action.c:1152
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
-msgstr "?ƒbdra r‰ttigheterna pÂ '%s'?"
+msgstr "?√Ñbdra r√§ttigheterna p√• '%s'?"
 
-#: action.c:1133
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
-msgstr "'ƒndrar r‰ttigheter pÂ '%s'\n"
+msgstr "'√Ñndrar r√§ttigheter p√• '%s'\n"
 
-#: action.c:1150
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
-msgstr "!Ogiltigt mode-kommando - r‰tta det och fˆrsˆk igen\n"
+msgstr "!Ogiltigt mode-kommando - r√§tta det och f√∂rs√∂k igen\n"
 
-#: action.c:1207 action.c:1227
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?√Ñbdra r√§ttigheterna p√• '%s'?"
+
+#: action.c:1335 action.c:1355
 #, fuzzy, c-format
 msgid "?Change type of '%s'?"
-msgstr "?ƒbdra r‰ttigheterna pÂ '%s'?"
+msgstr "?√Ñbdra r√§ttigheterna p√• '%s'?"
 
-#: action.c:1224
+#: action.c:1352
 #, fuzzy
 msgid "!Invalid type - change it and try again\n"
-msgstr "!Ogiltigt mode-kommando - r‰tta det och fˆrsˆk igen\n"
+msgstr "!Ogiltigt mode-kommando - r√§tta det och f√∂rs√∂k igen\n"
 
-#: action.c:1246
+#: action.c:1374
 #, fuzzy, c-format
 msgid "'Changing type of '%s' to '%s'\n"
-msgstr "'ƒndrar r‰ttigheter pÂ '%s'\n"
+msgstr "'√Ñndrar r√§ttigheter p√• '%s'\n"
 
-#: action.c:1325
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'√Ñndrar r√§ttigheter p√• '%s'\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' finns redan - %s?"
 
-#: action.c:1327
+#: action.c:1550 action.c:1859
 msgid "merge contents"
-msgstr "sammansm‰lt innehÂll"
+msgstr "sammansm√§lt inneh√•ll"
 
-#: action.c:1328
+#: action.c:1551 action.c:1860
 msgid "overwrite"
-msgstr "skriv ˆver"
+msgstr "skriv √∂ver"
 
-#: action.c:1344
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
-msgstr "'Fˆrsˆker kopiera iallafall...\n"
+msgstr "'F√∂rs√∂ker kopiera iallafall...\n"
 
-#: action.c:1353
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Kopierar %s som %s?"
 
-#: action.c:1357
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Kopierar %s som %s\n"
 
-#: action.c:1372
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
-msgstr "!FEL: Destinationen finns redan, men ‰r inte en katalog\n"
+msgstr "!FEL: Destinationen finns redan, men √§r inte en katalog\n"
 
-#: action.c:1444
+#: action.c:1686
 #, fuzzy, c-format
 msgid ""
 "!%s\n"
@@ -362,26 +388,7 @@ msgstr ""
 "!%s\n"
 "Kopiering av '%s' misslyckades"
 
-#: action.c:1488
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' finns redan - skriv ˆver?"
-
-#: action.c:1503
-msgid "'Trying move anyway...\n"
-msgstr "'Fˆrsˆker flytta iallafall...\n"
-
-#: action.c:1511
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Flytta %s som %s?"
-
-#: action.c:1515
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Flyttar %s som %s\n"
-
-#: action.c:1523
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -390,45 +397,59 @@ msgstr ""
 "!%s\n"
 "!FEL: Misslyckades med att flytta %s som %s\n"
 
-#: action.c:1544
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'F√∂rs√∂ker flytta iallafall...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Flytta %s som %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Flyttar %s som %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
-msgstr "!FEL: Kan inte kopiera objektet till sig s‰lv\n"
+msgstr "!FEL: Kan inte kopiera objektet till sig s√§lv\n"
 
-#: action.c:1559
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
-msgstr "!FEL: Kan inte flytta/byta namn pÂ objekt till sig s‰lv\n"
+msgstr "!FEL: Kan inte flytta/byta namn p√• objekt till sig s√§lv\n"
 
-#: action.c:1571
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
-msgstr "'Skapar genv‰g till %s som %s\n"
+msgstr "'Skapar genv√§g till %s som %s\n"
 
-#: action.c:1576
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
-msgstr "?Skapar genv‰g till %s som %s?"
+msgstr "?Skapar genv√§g till %s som %s?"
 
-#: action.c:1618
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Monterar %s\n"
 
-#: action.c:1619
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Avmonterar %s\n"
 
-#: action.c:1622
+#: action.c:2025
 #, fuzzy, c-format
 msgid "?Mount %s?"
 msgstr "?Montera %s?\n"
 
-#: action.c:1623
+#: action.c:2026
 #, fuzzy, c-format
 msgid "?Unmount %s?"
 msgstr "?Avmontera %s?\n"
 
-#: action.c:1643
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -437,7 +458,7 @@ msgstr ""
 "!%s\n"
 "Montering misslyckades\n"
 
-#: action.c:1644
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -446,11 +467,11 @@ msgstr ""
 "!%s\n"
 "Avmontering misslyckades\n"
 
-#: action.c:1652
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr ""
 
-#: action.c:1698
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -459,304 +480,328 @@ msgstr ""
 "'\n"
 "Totalt: %s ("
 
-#: action.c:1704
+#: action.c:2108
 msgid "file"
 msgstr "fil"
 
-#: action.c:1704
+#: action.c:2108
 msgid "files"
 msgstr "filer"
 
-#: action.c:1708
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "inga inga kataloger)\n"
 
-#: action.c:1712
+#: action.c:2116
 msgid "directory"
 msgstr "katalog"
 
-#: action.c:1713
+#: action.c:2117
 msgid "directories"
 msgstr "katalog"
 
-#: action.c:1754
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Inga monteringspunkter valda!\n"
 
-#: action.c:1839
+#: action.c:2231
 msgid "?Another search?"
-msgstr "?En sˆkning till?"
+msgstr "?En s√∂kning till?"
 
-#: action.c:1869 action.c:1900
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
-msgstr "!'%s' ‰r en symbolsk genv‰g\n"
+msgstr "!'%s' √§r en symbolsk genv√§g\n"
 
-#: action.c:1940
+#: action.c:2342
 msgid "You need to select some items to search through"
-msgstr "Du mÂste v‰lja nÂgot/nÂgra objekt att genomsˆka"
+msgstr "Du m√•ste v√§lja n√•got/n√•gra objekt att genoms√∂ka"
 
-#: action.c:1950 menu.c:223
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Leta"
 
-#: action.c:1983
+#: action.c:2387
 msgid "You need to select some items to count"
-msgstr "Du mÂste v‰lja nÂgot/nÂgra objekt att r‰kna igenom"
+msgstr "Du m√•ste v√§lja n√•got/n√•gra objekt att r√§kna igenom"
 
-#: action.c:1987
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Diskutnyttjande"
 
-#: action.c:2021
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Montera/avmontera"
 
-#: action.c:2034
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
-msgstr "ROX-Filer stˆdjer tyv‰rr ‰nnu inte monteringspunkter pÂ ditt system."
+msgstr "ROX-Filer st√∂djer tyv√§rr √§nnu inte monteringspunkter p√• ditt system."
 
-#: action.c:2048 menu.c:210 tips:208
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Radera"
 
-#: action.c:2058 tips:213
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Tvinga"
 
-#: action.c:2058
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
-msgstr "FrÂga inte om lov fˆr att radera skrivskyddade objekt."
+msgstr "Fr√•ga inte om lov f√∂r att radera skrivskyddade objekt."
 
-#: action.c:2061 action.c:2116 action.c:2175 action.c:2228 action.c:2264
-#: tips:215
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Kort"
 
-#: action.c:2061
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Logga endast radering av kataloger"
 
-#: action.c:2078
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
-msgstr "Du mÂste v‰lja nÂgot/nÂgra objekt att ‰ndra r‰ttigheter pÂ"
+msgstr "Du m√•ste v√§lja n√•got/n√•gra objekt att √§ndra r√§ttigheter p√•"
 
-#: action.c:2086
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
-msgstr "a+x (Gˆr kˆr-/sˆkbar)"
+msgstr "a+x (G√∂r k√∂r-/s√∂kbar)"
 
-#: action.c:2088
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
-msgstr "a-x (Gˆr icke kˆr-/sˆkbar)"
+msgstr "a-x (G√∂r icke k√∂r-/s√∂kbar)"
 
-#: action.c:2090
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
-msgstr "u+rw (Ge ‰garen l‰s- och skrivr‰ttigheter)"
+msgstr "u+rw (Ge √§garen l√§s- och skrivr√§ttigheter)"
 
-#: action.c:2092
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
-msgstr "go-rwx (Privat - endast ‰garen har tillgÂng)"
+msgstr "go-rwx (Privat - endast √§garen har tillg√•ng)"
 
-#: action.c:2094
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
-msgstr "go=u-w (Allm‰nn, ej skrivbar)"
+msgstr "go=u-w (Allm√§nn, ej skrivbar)"
 
-#: action.c:2105 menu.c:184 menu.c:221 tips:75
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
-msgstr "R‰ttigheter"
+msgstr "R√§ttigheter"
 
-#: action.c:2116 action.c:2175
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Lista ej bearbetade filer "
 
-#: action.c:2119 action.c:2178 tips:217
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Rekursivt"
 
-#: action.c:2119
+#: action.c:2543
 msgid "Also change contents of subdirectories"
-msgstr "InnehÂllet i underkataloger skall ocksÂ ‰ndras."
+msgstr "Inneh√•llet i underkataloger skall ocks√• √§ndras."
 
-#: action.c:2123
+#: action.c:2547
 msgid "Command:"
 msgstr "Kommando:"
 
-#: action.c:2151
+#: action.c:2577
 #, fuzzy
 msgid "You need to select the items whose type you want to change"
-msgstr "Du mÂste v‰lja nÂgot/nÂgra objekt att ‰ndra r‰ttigheter pÂ"
+msgstr "Du m√•ste v√§lja n√•got/n√•gra objekt att √§ndra r√§ttigheter p√•"
 
-#: action.c:2164
+#: action.c:2590
 #, fuzzy
 msgid "Set type"
 msgstr "Sortera efter typ"
 
-#: action.c:2178
+#: action.c:2608
 #, fuzzy
 msgid "Change contents of subdirectories"
-msgstr "InnehÂllet i underkataloger skall ocksÂ ‰ndras."
+msgstr "Inneh√•llet i underkataloger skall ocks√• √§ndras."
 
-#: action.c:2185 infobox.c:615
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Typ:"
 
-#: action.c:2214 dnd.c:124 menu.c:1999 tips:202
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Kopiera"
 
-#: action.c:2224 action.c:2260 tips:219
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Bekr√§fta inte alla kommandon"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Skriv endast √∂ver om k√§llan √§r nyare √§n destinationen"
+
+#: action.c:2687 action.c:2744 tips:259
 #, fuzzy
 msgid "Newer"
 msgstr "Nyare"
 
-#: action.c:2225 action.c:2261 tips:220
-msgid "Only over-write if source is newer than destination."
-msgstr "Skriv endast ˆver om k‰llan ‰r nyare ‰n destinationen"
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
+msgstr "Skriv endast √∂ver om k√§llan √§r nyare √§n destinationen"
 
-#: action.c:2228
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "katalog"
+
+#: action.c:2695
 #, fuzzy
 msgid "Only log directories as they are copied"
 msgstr "Logga endast radering av kataloger"
 
-#: action.c:2250 dnd.c:125 tips:204
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Flytta"
 
-#: action.c:2264
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr ""
 
-#: action.c:2284 tips:206
+#: action.c:2775 tips:244
 msgid "Link"
-msgstr "Gˆr en genv‰g"
+msgstr "G√∂r en genv√§g"
 
-#: action.c:2303 appmenu.c:113
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr ""
 
-#: action.c:2360
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Raderar objekt som tex. "
 
-#: action.c:2364
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Raderar objektet "
 
-#: action.c:2366
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Raderar objekten "
 
-#: action.c:2385
+#: action.c:2900
 msgid " and "
 msgstr " och "
 
-#: action.c:2394
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr ""
-" kommer pÂverka ett objekt pÂ skrivbordet eller panelen - ‰r du s‰ker pÂ att "
+" kommer p√•verka ett objekt p√• skrivbordet eller panelen - √§r du s√§ker p√• att "
 "du vill radera det?"
 
-#: action.c:2401
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr ""
-" kommer pÂverka nÂgra objekt pÂ skrivbordet eller panelen - ‰r du s‰ker pÂ "
+" kommer p√•verka n√•gra objekt p√• skrivbordet eller panelen - √§r du s√§ker p√• "
 "att du vill radera dem?"
 
-#: appmenu.c:198
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<titel saknas>"
 
-#: appmenu.c:295
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
 "menu for all items of this type (%s/%s)."
 msgstr ""
 
-#: appmenu.c:339 menu.c:234
+#: appmenu.c:331 menu.c:753
 #, fuzzy
 msgid "Customise Menu..."
-msgstr "St‰ll in"
+msgstr "St√§ll in"
 
-#: appmenu.c:396 menu.c:251 toolbar.c:159
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
-msgstr "Hj‰lp"
+msgstr "Hj√§lp"
 
-#: bookmarks.c:147
-#, fuzzy
-msgid "Path"
-msgstr "Sti: "
-
-#: bookmarks.c:155
+#: bookmarks.c:268
 #, fuzzy
 msgid "Title"
 msgstr "Upprepad"
 
-#: bookmarks.c:304
+#: bookmarks.c:276 log.c:176
+#, fuzzy
+msgid "Path"
+msgstr "Sti: "
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr ""
 
-#: bookmarks.c:312 bookmarks.c:630
+#: bookmarks.c:474 bookmarks.c:823
 #, fuzzy, c-format
 msgid "'%s' isn't a directory"
-msgstr "Kan inte ˆppna katalogen: %s"
+msgstr "Kan inte √∂ppna katalogen: %s"
 
-#: bookmarks.c:518
+#: bookmarks.c:711
 #, fuzzy
 msgid "You should first select some rows to delete"
-msgstr "Du mÂste fˆrst v‰lja nÂgot/nÂgra objekt att ta bort"
+msgstr "Du m√•ste f√∂rst v√§lja n√•got/n√•gra objekt att ta bort"
 
-#: bookmarks.c:542
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr ""
 
-#: bookmarks.c:562
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr ""
 
-#: bookmarks.c:636
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr ""
 
-#: bookmarks.c:778
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr ""
 
-#: bookmarks.c:785
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr ""
 
-#: bookmarks.c:790
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr ""
 
-#: bulk_rename.c:68
+#: bulk_rename.c:69
 #, fuzzy
 msgid "Bulk rename files"
-msgstr "L‰s om filer"
+msgstr "L√§s om filer"
 
-#: bulk_rename.c:71
+#: bulk_rename.c:72
 #, fuzzy
 msgid "Reset"
-msgstr "ƒndra tillbaka"
+msgstr "√Ñndra tillbaka"
 
-#: bulk_rename.c:76
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr ""
 
-#: bulk_rename.c:81
+#: bulk_rename.c:82
 #, fuzzy
 msgid "_Rename"
-msgstr "ƒndra namn"
+msgstr "√Ñndra namn"
 
-#: bulk_rename.c:94
+#: bulk_rename.c:95
 #, fuzzy
 msgid "Replace:"
 msgstr "_Byt ut"
 
-#: bulk_rename.c:101
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -772,58 +817,59 @@ msgstr "objekt"
 
 #: bulk_rename.c:116
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
-msgstr "SlÂ til"
+msgstr "Sl√• til"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
 msgstr ""
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr ""
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 #, fuzzy
 msgid "New name"
-msgstr "ƒndra namn"
+msgstr "√Ñndra namn"
 
-#: bulk_rename.c:259
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr ""
 
-#: bulk_rename.c:264
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr ""
 
-#: bulk_rename.c:267
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr ""
 
-#: bulk_rename.c:293
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr ""
 
-#: bulk_rename.c:310
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr ""
 
-#: bulk_rename.c:343
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr ""
 
-#: bulk_rename.c:348
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -831,67 +877,83 @@ msgid ""
 "Aborting bulk rename."
 msgstr ""
 
-#: bulk_rename.c:410
+#: bulk_rename.c:447
 #, fuzzy, c-format
 msgid "A file called '%s' already exists"
 msgstr "?'%s' finns redan - %s?"
 
-#: bulk_rename.c:421
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
 "files to end up in different directories. Continue?"
 msgstr ""
 
-#: bulk_rename.c:436
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr ""
 
-#: choices.c:428
-#, fuzzy
-msgid "Choices migration"
-msgstr "Kinesiska (traditionell)"
+#: choices.c:434
+#, c-format
+msgid "%d directories could not be migrated"
+msgstr ""
 
 #: choices.c:436
 #, c-format
 msgid ""
 "Choices have been moved from \n"
-"<b>%s</b>\n"
+"%s\n"
 " to the new location \n"
-"<b>%s</b>\n"
+"%s\n"
+"%s"
 msgstr ""
 
-#: choices.c:447
-#, c-format
-msgid "%d directories could not be migrated"
-msgstr ""
-
-#: dir.c:982
+#: dir.c:1077
 #, fuzzy, c-format
 msgid "Can't stat directory: %s"
-msgstr "Kan inte ˆppna katalogen: %s"
+msgstr "Kan inte √∂ppna katalogen: %s"
 
-#: dir.c:991
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
-msgstr "Kan inte ˆppna katalogen: %s"
+msgstr "Kan inte √∂ppna katalogen: %s"
 
-#: display.c:588
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Storlek"
+
+#: display.c:705
+msgid "‚î§"
+msgstr ""
+
+#: display.c:706
+msgid "‚îê"
+msgstr ""
+
+#: display.c:707
+msgid "‚îò"
+msgstr ""
+
+#: display.c:709
+msgid "‚îú"
+msgstr ""
+
+#: display.c:709
+msgid "‚îå"
+msgstr ""
+
+#: display.c:710
+msgid "‚îº"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) misslyckades: %s"
 
-#: dnd.c:126
-msgid "Link (relative)"
-msgstr ""
-
-#: dnd.c:127
-msgid "Link (absolute)"
-msgstr ""
-
-#: dnd.c:426
+#: dnd.c:423
 msgid "Internal error - bad info type"
-msgstr "Internt fel - dÂlig info-typ"
+msgstr "Internt fel - d√•lig info-typ"
 
 #: dnd.c:565
 msgid "Drag a directory here to bookmark it."
@@ -899,27 +961,27 @@ msgstr ""
 
 #: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
-msgstr "XDS-protokollfel: namn fÂr inte innehÂlla '/'\n"
+msgstr "XDS-protokollfel: namn f√•r inte inneh√•lla '/'\n"
 
 #: dnd.c:605
 msgid ""
 "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
 "plain) did not contain a leafname\n"
 msgstr ""
-"XdndDirectSave0-mÂl givet, men atomem XdndDirectSave0 (typ text/plain) kan "
-"inte innehÂlla et lˆvnamn\n"
+"XdndDirectSave0-m√•l givet, men atomem XdndDirectSave0 (typ text/plain) kan "
+"inte inneh√•lla et l√∂vnamn\n"
 
 #: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
 msgstr ""
-"Tyv‰rr - Jag behˆver en destination av typ text/uri-list eller "
+"Tyv√§rr - Jag beh√∂ver en destination av typ text/uri-list eller "
 "XdndDirectSave0."
 
 #: dnd.c:621
 msgid ""
 "Sorry - I require a target type of text/uri-list or application/octet-stream."
 msgstr ""
-"Tyv‰rr - Jag behˆver en destination av typ text/uri-list eller application/"
+"Tyv√§rr - Jag beh√∂ver en destination av typ text/uri-list eller application/"
 "octet-stream."
 
 #: dnd.c:691
@@ -933,11 +995,11 @@ msgstr ""
 
 #: dnd.c:766
 msgid "Unknown target"
-msgstr "Ok‰nd destination"
+msgstr "Ok√§nd destination"
 
 #: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
-msgstr "Det andra programmer kan eller vill inte skicka mig datan - tyv‰rr"
+msgstr "Det andra programmer kan eller vill inte skicka mig datan - tyv√§rr"
 
 #: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
@@ -946,8 +1008,8 @@ msgstr "XDS-protokollfel: returkoden skall vara 'S', 'F' eller 'E'\n"
 #: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
 msgstr ""
-"Tyv‰rr, kan inte visa en meny med kommandon fˆr en fil pÂ en annanmaskin "
-"eller rÂdata"
+"Tyv√§rr, kan inte visa en meny med kommandon f√∂r en fil p√• en annanmaskin "
+"eller r√•data"
 
 #: dnd.c:861
 msgid "UntitledData"
@@ -960,77 +1022,93 @@ msgstr "Fel vid sparande av fil: %s"
 
 #: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
-msgstr "Inga URI:er i text/uri-list (inget att gˆra!)"
+msgstr "Inga URI:er i text/uri-list (inget att g√∂ra!)"
 
 #: dnd.c:993
 msgid ""
 "Can't get data from remote machine (application/octet-stream not provided)"
 msgstr ""
-"Kan inte fÂ data frÂn den andra maskinen (application/octet-stream inte "
+"Kan inte f√• data fr√•n den andra maskinen (application/octet-stream inte "
 "givet)"
 
-#: dnd.c:1016
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
-"NÂgon av dessa filer finns pÂ en annan maskin - dessa kommer hoppas ˆver - "
-"tyv‰rr"
+"N√•gon av dessa filer finns p√• en annan maskin - dessa kommer hoppas √∂ver - "
+"tyv√§rr"
 
-#: dnd.c:1023
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
 msgstr ""
-"Ingen av desse filerna finns pÂ den h‰r maskinen - Jag kan inte arbeta pÂ "
-"n‰tv‰rks-filer - tyv‰rr."
+"Ingen av desse filerna finns p√• den h√§r maskinen - Jag kan inte arbeta p√• "
+"n√§tv√§rks-filer - tyv√§rr."
 
-#: dnd.c:1036
+#: dnd.c:1040
 msgid "Unknown action requested"
-msgstr "Ok‰nd handling fˆrfrÂgad"
+msgstr "Ok√§nd handling f√∂rfr√•gad"
 
-#: dnd.c:1044
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
-msgstr "Fel vid h‰mtning av fillista: %s"
+msgstr "Fel vid h√§mtning av fillista: %s"
 
-#: dropbox.c:114
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr ""
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr ""
+
+#: dnd.c:1109
+msgid "Link (relative, sym path)"
+msgstr ""
+
+#: dnd.c:1110
+msgid "Link (absolute, sym path)"
+msgstr ""
+
+#: dropbox.c:112
 #, fuzzy
 msgid "Show"
 msgstr "Visa information"
 
-#: dropbox.c:120
+#: dropbox.c:118
 #, fuzzy
 msgid "Show the current choice in a filer window"
-msgstr "TillÂt att dra ikoner till 'filer'-fˆnster"
+msgstr "Till√•t att dra ikoner till 'filer'-f√∂nster"
 
-#: dropbox.c:174
+#: dropbox.c:172
 #, fuzzy
 msgid "<nothing>"
-msgstr "<inget ‰nnu>"
+msgstr "<inget √§nnu>"
 
-#: dropbox.c:239
+#: dropbox.c:237
 msgid ""
 "I can't show you the currently set item, because nothing is currently set. "
 "Drag something onto me!"
 msgstr ""
 
-#: dropbox.c:263
+#: dropbox.c:261
 msgid "Sorry, you need to drop exactly one file onto the drop area."
 msgstr ""
 
-#: dropbox.c:273
+#: dropbox.c:271
 #, c-format
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr ""
 
-#: dropbox.c:280 pinboard.c:853
+#: dropbox.c:278 pinboard.c:932
 #, fuzzy, c-format
 msgid ""
 "Can't access '%s':\n"
 "%s"
 msgstr "Kan inte ta bort %s: %s"
 
-#: filer.c:453
+#: filer.c:718
 #, fuzzy, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1039,375 +1117,424 @@ msgstr ""
 "Fel under scanning av '%s:\n"
 "%s"
 
-#: filer.c:457
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Fel under scanning av '%s:\n"
-"%s"
-
-#: filer.c:562
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
 "Unmounting a device makes it safe to remove the disk."
 msgstr ""
 
-#: filer.c:566
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 #, fuzzy
 msgid "No change"
 msgstr "Inget"
 
-#: filer.c:572 menu.c:862
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Avmontera"
 
-#: filer.c:669
-msgid "Directory missing/deleted"
-msgstr "Katalogen saknas/‰r raderad"
-
-#: filer.c:1031
+#: filer.c:1490
 #, fuzzy, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
 "Press %s on its own to reselect the files later.\n"
 "Make sure NumLock is on if you use the keypad."
 msgstr ""
-"Grupp %s ‰r inte satt. V‰lj nÂgon/nÂgra filer och tryck Ctrl+%s fˆr att "
-"s‰tta gruppen. Tryck %s fˆr att Âter v‰lja filerne senare."
+"Grupp %s √§r inte satt. V√§lj n√•gon/n√•gra filer och tryck Ctrl+%s f√∂r att "
+"s√§tta gruppen. Tryck %s f√∂r att √•ter v√§lja filerne senare."
 
-#: filer.c:1267
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Katalogen '%s' ‰r inte tillg‰nglig"
+#: filer.c:2655
+msgid "A"
+msgstr ""
 
-#: filer.c:1419
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Katalogen '%s' hittades inte."
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
 
-#: filer.c:1713
-msgid "Cancel"
-msgstr "Avbryt"
+#: filer.c:2659 find.c:923
+msgid "G"
+msgstr ""
 
-#: filer.c:2002
+#: filer.c:2664
 msgid "S"
 msgstr ""
 
-#: filer.c:2004
+#: filer.c:2669
 msgid "T"
 msgstr ""
 
-#: filer.c:2026
+#: filer.c:2670
+msgid "D"
+msgstr ""
+
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
+#, c-format
+msgid "Glob (%s), "
+msgstr ""
+
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Skannar, "
 
-#: filer.c:2028
+#: filer.c:2697
 msgid "Thumbs, "
-msgstr "Fˆrhandsgranskning, "
+msgstr "F√∂rhandsgranskning, "
 
-#: filer.c:2304
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "F√∂rhandsgranskning, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
-msgstr "Symbolisk genv‰g till "
+msgstr "Symbolisk genv√§g till "
 
-#: filer.c:2335
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
-msgstr "Detta filnamn ‰r inte giltig UTF-8. Du mÂste ‰ndra dess namn.\n"
+msgstr "Detta filnamn √§r inte giltig UTF-8. Du m√•ste √§ndra dess namn.\n"
 
-#: filer.c:2643 menu.c:1989
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
-msgstr "Objektet finns inte l‰ngre!"
+msgstr "Objektet finns inte l√§ngre!"
 
-#: filer.c:3327
+#: filer.c:4451
+msgid "‚ñº"
+msgstr ""
+
+#: filer.c:4451
+msgid "‚ñΩ"
+msgstr ""
+
+#: filer.c:4462
+msgid "‚ñ∑"
+msgstr ""
+
+#: filer.c:4462
+msgid "‚ñ∂"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr ""
 
-#: filer.c:3334
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Standardinst√§llning:"
+
+#: filer.c:4727
 msgid "Position"
 msgstr ""
 
-#: filer.c:3339 toolbar.c:135 toolbar.c:139 tips:63
-msgid "Size"
-msgstr "Storlek"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Vindues-st√∏rrelse gr√¶nse"
 
-#: filer.c:3344
+#: filer.c:4737
 #, fuzzy
 msgid "Show hidden"
-msgstr "Visa gˆmda"
+msgstr "Visa g√∂mda"
 
-#: filer.c:3350
+#: filer.c:4743
 #, fuzzy
-msgid "Display style"
+msgid "Display style (Icon size)"
 msgstr "Visa"
 
-#: filer.c:3356
+#: filer.c:4749
 #, fuzzy
 msgid "Sort type and order"
 msgstr "Sortera efter storlek"
 
-#: filer.c:3361 toolbar.c:143
+#: filer.c:4754
 msgid "Details"
 msgstr "Detaljer"
 
-#: filer.c:3366 tips:114 tips:115
+#: filer.c:4759 tips:152 tips:153
 #, fuzzy
 msgid "Thumbnails"
-msgstr "Visa fˆrhandsgranskningar"
+msgstr "Visa f√∂rhandsgranskningar"
 
-#: filer.c:3372
+#: filer.c:4765
 #, fuzzy
 msgid "Filter"
 msgstr "Fil"
 
-#: find.c:487
+#: find.c:485
 msgid "And"
 msgstr "Och"
 
-#: find.c:511
+#: find.c:509
 msgid "Not"
 msgstr "Icke"
 
-#: find.c:554
+#: find.c:552
 msgid "system"
 msgstr "system"
 
-#: find.c:562
+#: find.c:560
 msgid "prune"
-msgstr "besk‰r"
+msgstr "besk√§r"
 
-#: find.c:650
+#: find.c:648
 msgid "After"
 msgstr "Efter"
 
-#: find.c:652
+#: find.c:650
 msgid "Before"
-msgstr "Fˆre"
+msgstr "F√∂re"
+
+#: find.c:744
+msgid "IsReg"
+msgstr "√ÑrVanlig"
 
 #: find.c:746
-msgid "IsReg"
-msgstr "ƒrVanlig"
+msgid "IsLink"
+msgstr "√ÑrGenv√§g"
 
 #: find.c:748
-msgid "IsLink"
-msgstr "ƒrGenv‰g"
+msgid "IsDir"
+msgstr "√ÑrKatalog"
 
 #: find.c:750
-msgid "IsDir"
-msgstr "ƒrKatalog"
+msgid "IsChar"
+msgstr "√ÑrChar"
 
 #: find.c:752
-msgid "IsChar"
-msgstr "ƒrChar"
+msgid "IsBlock"
+msgstr "√ÑrBlock"
 
 #: find.c:754
-msgid "IsBlock"
-msgstr "ƒrBlock"
+msgid "IsDev"
+msgstr "√ÑrDev"
 
 #: find.c:756
-msgid "IsDev"
-msgstr "ƒrDev"
+msgid "IsPipe"
+msgstr "√ÑrPipe"
 
 #: find.c:758
-msgid "IsPipe"
-msgstr "ƒrPipe"
+msgid "IsSocket"
+msgstr "√ÑrSocket"
 
 #: find.c:760
-msgid "IsSocket"
-msgstr "ƒrSocket"
-
-#: find.c:762
 #, fuzzy
 msgid "IsDoor"
-msgstr "ƒrDoor"
+msgstr "√ÑrDoor"
+
+#: find.c:762
+msgid "IsSUID"
+msgstr "√ÑrSUID"
 
 #: find.c:764
-msgid "IsSUID"
-msgstr "ƒrSUID"
+msgid "IsSGID"
+msgstr "√ÑrSGID"
 
 #: find.c:766
-msgid "IsSGID"
-msgstr "ƒrSGID"
+msgid "IsSticky"
+msgstr "√ÑrSticky"
 
 #: find.c:768
-msgid "IsSticky"
-msgstr "ƒrSticky"
+msgid "IsReadable"
+msgstr "√ÑrL√§sbar"
 
 #: find.c:770
-msgid "IsReadable"
-msgstr "ƒrL‰sbar"
+msgid "IsWriteable"
+msgstr "√ÑrSkrivbar"
 
 #: find.c:772
-msgid "IsWriteable"
-msgstr "ƒrSkrivbar"
+msgid "IsExecutable"
+msgstr "√ÑrK√∂rbar"
 
 #: find.c:774
-msgid "IsExecutable"
-msgstr "ƒrKˆrbar"
+msgid "IsEmpty"
+msgstr "√ÑrTom"
 
 #: find.c:776
-msgid "IsEmpty"
-msgstr "ƒrTom"
-
-#: find.c:778
 msgid "IsMine"
-msgstr "ƒrMin"
+msgstr "√ÑrMin"
 
-#: find.c:906
+#: find.c:904
 msgid "Now"
 msgstr "Nu"
 
-#: find.c:919
+#: find.c:917
 msgid "Byte"
 msgstr "Byte"
 
-#: find.c:919
+#: find.c:917
 msgid "Bytes"
 msgstr "Byte"
 
-#: find.c:921
+#: find.c:919
 msgid "Kb"
 msgstr ""
 
-#: find.c:921
+#: find.c:919
 #, fuzzy
 msgid "K"
 msgstr "OK"
 
-#: find.c:923
+#: find.c:921
 msgid "Mb"
 msgstr ""
 
-#: find.c:923
+#: find.c:921
 msgid "M"
 msgstr ""
 
-#: find.c:925
+#: find.c:923
 msgid "Gb"
 msgstr ""
 
 #: find.c:925
-msgid "G"
-msgstr ""
-
-#: find.c:927
 msgid "Sec"
 msgstr "Sekund"
 
-#: find.c:927
+#: find.c:925
 msgid "Secs"
 msgstr "Sekunder"
 
-#: find.c:929
+#: find.c:927
 msgid "Min"
 msgstr "Minut"
 
-#: find.c:929
+#: find.c:927
 msgid "Mins"
 msgstr "Minuter"
 
-#: find.c:931
+#: find.c:929
 msgid "Hour"
 msgstr "Timme"
 
-#: find.c:931
+#: find.c:929
 msgid "Hours"
 msgstr "Timmar"
 
-#: find.c:933
+#: find.c:931
 msgid "Day"
 msgstr "Dag"
 
-#: find.c:933
+#: find.c:931
 msgid "Days"
 msgstr "Dagar"
 
-#: find.c:935
+#: find.c:933
 msgid "Week"
 msgstr "Vecka"
 
-#: find.c:935
+#: find.c:933
 msgid "Weeks"
 msgstr "Veckor"
 
-#: find.c:937
+#: find.c:935
 msgid "Year"
-msgstr "≈r"
+msgstr "√Ör"
 
-#: find.c:937
+#: find.c:935
 msgid "Years"
-msgstr "≈r"
+msgstr "√Ör"
 
-#: find.c:946
+#: find.c:944
 msgid "Ago"
 msgstr "Sedan"
 
-#: find.c:948
+#: find.c:946
 msgid "Hence"
 msgstr "Om"
 
-#: find.c:963
+#: find.c:961
 msgid "atime"
 msgstr "a-tid"
 
-#: find.c:965
+#: find.c:963
 msgid "ctime"
 msgstr "c-tid"
 
-#: find.c:967
+#: find.c:965
 msgid "mtime"
 msgstr "m-tid"
 
-#: find.c:969
+#: find.c:967
 msgid "size"
 msgstr "storlek"
 
-#: find.c:971
+#: find.c:969
 msgid "inode"
 msgstr "i-nod"
 
-#: find.c:973
+#: find.c:971
 msgid "nlinks"
-msgstr "antal genv‰gar"
+msgstr "antal genv√§gar"
+
+#: find.c:973
+msgid "uid"
+msgstr "anv√§ndar-ID"
 
 #: find.c:975
-msgid "uid"
-msgstr "anv‰ndar-ID"
-
-#: find.c:977
 msgid "gid"
 msgstr "grupp-ID"
 
-#: find.c:979
+#: find.c:977
 msgid "blocks"
 msgstr "block"
 
-#: gtksavebox.c:251
+#: gtksavebox.c:249
 msgid "Save As:"
 msgstr "Spara som:"
 
-#: gtksavebox.c:397
+#: gtksavebox.c:401
 msgid "Unnamed"
-msgstr "Namnlˆs"
+msgstr "Namnl√∂s"
 
-#: gtksavebox.c:473
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
 msgstr ""
-"Det andra programmet vill anv‰nda Direct Save, men jag kan inte l‰sa "
+"Det andra programmet vill anv√§nda Direct Save, men jag kan inte l√§sa "
 "XdndDirectSave0(typ text/plain)-delen.\n"
 
-#: gtksavebox.c:598
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
 msgstr ""
 "Dra ikonen till en katalogvy\n"
-"(eller skriv den fullst‰ndiga sˆkv‰gen)"
+"(eller skriv den fullst√§ndiga s√∂kv√§gen)"
 
-#: gui_support.c:331
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1415,380 +1542,455 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:400
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr ""
-"Forsˆk att l‰se en XML-fil som en textfil. Filen '%s' ‰r kanske trasig."
+"Fors√∂k att l√§se en XML-fil som en textfil. Filen '%s' √§r kanske trasig."
 
-#: gui_support.c:417
-#, c-format
+#: gui_support.c:542
+#, fuzzy, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
 "\"%s\"\n"
 "This may be due to upgrading from a previous version of ROX-Filer. Open the "
-"Options window and click on Save.\n"
+"Options window and try changing something and then changing it back (causing "
+"the file to be resaved).\n"
 "Further errors will be ignored."
 msgstr ""
-"Fel i filen '%s' pÂ rad %d: \n"
+"Fel i filen '%s' p√• rad %d: \n"
 "\"%s\"\n"
-"Detta kan bero pÂ en uppgradering frÂn en tidigare verson av ROX-Filer. "
-"÷ppna inst‰lliningar och klicka pÂ Spara.\n"
+"Detta kan bero p√• en uppgradering fr√•n en tidigare verson av ROX-Filer. "
+"√ñppna inst√§lliningar och klicka p√• Spara.\n"
 "Fler av detta fel kommer ignoreras."
 
-#: gui_support.c:1000
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Inkorrekt eller avsaknad radbrytning i text-/uri-list-data"
 
-#: gui_support.c:1332
+#: gui_support.c:1473
 #, fuzzy, c-format
 msgid "Failed to open file '%s': %s"
-msgstr "Mislykkedes i at skabe en b¯rne-process"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
 
-#: gui_support.c:1376
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
 msgstr ""
 
-#: gui_support.c:1427
+#: gui_support.c:1583
+#, c-format
 msgid ""
-"This program cannot be run, as the 0launch command is not available. It can "
-"be downloaded from here:\n"
+"This program (%s) cannot be run, as the 0launch command is not available. It "
+"can be downloaded from here:\n"
 "\n"
 "http://0install.net/injector.html"
 msgstr ""
 
-#: i18n.c:38
+#: i18n.c:39
 #, fuzzy
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
 msgstr ""
-"Du mÂste starta om programmet fˆr att de nya sprÂkinst‰llningarna ska fÂ "
+"Du m√•ste starta om programmet f√∂r att de nya spr√•kinst√§llningarna ska f√• "
 "effekt"
 
-#: icon.c:78
+#: icon.c:77
 msgid "(click to set)"
 msgstr ""
 
-#: icon.c:133
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:134 menu.c:252
-#, fuzzy
-msgid "About ROX-Filer..."
-msgstr "Om ROX-Filer"
-
-#: icon.c:135 menu.c:253
-#, fuzzy
-msgid "Show Help Files"
-msgstr "Visa hj‰lpfiler"
-
-#: icon.c:136 menu.c:254
-msgid "Manual"
-msgstr "Manual"
-
-#: icon.c:138 menu.c:230
-msgid "Options..."
-msgstr "Inst‰llningar..."
-
-#: icon.c:139 menu.c:239
-msgid "Home Directory"
-msgstr "Hemkatalogen"
-
-#: icon.c:140 icon.c:1340 menu.c:206 type.c:212
-msgid "File"
-msgstr "Fil"
-
-#: icon.c:141 menu.c:212 menu.c:875
-msgid "Shift Open"
-msgstr "Shift-ˆppna"
-
-#: icon.c:142 menu.c:218
-msgid "Properties"
-msgstr ""
-
-#: icon.c:143 menu.c:216
-msgid "Set Run Action..."
-msgstr "S‰tt kˆrh‰ndelse..."
-
-#: icon.c:144 menu.c:217
-msgid "Set Icon..."
-msgstr "S‰tt ikon..."
-
-#: icon.c:145 icon.c:806
-msgid "Edit Item"
-msgstr "Redigera objektet"
-
-#: icon.c:146
-msgid "Show Location"
-msgstr "Visa plats"
-
-#: icon.c:147
-msgid "Remove Item(s)"
-msgstr "Ta bort objekt"
-
-#: icon.c:278 menu.c:764
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr ""
 
-#: icon.c:291
+#: icon.c:311
 msgid "Nothing"
 msgstr "Inget"
 
-#: icon.c:547
+#: icon.c:576
 msgid "The location must contain at least one character!"
-msgstr "Sˆkv‰gen mÂste innehÂlla minst ett tecken!"
+msgstr "S√∂kv√§gen m√•ste inneh√•lla minst ett tecken!"
 
-#: icon.c:613
+#: icon.c:641
+#, c-format
+msgid "You must unlock '%s' before removing it"
+msgstr ""
+
+#: icon.c:651
 msgid "You must first select some items to remove"
-msgstr "Du mÂste fˆrst v‰lja nÂgot/nÂgra objekt att ta bort"
+msgstr "Du m√•ste f√∂rst v√§lja n√•got/n√•gra objekt att ta bort"
 
-#: icon.c:627
+#: icon.c:657
+msgid "An item must be unlocked before it can be removed."
+msgstr ""
+
+#: icon.c:671
 msgid "You must open the menu over an item"
-msgstr "Du mÂste ˆppna menyn ˆver ett objekt"
+msgstr "Du m√•ste √∂ppna menyn √∂ver ett objekt"
 
-#: icon.c:652 menu.c:1260
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
-msgstr "Du kan endast s‰tta kˆrh‰ndelsen fˆr en vanlig fil"
+msgstr "Du kan endast s√§tta k√∂rh√§ndelsen f√∂r en vanlig fil"
 
-#: icon.c:738
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr ""
 
-#: icon.c:760
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr ""
 
-#: icon.c:809
-msgid "Clicking the icon opens:"
-msgstr "Klicka pÂ ikonen ˆppnar:"
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Redigera objektet"
 
-#: icon.c:819
+#: icon.c:853
+msgid "Clicking the icon opens:"
+msgstr "Klicka p√• ikonen √∂ppnar:"
+
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr ""
 
-#: icon.c:833
+#: icon.c:877
 msgid "The text displayed under the icon is:"
-msgstr "Texten som visas under ikonen ‰r:"
+msgstr "Texten som visas under ikonen √§r:"
 
-#: icon.c:846
+#: icon.c:890
 #, fuzzy
 msgid "The keyboard shortcut is:"
-msgstr "St‰ll in kortkommandon"
+msgstr "St√§ll in kortkommandon"
 
-#: infobox.c:112
-#, c-format
-msgid "Are you sure you want to open %d windows?"
-msgstr "ƒr du s‰ker pÂ att du vill ˆppna %d fˆnster?"
+# Socket:
+#: icon.c:910
+#, fuzzy
+msgid "Locked"
+msgstr "Socket:"
+
+#: icon.c:915
+msgid "Locking an item prevents it from being accidentally removed"
+msgstr ""
+
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+#, fuzzy
+msgid "About ROX-Filer..."
+msgstr "Om ROX-Filer"
+
+#: icon.c:1393 menu.c:788
+#, fuzzy
+msgid "Show Help Files"
+msgstr "Visa hj√§lpfiler"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Manual"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Inst√§llningar..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Hemkatalogen"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Fil"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Shift-√∂ppna"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr ""
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "S√§tt k√∂rh√§ndelse..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "S√§tt ikon..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Visa plats"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Ta bort objekt"
 
 #: infobox.c:113
+#, c-format
+msgid "Are you sure you want to open %d windows?"
+msgstr "√Ñr du s√§ker p√• att du vill √∂ppna %d f√∂nster?"
+
+#: infobox.c:114
 #, fuzzy
 msgid "Show Info"
 msgstr "Visa information"
 
-#: infobox.c:135 menu.c:769
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr ""
 
-#: infobox.c:259
+#: infobox.c:278
 #, fuzzy
 msgid "Show _Help Files"
-msgstr "Visa _hj‰lpfiler"
+msgstr "Visa _hj√§lpfiler"
 
-#: infobox.c:272
+#: infobox.c:291
 #, fuzzy
 msgid "<b>Permissions</b>"
-msgstr "R‰ttigheter"
+msgstr "R√§ttigheter"
 
-#: infobox.c:286
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr ""
 
-#: infobox.c:423 infobox.c:560 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Logga endast radering av kataloger"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "byte"
 
-#: infobox.c:446
+#: infobox.c:480
 #, fuzzy
 msgid "Failed to read size"
 msgstr "fork() af barn mislykkedes"
 
-#: infobox.c:504
+#: infobox.c:543
 #, fuzzy, c-format
 msgid "'%s' is no longer a symlink"
-msgstr "!'%s' ‰r en symbolsk genv‰g\n"
+msgstr "!'%s' √§r en symbolsk genv√§g\n"
 
-#: infobox.c:511
+#: infobox.c:550
 #, fuzzy, c-format
 msgid ""
 "Failed to unlink '%s':\n"
 "%s"
-msgstr "Mislykkedes i at skabe en b¯rne-process"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
 
-#: infobox.c:516
+#: infobox.c:555
 #, fuzzy, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
 "%s\n"
 "(note: old link has been deleted)"
-msgstr "Mislykkedes i at skabe en b¯rne-process"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
 
-#: infobox.c:539 tips:270
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Fel:"
 
-#: infobox.c:546
+#: infobox.c:586
 #, fuzzy
 msgid "Real directory:"
 msgstr "Katalog"
 
-#: infobox.c:549
+#: infobox.c:589
 msgid "Owner, Group:"
-msgstr "ƒgare, grupp:"
+msgstr "√Ñgare, grupp:"
 
-#: infobox.c:556 infobox.c:571 infobox.c:580
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Storlek:"
 
-#: infobox.c:581
+#: infobox.c:621
 #, fuzzy
 msgid "Scanning"
 msgstr "Skannar, "
 
-#: infobox.c:602
+#: infobox.c:646
 #, fuzzy
 msgid "Failed to scan"
 msgstr "fork() af barn mislykkedes"
 
-#: infobox.c:609
+#: infobox.c:653
 msgid "Change time:"
-msgstr "ƒndrad:"
+msgstr "√Ñndrad:"
 
-#: infobox.c:611
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Modifierad:"
 
-#: infobox.c:613
+#: infobox.c:657
 msgid "Access time:"
-msgstr "≈tkomsttid:"
+msgstr "√Ötkomsttid:"
 
-#: infobox.c:621
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr ""
 
-#: infobox.c:623
+#: infobox.c:667
 msgid "Present"
 msgstr ""
 
-#: infobox.c:624
+#: infobox.c:668
 msgid "None"
 msgstr "Inget"
 
-#: infobox.c:625
+#: infobox.c:669
 #, fuzzy
 msgid "Not supported"
-msgstr "Gtk+-2.0 underst¯ttelse"
+msgstr "Gtk+-2.0 underst√∏ttelse"
 
-#: infobox.c:637
+#: infobox.c:681
 #, fuzzy
 msgid "Link target:"
-msgstr "Ok‰nd destination"
+msgstr "Ok√§nd destination"
 
-#: infobox.c:649 infobox.c:652
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
-msgstr "Kˆrh‰ndelse:"
+msgstr "K√∂rh√§ndelse:"
 
-#: infobox.c:649
+#: infobox.c:693
 msgid "Execute file"
-msgstr "Kˆr fil"
+msgstr "K√∂r fil"
 
-#: infobox.c:744
+#: infobox.c:805
+#, fuzzy
+msgid "Comment"
+msgstr "Kommando:"
+
+#: infobox.c:807
+#, fuzzy
+msgid "Execute"
+msgstr "K√∂r fil"
+
+#: infobox.c:822
 msgid "<nothing yet>"
-msgstr "<inget ‰nnu>"
+msgstr "<inget √§nnu>"
 
-#: infobox.c:814
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
-msgstr "file(1) s‰ger... %s"
+msgstr "file(1) s√§ger... %s"
 
-#: infobox.c:871
+#: infobox.c:952
 #, fuzzy, c-format
 msgid "Could not change permissions: %s"
 msgstr "Kunne ikke gemme indstillinger: %s"
 
-#: infobox.c:889
+#: infobox.c:970 tips:120
 #, fuzzy
 msgid "Owner"
 msgstr "Nyare"
 
-#: infobox.c:891
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr ""
 
-#: infobox.c:893
+#: infobox.c:974
 msgid "World"
 msgstr ""
 
-#: infobox.c:896
+#: infobox.c:977
 #, fuzzy
 msgid "Read"
-msgstr "ƒndra namn"
+msgstr "√Ñndra namn"
 
-#: infobox.c:898
+#: infobox.c:980
 #, fuzzy
 msgid "Write"
 msgstr "objekt"
 
-#: infobox.c:900
+#: infobox.c:983
 msgid "Exec"
 msgstr ""
 
-#: infobox.c:917
+#: infobox.c:1001
 #, fuzzy
 msgid "SUID"
-msgstr "ƒrSUID"
+msgstr "√ÑrSUID"
 
-#: infobox.c:924
+#: infobox.c:1008
 #, fuzzy
 msgid "SGID"
-msgstr "ƒrSGID"
+msgstr "√ÑrSGID"
 
-#: infobox.c:931
+#: infobox.c:1015
 #, fuzzy
 msgid "Sticky"
-msgstr "ƒrSticky"
+msgstr "√ÑrSticky"
 
-#: infobox.c:953
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<inget √§nnu>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
-msgstr "Symbolisk genv‰g"
+msgstr "Symbolisk genv√§g"
 
-#: infobox.c:956
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX-programmet"
 
-#: infobox.c:964
+#: infobox.c:1100
 #, fuzzy
 msgid "mounted"
 msgstr "monterad"
 
-#: infobox.c:964
+#: infobox.c:1100
 #, fuzzy
 msgid "unmounted"
 msgstr "avmonterad"
 
-#: infobox.c:968
+#: infobox.c:1104
 #, fuzzy, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Monteringspunkt"
 
-#: infobox.c:971
+#: infobox.c:1107
 #, fuzzy, c-format
 msgid "Mount point (%s)"
 msgstr "Mounteringspunkt (%s) "
+
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d objekt"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Kopiera..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "objekt"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Tider"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Program"
 
 #: main.c:95
 #, fuzzy
@@ -1802,18 +2004,18 @@ msgid ""
 msgstr ""
 "Copyright (C) 2002 Thomas Leonard.\n"
 "ROX-Filer kommer med ABSOLUT INGEN GARANTI,\n"
-"i den grad det ‰r tillÂtet enligt lag.\n"
-"Du fÂr Âterdistribuera kopior av ROX-Filer\n"
+"i den grad det √§r till√•tet enligt lag.\n"
+"Du f√•r √•terdistribuera kopior av ROX-Filer\n"
 "under villkoren i GNU General Public License.\n"
-"Fˆr mer information om detta, se filen COPYING.\n"
+"F√∂r mer information om detta, se filen COPYING.\n"
 
 #: main.c:104
 msgid "Try `ROX-Filer/AppRun --help' for more information.\n"
-msgstr "Prova 'ROX-Filer/AppRun --help' fˆr mer information.\n"
+msgstr "Prova 'ROX-Filer/AppRun --help' f√∂r mer information.\n"
 
 #: main.c:107
 msgid "Try `ROX-Filer/AppRun -h' for more information.\n"
-msgstr "Prova 'ROX-Filer/AppRun -h' fˆr mer information.\n"
+msgstr "Prova 'ROX-Filer/AppRun -h' f√∂r mer information.\n"
 
 #: main.c:109
 msgid ""
@@ -1821,11 +2023,11 @@ msgid ""
 "you must use the short versions instead.\n"
 "\n"
 msgstr ""
-"NOTERA: Ditt system stˆdjer inte lÂnga kommandoradsparametrar - \n"
-"du mÂste anv‰nda de korta ist‰llet.\n"
+"NOTERA: Ditt system st√∂djer inte l√•nga kommandoradsparametrar - \n"
+"du m√•ste anv√§nda de korta ist√§llet.\n"
 
 #: main.c:115
-#, fuzzy
+#, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
 "Open each directory or file listed, or the current working\n"
@@ -1847,45 +2049,41 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
-"Report bugs to "
+"Report bugs to %s.\n"
+"Home page (including updated versions): http://rox.sourceforge.net/\n"
 msgstr ""
-"Anv‰ndning: ROX-Filer/AppRun [VALM÷JLIGHETER]... [FIL]...\n"
-"÷ppna alla kataloger eller filer, eller den nuvarande arbets-\n"
-"katalogen om inget annat ‰r givet.\n"
+"Anv√§ndning: ROX-Filer/AppRun [VALM√ñJLIGHETER]... [FIL]...\n"
+"√ñppna alla kataloger eller filer, eller den nuvarande arbets-\n"
+"katalogen om inget annat √§r givet.\n"
 "\n"
-"  -b, --bottom=PANEL\tˆppna PANEL som en underkantspanel\n"
-"  -c, --client-id=ID\tanv‰nd som sessionshanterare\n"
-"  -d, --dir=KATALOG\t\tˆppna KATALOG som katalog (inte program)\n"
-"  -D, --close=KATALOG\tst‰ng KATALOG och dess underkataloger\n"
-"  -h, --help\t\tvisa denna hj‰lp och avsluta\n"
-"  -l, --left=PANEL\tˆppna PANEL som en v‰nsterkantspanel\n"
-"  -m, --mime-type=FIL\tskriv ut MIME-typen fˆr FIL och avsluta\n"
-"  -n, --new\t\tstarta en ny 'filer', ‰ven om en redan ‰r igÂng\n"
-"  -o, --override\tfˆrbigÂ fˆnsterhanterarens kontroll av paneler\n"
-"  -p, --pinboard=SKRIVBORD\tanv‰nd skrivbord SKRIVBORD som skrivbord\n"
-"  -r, --right=PANEL\tˆppna PANEL som en hˆgerkantspanel\n"
-"  -R, --RPC\t\tkˆr metodanrop l‰st frÂn stdin\n"
-"  -s, --show=FIL\tˆppna den katalog som innehÂller FIL\n"
-"  -t, --top=PANEL\tˆppna PANEL som eb toppkantspanel\n"
-"  -u, --user\t\tvisa anv‰ndarnamn i alla fˆnster \n"
+"  -b, --bottom=PANEL\t√∂ppna PANEL som en underkantspanel\n"
+"  -c, --client-id=ID\tanv√§nd som sessionshanterare\n"
+"  -d, --dir=KATALOG\t\t√∂ppna KATALOG som katalog (inte program)\n"
+"  -D, --close=KATALOG\tst√§ng KATALOG och dess underkataloger\n"
+"  -h, --help\t\tvisa denna hj√§lp och avsluta\n"
+"  -l, --left=PANEL\t√∂ppna PANEL som en v√§nsterkantspanel\n"
+"  -m, --mime-type=FIL\tskriv ut MIME-typen f√∂r FIL och avsluta\n"
+"  -n, --new\t\tstarta en ny 'filer', √§ven om en redan √§r ig√•ng\n"
+"  -o, --override\tf√∂rbig√• f√∂nsterhanterarens kontroll av paneler\n"
+"  -p, --pinboard=SKRIVBORD\tanv√§nd skrivbord SKRIVBORD som skrivbord\n"
+"  -r, --right=PANEL\t√∂ppna PANEL som en h√∂gerkantspanel\n"
+"  -R, --RPC\t\tk√∂r metodanrop l√§st fr√•n stdin\n"
+"  -s, --show=FIL\t√∂ppna den katalog som inneh√•ller FIL\n"
+"  -t, --top=PANEL\t√∂ppna PANEL som eb toppkantspanel\n"
+"  -u, --user\t\tvisa anv√§ndarnamn i alla f√∂nster \n"
 "  -v, --version\t\tvisa versionsinformationen och avsluta\n"
-"  -x, --examine=FIL\tFIL har ‰ndrats - undersˆk den igen\n"
+"  -x, --examine=FIL\tFIL har √§ndrats - unders√∂k den igen\n"
 "\n"
-"Den nyeste versionen finns pÂ:\n"
+"Den nyeste versionen finns p√•:\n"
 "\thttp://rox.sourceforge.net\n"
 "\n"
 "Rapportera fel till <tal197@users.sourceforge.net>.\n"
 
-#: main.c:136
-msgid ""
-".\n"
-"Home page (including updated versions): http://rox.sourceforge.net/\n"
-msgstr ""
-
-#: main.c:234
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1893,301 +2091,395 @@ msgid ""
 "Trying to continue..."
 msgstr ""
 
-#: main.c:382
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
 msgstr ""
 
-#: main.c:489
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
-msgstr "Kˆr som anv‰ndare '%s'"
+msgstr "K√∂r som anv√§ndare '%s'"
 
-#: main.c:666
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr ""
 
-#: main.c:667
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr ""
 
-#: main.c:671
+#: main.c:693
 msgid "features set at compile time"
 msgstr "funktioner satt vid kompilering"
 
-#: main.c:672
+#: main.c:694
 msgid "Large File Support"
-msgstr "Stˆd fˆr stora filer"
+msgstr "St√∂d f√∂r stora filer"
 
-#: main.c:679
-msgid "GNOME-VFS library"
-msgstr "GNOME-VFS-bibliotek"
-
-#: main.c:683
-msgid "No (need 2.8.0 or later)"
-msgstr ""
-
-#: main.c:686
-msgid "Dnotify support"
-msgstr ""
-
-#: main.c:693
+#: main.c:701
 msgid "Binary compatibility"
 msgstr ""
 
-#: main.c:695
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr ""
 
-#: main.c:697
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr ""
 
-#: menu.c:180 tips:52
+#: main.c:709
+#, fuzzy
+msgid "Extended attribute support"
+msgstr "Anv√§nd inte maskinnamn"
+
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
+
+#: main.c:895
+#, c-format
+msgid ""
+"Left-click to run %s.\n"
+"Right-click for a list of versions."
+msgstr ""
+
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Fel n√§r '%s' skapades: %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Spara som:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Visa"
 
-#: menu.c:181 tips:57
+#: menu.c:641 tips:49
 #, fuzzy
 msgid "Icons View"
 msgstr "Ikonstorlek"
 
-#: menu.c:182
+#: menu.c:642
 #, fuzzy
-msgid "Icons, With..."
-msgstr "J‰ttestora, med..."
+msgid "Icons With Sizes"
+msgstr "J√§ttestora, med..."
 
-#: menu.c:183 tips:74
-msgid "Sizes"
-msgstr "Storlekar"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Minimera till"
 
-#: menu.c:185 tips:254
-msgid "Types"
-msgstr "Typer"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "R√§ttigheter"
 
-#: menu.c:186 tips:77
-msgid "Times"
-msgstr "Tider"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "J√§ttestora, med..."
 
-#: menu.c:187 tips:58 tips:92
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr ""
 
-#: menu.c:189
+#: menu.c:651
 #, fuzzy
 msgid "Bigger Icons"
-msgstr "J‰ttestora ikoner"
+msgstr "J√§ttestora ikoner"
 
-#: menu.c:190
+#: menu.c:653
 #, fuzzy
 msgid "Smaller Icons"
-msgstr "SmÂ ikoner"
+msgstr "Sm√• ikoner"
 
-#: menu.c:191 tips:71
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr ""
 
-#: menu.c:193
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Sortera efter mann"
 
-#: menu.c:194
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Sortera efter typ"
 
-#: menu.c:195
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Sortera efter datum"
 
-#: menu.c:196
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Sortera efter datum"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Sortera efter datum"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Sortera efter storlek"
 
-#: menu.c:197
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "R√§ttigheter"
+
+#: menu.c:668
 #, fuzzy
 msgid "Sort by Owner"
 msgstr "Sortera efter storlek"
 
-#: menu.c:198
+#: menu.c:669
 #, fuzzy
 msgid "Sort by Group"
 msgstr "Sortera efter typ"
 
-#: menu.c:199
+#: menu.c:671
 #, fuzzy
 msgid "Reversed"
-msgstr "ƒndra tillbaka"
+msgstr "√Ñndra tillbaka"
 
-#: menu.c:201
+#: menu.c:675
 msgid "Show Hidden"
-msgstr "Visa gˆmda"
+msgstr "Visa g√∂mda"
 
-#: menu.c:202
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Visa hj√§lpfiler"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "inga inga kataloger)\n"
+
+#: menu.c:679
 #, fuzzy
 msgid "Filter Files..."
 msgstr "ROX-Filer: fil(1) siger..."
 
-#: menu.c:203
-msgid "Show Thumbnails"
-msgstr "Visa fˆrhandsgranskningar"
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "ROX-Filer: fil(1) siger..."
 
-#: menu.c:204
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
+msgid "Show Thumbnails"
+msgstr "Visa f√∂rhandsgranskningar"
+
+#: menu.c:683
 msgid "Refresh"
 msgstr "Uppdatera"
 
-#: menu.c:205
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Uppdatera"
+
+#: menu.c:686
 #, fuzzy
 msgid "Save Display Settings..."
 msgstr "Vis meddelelser i..."
 
-#: menu.c:207
-msgid "Copy..."
-msgstr "Kopiera..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Vis meddelelser i..."
 
-#: menu.c:208
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "R√§kna"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "Byt namn..."
 
-#: menu.c:209
+#: menu.c:700
 msgid "Link..."
-msgstr "S‰tt genv‰g..."
+msgstr "S√§tt genv√§g..."
 
-#: menu.c:213
-msgid "Open AVFS"
-msgstr "÷ppna med virtuellt filsystem"
-
-#: menu.c:214
+#: menu.c:708
 msgid "Send To..."
-msgstr "S‰nd till..."
+msgstr "S√§nd till..."
 
-#: menu.c:219
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Anv√§nd inte maskinnamn"
+
+#: menu.c:721
 #, fuzzy
 msgid "Count"
-msgstr "R‰kna"
+msgstr "R√§kna"
 
-#: menu.c:220
+#: menu.c:723
 #, fuzzy
 msgid "Set Type..."
-msgstr "S‰nd till..."
+msgstr "S√§nd till..."
 
-#: menu.c:224 toolbar.c:155
+#: menu.c:731 toolbar.c:179
 msgid "Select"
-msgstr "V‰lj"
+msgstr "V√§lj"
 
-#: menu.c:225
+#: menu.c:733
 msgid "Select All"
-msgstr "V‰lj alla"
+msgstr "V√§lj alla"
 
-#: menu.c:226
+#: menu.c:735
 msgid "Clear Selection"
-msgstr "V‰lj ingen"
+msgstr "V√§lj ingen"
 
-#: menu.c:227
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "Invertera val"
 
-#: menu.c:228
+#: menu.c:737
 #, fuzzy
 msgid "Select by Name..."
 msgstr "Sortera efter mann"
 
-#: menu.c:229
-msgid "Select If..."
-msgstr "V‰lj om..."
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "V√§lj om..."
 
-#: menu.c:231
+#: menu.c:741
+msgid "Select If..."
+msgstr "V√§lj om..."
+
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Ny"
 
-#: menu.c:233
+#: menu.c:752
 msgid "Blank file"
 msgstr "Tom fil"
 
-#: menu.c:235 tasklist.c:308
+#: menu.c:756 tasklist.c:305
 msgid "Window"
-msgstr "Fˆnster"
+msgstr "F√∂nster"
 
-#: menu.c:236
+#: menu.c:758
 msgid "Parent, New Window"
-msgstr "Fˆr‰lder, nytt fˆnster"
+msgstr "F√∂r√§lder, nytt f√∂nster"
 
-#: menu.c:237
+#: menu.c:759
 msgid "Parent, Same Window"
-msgstr "Fˆr‰lder, samma fˆnster"
+msgstr "F√∂r√§lder, samma f√∂nster"
 
-#: menu.c:238
+#: menu.c:761 tips:44
 msgid "New Window"
-msgstr "Nytt fˆnster"
+msgstr "Nytt f√∂nster"
 
-#: menu.c:240
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr ""
 
-#: menu.c:241
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Visa information"
+
+#: menu.c:768
 #, fuzzy
 msgid "Follow Symbolic Links"
-msgstr "Symbolsk genv‰g"
+msgstr "Symbolsk genv√§g"
 
-#: menu.c:242
+#: menu.c:769
 msgid "Resize Window"
-msgstr "ƒndra storlek pÂ fˆnster"
+msgstr "√Ñndra storlek p√• f√∂nster"
 
-#: menu.c:245
+#: menu.c:771
 msgid "Close Window"
-msgstr "St‰ng fˆnster"
+msgstr "St√§ng f√∂nster"
 
-#: menu.c:247
+#: menu.c:776
 msgid "Enter Path..."
-msgstr "Skriv in sˆkv‰g..."
+msgstr "Skriv in s√∂kv√§g..."
 
-#: menu.c:248
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Shell-kommando..."
 
-#: menu.c:249
-msgid "Xterm Here"
+#: menu.c:780
+#, fuzzy
+msgid "Terminal Here"
 msgstr "Terminalemulator i denna katalog"
 
-#: menu.c:250
-msgid "Switch to xterm"
+#: menu.c:782
+#, fuzzy
+msgid "Switch to Terminal"
 msgstr "Byt till terminalemulator"
 
-#: menu.c:718
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr ""
-"Du mÂste klicka med shift-tangenten nertryckt pÂ en fil fˆr att skicka den "
-"nÂgonstans"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "St√§ll in"
 
-#: menu.c:754
+#: menu.c:976
 msgid "Next Click"
-msgstr "N‰sta klickning"
+msgstr "N√§sta klickning"
 
-#: menu.c:776
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d objekt"
 
-#: menu.c:864
+#: menu.c:1094
 #, fuzzy
 msgid "Open unmounted"
 msgstr "avmonterad"
 
-#: menu.c:867
+#: menu.c:1097
 msgid "Show Target"
 msgstr "Visa destination"
 
-#: menu.c:869
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "Titta inuti"
 
-#: menu.c:871
+#: menu.c:1101
 msgid "Open As Text"
-msgstr "÷ppna som text"
+msgstr "√ñppna som text"
 
-#: menu.c:1031
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2196,66 +2488,76 @@ msgid ""
 "mount option ('user_xattr' on Linux)."
 msgstr ""
 
-#: menu.c:1037
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr ""
 
-#: menu.c:1072
+#: menu.c:1364
 #, fuzzy
 msgid "_Relative link"
-msgstr "Relativ genv‰g"
+msgstr "Relativ genv√§g"
 
-#: menu.c:1078
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
 "If off, the path from the root directory is stored - use this if the symlink "
 "may move but the target will stay put."
 msgstr ""
-"Om pÂslaget kommer den symbolske genv‰gen endast innehÂlla filnamnet pÂ "
-"destinations-filen. Anv‰nd detta om genv‰gen och destinationen alltid kommer "
+"Om p√•slaget kommer den symbolske genv√§gen endast inneh√•lla filnamnet p√• "
+"destinations-filen. Anv√§nd detta om genv√§gen och destinationen alltid kommer "
 "flyttas tillsammans.\n"
-"Om avslaget kommer den fulla sˆkvgen till destinationsfilen sparas - anv‰nd "
-"detta om genv‰gen kan bli flyttad, men destinationsfilen alltid kommer "
-"finnas pÂ samma st‰lle."
+"Om avslaget kommer den fulla s√∂kvgen till destinationsfilen sparas - anv√§nd "
+"detta om genv√§gen kan bli flyttad, men destinationsfilen alltid kommer "
+"finnas p√• samma st√§lle."
 
-#: menu.c:1148
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
-msgstr "Nytt katalognamn ‰r inte absolut"
+msgstr "Nytt katalognamn √§r inte absolut"
 
-#: menu.c:1214
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
-msgstr "Genv‰g frÂn '%s' finns redan. Byt ut den mot en genv‰g till '%s'?"
+msgstr "Genv√§g fr√•n '%s' finns redan. Byt ut den mot en genv√§g till '%s'?"
 
-#: menu.c:1220
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Byt ut"
 
-#: menu.c:1351 menu.c:1392 menu.c:1452
+#: menu.c:1704
+msgid "NewDir"
+msgstr "Ny katalog"
+
+#: menu.c:1706 menu.c:1757 menu.c:1827
 #, fuzzy
 msgid "Create"
 msgstr "Skapa"
 
-#: menu.c:1352
-msgid "NewDir"
-msgstr "Ny katalog"
-
-#: menu.c:1366 menu.c:1372
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Fel n‰r '%s' skapades: %s"
-
-#: menu.c:1393
+#: menu.c:1755
 msgid "NewFile"
 msgstr "Ny fil"
 
-#: menu.c:1411
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
-msgstr "Fel n‰r fil skapades: kunde inte finna mall fˆr %s"
+msgstr "Fel n√§r fil skapades: kunde inte finna mall f√∂r %s"
 
-#: menu.c:1482
+#: menu.c:1847
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+
+#: menu.c:1883
 #, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
@@ -2268,30 +2570,31 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
-"'S‰nd till'-menyn ‰r ett snabbt s‰tt att skicka filer till ett program. "
-"Programmen i listan ‰r i fˆljande kataloger:\n"
+"'S√§nd till'-menyn √§r ett snabbt s√§tt att skicka filer till ett program. "
+"Programmen i listan √§r i f√∂ljande kataloger:\n"
 "\n"
 "%s\n"
 "%s\n"
-"'S‰nd till'-menyn kan ˆppnas genom att Shift-klicka pÂ en fil."
+"'S√§nd till'-menyn kan √∂ppnas genom att Shift-klicka p√• en fil."
 
-#: menu.c:1493
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
 msgstr ""
-"Jag visar dig nu din 'Send till'-katalog; du bˆr s‰tta symboliske genv‰gar "
+"Jag visar dig nu din 'Send till'-katalog; du b√∂r s√§tta symboliske genv√§gar "
 "(Ctrl+Shift-klicka) till varje program du vill ha i den."
 
-#: menu.c:1496 menu.c:1536
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr ""
-"Din inst‰llning av CHOICESPATH-variabeln omˆjliggˆr ‰ndringar - tyv‰rr."
+"Din inst√§llning av CHOICESPATH-variabeln om√∂jligg√∂r √§ndringar - tyv√§rr."
 
-#: menu.c:1529
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2303,102 +2606,137 @@ msgid ""
 "%s\n"
 msgstr ""
 
-#: menu.c:1534
+#: menu.c:1936
 #, fuzzy
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
 msgstr ""
-"Jag visar dig nu din 'Send till'-katalog; du bˆr s‰tta symboliske genv‰gar "
+"Jag visar dig nu din 'Send till'-katalog; du b√∂r s√§tta symboliske genv√§gar "
 "(Ctrl+Shift-klicka) till varje program du vill ha i den."
 
-#: menu.c:1651
-msgid "Customise"
-msgstr "St‰ll in"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
+msgstr "St√§ll in"
 
-#: menu.c:1717
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "St√§ll in"
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
-msgstr "Detta ‰r redan ett entydigt naman fˆr denna katalog"
+msgstr "Detta √§r redan ett entydigt naman f√∂r denna katalog"
 
-#: menu.c:1748
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
 msgstr ""
-"Du kan inte ˆppna en till ˆversikt av denna katalog d‰rfˆr att 'Unika "
-"fˆnster' ‰r pÂslagen i inst‰llingar."
+"Du kan inte √∂ppna en till √∂versikt av denna katalog d√§rf√∂r att 'Unika "
+"f√∂nster' √§r p√•slagen i inst√§llingar."
 
-#: menu.c:1869
-msgid "Copy ... ?"
-msgstr "Kopiera ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1872
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Kopierar %s som %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Kopierar %s som %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Byt namn ... ?"
 
-#: menu.c:1875
+#: menu.c:2462
 msgid "Symlink ... ?"
-msgstr "S‰tt symbolisk genv‰g ... ?"
+msgstr "S√§tt symbolisk genv√§g ... ?"
 
-#: menu.c:1878
+#: menu.c:2465
 msgid "Shift Open ... ?"
-msgstr "Shift-ˆppna ... ?"
+msgstr "Shift-√∂ppna ... ?"
 
-#: menu.c:1881
+#: menu.c:2468
 #, fuzzy
 msgid "Properties of ... ?"
-msgstr "R‰kna ut storleken av ... ?"
+msgstr "R√§kna ut storleken av ... ?"
 
-#: menu.c:1884
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Anv√§nd inte maskinnamn"
+
+#: menu.c:2476
 #, fuzzy
 msgid "Set type of ... ?"
-msgstr "S‰tt ikonen fˆr ... ?"
+msgstr "S√§tt ikonen f√∂r ... ?"
 
-#: menu.c:1887
+#: menu.c:2479
 msgid "Set run action for ... ?"
-msgstr "S‰tt kˆrh‰ndelsen fˆr ... ?"
+msgstr "S√§tt k√∂rh√§ndelsen f√∂r ... ?"
 
-#: menu.c:1890
+#: menu.c:2482
 msgid "Set icon for ... ?"
-msgstr "S‰tt ikonen fˆr ... ?"
+msgstr "S√§tt ikonen f√∂r ... ?"
 
-#: menu.c:1893
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Skicka ... till ... ?"
 
-#: menu.c:1896
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "RADERA ... ?"
 
-#: menu.c:1899
+#: menu.c:2491
 msgid "Count the size of ... ?"
-msgstr "R‰kna ut storleken av ... ?"
+msgstr "R√§kna ut storleken av ... ?"
 
-#: menu.c:1902
+#: menu.c:2494
 msgid "Set permissions on ... ?"
-msgstr "S‰tt r‰ttigheterna pÂ ... ?"
+msgstr "S√§tt r√§ttigheterna p√• ... ?"
 
-#: menu.c:1905
+#: menu.c:2497
 msgid "Search inside ... ?"
-msgstr "Sˆk inuti ... ?"
+msgstr "S√∂k inuti ... ?"
 
-#: menu.c:1908
-msgid "Look inside ... ?"
-msgstr "Titta inuti ... ?"
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Kopiera ... ?"
 
-#: menu.c:1972
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
-msgstr "Du kan inte gˆra detta med mer ‰n ett objekt Ât gÂngen"
+msgstr "Du kan inte g√∂ra detta med mer √§n ett objekt √•t g√•ngen"
 
-#: menu.c:2004
+#: menu.c:2609
+#, fuzzy
+msgid "Duplicate"
+msgstr "Program"
+
+#: menu.c:2614
 msgid "Rename"
-msgstr "ƒndra namn"
+msgstr "√Ñndra namn"
 
-#: menu.c:2009
+#: menu.c:2619
 msgid "Symlink"
-msgstr "S‰tt symbolisk genv‰g"
+msgstr "S√§tt symbolisk genv√§g"
 
-#: menu.c:2041
+#: menu.c:2654
 #, fuzzy
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
@@ -2411,14 +2749,14 @@ msgid ""
 "\tgtk-can-change-accels = 1\n"
 "\t(this only works if NOT using XSETTINGS)"
 msgstr ""
-"Anv‰ndardefinerade kortkommandon ‰r avst‰ngda som standard i Gtk2 och duhar "
-"inte slagit pÂ dem. Du kan slÂ pÂ dessa genom att:\n"
-"1) anv‰nda en XSettings-hanterare som tex. ROX-Session\n"
+"Anv√§ndardefinerade kortkommandon √§r avst√§ngda som standard i Gtk2 och duhar "
+"inte slagit p√• dem. Du kan sl√• p√• dessa genom att:\n"
+"1) anv√§nda en XSettings-hanterare som tex. ROX-Session\n"
 "eller\n"
-"2) l‰gga till denna rad i ~/.gtkrc-2.9:\n"
+"2) l√§gga till denna rad i ~/.gtkrc-2.9:\n"
 "\tgtk-can-change-accels = 1"
 
-#: menu.c:2052
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2429,56 +2767,77 @@ msgid ""
 "The key will appear next to the menu item and you can just press that key "
 "without opening the menu in future."
 msgstr ""
-"Fˆr att st‰lla in ett kortkommando fˆr en menyfunktion:\n"
+"F√∂r att st√§lla in ett kortkommando f√∂r en menyfunktion:\n"
 "\n"
-"- ÷ppna menyn,\n"
-"- Flytta muspekaran till den funktion du vill ‰ndra,\n"
-"- Tryck pÂ den tangent du vill binda till funktionen.\n"
+"- √ñppna menyn,\n"
+"- Flytta muspekaran till den funktion du vill √§ndra,\n"
+"- Tryck p√• den tangent du vill binda till funktionen.\n"
 "\n"
 "Tangentan kommer visa sig vid sidan av funktionen och du kan nu trycka "
-"dennatangent fˆr att anv‰nda funktionen."
+"dennatangent f√∂r att anv√§nda funktionen."
 
-#: menu.c:2067
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
-msgstr "St‰ll in kortkommandon"
+msgstr "St√§ll in kortkommandon"
 
-#: minibuffer.c:131
+#: minibuffer.c:140
 msgid "Goto:"
-msgstr "GÂ till:"
+msgstr "G√• till:"
 
-#: minibuffer.c:132
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Shell:"
 
-#: minibuffer.c:133
+#: minibuffer.c:142
 msgid "Select If:"
-msgstr "V‰lj om:"
+msgstr "V√§lj om:"
 
-#: minibuffer.c:134
+#: minibuffer.c:143
 #, fuzzy
 msgid "Select Named:"
-msgstr "V‰lj om:"
+msgstr "V√§lj om:"
 
-#: minibuffer.c:135
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "V√§lj om:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr ""
 
-#: minibuffer.c:264
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
 msgstr ""
-"Skriv namner pÂ en fil och jag kommer visa den fˆr dig. Tryck pÂ Tab for att "
-"fylla den l‰ngsta matchningen. Escapetangenten st‰nger inmatningsraden."
+"Skriv namner p√• en fil och jag kommer visa den f√∂r dig. Tryck p√• Tab for att "
+"fylla den l√§ngsta matchningen. Escapetangenten st√§nger inmatningsraden."
 
-#: minibuffer.c:270
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
-"Skriv ett shell-kommando som skall kˆras. Klicka pÂ en fil for att l‰gga "
+"Skriv ett shell-kommando som skall k√∂ras. Klicka p√• en fil for att l√§gga "
 "till den till bufferten."
 
-#: minibuffer.c:275
+#: minibuffer.c:331
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2489,177 +2848,187 @@ msgid ""
 "*.png means any name ending in '.png'"
 msgstr ""
 
-#: minibuffer.c:287
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
 msgstr ""
 
-#: minibuffer.c:895
-msgid "Invalid Find condition"
-msgstr "Ogiltigt sˆkvillkor"
+#: minibuffer.c:358
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
 
-#: mount.c:374
+#: minibuffer.c:1045
+msgid "Invalid Find condition"
+msgstr "Ogiltigt s√∂kvillkor"
+
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr ""
 
-#: options.c:277
+#: options.c:272
 #, fuzzy
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "Din gamla panelfil har blivit konverterad till det nya XML-formatet."
 
-#: options.c:535 options.c:1258
+#: options.c:560 options.c:1250
 #, fuzzy
 msgid "(use default)"
 msgstr "Samma som standardstorleken"
 
-#: options.c:806
+#: options.c:844
 #, fuzzy, c-format
 msgid "Internal error: %s unreadable"
-msgstr "Internt fel - dÂlig info-typ"
+msgstr "Internt fel - d√•lig info-typ"
 
-#: options.c:917
+#: options.c:929
 #, fuzzy
 msgid "Options"
-msgstr "Inst‰llningar..."
+msgstr "Inst√§llningar..."
 
-#: options.c:962
+#: options.c:974
 #, fuzzy
 msgid "_Revert"
-msgstr "ƒndra tillbaka"
+msgstr "√Ñndra tillbaka"
 
-#: options.c:968
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr ""
-"≈terst‰ll alla inst‰llningar som de var innan inst‰llningsfˆnstret ˆppnades"
+"√Öterst√§ll alla inst√§llningar som de var innan inst√§llningsf√∂nstret √∂ppnades"
 
-#: options.c:983
+#: options.c:996
 #, fuzzy, c-format
 msgid ""
 "Choices will be saved as:\n"
 "%s"
-msgstr "Inst‰llingar kommer sparas som %s"
+msgstr "Inst√§llingar kommer sparas som %s"
 
-#: options.c:991
+#: options.c:1004
 #, fuzzy
 msgid "(saving disabled by CHOICESPATH)"
-msgstr "Sparande av inst‰llingar ‰r avslaget i CHOICESPATH-variablen"
+msgstr "Sparande av inst√§llingar √§r avslaget i CHOICESPATH-variablen"
 
-#: options.c:1164 usericons.c:450
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Fel vid sparande av %s: %s"
 
-#: options.c:1794
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Saknas '='"
 
-#: panel.c:439
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "Din gamla panelfil har blivit konverterad till det nya XML-formatet."
 
-#: panel.c:546
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
 msgstr ""
-"Du har fˆrsˆkt att st‰nga en panel via fˆnsterhanteraren - Jag tror att "
-"detta ‰r ett misstag... vilk du verkligen st‰nga den?"
+"Du har f√∂rs√∂kt att st√§nga en panel via f√∂nsterhanteraren - Jag tror att "
+"detta √§r ett misstag... vilk du verkligen st√§nga den?"
 
-#: panel.c:639
+#: panel.c:771
 msgid "Missing < or > in panel config file"
-msgstr "Saknas < eller > i panelinst‰llingsfilen"
+msgstr "Saknas < eller > i panelinst√§llingsfilen"
 
-#: panel.c:1519
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Fel vid sparande av panel %s: %s"
 
-#: panel.c:1835
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "Applet avslutade utan att skapa en widget!"
 
-#: panel.c:1934
+#: panel.c:2077
 #, fuzzy, c-format
 msgid ""
 "Error running applet:\n"
 "%s"
-msgstr "Fel vid kˆrning av '%s:"
+msgstr "Fel vid k√∂rning av '%s:"
 
-#: panel.c:2335
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "√Ñr du s√§ker p√• att du vill √∂ppna %d f√∂nster?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Ta bort"
+
+#: panel.c:2777
 #, fuzzy
 msgid "Panel Options..."
-msgstr "Inst‰llningar..."
+msgstr "Inst√§llningar..."
 
-#: panel.c:2427
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr ""
 
-#: panel.c:2502
+#: panel.c:2897
+msgid "Top"
+msgstr ""
+
+#: panel.c:2899
+msgid "Bottom"
+msgstr ""
+
+#: panel.c:2901
+msgid "Left"
+msgstr ""
+
+#: panel.c:2903
+msgid "Right"
+msgstr ""
+
+#: panel.c:2905
 #, fuzzy
-msgid "Panel Options"
-msgstr "Inst‰llningar..."
+msgid "Default"
+msgstr "Standardinst√§llning:"
 
-#: panel.c:2517
-#, fuzzy, c-format
-msgid "Panel: %s"
-msgstr "Paneler"
-
-#: panel.c:2525
-msgid "Select the panel's position:"
-msgstr ""
-
-#: panel.c:2531
+#: panel.c:2909
 #, fuzzy
-msgid "Top-edge panel"
-msgstr "St‰ng panelen?"
-
-#: panel.c:2532
-msgid "Top edge"
-msgstr ""
-
-#: panel.c:2533
-msgid "Bottom edge panel"
-msgstr ""
-
-#: panel.c:2534
-msgid "Bottom edge"
-msgstr ""
-
-#: panel.c:2535
-msgid "Left edge panel"
-msgstr ""
-
-#: panel.c:2536
-msgid "Left edge"
-msgstr ""
-
-#: panel.c:2537
-msgid "Right-edge panel"
-msgstr ""
-
-#: panel.c:2538
-msgid "Right edge"
-msgstr ""
+msgid "Unknown side"
+msgstr "Ok√§nd"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
 msgstr ""
 "Din gamla skrivbordsfil har blivit konverterad till det nya XML-formatet."
 
-#: pinboard.c:635
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
 "the SOAP SetBackdropApp method."
 msgstr ""
-"Bakgrundshanteraren mÂste vara en applikationskatalog. Dra en "
-"applikationskatalog till dialogrutan S‰tt bakgrund, eller (fˆr "
+"Bakgrundshanteraren m√•ste vara en applikationskatalog. Dra en "
+"applikationskatalog till dialogrutan S√§tt bakgrund, eller (f√∂r "
 "programmerare) skicka den till metodenSetBackdropApp i SOAP"
 
-#: pinboard.c:654
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2667,96 +3036,112 @@ msgid ""
 "Programmers: the application's AppInfo.xml must contain the CanSetBackdrop "
 "element, as described in ROX-Filer's manual."
 msgstr ""
-"Du kan endast s‰tta bakgrunden till en bild eller ett program som k‰nner "
-"tillhur det anv‰nder ROX-Filers bakgrund\n"
+"Du kan endast s√§tta bakgrunden till en bild eller ett program som k√§nner "
+"tillhur det anv√§nder ROX-Filers bakgrund\n"
 "\n"
-"Programmerare: applikationens AppInfo.xml mÂste innehÂlla elementet "
+"Programmerare: applikationens AppInfo.xml m√•ste inneh√•lla elementet "
 "CanSetBackdrop som beskrivs i ROX-Filers manual"
 
-#: pinboard.c:674
+#: pinboard.c:750
 #, fuzzy
 msgid "Set backdrop"
-msgstr "S‰tt bakgrund"
+msgstr "S√§tt bakgrund"
 
-#: pinboard.c:685
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
 msgstr ""
 
-#: pinboard.c:698
+#: pinboard.c:774
 #, fuzzy
 msgid "Centre the image without scaling it"
-msgstr "Radera filer utan att frÂga fˆrst."
+msgstr "Radera filer utan att fr√•ga f√∂rst."
 
-#: pinboard.c:699
+#: pinboard.c:775
 #, fuzzy
 msgid "Centre"
 msgstr "Centrerad"
 
-#: pinboard.c:700
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr ""
 
-#: pinboard.c:702
+#: pinboard.c:778
 #, fuzzy
 msgid "Scale"
 msgstr "Skalad"
 
-#: pinboard.c:703
+#: pinboard.c:779
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr ""
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Fil"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
 msgstr ""
 
-#: pinboard.c:704
+#: pinboard.c:783
 #, fuzzy
 msgid "Stretch"
 msgstr "Franska"
 
-#: pinboard.c:705
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr ""
 
-#: pinboard.c:706
+#: pinboard.c:785
 #, fuzzy
 msgid "Tile"
 msgstr "Upprepad"
 
-#: pinboard.c:711
+#: pinboard.c:790
 #, fuzzy
 msgid "Drop an image here"
-msgstr "Sl‰pp en bild h‰r"
+msgstr "Sl√§pp en bild h√§r"
 
-#: pinboard.c:772
+#: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
 msgstr ""
-"Ingen skrivbord anv‰ndes... standardskrivbordet har valts. Kˆr som'rox -"
-"p=Default' fˆr att anv‰nda det i framtiden"
+"Ingen skrivbord anv√§ndes... standardskrivbordet har valts. K√∂r som'rox -"
+"p=Default' f√∂r att anv√§nda det i framtiden"
 
-#: pinboard.c:866
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
 msgstr ""
-"Endast filer (och vissa program) kan anv‰ndas fˆr att s‰tta bakgrundsbilden"
+"Endast filer (och vissa program) kan anv√§ndas f√∂r att s√§tta bakgrundsbilden"
 
-#: pinboard.c:1471
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Saknas '>' i ikontiteln"
 
-#: pinboard.c:1480
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Saknas ',' efter ikontiteln"
 
-#: pinboard.c:1565
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Fel vid sparande av skrivbord %s: %s"
 
-#: pinboard.c:2109
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Bakgrund..."
 
-#: pinboard.c:2202
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Paneler"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2767,108 +3152,58 @@ msgstr ""
 "%s\n"
 "Bakgrunden borttagen"
 
-#: pixmaps.c:991
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
 "%s"
 msgstr ""
 
-#: pixmaps.c:1012
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr ""
 
-#: pixmaps.c:1025
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr ""
 
-#: remote.c:624
+#: remote.c:764
 #, fuzzy, c-format
 msgid "Unknown style '%s'"
-msgstr "Ok‰nd typ:"
+msgstr "Ok√§nd typ:"
 
-#: remote.c:646
+#: remote.c:786
 #, fuzzy, c-format
 msgid "Unknown details type '%s'"
-msgstr "Ok‰nd typ:"
+msgstr "Ok√§nd typ:"
 
-#: remote.c:674
+#: remote.c:815
 #, fuzzy, c-format
 msgid "Unknown sorting type '%s'"
-msgstr "Ok‰nd typ:"
+msgstr "Ok√§nd typ:"
 
-#: remote.c:1117
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
-msgstr "Fˆrsˆkte anropa ok‰nd SOAP-metod '%s'"
+msgstr "F√∂rs√∂kte anropa ok√§nd SOAP-metod '%s'"
 
-#: rox_gettext.c:95
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Ogiltig .gmo-ˆvers‰ttningsfil (fˆr kort): %s"
-
-#: rox_gettext.c:108
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Ogiltig .gmo-ˆvers‰ttningsfil ('GNU magic number' hittades inte): %s"
-
-#: run.c:96 run.c:141
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "Programmet %s hittades inte - raderat?"
 
-#: run.c:287
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "Filen existerer inte, eller jag har inte tillgÂng till den: %s"
-
-#: run.c:292
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "Jag vet inte hur man ˆppnar '%s'"
-
-#: run.c:323
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"Program:\n"
-"Detta ‰r en applikationskatalog - du kan ˆppna den som ett program, eller "
-"ˆppna den \n"
-"som en katalog (hÂll ner Shift medan du ˆppnar den). \n"
-"De flesta program har sin egen hj‰lp d‰r, men detta program har inte det."
-
-#: run.c:407
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "Kunde inte skicka data till programmet %s"
-
-#: run.c:437
-#, c-format
-msgid "Could not read link: %s"
-msgstr "Kunde inte l‰sa genv‰gen: %s"
-
-#: run.c:465
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr ""
-"Bruten symbolisk genv‰g (eller sÂ har du inte r‰ttighet att l‰sa "
-"destinationen): %s"
-
-#: run.c:502
+#: run.c:359
 #, fuzzy, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
 "action by choosing `Set Run Action' from the File menu, or you can just drag "
 "the file to an application.%s"
 msgstr ""
-"Det ‰r inte satt nÂgon kˆrh‰ndelse fˆr filer av typ (%s/%s) - du kan s‰tta "
-"denna genom att v‰lja 'S‰tt kˆrh‰ndelse' frÂn filmenyn, eller sÂ kan du "
-"ocksÂ dra filen till ett program"
+"Det √§r inte satt n√•gon k√∂rh√§ndelse f√∂r filer av typ (%s/%s) - du kan s√§tta "
+"denna genom att v√§lja 'S√§tt k√∂rh√§ndelse' fr√•n filmenyn, eller s√• kan du "
+"ocks√• dra filen till ett program"
 
-#: run.c:508
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -2876,196 +3211,67 @@ msgid ""
 "the execute bit by choosing Permissions from the File menu."
 msgstr ""
 
-#: support.c:272
-msgid "B"
-msgstr ""
-
-#: support.c:351
-msgid "byte"
-msgstr "byte"
-
-#: toolbar.c:115
-msgid "Close"
-msgstr "St‰ng"
-
-#: toolbar.c:115
-msgid "Close filer window"
-msgstr "St‰ng 'filer'-fˆnstret"
-
-#: toolbar.c:119
-msgid "Up"
-msgstr "Upp"
-
-#: toolbar.c:119
-msgid "Change to parent directory"
-msgstr "GÂ till fˆr‰ldekatalogen"
-
-#: toolbar.c:123
-msgid "Home"
-msgstr "Hem"
-
-#: toolbar.c:123
-msgid "Change to home directory"
-msgstr "GÂ till hemkatalogen"
-
-#: toolbar.c:127
-msgid "Bookmarks"
-msgstr ""
-
-#: toolbar.c:127
-msgid "Bookmarks menu"
-msgstr ""
-
-#: toolbar.c:131
-msgid "Scan"
-msgstr "Skanna"
-
-#: toolbar.c:131
-msgid "Rescan directory contents"
-msgstr "Skanna om katalogens innehÂll"
-
-#: toolbar.c:135
-msgid "Change icon size"
-msgstr "ƒndra ikonstorleken"
-
-#: toolbar.c:139
-msgid "Automatic size mode"
-msgstr ""
-
-#: toolbar.c:143
-msgid "Show extra details"
-msgstr "Visa extra detaljer"
-
-#: toolbar.c:147
-#, fuzzy
-msgid "Sort"
-msgstr "Sorterar"
-
-#: toolbar.c:147
-#, fuzzy
-msgid "Change sort criteria"
-msgstr "ƒndrad:"
-
-#: toolbar.c:151
-msgid "Hidden"
-msgstr "Gˆm"
-
-#: toolbar.c:151
-msgid "Show/hide hidden files"
-msgstr "Visa/gˆm osynliga filer"
-
-#: toolbar.c:155
-#, fuzzy
-msgid "Select all/invert selection"
-msgstr "Invertera val"
-
-#: toolbar.c:159
-msgid "Show ROX-Filer help"
-msgstr "Visa ROX-Filers hj‰lp"
-
-#: toolbar.c:220
+#: run.c:373
 #, c-format
-msgid " (%u hidden)"
-msgstr " (%u osynliga)"
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "Filen existerer inte, eller jag har inte tillg√•ng till den: %s"
 
-#: toolbar.c:228 tips:80
-msgid "items"
-msgstr "objekt"
-
-#: toolbar.c:228
-msgid "item"
-msgstr "objekt"
-
-#: toolbar.c:231
+#: run.c:378
 #, c-format
-msgid "No items%s"
-msgstr "Inga objekt%s"
+msgid "I don't know how to open '%s'"
+msgstr "Jag vet inte hur man √∂ppnar '%s'"
 
-#: toolbar.c:250
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "!'%s' √§r en symbolsk genv√§g\n"
+
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "Katalogen '%s' √§r inte tillg√§nglig"
+
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "Icke-k√∂rbar fil %s"
+
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Fel i behandlaren %s: %s"
+
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
+msgstr ""
+"Program:\n"
+"Detta √§r en applikationskatalog - du kan √∂ppna den som ett program, eller "
+"√∂ppna den \n"
+"som en katalog (h√•ll ner Shift medan du √∂ppnar den). \n"
+"De flesta program har sin egen hj√§lp d√§r, men detta program har inte det."
+
+#: run.c:549
 #, c-format
-msgid "%u selected (%s)"
-msgstr "%u valda (%s)"
+msgid "Could not send data to program: %s"
+msgstr "Kunde inte skicka data till programmet %s"
 
-#: toolbar.c:422
-#, fuzzy
-msgid "Sort by name"
-msgstr "Sortera efter mann"
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "Kunde inte l√§sa genv√§gen: %s"
 
-#: toolbar.c:422
-#, fuzzy
-msgid "Sort by type"
-msgstr "Sortera efter typ"
-
-#: toolbar.c:422
-#, fuzzy
-msgid "Sort by date"
-msgstr "Sortera efter datum"
-
-#: toolbar.c:423
-#, fuzzy
-msgid "Sort by size"
-msgstr "Sortera efter storlek"
-
-#: toolbar.c:423
-#, fuzzy
-msgid "Sort by owner"
-msgstr "Sortera efter storlek"
-
-#: toolbar.c:423
-#, fuzzy
-msgid "Sort by group"
-msgstr "Sortera efter typ"
-
-#: toolbar.c:457
-#, fuzzy
-msgid "ascending"
-msgstr "Muse-funktioner"
-
-#: toolbar.c:457
-msgid "descending"
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
 msgstr ""
+"Bruten symbolisk genv√§g (eller s√• har du inte r√§ttighet att l√§sa "
+"destinationen): %s"
 
-#: type.c:203
-msgid "Sym link"
-msgstr "Symbolisk genv‰g"
-
-#: type.c:205
-msgid "Mount point"
-msgstr "Monteringspunkt"
-
-#: type.c:207
-msgid "App dir"
-msgstr "Programkatalog"
-
-#: type.c:214
-msgid "Dir"
-msgstr "Katalog"
-
-#: type.c:216
-msgid "Char dev"
-msgstr ""
-
-#: type.c:218
-msgid "Block dev"
-msgstr ""
-
-#: type.c:220
-msgid "Pipe"
-msgstr "Rˆr"
-
-#: type.c:222
-msgid "Socket"
-msgstr ""
-
-#: type.c:224
-msgid "Door"
-msgstr "Dˆrr"
-
-#: type.c:227
-msgid "Unknown"
-msgstr "Ok‰nd"
-
-#: type.c:355
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3079,568 +3285,879 @@ msgid ""
 "Otherwise, you should check, or even just delete, all the existing run "
 "actions."
 msgstr ""
-"Programmet '%s' ‰r skrivbart fˆr alla! V‰grar kˆra. Var sn‰ll och "
-"‰ndrar‰ttigheterna nu (detta problem kan ha orsakats av ett fel i en "
+"Programmet '%s' √§r skrivbart f√∂r alla! V√§grar k√∂ra. Var sn√§ll och "
+"√§ndrar√§ttigheterna nu (detta problem kan ha orsakats av ett fel i en "
 "tidigare version av filhanteraren).\n"
 "\n"
-"Om du litar pÂ alla som kan skriva till dessa filer behˆver du inte oroa "
+"Om du litar p√• alla som kan skriva till dessa filer beh√∂ver du inte oroa "
 "dig. I annat fall, kontollera, eller tom. ta bort, alla nuvarande "
-"kˆrh‰ndelser. "
+"k√∂rh√§ndelser. "
 
-#: type.c:368
+#: run.c:798
 msgid "go-w (Fix security problem)"
-msgstr "go-w (R‰ttar till s‰kerhetsluckan)"
+msgstr "go-w (R√§ttar till s√§kerhetsluckan)"
 
-#: type.c:498
+#: support.c:288
+msgid " "
+msgstr ""
+
+#: support.c:381
+msgid "byte"
+msgstr "byte"
+
+#: support.c:1531 support.c:1585
+#, fuzzy, c-format
+msgid "Failed to open and stat file '%s': %s"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
+
+#: support.c:1542 support.c:1596
+#, fuzzy, c-format
+msgid "Failed to mmap file '%s': %s"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
+
+#: toolbar.c:116
+msgid "Close"
+msgstr "St√§ng"
+
+#: toolbar.c:116
+msgid "Close filer window"
+msgstr "St√§ng 'filer'-f√∂nstret"
+
+#: toolbar.c:120
+msgid "Up"
+msgstr "Upp"
+
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
+
+#: toolbar.c:126
+msgid "Home"
+msgstr "Hem"
+
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
+
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
+
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
+
+#: toolbar.c:138
+msgid "Scan"
+msgstr "Skanna"
+
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
+
+#: toolbar.c:143
+#, fuzzy
+msgid "Size‚îº"
+msgstr "Storlek"
+
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ‚îò : Huge\n"
+"  ‚î§ : Large\n"
+"  ‚îê : Small\n"
+"  ‚îå, ‚îú : Auto"
+msgstr ""
+
+#: toolbar.c:155
+msgid "Auto"
+msgstr ""
+
+#: toolbar.c:155
+msgid "Automatic size mode"
+msgstr ""
+
+#: toolbar.c:159
+msgid "List"
+msgstr ""
+
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
+#, fuzzy
+msgid "Sort"
+msgstr "Sorterar"
+
+#: toolbar.c:165
+#, fuzzy
+msgid "Change sort criteria"
+msgstr "√Ñndrad:"
+
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
+
+#: toolbar.c:169
+msgid ""
+"Left: Show/hide hidden files\n"
+"Right: Show/hide thumbnails"
+msgstr ""
+
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
+msgstr "Invertera val"
+
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "‚óã"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ‚ñΩ: No settings\n"
+"  ‚ñº: Own settings\n"
+"  ‚ñ∂: Parent settings\n"
+"  ‚ñ∑: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
+msgid "Show ROX-Filer help"
+msgstr "Visa ROX-Filers hj√§lp"
+
+#: toolbar.c:270
+#, c-format
+msgid " (%u hidden)"
+msgstr " (%u osynliga)"
+
+#: toolbar.c:276 tips:79
+msgid "items"
+msgstr "objekt"
+
+#: toolbar.c:276
+msgid "item"
+msgstr "objekt"
+
+#: toolbar.c:279
+#, c-format
+msgid "No items%s"
+msgstr "Inga objekt%s"
+
+#: toolbar.c:298
+#, c-format
+msgid "%u selected (%s)"
+msgstr "%u valda (%s)"
+
+#: toolbar.c:535
+#, fuzzy
+msgid "Sort by name"
+msgstr "Sortera efter mann"
+
+#: toolbar.c:535
+#, fuzzy
+msgid "Sort by type"
+msgstr "Sortera efter typ"
+
+#: toolbar.c:535
+#, fuzzy
+msgid "Sort by date"
+msgstr "Sortera efter datum"
+
+#: toolbar.c:535
+#, fuzzy
+msgid "Sort by size"
+msgstr "Sortera efter storlek"
+
+#: toolbar.c:536
+#, fuzzy
+msgid "Sort by owner"
+msgstr "Sortera efter storlek"
+
+#: toolbar.c:536
+#, fuzzy
+msgid "Sort by group"
+msgstr "Sortera efter typ"
+
+#: toolbar.c:568
+#, fuzzy
+msgid "ascending"
+msgstr "Muse-funktioner"
+
+#: toolbar.c:568
+msgid "descending"
+msgstr ""
+
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
+msgid "Sym link"
+msgstr "Symbolisk genv√§g"
+
+#: type.c:223
+msgid "Mount point"
+msgstr "Monteringspunkt"
+
+#: type.c:225
+msgid "App dir"
+msgstr "Programkatalog"
+
+#: type.c:232
+msgid "Dir"
+msgstr "Katalog"
+
+#: type.c:234
+msgid "Char dev"
+msgstr ""
+
+#: type.c:236
+msgid "Block dev"
+msgstr ""
+
+#: type.c:238
+msgid "Pipe"
+msgstr "R√∂r"
+
+#: type.c:240
+msgid "Socket"
+msgstr ""
+
+#: type.c:242
+msgid "Door"
+msgstr "D√∂rr"
+
+#: type.c:245
+msgid "Unknown"
+msgstr "Ok√§nd"
+
+#: type.c:583
 #, fuzzy
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
 "gimp \"$@\""
 msgstr ""
-"Skriv ett shell-kommando som skall ˆppna \"$1\" i ett program. Tex..:\n"
+"Skriv ett shell-kommando som skall √∂ppna \"$1\" i ett program. Tex..:\n"
 "\n"
 "gimp \"$1\""
 
-#: type.c:679
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
-msgstr "Detta ‰r inte ett program! Ge mig ett program ist‰llet!"
+msgstr "Detta √§r inte ett program! Ge mig ett program ist√§llet!"
 
-#: type.c:740
+#: type.c:839
 msgid "No run action defined"
-msgstr "Ingen kˆrh‰ndelse ‰r definierad"
+msgstr "Ingen k√∂rh√§ndelse √§r definierad"
 
-#: type.c:766
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Fel i behandlaren %s: %s"
 
-#: type.c:781
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Ogiltigt program %s (trasig AppRun)"
 
-#: type.c:792
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
-msgstr "Icke-kˆrbar fil %s"
+msgstr "Icke-k√∂rbar fil %s"
 
-#: type.c:825
+#: type.c:902
 msgid "Set run action"
-msgstr "S‰tt kˆrh‰ndelse"
+msgstr "S√§tt k√∂rh√§ndelse"
 
-#: type.c:831
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 
-#: type.c:833
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
-msgstr "S‰tt som standard fˆr alla `%s/<vad som helst>'"
+msgstr "S√§tt som standard f√∂r alla `%s/<vad som helst>'"
 
-#: type.c:837
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr ""
 
-#: type.c:839
+#: type.c:916
 #, fuzzy, c-format
 msgid "Only for the type `%s' (%s/%s)"
-msgstr "Endast fˆr typen `%s/%s'"
+msgstr "Endast f√∂r typen `%s/%s'"
 
-#: type.c:845
+#: type.c:922
 #, fuzzy
 msgid "Drop a suitable application here"
 msgstr ""
-"Sl‰pp ett passande\n"
-"program h‰r"
+"Sl√§pp ett passande\n"
+"program h√§r"
 
-#: type.c:860
+#: type.c:963
 msgid "OR"
 msgstr "ELLER"
 
-#: type.c:867
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Skriv in ett shell-kommando:"
 
-#: type.c:896
+#: type.c:1000
 #, fuzzy
 msgid "_Use Command"
 msgstr "Kommando:"
 
-#: type.c:926
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
 msgstr ""
-"Det finns redan en kˆrh‰ndelse och den ‰r ett ganska stort program - ‰r du "
-"s‰ker pÂ att du vill radera den?"
+"Det finns redan en k√∂rh√§ndelse och den √§r ett ganska stort program - √§r du "
+"s√§ker p√• att du vill radera den?"
 
-#: type.c:937
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Kan inte ta bort %s: %s"
 
-#: type.c:974
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
-msgstr "Sparande av Choices ‰r avslaget i CHOICESPATH-variabeln"
+msgstr "Sparande av Choices √§r avslaget i CHOICESPATH-variabeln"
 
-#: type.c:1249
-#, c-format
-msgid ""
-"Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr ""
-
-#: type.c:1263
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason)"
-msgstr ""
+"%s"
+msgstr "Mislykkedes i at skabe en b√∏rne-process"
 
-#: usericons.c:181
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
-msgstr "Sˆkv‰gen du angav finns. Ikonen har inte ‰ndrats."
+msgstr "S√∂kv√§gen du angav finns. Ikonen har inte √§ndrats."
 
-#: usericons.c:191 usericons.c:616
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
 "The icon has not been changed."
 msgstr ""
-"Kunde inte l‰sa bildfilen -- den kanske inte ‰r i ett format jag fˆrstÂrr,  "
-"eller sÂ kanske r‰ttigheterna ‰r fel?\n"
-"Ikonen har inte ‰ndrats."
+"Kunde inte l√§sa bildfilen -- den kanske inte √§r i ett format jag f√∂rst√•rr,  "
+"eller s√• kanske r√§ttigheterna √§r fel?\n"
+"Ikonen har inte √§ndrats."
 
-#: usericons.c:238
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr ""
 
-#: usericons.c:242
+#: usericons.c:248
 #, fuzzy, c-format
 msgid ""
 "Can't delete '%s':\n"
 "%s"
 msgstr "Kan inte ta bort %s: %s"
 
-#: usericons.c:270
+#: usericons.c:281
 msgid "Set icon"
-msgstr "S‰tt ikon"
+msgstr "S√§tt ikon"
 
-#: usericons.c:279
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr ""
 
-#: usericons.c:281
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
-msgstr "S‰tt som ikon for alla `%s/<vad som helst>'"
+msgstr "S√§tt som ikon for alla `%s/<vad som helst>'"
 
-#: usericons.c:286
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr ""
 
-#: usericons.c:288
+#: usericons.c:299
 #, fuzzy, c-format
 msgid "For all files of type `%s' (%s/%s)"
-msgstr "Endast fˆr typen `%s/%s'"
+msgstr "Endast f√∂r typen `%s/%s'"
 
-#: usericons.c:294
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
 msgstr ""
-"L‰gg till filen och namn pÂ bildfiler till din personliga lista. "
-"Inst‰llningarnakommer gÂ fˆrlorade om filen eller bilderna flyttas."
+"L√§gg till filen och namn p√• bildfiler till din personliga lista. "
+"Inst√§llningarnakommer g√• f√∂rlorade om filen eller bilderna flyttas."
 
-#: usericons.c:297
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
-msgstr "Endast fˆr filen `%s'"
+msgstr "Endast f√∂r filen `%s'"
 
-#: usericons.c:305
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
 "This is usually the best option if you can write to the directory."
 msgstr ""
 "Kopiera bilden in i katalogen som en osynlig fil '.DirIcon'. Alla "
-"anv‰ndarekan dÂ se ikonen och du kan flytta katalogen utan problem.Detta ‰r "
-"vanligtvis den b‰sta lˆsningen om du kan skriva till katalogen."
+"anv√§ndarekan d√• se ikonen och du kan flytta katalogen utan problem.Detta √§r "
+"vanligtvis den b√§sta l√∂sningen om du kan skriva till katalogen."
 
-#: usericons.c:311
+#: usericons.c:322
 #, fuzzy
 msgid "Copy image into directory"
-msgstr "GÂ till hemkatalogen"
+msgstr "G√• till hemkatalogen"
 
-#: usericons.c:317
+#: usericons.c:328
 msgid "Drop an icon file here"
-msgstr "Sl‰pp en ikonfil h‰r"
+msgstr "Sl√§pp en ikonfil h√§r"
 
-#: usericons.c:587
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
-msgstr "S‰tter ikon som ‰r avslagen av variabeln CHOICESPATH"
+msgstr "S√§tter ikon som √§r avslagen av variabeln CHOICESPATH"
 
-#: usericons.c:631
+#: usericons.c:659
 #, fuzzy, c-format
 msgid ""
 "Error creating image '%s':\n"
 "%s"
-msgstr "Fel n‰r '%s' skulle skapas: %s"
+msgstr "Fel n√§r '%s' skulle skapas: %s"
 
-#: view_details.c:1009
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
+msgid "Mono font"
+msgstr ""
+
+#: view_details.c:1019
+msgid "Font for displaying mono-spaced text"
+msgstr ""
+
+#: view_details.c:1233
 #, fuzzy
 msgid "_Name"
 msgstr "Namn"
 
-#: view_details.c:1012
+#: view_details.c:1236
 #, fuzzy
 msgid "_Type"
 msgstr "Typ"
 
-#: view_details.c:1015
-#, fuzzy
-msgid "_Permissions"
-msgstr "R‰ttigheter"
-
-#: view_details.c:1016
-msgid "_Owner"
-msgstr ""
-
-#: view_details.c:1018
-msgid "_Group"
-msgstr ""
-
-#: view_details.c:1020
+#: view_details.c:1238
 #, fuzzy
 msgid "_Size"
 msgstr "Storlek"
 
-#: view_details.c:1022
+#: view_details.c:1244
+#, fuzzy
+msgid "_Permissions"
+msgstr "R√§ttigheter"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr ""
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr ""
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr ""
 
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr ""
+
 #: tips:1
-msgid "Translation"
-msgstr "÷vers‰ttning"
+msgid "Filer windows"
+msgstr "'Filer'-f√∂nster"
 
 #: tips:2
 #, fuzzy
-msgid "Language"
-msgstr "SprÂk"
+msgid "Auto-resize filer windows"
+msgstr "√Ñndra automatiskt storlek p√• 'filer'-f√∂nster..."
 
 #: tips:3
-msgid "Use the LANG environment variable"
-msgstr "Anv‰nd miljˆvariabeln LANG"
-
-#: tips:4
-msgid "Basque"
-msgstr ""
-
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Kinesiska (traditionell)"
-
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Kinesiska (fˆrenklad)"
-
-#: tips:7
-msgid "Czech"
-msgstr ""
-
-# tips=x
-#: tips:8
-msgid "Danish"
-msgstr "Danska"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Holl‰ndska"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Engelska (ingen ˆvers‰ttning)"
-
-#: tips:11
-msgid "Estonian"
-msgstr ""
-
-# tips=x
-#: tips:12
-#, fuzzy
-msgid "Finnish"
-msgstr "Danska"
-
-#: tips:13
-msgid "French"
-msgstr "Franska"
-
-#: tips:14
-msgid "German"
-msgstr "Tyska"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Ungerska"
-
-#: tips:16
-msgid "Japanese"
-msgstr ""
-
-#: tips:17
-msgid "Norwegian"
-msgstr ""
-
-#: tips:18
-msgid "Italian"
-msgstr "Italienska"
-
-#: tips:19
-msgid "Polish"
-msgstr "Polska"
-
-#: tips:20
-msgid "Portuguese (Brasil)"
-msgstr ""
-
-#: tips:21
-msgid "Romanian"
-msgstr ""
-
-#: tips:22
-msgid "Russian"
-msgstr "Ryska"
-
-#: tips:23
-msgid "Spanish"
-msgstr "Spanska"
-
-#: tips:24
-msgid "Swedish"
-msgstr ""
-
-#: tips:25
-msgid "Filer windows"
-msgstr "'Filer'-fˆnster"
-
-#: tips:26
-#, fuzzy
-msgid "Auto-resize filer windows"
-msgstr "ƒndra automatiskt storlek pÂ 'filer'-fˆnster..."
-
-#: tips:27
 #, fuzzy
 msgid "Never automatically resize"
-msgstr "ƒndra aldrig storlek pÂ 'filer'-fˆnster..."
+msgstr "√Ñndra aldrig storlek p√• 'filer'-f√∂nster..."
 
-#: tips:28
+#: tips:4
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
 msgstr ""
-"Du kommer bli tvungen att ‰ndra storlek pÂ fˆnster manuellt. Antigen mha. "
-"fˆnsterhateraren, genom menyn 'ƒndra fˆnsterstorlek' eller genom att "
-"dubbelklicka pÂ fˆnstrets bakgrund."
+"Du kommer bli tvungen att √§ndra storlek p√• f√∂nster manuellt. Antigen mha. "
+"f√∂nsterhateraren, genom menyn '√Ñndra f√∂nsterstorlek' eller genom att "
+"dubbelklicka p√• f√∂nstrets bakgrund."
 
-#: tips:29
+#: tips:5
 #, fuzzy
 msgid "Resize when changing the display style"
-msgstr "ƒndra storlek n‰r vystil ‰ndras"
+msgstr "√Ñndra storlek n√§r vystil √§ndras"
 
-#: tips:30
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
 msgstr ""
-"N‰r du ‰ndrar storlek pÂ ikoner eller ‰ndrar vilka detaljer som visas\n"
-"kommer fˆnstret ‰ndra storlek."
+"N√§r du √§ndrar storlek p√• ikoner eller √§ndrar vilka detaljer som visas\n"
+"kommer f√∂nstret √§ndra storlek."
 
-#: tips:31
+#: tips:7
 msgid "Always resize"
-msgstr "ƒndra alltid storlek"
+msgstr "√Ñndra alltid storlek"
 
-#: tips:32
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
 msgstr ""
-"Fˆnstet kommer ‰ndrar storlek n‰r det ‰r vettigt \n"
+"F√∂nstet kommer √§ndrar storlek n√§r det √§r vettigt \n"
 "(dvs. vid byte av katalog eller vystil)."
 
-#: tips:33
+#: tips:9
 #, fuzzy
 msgid "Largest window size:"
-msgstr "S‰tt fˆnstertorlek:"
+msgstr "S√§tt f√∂nstertorlek:"
 
-#: tips:34
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:35
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
 msgstr ""
-"Den stˆrsta storlek i procent av sk‰rmen som fˆnstret kan ‰ndra storlek\n"
+"Den st√∂rsta storlek i procent av sk√§rmen som f√∂nstret kan √§ndra storlek\n"
 "till"
 
-#: tips:36
-msgid "Window behaviour"
-msgstr "Fˆnsterbeteeende"
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "S√§tt f√∂nstertorlek:"
 
-#: tips:37
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Den st√∂rsta storlek i procent av sk√§rmen som f√∂nstret kan √§ndra storlek\n"
+"till"
+
+#: tips:15
+msgid "Window behaviour"
+msgstr "F√∂nsterbeteeende"
+
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Korta titelradsflaggor"
 
-#: tips:38
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
 msgstr ""
-"Visa enstaka bokst‰ver ist‰llet fˆr ord fˆr 'Skannar', 'Alla' och "
-"'Fˆrhandsgranskning\n"
+"Visa enstaka bokst√§ver ist√§llet f√∂r ord f√∂r 'Skannar', 'Alla' och "
+"'F√∂rhandsgranskning\n"
 "i titelraden"
 
-#: tips:39
+#: tips:18
 msgid "Unique windows"
-msgstr "Unika fˆnster"
+msgstr "Unika f√∂nster"
 
-#: tips:40
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
 msgstr ""
-"Om du ˆppnar en katalog och den redan visas i ett annat fˆnster\n"
-"kommer det andra fˆnstret st‰ngas."
+"Om du √∂ppnar en katalog och den redan visas i ett annat f√∂nster\n"
+"kommer det andra f√∂nstret st√§ngas."
 
-#: tips:41
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "F√∂nster"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 #, fuzzy
 msgid "New window on button 1"
-msgstr "Nytt fˆnster med musknapp 1 (RISC OS-stil)"
+msgstr "Nytt f√∂nster med musknapp 1 (RISC OS-stil)"
 
-#: tips:42
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
 "reuse the current window."
 msgstr ""
-"Att klicka med musknapp 1 (vanligtvis v‰nster musknapp) ˆppnar en katalog i\n"
-"ett nytt fˆnster n‰r detta ‰r pÂslaget. Klicka med musknapp 2 (mitten) "
+"Att klicka med musknapp 1 (vanligtvis v√§nster musknapp) √∂ppnar en katalog i\n"
+"ett nytt f√∂nster n√§r detta √§r p√•slaget. Klicka med musknapp 2 (mitten) "
 "kommer\n"
-"Âteranv‰nda samma fˆnster."
+"√•teranv√§nda samma f√∂nster."
 
-#: tips:43
+#: tips:26
 #, fuzzy
 msgid "Single-click navigation"
-msgstr "Enkelklick fˆr att ˆppna"
+msgstr "Enkelklick f√∂r att √∂ppna"
 
-#: tips:44 tips:137
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
 "things."
 msgstr ""
-"Ett klick med detta pÂslaget ˆppnar objektet. HÂll ner Control fˆr att\n"
-"v‰lja det ist‰llet. Om avslaget ˆppnar dubbelklick objekt."
+"Ett klick med detta p√•slaget √∂ppnar objektet. H√•ll ner Control f√∂r att\n"
+"v√§lja det ist√§llet. Om avslaget √∂ppnar dubbelklick objekt."
 
-#: tips:45
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr ""
 
-#: tips:46
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
 msgstr ""
 
-#: tips:47
+#: tips:30
 #, fuzzy
 msgid "Sorting"
 msgstr "Sorterar"
 
-#: tips:48
+#: tips:31
 #, fuzzy
 msgid "Directories come first (for sort by name)"
-msgstr "Kataloger kommer alltid fˆrst"
+msgstr "Kataloger kommer alltid f√∂rst"
 
-#: tips:49
+#: tips:32
 #, fuzzy
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
 msgstr ""
-"Om detta ‰r pÂslaget kommer kataloger alltid att visas fˆre andra objekt "
-"oavs‰tt\n"
-"hur sortering gˆrs."
+"Om detta √§r p√•slaget kommer kataloger alltid att visas f√∂re andra objekt "
+"oavs√§tt\n"
+"hur sortering g√∂rs."
 
-#: tips:50
+#: tips:33
 #, fuzzy
 msgid "Capitalised names first (for sort by name)"
-msgstr "Kataloger kommer alltid fˆrst"
+msgstr "Kataloger kommer alltid f√∂rst"
 
-#: tips:51
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
 msgstr ""
 
-#: tips:53
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Kataloger kommer alltid f√∂rst"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Sekund"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "Anv√§nd inte maskinnamn"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 #, fuzzy
 msgid "Default settings for new windows"
-msgstr "Standardstorlek fˆr nya fˆnster"
+msgstr "Standardstorlek f√∂r nya f√∂nster"
 
-#: tips:54
+#: tips:46
 msgid "Inherit options from source window"
-msgstr "ƒrv inst‰llningar frÂn fˆregÂende fˆnster"
+msgstr "√Ñrv inst√§llningar fr√•n f√∂reg√•ende f√∂nster"
 
-#: tips:55
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
 msgstr ""
-"Om detta ‰r pÂslaget kommer inst‰llningar fˆr nya fˆnster att ‰rvas frÂn det "
-"fˆnster\n"
-"frÂn vilket det nya ˆppnades, annars s‰tts det till nedandstÂende "
-"inst‰llingar."
+"Om detta √§r p√•slaget kommer inst√§llningar f√∂r nya f√∂nster att √§rvas fr√•n det "
+"f√∂nster\n"
+"fr√•n vilket det nya √∂ppnades, annars s√§tts det till nedandst√•ende "
+"inst√§llingar."
 
-#: tips:56
+#: tips:48
 #, fuzzy
 msgid "View type:"
-msgstr "Ok‰nd typ:"
+msgstr "Ok√§nd typ:"
 
-#: tips:59
+#: tips:51
 #, fuzzy
 msgid "Sort by:"
 msgstr "Sortera efter"
 
-#: tips:61 tips:76
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Typ"
 
-#: tips:62
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Datum"
 
-#: tips:64
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Datum"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Datum"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Visa dolda filer"
 
-#: tips:65
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
 msgstr ""
-"Om detta ‰r pÂslaget kommer ‰ven filer vars namn bˆrjar med en punk att "
+"Om detta √§r p√•slaget kommer √§ven filer vars namn b√∂rjar med en punk att "
 "visas,\n"
 "annars visas dom inte."
 
-#: tips:66
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Visa dolda filer"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Om detta √§r p√•slaget kommer √§ven filer vars namn b√∂rjar med en punk att "
+"visas,\n"
+"annars visas dom inte."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "J√§ttestora ikoner"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "pixlar"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 #, fuzzy
 msgid "Icon View"
 msgstr "Ikonstorlek"
@@ -3648,423 +4165,622 @@ msgstr "Ikonstorlek"
 #: tips:67
 #, fuzzy
 msgid "Default size:"
-msgstr "Standardinst‰llning:"
+msgstr "Standardinst√§llning:"
 
 #: tips:68
 msgid "Huge Icons"
-msgstr "J‰ttestora ikoner"
+msgstr "J√§ttestora ikoner"
 
-#: tips:69 tips:245
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Stora ikoner"
 
-#: tips:70 tips:244
+#: tips:70 tips:295
 msgid "Small Icons"
-msgstr "SmÂ ikoner"
+msgstr "Sm√• ikoner"
 
 #: tips:72
 #, fuzzy
 msgid "Default details:"
-msgstr "Standardinst‰llning:"
+msgstr "Standardinst√§llning:"
 
 #: tips:73
 msgid "No details"
 msgstr "Inga detaljer"
 
+#: tips:74
+msgid "Sizes"
+msgstr "Storlekar"
+
+#: tips:77
+msgid "Times"
+msgstr "Tider"
+
 #: tips:78
-msgid "Automatic small icons:"
+msgid "Automatic small icons: Change at:"
 msgstr ""
 
-#: tips:79
-#, fuzzy
-msgid "Change at:"
-msgstr "ƒndrad:"
-
-#: tips:81
+#: tips:80
 #, fuzzy
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
 "used."
 msgstr ""
-"Om katalogen innehÂller minst sÂ h‰r mÂnga objekt kommer det att visas med\n"
-"smÂ ikoner"
+"Om katalogen inneh√•ller minst s√• h√§r m√•nga objekt kommer det att visas med\n"
+"sm√• ikoner"
 
-#: tips:82
-msgid "Max width (Large icons):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Radbrytningsbredd f√∂r stora ikoner"
+
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
-
-#: tips:83 tips:86
-msgid "pixels"
-msgstr "pixlar"
+"Text som √§r bredare √§n detta delas p√• tv√• rader n√§r stora ikoner visas.\n"
+"Vid j√§ttestora ikoner bryts text som √§r 50% bredare √§n detta."
 
 #: tips:84
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+msgid "(Wrapped, Details):"
 msgstr ""
-"Text som ‰r bredare ‰n detta delas pÂ tvÂ rader n‰r stora ikoner visas.\n"
-"Vid j‰ttestora ikoner bryts text som ‰r 50% bredare ‰n detta."
 
-#: tips:85
-#, fuzzy
-msgid "(Small Icons):"
-msgstr "SmÂ ikoner"
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
 
 #: tips:87
-msgid "Maximum width for the text beside a Small Icon."
-msgstr "Maximal bredd fˆr texten bredvid smÂ ikoner."
+msgid "Wrap by characters"
+msgstr ""
 
 #: tips:88
-msgid "Order small icons vertically"
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
 msgstr ""
 
 #: tips:89
-msgid ""
-"If this option is on, then small icons are ordered vertically, not "
-"horizontally."
-msgstr ""
-
-#: tips:90
-msgid "Order large icons vertically"
-msgstr ""
+#, fuzzy
+msgid "Small Icons (Max width):"
+msgstr "Maximal bredd f√∂r sm√• ikoner:"
 
 #: tips:91
-msgid ""
-"If this option is on, then large icons are sorted vertically, not "
-"horizontally."
+msgid "Maximum width for the text beside a Small Icon."
+msgstr "Maximal bredd f√∂r texten bredvid sm√• ikoner."
+
+#: tips:92
+msgid "Order small icons vertically"
 msgstr ""
 
 #: tips:93
-#, fuzzy
-msgid "Show column headings"
-msgstr "Visa fˆrhandsgranskningar"
+msgid ""
+"If this option is on, then small icons are arranged in columns, not rows."
+msgstr ""
 
 #: tips:94
-msgid "If this is on then column headings will be shown in the list view."
+msgid "Order large icons vertically"
 msgstr ""
 
 #: tips:95
+msgid ""
+"If this option is on, then large icons are arranged in columns, not rows."
+msgstr ""
+
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
+#, fuzzy
+msgid "Show column headings"
+msgstr "Visa f√∂rhandsgranskningar"
+
+#: tips:101
+msgid "If this is on then column headings will be shown in the list view."
+msgstr ""
+
+#: tips:102
 #, fuzzy
 msgid "Show full type"
 msgstr "Sortera efter typ"
 
-#: tips:96
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr ""
 
-#: tips:97
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Maximal bredd f√∂r texten bredvid sm√• ikoner."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Visa f√∂rhandsgranskningar"
+
+#: tips:113
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+
+#: tips:115
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+
+#: tips:117
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+
+#: tips:119
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+
+#: tips:121
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+
+#: tips:123
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+
+#: tips:124
+msgid "Last Modified"
+msgstr ""
+
+#: tips:125
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+
+#: tips:130
 #, fuzzy
 msgid "Tools/Minibuffer"
 msgstr "Minbuffertar"
 
-#: tips:98
+#: tips:131
 msgid "Toolbar"
-msgstr "Verktygsf‰lt"
+msgstr "Verktygsf√§lt"
 
-#: tips:99
+#: tips:132
 #, fuzzy
 msgid "Toolbar type:"
-msgstr "Verktygsf‰ltstyp:"
+msgstr "Verktygsf√§ltstyp:"
 
-#: tips:100
+#: tips:133
 #, fuzzy
 msgid "No toolbar"
-msgstr "Verktygsf‰lt"
+msgstr "Verktygsf√§lt"
 
-#: tips:101
+#: tips:134
 #, fuzzy
 msgid "Icons only"
 msgstr "Endast ikoner"
 
-#: tips:102
+#: tips:135
 #, fuzzy
 msgid "Text under icons"
 msgstr "Text under ikonerna"
 
-#: tips:103
+#: tips:136
 msgid "Text beside icons"
 msgstr "Text vid sidan om ikonerna"
 
-#: tips:104
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Endast bilder"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Visa totalt antal objekt"
 
-#: tips:105
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
 "selected items and their combined size."
 msgstr ""
-"Visa antalet objekt som visas i ett fˆnster och antalet dolda objekt.\n"
-"N‰r objekt ‰r markerade, visa antalet och deras sammalagda storlek"
+"Visa antalet objekt som visas i ett f√∂nster och antalet dolda objekt.\n"
+"N√§r objekt √§r markerade, visa antalet och deras sammalagda storlek"
 
-#: tips:106
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr ""
 
-#: tips:107
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr ""
 
-#: tips:108
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
 msgstr ""
 
-#: tips:109
+#: tips:143
 #, fuzzy
 msgid "Minibuffer"
 msgstr "Minbuffertar"
 
-#: tips:110
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Ge en ljudsignal om tabb-komplettering misslyckas"
 
-#: tips:111
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
 "letter varies)."
 msgstr ""
-"Vid anv‰ndade av 'Skriv in sˆkv‰g...'-minibufferten om tabb trycks ner,\n"
-"kommer inget att h‰nda (tex. fˆr att det finns flera mˆjligheter fˆr n‰sta "
+"Vid anv√§ndade av 'Skriv in s√∂kv√§g...'-minibufferten om tabb trycks ner,\n"
+"kommer inget att h√§nda (tex. f√∂r att det finns flera m√∂jligheter f√∂r n√§sta "
 "tecken)."
 
-#: tips:112
+#: tips:146
 msgid "Beep if there are several matches"
-msgstr "Ge ljudsignal om det finns flera tr‰ffar"
+msgstr "Ge ljudsignal om det finns flera tr√§ffar"
 
-#: tips:113
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
 msgstr ""
-"Vid anv‰ndande av 'Skriv in sˆkv‰g...'-minibufferten om tabb trycks ner,\n"
-"ges en ljudsignal om det finns fler ‰n en matchande fil, ‰ven om fler "
+"Vid anv√§ndande av 'Skriv in s√∂kv√§g...'-minibufferten om tabb trycks ner,\n"
+"ges en ljudsignal om det finns fler √§n en matchande fil, √§ven om fler "
 "tecken\n"
 "las till."
 
-#: tips:116
+#: tips:148
+msgid "Stdout handler"
+msgstr ""
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Fel i behandlaren %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
 msgstr ""
 
-#: tips:117
+#: tips:155
 msgid "Show image thumbnails"
-msgstr "Visa fˆrhandsgransking av bilder (thumnails)"
+msgstr "Visa f√∂rhandsgransking av bilder (thumnails)"
 
-#: tips:118
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
 msgstr ""
 
-#: tips:119
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Visa f√∂rhandsgransking av bilder (thumnails)"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 #, fuzzy
 msgid "Video thumbnails"
 msgstr "Gem thumbnails"
 
-#: tips:120
+#: tips:160
 #, fuzzy
 msgid "Thumbnails cache"
-msgstr "Visa fˆrhandsgranskningar"
+msgstr "Visa f√∂rhandsgranskningar"
 
-#: tips:121
+#: tips:161
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 
-#: tips:122 tips:195
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
+#, fuzzy
+msgid "Manage thumbnails"
+msgstr "Visa f√∂rhandsgransking av bilder (thumnails)"
+
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Gem thumbnails"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Sekund"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Skrivbord"
 
-#: tips:123
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
 msgstr ""
-"N‰r du anv‰nder ett skrivbord kan du dra filer och program till detta\n"
-"fˆr att skapa genv‰gar till dem."
+"N√§r du anv√§nder ett skrivbord kan du dra filer och program till detta\n"
+"f√∂r att skapa genv√§gar till dem."
 
-#: tips:124 tips:241
+#: tips:178 tips:292
 #, fuzzy
 msgid "Appearance"
-msgstr "Utseende pÂ verktygsf‰ltet"
+msgstr "Utseende p√• verktygsf√§ltet"
 
-#: tips:125
+#: tips:179
 #, fuzzy
 msgid "Foreground:"
-msgstr "Fˆrgrund:"
+msgstr "F√∂rgrund:"
 
-#: tips:126
+#: tips:180
 msgid "Text shadow:"
 msgstr ""
 
-#: tips:127
+#: tips:181
 #, fuzzy
 msgid "Background:"
 msgstr "Bakgrund:"
 
-#: tips:128
+#: tips:182
 msgid "No shadow"
 msgstr ""
 
-#: tips:129
+#: tips:183
 msgid "Thin"
 msgstr ""
 
-#: tips:130
+#: tips:184
 msgid "Thick"
 msgstr ""
 
-#: tips:131
+#: tips:185
 #, fuzzy
 msgid "Use custom font:"
 msgstr "Fjern specielt ikon"
 
-#: tips:132
+#: tips:186
 #, fuzzy
 msgid "The font used for the text displayed under the icons"
-msgstr "Texten som visas under ikonen ‰r:"
+msgstr "Texten som visas under ikonen √§r:"
 
-#: tips:133
+#: tips:187
 msgid "Fast scaling of images"
 msgstr ""
 
-#: tips:134
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
 msgstr ""
 
-#: tips:135
+#: tips:189
 #, fuzzy
 msgid "Pinboard behaviour"
 msgstr "Skrivbordsbeteende"
 
-#: tips:136
+#: tips:190
 msgid "Single-click to open"
-msgstr "Enkelklick fˆr att ˆppna"
+msgstr "Enkelklick f√∂r att √∂ppna"
 
-#: tips:138
+#: tips:192
 msgid "Keep icons within screen limits"
-msgstr "HÂll ikoner inom sk‰rmytan"
+msgstr "H√•ll ikoner inom sk√§rmytan"
 
-#: tips:139
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
-msgstr "Om detta ‰r pÂslaget kommer ikoner alltid att visas inom sk‰rmens yta."
+msgstr "Om detta √§r p√•slaget kommer ikoner alltid att visas inom sk√§rmens yta."
 
-#: tips:140
+#: tips:194
 msgid "Icon grid step:"
-msgstr "Rutn‰tst‰thet fˆr ikoner:"
+msgstr "Rutn√§tst√§thet f√∂r ikoner:"
 
-#: tips:141
+#: tips:195
 msgid "Fine"
 msgstr "Fin"
 
-#: tips:142
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
-msgstr "Anv‰nd ett 2-pixlarsn‰t fˆr placering av ikoner pÂ skrivbordet."
+msgstr "Anv√§nd ett 2-pixlarsn√§t f√∂r placering av ikoner p√• skrivbordet."
 
-#: tips:143
+#: tips:197
 msgid "Medium"
 msgstr "Medium"
 
-#: tips:144
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
-msgstr "Anv‰nd ett 16-pixlarsn‰t fˆr placering av ikoner pÂ skrivbordet."
+msgstr "Anv√§nd ett 16-pixlarsn√§t f√∂r placering av ikoner p√• skrivbordet."
 
-#: tips:145
+#: tips:199
 msgid "Coarse"
 msgstr "Grovt"
 
-#: tips:146
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
-msgstr "Anv‰nd ett 32-pixlarsn‰t fˆr placering av ikoner pÂ skrivbordet."
+msgstr "Anv√§nd ett 32-pixlarsn√§t f√∂r placering av ikoner p√• skrivbordet."
 
-#: tips:147 tips:149
+#: tips:201 tips:203
 #, fuzzy
 msgid "Iconified windows"
-msgstr "Minimerade fˆnster"
+msgstr "Minimerade f√∂nster"
 
-#: tips:148
+#: tips:202
 #, fuzzy
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
 "windows."
 msgstr ""
-"De flesta fˆnsterhanterare tillhandahÂller ett s‰tt att minimera "
+"De flesta f√∂nsterhanterare tillhandah√•ller ett s√§tt att minimera "
 "(ikonifiera)\n"
-"fˆnster och vissa program, som ROX-Filer, kan anv‰ndas fˆr att visa "
+"f√∂nster och vissa program, som ROX-Filer, kan anv√§ndas f√∂r att visa "
 "minimerade\n"
-"fˆnster. Om detta ‰r pÂslaget visas varje minimerat katalogfˆnster som en\n"
-"liten knapp pÂ sk‰rmen. Kr‰ver en kompatibel fˆnsterhanterare."
+"f√∂nster. Om detta √§r p√•slaget visas varje minimerat katalogf√∂nster som en\n"
+"liten knapp p√• sk√§rmen. Kr√§ver en kompatibel f√∂nsterhanterare."
 
-#: tips:150
+#: tips:204
 #, fuzzy
 msgid "Show iconified windows"
-msgstr "Visa minimerade fˆnster"
+msgstr "Visa minimerade f√∂nster"
 
-#: tips:151
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
 "pinboard must be in use."
 msgstr ""
 
-#: tips:152
+#: tips:206
 msgid "Show per workspace"
 msgstr ""
 
-#: tips:153
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
 msgstr ""
 
-#: tips:154
+#: tips:208
 msgid "Iconify to the"
 msgstr "Minimera till"
 
-#: tips:155
+#: tips:209
 msgid "top-left"
-msgstr "ˆvre v‰nstra hˆrnet"
+msgstr "√∂vre v√§nstra h√∂rnet"
 
-#: tips:156
+#: tips:210
 msgid "top-right"
-msgstr "ˆvre hˆgra hˆrnet"
+msgstr "√∂vre h√∂gra h√∂rnet"
 
-#: tips:157
+#: tips:211
 msgid "bottom-left"
-msgstr "undre v‰nstra hˆrnet"
+msgstr "undre v√§nstra h√∂rnet"
 
-#: tips:158
+#: tips:212
 msgid "bottom-right"
-msgstr "undre hˆgra hˆrnet"
+msgstr "undre h√∂gra h√∂rnet"
 
-#: tips:159
+#: tips:213
 msgid ", going"
 msgstr ", sprid"
 
-#: tips:160
+#: tips:214
 msgid "horizontally"
 msgstr "horisontellt"
 
-#: tips:161
+#: tips:215
 msgid "vertically"
 msgstr "vertikalt"
 
-#: tips:162
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4072,337 +4788,303 @@ msgid ""
 "about its own panel."
 msgstr ""
 
-#: tips:163
+#: tips:217
 msgid "Top margin"
 msgstr ""
 
-#: tips:164
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr ""
 
-#: tips:165
+#: tips:219
 msgid "Bottom margin"
 msgstr ""
 
-#: tips:166
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr ""
 
-#: tips:167
-msgid "Panels"
-msgstr "Paneler"
-
-#: tips:168
-#, fuzzy
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr ""
-"Paneler ‰r rader med ikoner som lˆper l‰ngs sk‰rmens kanter. Se manualen "
-"fˆr\n"
-"information om att anv‰nda paneler."
-
-#: tips:169
-#, fuzzy
-msgid "Panel style"
-msgstr "Panelutseende"
-
-#: tips:170
-msgid "Image and text"
-msgstr "Bilder och text"
-
-#: tips:171
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Varje panelikon visas som en bild och text."
-
-#: tips:172
-msgid "Image only for applications"
-msgstr "Endast bilder fˆr program"
-
-#: tips:173
-msgid ""
-"Applications have just an image, everything else has both an image and text."
-msgstr ""
-"Program har endast en bild. Allt annat visas med bÂde en bild och text."
-
-#: tips:174
-msgid "Image only"
-msgstr "Endast bilder"
-
-#: tips:175
-msgid "Only the image is shown."
-msgstr "Endast bilder visas."
-
-#: tips:176
-msgid "Panel width (thin)"
+#: tips:221
+msgid "Left margin"
 msgstr ""
 
-#: tips:177
-msgid "(thick)"
+#: tips:222
+msgid "Width of no-go area at left of screen."
 msgstr ""
 
-#: tips:178
-msgid "The size of the panels."
+#: tips:223
+msgid "Right margin"
 msgstr ""
 
-#: tips:179
-msgid "Do not cover panel"
+#: tips:224
+msgid "Width of no-go area at right of screen."
 msgstr ""
 
-#: tips:180
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
-msgstr ""
-
-#: tips:181
-msgid "Xinerama"
-msgstr ""
-
-#: tips:182
-msgid "Confine to Xinerama monitor"
-msgstr ""
-
-#: tips:183
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
-msgstr ""
-
-#: tips:184
-msgid ""
-"The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr ""
-
-#: tips:185
+#: tips:225
 msgid "Desktop"
 msgstr ""
 
-#: tips:186
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
 msgstr ""
 
-#: tips:187
+#: tips:227
 #, fuzzy
 msgid "Panel only"
 msgstr "Endast bilder"
 
-#: tips:188
+#: tips:228
 #, fuzzy
 msgid "Only a panel is shown."
 msgstr "Endast bilder visas."
 
-#: tips:189
+#: tips:229
 #, fuzzy
 msgid "Pinboard only"
 msgstr "Skrivbord"
 
-#: tips:190
+#: tips:230
 #, fuzzy
 msgid "Only the pinboard is shown."
 msgstr "Endast bilder visas."
 
-#: tips:191
+#: tips:231
 #, fuzzy
 msgid "Panel and pinboard"
 msgstr "Skrivbord"
 
-#: tips:192
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr ""
 
-#: tips:193
-#, fuzzy
-msgid "Panel"
-msgstr "Paneler"
-
-#: tips:194
-msgid "Enter the name of the panel to show here."
-msgstr ""
-
-#: tips:196
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr ""
 
-#: tips:197
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr ""
 
-#: tips:198
+#: tips:236
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 
-#: tips:199
+#: tips:237
 msgid "Action windows"
-msgstr "Handlingsfˆnster"
+msgstr "Handlingsf√∂nster"
 
-#: tips:200
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
 msgstr ""
-"H‰ndelsefˆnster kommer upp n‰r du startar en bakgrundshandling, tex.\n"
+"H√§ndelsef√∂nster kommer upp n√§r du startar en bakgrundshandling, tex.\n"
 "kopiering eller radering av filer. "
 
-#: tips:201
+#: tips:239
 #, fuzzy
 msgid "Auto-start (Quiet) these actions"
-msgstr "Starta dessa h‰ndelser automatiskt:"
+msgstr "Starta dessa h√§ndelser automatiskt:"
 
-#: tips:203
+#: tips:241
 msgid "Copy files without confirming first."
-msgstr "Kopiera filer utan att frÂga fˆrst."
+msgstr "Kopiera filer utan att fr√•ga f√∂rst."
 
-#: tips:205
+#: tips:243
 msgid "Move files without confirming first."
-msgstr "Flytta filer utan att frÂga fˆrst."
+msgstr "Flytta filer utan att fr√•ga f√∂rst."
 
-#: tips:207
+#: tips:245
 msgid "Create links to files without confirming first."
-msgstr "Skapa genv‰gar till filer utan att frÂga fˆrst."
+msgstr "Skapa genv√§gar till filer utan att fr√•ga f√∂rst."
 
-#: tips:209
+#: tips:247
 msgid "Delete files without confirming first."
-msgstr "Radera filer utan att frÂga fˆrst."
+msgstr "Radera filer utan att fr√•ga f√∂rst."
 
-#: tips:210
+#: tips:248
 msgid "Mount"
 msgstr "Montera"
 
-#: tips:211
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
-msgstr "Montera och avmontera filsystem utan att frÂga fˆrst."
+msgstr "Montera och avmontera filsystem utan att fr√•ga f√∂rst."
 
-#: tips:212
+#: tips:250
 #, fuzzy
 msgid "Default settings"
-msgstr "Standardinst‰llning:"
+msgstr "Standardinst√§llning:"
 
-#: tips:214
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Tvinga"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
-msgstr "FrÂga inte angÂende radering av icke-skrivbara objekt."
+msgstr "Fr√•ga inte ang√•ende radering av icke-skrivbara objekt."
 
-#: tips:216
+#: tips:254
 msgid "Don't display so much information in the message area."
-msgstr "Visa inte sÂ mycket information i meddelandeomrÂdet."
+msgstr "Visa inte s√• mycket information i meddelandeomr√•det."
 
-#: tips:218
+#: tips:256
 msgid "Also change contents of subdirectories."
-msgstr "ƒndra ‰ven innehÂllet i underkataloger."
+msgstr "√Ñndra √§ven inneh√•llet i underkataloger."
 
-#: tips:221
+#: tips:263
+#, fuzzy
+msgid "Mount commands"
+msgstr "Monteringspunkt"
+
+#: tips:264
+#, fuzzy
+msgid "Mount command"
+msgstr "Monteringspunkt"
+
+#: tips:265
+msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
+msgstr ""
+
+#: tips:266
+#, fuzzy
+msgid "Unmount command"
+msgstr "Avmontera"
+
+#: tips:267
+msgid ""
+"The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
+"without the first \"n\")."
+msgstr ""
+
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "Kommando:"
+
+#: tips:269
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
-msgstr "Dra och sl‰pp"
+msgstr "Dra och sl√§pp"
 
-#: tips:222
+#: tips:273
 #, fuzzy
 msgid "Dragging to icons"
 msgstr "Gemmer indstillinger"
 
-#: tips:223
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
-msgstr "TillÂt att dra ikoner till 'filer'-fˆnster"
+msgstr "Till√•t att dra ikoner till 'filer'-f√∂nster"
 
-#: tips:224
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
 "will put it into that directory, or load it into the program."
 msgstr ""
-"N‰r detta ‰r pÂslaget kan du dra filer till en katalog eller ett program i\n"
-"ett fˆnster. Objektet kommer markeras och att sl‰ppa filen flyttar den till\n"
-"katalogen eller ˆppnar den med programmet."
+"N√§r detta √§r p√•slaget kan du dra filer till en katalog eller ett program i\n"
+"ett f√∂nster. Objektet kommer markeras och att sl√§ppa filen flyttar den till\n"
+"katalogen eller √∂ppnar den med programmet."
 
-#: tips:225
+#: tips:276
 msgid "Directories spring open"
-msgstr "Kataloger ˆppnas automatiskt"
+msgstr "Kataloger √∂ppnas automatiskt"
 
-#: tips:226
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
 "short while."
 msgstr ""
-"Denna inst‰lling, som kr‰ver att fˆregÂende ‰r pÂslaget, gˆr att den "
+"Denna inst√§lling, som kr√§ver att f√∂reg√•ende √§r p√•slaget, g√∂r att den "
 "markerade\n"
-"katalogen 'poppar upp' efter det att filen hÂllts ˆver den en kort tid."
+"katalogen 'poppar upp' efter det att filen h√•llts √∂ver den en kort tid."
 
-#: tips:227
+#: tips:278
 #, fuzzy
 msgid "Spring delay:"
-msgstr "V‰ntetid fˆr 'poppa upp':"
+msgstr "V√§ntetid f√∂r 'poppa upp':"
 
-#: tips:228
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:229
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
 "have any effect."
 msgstr ""
-"Denna inst‰llning s‰tter hur lÂng tid, i millisekunder, du mÂste hÂlla en "
+"Denna inst√§llning s√§tter hur l√•ng tid, i millisekunder, du m√•ste h√•lla en "
 "fil\n"
-"ˆver en katalog fˆr att katalogen ska ˆppnas. FˆregÂende inst‰llning mÂste\n"
-"vara pÂslagen fˆr att detta ska ha nÂgon effekt. "
+"√∂ver en katalog f√∂r att katalogen ska √∂ppnas. F√∂reg√•ende inst√§llning m√•ste\n"
+"vara p√•slagen f√∂r att detta ska ha n√•gon effekt. "
 
-#: tips:230
+#: tips:281
 #, fuzzy
 msgid "When dragging files with the left mouse button"
 msgstr "Dra filer med mittersta musknappen"
 
-#: tips:231 tips:235
+#: tips:282 tips:286
 #, fuzzy
 msgid "Show a menu of possible actions"
-msgstr "... visar en meny med mˆjliga handlingar"
+msgstr "... visar en meny med m√∂jliga handlingar"
 
-#: tips:232
+#: tips:283
 #, fuzzy
 msgid "Copy the files"
 msgstr ".... flyttar filerna"
 
-#: tips:233
+#: tips:284
 #, fuzzy
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
 msgstr ""
-"Observera att du fortfarande fÂr upp menyn genom att dra med v‰nstra "
+"Observera att du fortfarande f√•r upp menyn genom att dra med v√§nstra "
 "musknappen\n"
-"och hÂlla in Alt-tangenten"
+"och h√•lla in Alt-tangenten"
 
-#: tips:234
+#: tips:285
 #, fuzzy
 msgid "When dragging files with the middle mouse button"
 msgstr "Dra filer med mittersta musknappen"
 
-#: tips:236
+#: tips:287
 #, fuzzy
 msgid "Move the files"
 msgstr ".... flyttar filerna"
 
-#: tips:237
+#: tips:288
 #, fuzzy
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
 msgstr ""
-"Observera att du fortfarande fÂr upp menyn genom att dra med v‰nstra "
+"Observera att du fortfarande f√•r upp menyn genom att dra med v√§nstra "
 "musknappen\n"
-"och hÂlla in Alt-tangenten"
+"och h√•lla in Alt-tangenten"
 
-#: tips:238
+#: tips:289
 msgid "Download handler"
 msgstr ""
 
-#: tips:239
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4410,193 +5092,226 @@ msgid ""
 "xterm -e wget $1"
 msgstr ""
 
-#: tips:240
+#: tips:291
 msgid "Menus"
 msgstr "Menyer"
 
-#: tips:242
+#: tips:293
 #, fuzzy
 msgid "Size of icons in menus:"
-msgstr "Storlek pÂ ikoner i menyer:"
+msgstr "Storlek p√• ikoner i menyer:"
 
-#: tips:243
+#: tips:294
 msgid "No Icons"
 msgstr "Inga ikoner"
 
-#: tips:246
+#: tips:297
 msgid "Same as current window"
-msgstr "Samma som i aktuellt fˆnster"
+msgstr "Samma som i aktuellt f√∂nster"
 
-#: tips:247
+#: tips:298
 msgid "Same as default"
 msgstr "Samma som standardstorleken"
 
-#: tips:248
+#: tips:299
 #, fuzzy
 msgid "Behaviour"
-msgstr "Fˆnsterbeteeende"
+msgstr "F√∂nsterbeteeende"
 
-#: tips:249
+#: tips:300
 msgid "File menu on right-click"
 msgstr ""
 
-#: tips:250
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
 msgstr ""
 
-#: tips:251
+#: tips:302
 #, fuzzy
-msgid "`Xterm Here' program"
-msgstr "Program fˆr 'Terminalemulator h‰r':"
+msgid "Terminal emulator program"
+msgstr "Program f√∂r 'Terminalemulator h√§r':"
 
-#: tips:252
-msgid "The program to launch when you choose `Xterm Here' from the menu."
-msgstr "Programmet som kˆrs n‰r du v‰ljer 'Terminalemulator h‰r' frÂn menyn."
+#: tips:303
+#, fuzzy
+msgid "The program to launch when you choose `Terminal Here' from the menu."
+msgstr "Programmet som k√∂rs n√§r du v√§ljer 'Terminalemulator h√§r' fr√•n menyn."
 
-#: tips:253
+#: tips:304
 #, fuzzy
 msgid "Keyboard shortcuts"
-msgstr "St‰ll in kortkommandon"
+msgstr "St√§ll in kortkommandon"
 
-#: tips:255
+#: tips:305
+msgid "Types"
+msgstr "Typer"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME-typer"
 
-#: tips:256
+#: tips:307
 #, fuzzy
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
 msgstr ""
-"Filhanteraren anv‰nder en upps‰ttning regler fˆr att hitta den r‰tta\n"
-"MIME-typen fˆr en vanlig fil och v‰ljer d‰refter en passande ikon fˆr den\n"
-"typen. Efter att ha ‰ndrat filer, tryck pÂ knappen 'l‰s om' nedan eller\n"
+"Filhanteraren anv√§nder en upps√§ttning regler f√∂r att hitta den r√§tta\n"
+"MIME-typen f√∂r en vanlig fil och v√§ljer d√§refter en passande ikon f√∂r den\n"
+"typen. Efter att ha √§ndrat filer, tryck p√• knappen 'l√§s om' nedan eller\n"
 "starta om filhanteraren."
 
-#: tips:257
+#: tips:308
 msgid "Edit MIME rules"
 msgstr ""
 
-#: tips:258
+#: tips:309
 #, fuzzy
 msgid "Themes"
 msgstr "Tider"
 
-#: tips:259
+#: tips:310
 #, fuzzy
 msgid "Icon theme"
 msgstr "Minimera till"
 
-#: tips:260
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr ""
 
-#: tips:261
+#: tips:312
 #, fuzzy
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
-msgstr "Anv‰nd 'S‰tt ikon...'-dialogrutan fˆr att s‰tta ikonen fˆr varje typ."
+msgstr "Anv√§nd 'S√§tt ikon...'-dialogrutan f√∂r att s√§tta ikonen f√∂r varje typ."
 
-#: tips:262
+#: tips:313
 #, fuzzy
 msgid "Colours"
-msgstr "F‰rger"
+msgstr "F√§rger"
 
-#: tips:263
+#: tips:314
 #, fuzzy
 msgid "File type colours"
-msgstr "F‰rger fˆr filtyper"
+msgstr "F√§rger f√∂r filtyper"
 
-#: tips:264
+#: tips:315
 msgid "Colour files based on their types"
-msgstr "F‰rg fˆr filer baserat pÂ deras typ"
+msgstr "F√§rg f√∂r filer baserat p√• deras typ"
 
-#: tips:265
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
-msgstr "Filnamn (och detaljer) visas med olika f‰rg beroende pÂ filtyp."
+msgstr "Filnamn (och detaljer) visas med olika f√§rg beroende p√• filtyp."
 
-#: tips:266
+#: tips:317
 #, fuzzy
 msgid "Directory:"
 msgstr "Katalog:"
 
-#: tips:267
+#: tips:318
 #, fuzzy
 msgid "Regular file:"
 msgstr "Vanlig fil:"
 
-#: tips:268
+#: tips:319
 #, fuzzy
 msgid "Pipe:"
-msgstr "Rˆr:"
+msgstr "R√∂r:"
 
 # Socket:
-#: tips:269
+#: tips:320
 #, fuzzy
 msgid "Socket:"
 msgstr "Socket:"
 
-#: tips:271
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
 msgstr ""
-"Fel, som tex. en symbolisk genv‰g som pekar pÂ ett objekt som inte finns "
+"Fel, som tex. en symbolisk genv√§g som pekar p√• ett objekt som inte finns "
 "eller\n"
-"en fil som filhanteraren inte har tillÂtelse att granska."
+"en fil som filhanteraren inte har till√•telse att granska."
 
-#: tips:272
+#: tips:323
 #, fuzzy
 msgid "Character device:"
 msgstr "Character device"
 
-#: tips:273
+#: tips:324
 #, fuzzy
 msgid "Block device:"
 msgstr "Block device"
 
-#: tips:274
+#: tips:325
 #, fuzzy
 msgid "Door:"
-msgstr "Dˆrr:"
+msgstr "D√∂rr:"
 
-#: tips:275
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
-msgstr "Dˆrrar ‰r likanande socket eller rˆr och har bara setts pÂ Solaris."
+msgstr "D√∂rrar √§r likanande socket eller r√∂r och har bara setts p√• Solaris."
 
-#: tips:276
+#: tips:327
 #, fuzzy
 msgid "Executable file:"
-msgstr "Kˆrbar fil"
+msgstr "K√∂rbar fil"
 
-#: tips:277
+#: tips:328
 #, fuzzy
 msgid "Application directory:"
 msgstr "Programkatalog"
 
-#: tips:278
+#: tips:329
 #, fuzzy
 msgid "Unknown type:"
-msgstr "Ok‰nd typ:"
+msgstr "Ok√§nd typ:"
 
-#: tips:279
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Bakgrund:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Bakgrund:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr ""
 
-#: tips:280
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr ""
 
-#: tips:281
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr ""
 
-#: tips:282
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4605,28 +5320,28 @@ msgid ""
 "them appear in window-select lists."
 msgstr ""
 
-#: tips:283
+#: tips:341
 #, fuzzy
 msgid "Pass all backdrop mouse clicks to window manager"
-msgstr "Skicka klick med musknapp 3 till fˆnsterhanteraren"
+msgstr "Skicka klick med musknapp 3 till f√∂nsterhanteraren"
 
-#: tips:284
+#: tips:342
 #, fuzzy
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
 "events to your window manager instead. Clicks on icons will not be forwarded."
 msgstr ""
-"Vanligtvis orsakar klick med musknapp pÂ skrivbordet att skrivbordsmenyn "
-"ˆppnas.\n"
-"SlÂ pÂ dette fˆr att lÂta din fˆnsterhanterare ta hand om dessa klick.\n"
-"Klick pÂ ikoner kommer inte att skickas vidare."
+"Vanligtvis orsakar klick med musknapp p√• skrivbordet att skrivbordsmenyn "
+"√∂ppnas.\n"
+"Sl√• p√• dette f√∂r att l√•ta din f√∂nsterhanterare ta hand om dessa klick.\n"
+"Klick p√• ikoner kommer inte att skickas vidare."
 
-#: tips:285
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr ""
 
-#: tips:286
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4634,45 +5349,64 @@ msgid ""
 "isn't necessary."
 msgstr ""
 
-#: tips:287
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr ""
 
-#: tips:288
+#: tips:346
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 
-#: tips:289
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Panelutseende"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 #, fuzzy
 msgid "Drag and drop"
-msgstr "Dra och sl‰pp"
+msgstr "Dra och sl√§pp"
 
-#: tips:290
+#: tips:352
 msgid "Don't use hostnames"
-msgstr "Anv‰nd inte maskinnamn"
+msgstr "Anv√§nd inte maskinnamn"
 
-#: tips:291
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
 "sign on the pointer but the drop doesn't work."
 msgstr ""
-"En del ‰ldre prohram stˆdjer inte XDND fullt ut och kan behˆva denna\n"
-"inst‰llning pÂslagen. Anv‰nd detta om ett +-tecken visas som pekera n‰r du\n"
-"drar filer till ett visst program, men det inte fungerar att sl‰ppa."
+"En del √§ldre prohram st√∂djer inte XDND fullt ut och kan beh√∂va denna\n"
+"inst√§llning p√•slagen. Anv√§nd detta om ett +-tecken visas som pekera n√§r du\n"
+"drar filer till ett visst program, men det inte fungerar att sl√§ppa."
 
-#: tips:292
-msgid "Extended attributes"
-msgstr ""
-
-#: tips:293
+#: tips:355
 #, fuzzy
 msgid "Don't use extended attributes"
-msgstr "Anv‰nd inte maskinnamn"
+msgstr "Anv√§nd inte maskinnamn"
 
-#: tips:294
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4680,14 +5414,342 @@ msgid ""
 "the properties window does not report extended attributes."
 msgstr ""
 
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+msgid "Bottom gap:"
+msgstr ""
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+msgid "Right gap:"
+msgstr ""
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "Ny Mappe"
+
+#: ../Templates.ui.h:4
+#, fuzzy
+msgid "Panel Options"
+msgstr "Inst√§llningar..."
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Bilder och text"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Varje panelikon visas som en bild och text."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Endast bilder f√∂r program"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"Program har endast en bild. Allt annat visas med b√•de en bild och text."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Endast bilder"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Endast bilder visas."
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Panelutseende"
+
+#: ../Templates.ui.h:12
+msgid "The size of this panel."
+msgstr ""
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "√ñvers√§ttning"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr ""
+
+#: ../Templates.ui.h:19
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Panelutseende"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr ""
+
+#: ../Templates.ui.h:22
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+
+#: ../Templates.ui.h:23
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "R√§ttigheter"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr ""
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr ""
+
+#: ../Templates.ui.h:27
+msgid "Bottom edge"
+msgstr ""
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr ""
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "R√§ttigheter"
+
+#~ msgid "<dir>"
+#~ msgstr "<katalog>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' finns redan - skriv √∂ver?"
+
+#, fuzzy
+#~ msgid "Choices migration"
+#~ msgstr "Kinesiska (traditionell)"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Fel under scanning av '%s:\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Katalogen saknas/√§r raderad"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Katalogen '%s' hittades inte."
+
+#~ msgid "Cancel"
+#~ msgstr "Avbryt"
+
+#~ msgid "GNOME-VFS library"
+#~ msgstr "GNOME-VFS-bibliotek"
+
+#~ msgid "Open AVFS"
+#~ msgstr "√ñppna med virtuellt filsystem"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Du m√•ste klicka med shift-tangenten nertryckt p√• en fil f√∂r att skicka "
+#~ "den n√•gonstans"
+
+#~ msgid "Look inside ... ?"
+#~ msgstr "Titta inuti ... ?"
+
+#, fuzzy
+#~ msgid "Panel: %s"
+#~ msgstr "Paneler"
+
+#, fuzzy
+#~ msgid "Top-edge panel"
+#~ msgstr "St√§ng panelen?"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Ogiltig .gmo-√∂vers√§ttningsfil (f√∂r kort): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr ""
+#~ "Ogiltig .gmo-√∂vers√§ttningsfil ('GNU magic number' hittades inte): %s"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "G√• till f√∂r√§ldekatalogen"
+
+#~ msgid "Change to home directory"
+#~ msgstr "G√• till hemkatalogen"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Skanna om katalogens inneh√•ll"
+
+#~ msgid "Change icon size"
+#~ msgstr "√Ñndra ikonstorleken"
+
+#~ msgid "Show extra details"
+#~ msgstr "Visa extra detaljer"
+
+#~ msgid "Hidden"
+#~ msgstr "G√∂m"
+
+#~ msgid "Show/hide hidden files"
+#~ msgstr "Visa/g√∂m osynliga filer"
+
+#, fuzzy
+#~ msgid "Language"
+#~ msgstr "Spr√•k"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "Anv√§nd milj√∂variabeln LANG"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Kinesiska (traditionell)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Kinesiska (f√∂renklad)"
+
+# tips=x
+#~ msgid "Danish"
+#~ msgstr "Danska"
+
+#~ msgid "Dutch"
+#~ msgstr "Holl√§ndska"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Engelska (ingen √∂vers√§ttning)"
+
+# tips=x
+#, fuzzy
+#~ msgid "Finnish"
+#~ msgstr "Danska"
+
+#~ msgid "French"
+#~ msgstr "Franska"
+
+#~ msgid "German"
+#~ msgstr "Tyska"
+
+#~ msgid "Hungarian"
+#~ msgstr "Ungerska"
+
+#~ msgid "Italian"
+#~ msgstr "Italienska"
+
+#~ msgid "Polish"
+#~ msgstr "Polska"
+
+#~ msgid "Russian"
+#~ msgstr "Ryska"
+
+#~ msgid "Spanish"
+#~ msgstr "Spanska"
+
+#, fuzzy
+#~ msgid "Change at:"
+#~ msgstr "√Ñndrad:"
+
+#, fuzzy
+#~ msgid "(Small Icons):"
+#~ msgstr "Sm√• ikoner"
+
+#~ msgid "Panels"
+#~ msgstr "Paneler"
+
+#, fuzzy
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Paneler √§r rader med ikoner som l√∂per l√§ngs sk√§rmens kanter. Se manualen "
+#~ "f√∂r\n"
+#~ "information om att anv√§nda paneler."
+
 #, fuzzy
 #~ msgid ""
 #~ "Error loading MIME database:\n"
 #~ "%s"
-#~ msgstr "Fejl under lÊsning af fil: %s: %s"
+#~ msgstr "Fejl under l√¶sning af fil: %s: %s"
 
 #~ msgid "File '%s' corrupted!"
-#~ msgstr "Filen '%s' ‰r trasig!"
+#~ msgstr "Filen '%s' √§r trasig!"
 
 #, fuzzy
 #~ msgid ""
@@ -4702,25 +5764,25 @@ msgstr ""
 #~ "share/mime/globs)."
 #~ msgstr ""
 #~ "Standard-MIME-databasen (version 0.8 eller senare) kunde inte hitas."
-#~ "Filhanteraren kommer troligtvis inte visa r‰tt typer fˆr olika filer. Du "
-#~ "borde laddaner och installera 'shared-mime-info-0.8' frÂn http://www."
+#~ "Filhanteraren kommer troligtvis inte visa r√§tt typer f√∂r olika filer. Du "
+#~ "borde laddaner och installera 'shared-mime-info-0.8' fr√•n http://www."
 #~ "freedesktop.org/standards/shared-mime-info.html"
 
 #, fuzzy
 #~ msgid "Executable files"
-#~ msgstr "Kˆrbar fil"
+#~ msgstr "K√∂rbar fil"
 
 #~ msgid "Ignore eXecutable bit for known extensions"
-#~ msgstr "Ignorera filer satt som kˆrbara fˆr k‰nda filtyper"
+#~ msgstr "Ignorera filer satt som k√∂rbara f√∂r k√§nda filtyper"
 
 #~ msgid ""
 #~ "If a file has a known extension (eg '.gif') then ignore the executable "
 #~ "bit. This is useful if you have files on a Windows-type filesystem which "
 #~ "are being shown as executable programs."
 #~ msgstr ""
-#~ "Om en fil har en k‰nd ‰ndelse (tex. '.gif') ignorera kˆrh‰ndelsen.\n"
-#~ "Detta ‰r anv‰ndbart om du har filer pÂ ett filsystem av Windows-typ d‰r\n"
-#~ "alla filer visas som kˆrbara."
+#~ "Om en fil har en k√§nd √§ndelse (tex. '.gif') ignorera k√∂rh√§ndelsen.\n"
+#~ "Detta √§r anv√§ndbart om du har filer p√• ett filsystem av Windows-typ d√§r\n"
+#~ "alla filer visas som k√∂rbara."
 
 #, fuzzy
 #~ msgid "Umount"
@@ -4733,29 +5795,29 @@ msgstr ""
 #~ msgstr "Information"
 
 #~ msgid "Symbolic link to %s"
-#~ msgstr "Symbolisk genv‰g till %s"
+#~ msgstr "Symbolisk genv√§g till %s"
 
 #~ msgid "No (gnome-vfs-config not found)"
 #~ msgstr "Nej (gnome-vfs-config hittades inte"
 
 #~ msgid "Examine ... ?"
-#~ msgstr "Undersˆk ... ?"
+#~ msgstr "Unders√∂k ... ?"
 
 #~ msgid "Permissions:"
-#~ msgstr "R‰ttigheter:"
+#~ msgstr "R√§ttigheter:"
 
 #~ msgid "file(1) says..."
-#~ msgstr "file(1) s‰ger..."
+#~ msgstr "file(1) s√§ger..."
 
 #~ msgid "Help about ... ?"
-#~ msgstr "Hj‰lp om ... ?"
+#~ msgstr "Hj√§lp om ... ?"
 
 #~ msgid ""
 #~ "Executable file:\n"
 #~ "This is a file with an eXecute bit set - it can be run as a program."
 #~ msgstr ""
-#~ "Kˆrbar fil:\n"
-#~ "Detta ‰r en fil som ‰r satt till att vara kˆrbar - den kan kˆras som ett "
+#~ "K√∂rbar fil:\n"
+#~ "Detta √§r en fil som √§r satt till att vara k√∂rbar - den kan k√∂ras som ett "
 #~ "program."
 
 #~ msgid ""
@@ -4763,8 +5825,8 @@ msgstr ""
 #~ "This is a data file. Try using the Info menu item to find out more..."
 #~ msgstr ""
 #~ "Fil:\n"
-#~ "Detta ‰r en datafil. Fˆrsˆk att anv‰nda 'Information' i menyn fˆr att fÂ "
-#~ "reda pÂ mer... "
+#~ "Detta √§r en datafil. F√∂rs√∂k att anv√§nda 'Information' i menyn f√∂r att f√• "
+#~ "reda p√• mer... "
 
 #~ msgid ""
 #~ "Mount point:\n"
@@ -4773,7 +5835,7 @@ msgstr ""
 #~ "directory."
 #~ msgstr ""
 #~ "Monteringspunkt:\n"
-#~ "En monteringspunk ‰r en katalog som ett annat filsystem kan monteras pÂ."
+#~ "En monteringspunk √§r en katalog som ett annat filsystem kan monteras p√•."
 #~ "Allt i det monterade filsystemet kommer att finnas inuti katalogen."
 
 #~ msgid ""
@@ -4782,7 +5844,7 @@ msgstr ""
 #~ "it was an ordinary file."
 #~ msgstr ""
 #~ "Device-fil:\n"
-#~ "Device-filer gˆr att du kan skriva till eller l‰sa frÂn en drivrutin "
+#~ "Device-filer g√∂r att du kan skriva till eller l√§sa fr√•n en drivrutin "
 #~ "precis som om det vore en vanlig fil."
 
 #~ msgid ""
@@ -4790,23 +5852,23 @@ msgstr ""
 #~ "Pipes allow different programs to communicate. One program writes data to "
 #~ "the pipe while another one reads it out again."
 #~ msgstr ""
-#~ "Namngivet rˆr:\n"
-#~ "Rˆr gˆr att olika program kan kommunicera. Ett program skriver data till "
-#~ "rˆret och ett annat program l‰ser datat frÂn rˆret."
+#~ "Namngivet r√∂r:\n"
+#~ "R√∂r g√∂r att olika program kan kommunicera. Ett program skriver data till "
+#~ "r√∂ret och ett annat program l√§ser datat fr√•n r√∂ret."
 
 #~ msgid ""
 #~ "Socket:\n"
 #~ "Sockets allow processes to communicate."
 #~ msgstr ""
 #~ "Socket:\n"
-#~ "Sockets gˆr att processer kan kommunicera."
+#~ "Sockets g√∂r att processer kan kommunicera."
 
 #~ msgid ""
 #~ "Door:\n"
 #~ "Doors are a little-used Solaris method for processes to communicate."
 #~ msgstr ""
-#~ "Dˆrr:\n"
-#~ "Dˆrrar ‰r en s‰llan anv‰nd metod i Solaris fˆr processer att kommunicera."
+#~ "D√∂rr:\n"
+#~ "D√∂rrar √§r en s√§llan anv√§nd metod i Solaris f√∂r processer att kommunicera."
 
 #~ msgid ""
 #~ "Unknown type:\n"
@@ -4814,8 +5876,8 @@ msgstr ""
 #~ "anymore or you don't have search permission on the directory it's in?"
 #~ msgstr ""
 #~ "Ukendt type:\n"
-#~ "Jag kunde inte komma pÂ vilken typ av fil det h‰r ‰r. Den kanske inte "
-#~ "existerar l‰ngre eller sÂ har du inte r‰ttighet att l‰sa frÂn katalogen?"
+#~ "Jag kunde inte komma p√• vilken typ av fil det h√§r √§r. Den kanske inte "
+#~ "existerar l√§ngre eller s√• har du inte r√§ttighet att l√§sa fr√•n katalogen?"
 
 #~ msgid ""
 #~ "Directory:\n"
@@ -4823,37 +5885,29 @@ msgstr ""
 #~ "the list."
 #~ msgstr ""
 #~ "Katalog:\n"
-#~ "Detta ‰r en katalog. Den inehÂller andra objekt - ˆppna den fˆr att se "
+#~ "Detta √§r en katalog. Den ineh√•ller andra objekt - √∂ppna den f√∂r att se "
 #~ "dessa."
 
 #~ msgid "Menu on button 2 (RISC OS style)"
-#~ msgstr "Meny pÂ knapp 2 (RISC OS-stil)"
+#~ msgstr "Meny p√• knapp 2 (RISC OS-stil)"
 
 #~ msgid ""
 #~ "Use button 2, the middle button (click both buttons at once on two button "
 #~ "mice), to pop up the menu. If off, use button 3 (right) instead."
 #~ msgstr ""
-#~ "Anv‰nd musknapp 2, mittenknappen (klicka med bÂda knapparna samtidigt pÂ\n"
-#~ "2-knapparsmus), fˆr att fÂ upp menyn. Om avslaget, anv‰nd musknapp 3 "
-#~ "(hˆger)\n"
-#~ "ist‰llet."
+#~ "Anv√§nd musknapp 2, mittenknappen (klicka med b√•da knapparna samtidigt p√•\n"
+#~ "2-knapparsmus), f√∂r att f√• upp menyn. Om avslaget, anv√§nd musknapp 3 "
+#~ "(h√∂ger)\n"
+#~ "ist√§llet."
 
 #~ msgid "Show name-to-type rules"
 #~ msgstr "Visa namn-till-typ-regler"
-
-#, fuzzy
-#~ msgid "DirItem"
-#~ msgstr "objekt"
-
-#, fuzzy
-#~ msgid "Background color"
-#~ msgstr "Bakgrund:"
 
 #~ msgid "Vertical Adjustment"
 #~ msgstr "Vertikal justering"
 
 #~ msgid "The GtkAdjustment for the vertical position."
-#~ msgstr "GtkAdjustment fˆr den vertikala positionen"
+#~ msgstr "GtkAdjustment f√∂r den vertikala positionen"
 
 #~ msgid "Has Discard"
 #~ msgstr "Har radera"
@@ -4862,10 +5916,10 @@ msgstr ""
 #~ msgstr "Dialogan har en raderaknapp"
 
 #~ msgid "Set Icon"
-#~ msgstr "S‰tt ikon"
+#~ msgstr "S√§tt ikon"
 
 #~ msgid "You can't use multiple files with Set Icon!"
-#~ msgstr "Du kan inte v‰lja flera filer med S‰tt ikon!"
+#~ msgstr "Du kan inte v√§lja flera filer med S√§tt ikon!"
 
 #~ msgid "Name:"
 #~ msgstr "Namn:"
@@ -4879,8 +5933,8 @@ msgstr ""
 #~ "image will be used for the desktop background. You can also drag certain "
 #~ "applications onto this box."
 #~ msgstr ""
-#~ "Du ska dra en bildfil till boxen - denna bild kommer anv‰ndas "
-#~ "somskrivbordsbakgrund. Du kan ocksÂ dra vissa program till denna box."
+#~ "Du ska dra en bildfil till boxen - denna bild kommer anv√§ndas "
+#~ "somskrivbordsbakgrund. Du kan ocks√• dra vissa program till denna box."
 
 #~ msgid "Large"
 #~ msgstr "Stor"
@@ -4892,17 +5946,17 @@ msgstr ""
 #~ "You should drop a single (local) application onto the drop box - that "
 #~ "application will be used to load files of this type in future"
 #~ msgstr ""
-#~ "Du kan dra ett (lokalt) pogram till boxen - detta program kommer anv‰ndas "
-#~ "fˆr att ˆppna filer av denna typ i framtiden"
+#~ "Du kan dra ett (lokalt) pogram till boxen - detta program kommer anv√§ndas "
+#~ "f√∂r att √∂ppna filer av denna typ i framtiden"
 
 #~ msgid "Currently %s"
 #~ msgstr "Just nu %s"
 
 #~ msgid "Menu of directories previously used for icons"
-#~ msgstr "Meny med kataloger som tidigare anv‰nts fˆr ikoner"
+#~ msgstr "Meny med kataloger som tidigare anv√§nts f√∂r ikoner"
 
 #~ msgid "Enter the path of an icon file:"
-#~ msgstr "Skriv in namnet pÂ en ikonfil:"
+#~ msgstr "Skriv in namnet p√• en ikonfil:"
 
 #, fuzzy
 #~ msgid "_Remove"
@@ -4912,30 +5966,22 @@ msgstr ""
 #~ "You should drop a single local icon file onto the drop box - that icon "
 #~ "will be used for this file from now on."
 #~ msgstr ""
-#~ "Du skall sl‰ppa en lokal ikonfil pÂ boxen - denna ikon kommer att "
-#~ "anv‰ndas till denna fil frÂn och med nu"
+#~ "Du skall sl√§ppa en lokal ikonfil p√• boxen - denna ikon kommer att "
+#~ "anv√§ndas till denna fil fr√•n och med nu"
 
 #~ msgid ""
 #~ "Enter the full path of a file that contains a valid image to be used as "
 #~ "the icon for this file or directory."
 #~ msgstr ""
-#~ "Skriv in den fullst‰ndiga sˆkv‰gen till en fil som innehÂller en giltig "
-#~ "bildfil som skall anv‰ndas som ikon fˆr denna katalog."
+#~ "Skriv in den fullst√§ndiga s√∂kv√§gen till en fil som inneh√•ller en giltig "
+#~ "bildfil som skall anv√§ndas som ikon f√∂r denna katalog."
 
 #~ msgid ""
 #~ "You have not yet set any special icons; therefore, I have no directories "
 #~ "to show you"
 #~ msgstr ""
-#~ "Du har ‰nnu inte satt nÂgra speciella ikoner, d‰rfˆr har jag inga "
+#~ "Du har √§nnu inte satt n√•gra speciella ikoner, d√§rf√∂r har jag inga "
 #~ "kataloger att visa dig"
-
-#, fuzzy
-#~ msgid "Large wrap width:"
-#~ msgstr "Radbrytningsbredd fˆr stora ikoner"
-
-#, fuzzy
-#~ msgid "Max Small Icons width:"
-#~ msgstr "Maximal bredd fˆr smÂ ikoner:"
 
 #, fuzzy
 #~ msgid ""
@@ -4943,49 +5989,49 @@ msgstr ""
 #~ "Just put the name of the file you're looking for in single quotes:\n"
 #~ "<b>'index.html'</b> (to find a file called 'index.html')\n"
 #~ msgstr ""
-#~ "Skriv namnet pÂ filen du letar efter inom citattecken:\n"
-#~ "'index.html'\t(fˆr att hitta en fil som heter 'index.html')"
+#~ "Skriv namnet p√• filen du letar efter inom citattecken:\n"
+#~ "'index.html'\t(f√∂r att hitta en fil som heter 'index.html')"
 
 #~ msgid "Summary"
-#~ msgstr "÷versikt"
+#~ msgstr "√ñversikt"
 
 #~ msgid "Large, With..."
 #~ msgstr "Stora, med..."
 
 #~ msgid "Small, With..."
-#~ msgstr "SmÂ, med..."
+#~ msgstr "Sm√•, med..."
 
 #~ msgid "fork: %s"
 #~ msgstr "fork: %s"
 
 #~ msgid "New window, as user..."
-#~ msgstr "Nytt fˆnster, som anv‰ndare ... "
+#~ msgstr "Nytt f√∂nster, som anv√§ndare ... "
 
 #~ msgid "Browse as which user?"
-#~ msgstr "Bl‰ddra som vilken anv‰ndare?"
+#~ msgstr "Bl√§ddra som vilken anv√§ndare?"
 
 #~ msgid "User:"
-#~ msgstr "Anv‰ndare:"
+#~ msgstr "Anv√§ndare:"
 
 #~ msgid "Change from Large icons to Small automatically:"
-#~ msgstr "ƒndra frÂn stora till smÂ ikoner automatiskt"
+#~ msgstr "√Ñndra fr√•n stora till sm√• ikoner automatiskt"
 
 #~ msgid ""
 #~ "If this is on then filer windows will change from Large icons to Small "
 #~ "when showing a new directory with lots of files."
 #~ msgstr ""
-#~ "Om detta ‰r pÂslaget kommer storleken pÂ ikoner att ‰ndras till smÂ\n"
-#~ "n‰r en katalog med mÂnga objekt visas."
+#~ "Om detta √§r p√•slaget kommer storleken p√• ikoner att √§ndras till sm√•\n"
+#~ "n√§r en katalog med m√•nga objekt visas."
 
 #, fuzzy
 #~ msgid "Small Icons if at least:"
-#~ msgstr "SmÂ ikoner om minst:"
+#~ msgstr "Sm√• ikoner om minst:"
 
 #~ msgid "Single-click navigation in filer windows"
-#~ msgstr "Enkelklicka fˆr att ˆppna filer och kataloger"
+#~ msgstr "Enkelklicka f√∂r att √∂ppna filer och kataloger"
 
 #~ msgid "Icon text width"
-#~ msgstr "Bredd fˆr ikontext"
+#~ msgstr "Bredd f√∂r ikontext"
 
 #, fuzzy
 #~ msgid "Details:"
@@ -4995,35 +6041,35 @@ msgstr ""
 #~ "Load every image file and display it, scaled-down, in the filer window "
 #~ "instead of the normal icon."
 #~ msgstr ""
-#~ "L‰s in varje bild och visa den nerskalad i fˆnstret ist‰llet fˆr en "
+#~ "L√§s in varje bild och visa den nerskalad i f√∂nstret ist√§llet f√∂r en "
 #~ "vanlig ikon."
 
 #, fuzzy
 #~ msgid "Toolbar buttons"
-#~ msgstr "Verktygsf‰ltsknappar"
+#~ msgstr "Verktygsf√§ltsknappar"
 
 #, fuzzy
 #~ msgid "Unshade the tools you want."
-#~ msgstr "V‰lj de verktygsknappar du vill se."
+#~ msgstr "V√§lj de verktygsknappar du vill se."
 
 #, fuzzy
 #~ msgid "Toolbar appearance"
-#~ msgstr "Utseende pÂ verktygsf‰ltet"
+#~ msgstr "Utseende p√• verktygsf√§ltet"
 
 #~ msgid ""
 #~ "The minibuffers are text entry fields that appear along the bottom of a "
 #~ "filer window. They are used to enter pathnames, search conditions and "
 #~ "shell commands."
 #~ msgstr ""
-#~ "Minibuffertarna ‰r textf‰lt som visas i undre delen av fˆnstren.\n"
-#~ "De anv‰nds fˆr att skriva in sˆkv‰gar, sˆkvillkor och shellkommandon."
+#~ "Minibuffertarna √§r textf√§lt som visas i undre delen av f√∂nstren.\n"
+#~ "De anv√§nds f√∂r att skriva in s√∂kv√§gar, s√∂kvillkor och shellkommandon."
 
 #~ msgid "Beeping"
 #~ msgstr "Ljudsignal"
 
 #, fuzzy
 #~ msgid "General"
-#~ msgstr "Allm‰nt"
+#~ msgstr "Allm√§nt"
 
 #~ msgid "Quick Start"
 #~ msgstr "Snabbstart"
@@ -5041,12 +6087,12 @@ msgstr ""
 #~ "IsReg system(grep -q fred \"%\")         (contains the word 'fred')"
 #~ msgstr ""
 #~ "'*.htm', '*.html'      (hittar HTML-filer)\n"
-#~ "ƒrKatalog 'lib'          (hittar kataloger som heter 'lib')\n"
-#~ "ƒrVanlig 'core'          (hittar vanliga filer som heter 'core')\n"
-#~ "! (ƒrKatalog, ƒrVanlig)    (‰r varken en katalog eller en vanlig fil)\n"
-#~ "mtime efter 1 dag sedan och stˆrre 1Mb (stor, och ‰ndrad nyligen)\n"
-#~ "'CVS' besk‰r, ‰rvanlig                 (en vanlig fil som inte ‰r i CVS)\n"
-#~ "ƒrVanlig system(grep -q fred \"%\")       (innehÂller ordet 'fred')"
+#~ "√ÑrKatalog 'lib'          (hittar kataloger som heter 'lib')\n"
+#~ "√ÑrVanlig 'core'          (hittar vanliga filer som heter 'core')\n"
+#~ "! (√ÑrKatalog, √ÑrVanlig)    (√§r varken en katalog eller en vanlig fil)\n"
+#~ "mtime efter 1 dag sedan och st√∂rre 1Mb (stor, och √§ndrad nyligen)\n"
+#~ "'CVS' besk√§r, √§rvanlig                 (en vanlig fil som inte √§r i CVS)\n"
+#~ "√ÑrVanlig system(grep -q fred \"%\")       (inneh√•ller ordet 'fred')"
 
 #~ msgid "Simple Tests"
 #~ msgstr "Enkla tester"
@@ -5065,19 +6111,19 @@ msgstr ""
 #~ "is \n"
 #~ "against the leafname only."
 #~ msgstr ""
-#~ "ƒrVanlig, ƒrGenv‰g, ƒrKatalog, ƒrChar, ƒrBlock, ƒrDev, ƒrPipe, ƒrSocket  "
+#~ "√ÑrVanlig, √ÑrGenv√§g, √ÑrKatalog, √ÑrChar, √ÑrBlock, √ÑrDev, √ÑrPipe, √ÑrSocket  "
 #~ "(typer)\n"
-#~ "ƒrSUID, ƒrSGID, ƒrKlibbig, ƒrL‰sbar, ƒrSkrivbar, ƒrKˆrbar (tillÂtelser)\n"
-#~ "ƒrTom, ƒrMin\n"
+#~ "√ÑrSUID, √ÑrSGID, √ÑrKlibbig, √ÑrL√§sbar, √ÑrSkrivbar, √ÑrK√∂rbar (till√•telser)\n"
+#~ "√ÑrTom, √ÑrMin\n"
 #~ "\n"
-#~ "Ett mˆnster i enkla citationstecken sˆks som ett \"wildcard\" i  shell-"
-#~ "stils-mˆnster.\n"
-#~ "Om det innehÂller ett snedstreck sÂ matchas den mot den fulla sˆkv‰gen; "
+#~ "Ett m√∂nster i enkla citationstecken s√∂ks som ett \"wildcard\" i  shell-"
+#~ "stils-m√∂nster.\n"
+#~ "Om det inneh√•ller ett snedstreck s√• matchas den mot den fulla s√∂kv√§gen; "
 #~ "om inte\n"
 #~ "matches den endast mot filnamnet."
 
 #~ msgid "Comparisons"
-#~ msgstr "J‰mfˆrelser"
+#~ msgstr "J√§mf√∂relser"
 
 #~ msgid ""
 #~ "<, <=, =, !=, >, >=, After, Before (compare two values)\n"
@@ -5085,11 +6131,11 @@ msgstr ""
 #~ "2 secs|mins|hours|days|weeks|years  ago|hence (times)\n"
 #~ "atime, ctime, mtime, now, size, inode, nlinks, uid, gid, blocks (values)"
 #~ msgstr ""
-#~ "<, <=, =, !=, >, >=, Efter, Fˆre (j‰mfˆr tvÂ v‰rden)\n"
+#~ "<, <=, =, !=, >, >=, Efter, F√∂re (j√§mf√∂r tv√• v√§rden)\n"
 #~ "5 byte, 1Kb, 2Mb, 3Gb (filstorlekar)\n"
-#~ "2 sekunder|minuter|timmar|dagar|veckor|Âr  sedan|om (tider)\n"
-#~ "atime, ctime, mtime, nu, storlek, i-nod, antal genv‰gar, anv‰ndar-ID, "
-#~ "grupp-ID, block (v‰rden)"
+#~ "2 sekunder|minuter|timmar|dagar|veckor|√•r  sedan|om (tider)\n"
+#~ "atime, ctime, mtime, nu, storlek, i-nod, antal genv√§gar, anv√§ndar-ID, "
+#~ "grupp-ID, block (v√§rden)"
 
 #~ msgid "Specials"
 #~ msgstr "Speciella"
@@ -5101,18 +6147,15 @@ msgstr ""
 #~ msgstr ""
 #~ "system(kommando) (sant om 'kommando' returnerer med en slut-status av 0; "
 #~ "ett % \n"
-#~ "i-'kommando' ers‰tts med sˆkv‰gen till den valda filen)\n"
-#~ "besk‰r (falsk, och fˆrebygger sˆkning i innehÂllet av en katalog)."
+#~ "i-'kommando' ers√§tts med s√∂kv√§gen till den valda filen)\n"
+#~ "besk√§r (falsk, och f√∂rebygger s√∂kning i inneh√•llet av en katalog)."
 
 #~ msgid "Permissions command reference"
-#~ msgstr "Referens till kommandor‰ttigheter"
+#~ msgstr "Referens till kommandor√§ttigheter"
 
 #, fuzzy
 #~ msgid "File Information"
 #~ msgstr "Filinformation"
-
-#~ msgid "Remove"
-#~ msgstr "Ta bort"
 
 #, fuzzy
 #~ msgid "Intelligent sorting"
@@ -5124,14 +6167,14 @@ msgstr ""
 #~ "File9, File10"
 #~ msgstr ""
 #~ "Om av sorteras objekt i ASCII-ordning: Fil10, Fil8, fil9\n"
-#~ "Om pÂ behandla stora/smÂ bokst‰ver lika, strunta i skiljetecken och\n"
+#~ "Om p√• behandla stora/sm√• bokst√§ver lika, strunta i skiljetecken och\n"
 #~ "hantera tal korrekt: fil8, Fil9, Fil10"
 
 #~ msgid "Unknown error"
-#~ msgstr "Ok‰nt fel"
+#~ msgstr "Ok√§nt fel"
 
 #~ msgid "Show ROX-Filer Help"
-#~ msgstr "Vis ROX-Filer HjÊlp"
+#~ msgstr "Vis ROX-Filer Hj√¶lp"
 
 #~ msgid "The label must contain at least one character!"
 #~ msgstr "Title skal indeholde i hvertfald et tegn!"
@@ -5147,7 +6190,7 @@ msgstr ""
 #~ msgstr "Mangler MIME-type"
 
 #~ msgid "Trailing chars after MIME-type"
-#~ msgstr "Eftef¯lgende tegn efter MIME-typen"
+#~ msgstr "Eftef√∏lgende tegn efter MIME-typen"
 
 #~ msgid ""
 #~ "The pinboard is the desktop background.\n"
@@ -5156,10 +6199,10 @@ msgstr ""
 #~ "See the manual for information about using the pinboard."
 #~ msgstr ""
 #~ "Opslagstavlen er desktoppens baggrund.\n"
-#~ "NÂr opslagstavlen er slÂet til kan du trÊkke filer\n"
-#~ "og programmer ind pÂ den for at oprette genveje til dem.\n"
-#~ "Opslagstavlen er ogsÂ kendt fra andre systemer under navne som Skrivebord "
-#~ "og ArbejdsbÊnk\n"
+#~ "N√•r opslagstavlen er sl√•et til kan du tr√¶kke filer\n"
+#~ "og programmer ind p√• den for at oprette genveje til dem.\n"
+#~ "Opslagstavlen er ogs√• kendt fra andre systemer under navne som Skrivebord "
+#~ "og Arbejdsb√¶nk\n"
 #~ "Se manualen for mere information om brug af opslagstavlen."
 
 #, fuzzy
@@ -5170,13 +6213,13 @@ msgstr ""
 #~ msgstr "Afbryd"
 
 #~ msgid "Can't allocate memory for buffer to load this file"
-#~ msgstr "Kan ikke allokere hukommelse til bufferen til at lÊse denne fil"
+#~ msgstr "Kan ikke allokere hukommelse til bufferen til at l√¶se denne fil"
 
 #~ msgid "Old VFS support"
-#~ msgstr "Gammel VFS underst¯ttelse"
+#~ msgstr "Gammel VFS underst√∏ttelse"
 
 #~ msgid "No (incompatible with Large File Support)"
-#~ msgstr "Nej (inkompatibel med Underst¯ttelse af Store Filer)"
+#~ msgstr "Nej (inkompatibel med Underst√∏ttelse af Store Filer)"
 
 #~ msgid "No (couldn't find a valid libvfs)"
 #~ msgstr "Nej (kunne ikke finde en gyldig libvfs)"
@@ -5191,16 +6234,16 @@ msgstr ""
 #~ msgstr "Ja (bruger libpng)"
 
 #~ msgid "No (needs libpng or Gtk+-2.0)"
-#~ msgstr "Nej (krÊver libpng eller Gtk+-2.0)"
+#~ msgstr "Nej (kr√¶ver libpng eller Gtk+-2.0)"
 
 #~ msgid "Character set translations"
-#~ msgstr "TegnsÊt oversÊttelser"
+#~ msgstr "Tegns√¶t overs√¶ttelser"
 
 #~ msgid "No (needs libiconv or Gtk+-2.0)"
-#~ msgstr "Nej (jrÊver libiconv eller Gtk+-2.0)"
+#~ msgstr "Nej (jr√¶ver libiconv eller Gtk+-2.0)"
 
 #~ msgid "Open VFS"
-#~ msgstr "≈ben med VFS"
+#~ msgstr "√Öben med VFS"
 
 #~ msgid "Unzip"
 #~ msgstr "Unzip"
@@ -5214,9 +6257,6 @@ msgstr ""
 #~ msgid "RPM"
 #~ msgstr "RPM"
 
-#~ msgid "New Directory"
-#~ msgstr "Ny Mappe"
-
 #~ msgid "New File"
 #~ msgstr "Ny Fil"
 
@@ -5227,14 +6267,14 @@ msgstr ""
 #~ "If off: Ben, animal, zoo.\n"
 #~ "If on: animal, Ben, zoo."
 #~ msgstr ""
-#~ "Hvis fra: B¯ffel, and, zebra.\n"
-#~ "Hvis til: and, B¯ffel, zebra."
+#~ "Hvis fra: B√∏ffel, and, zebra.\n"
+#~ "Hvis til: and, B√∏ffel, zebra."
 
 #~ msgid "No background"
 #~ msgstr "Ingen baggrund"
 
 #~ msgid "The text is drawn directly on the desktop background."
-#~ msgstr "Teksten bliver tegnet direkte pÂ desktoppens baggrund."
+#~ msgstr "Teksten bliver tegnet direkte p√• desktoppens baggrund."
 
 #~ msgid "Outlined text"
 #~ msgstr "Omridset tekst"
@@ -5246,16 +6286,13 @@ msgstr ""
 #~ msgstr "Firkantet baggrunds box"
 
 #~ msgid "The text is drawn on a solid rectangle."
-#~ msgstr "Teksten bliver tegnet pÂ en firkant"
+#~ msgstr "Teksten bliver tegnet p√• en firkant"
 
 #~ msgid "...never"
 #~ msgstr "... aldrig"
 
 #~ msgid "...always"
 #~ msgstr "...altid"
-
-#~ msgid "Window size limit"
-#~ msgstr "Vindues-st¯rrelse grÊnse"
 
 #~ msgid "Error"
 #~ msgstr "Fejl"
@@ -5264,25 +6301,25 @@ msgstr ""
 #~ msgstr "!FEJL: %s\n"
 
 #~ msgid "Force - don't confirm deletion of non-writeable items"
-#~ msgstr "Tving - bekrÊft ikke sletning af ikke-skrivbare objekter"
+#~ msgstr "Tving - bekr√¶ft ikke sletning af ikke-skrivbare objekter"
 
 #~ msgid "Recurse - also change contents of subdirectories"
-#~ msgstr "Recursivt - under-mappers indhold Êndres ogsÂ"
+#~ msgstr "Recursivt - under-mappers indhold √¶ndres ogs√•"
 
 #~ msgid "fork() failed"
 #~ msgstr "fork() mislykkedes"
 
 #~ msgid "Sorry, but the name must not contain < or >"
-#~ msgstr "DesvÊrre, men navnet mÂ hverken indeholde < eller >"
+#~ msgstr "Desv√¶rre, men navnet m√• hverken indeholde < eller >"
 
 #~ msgid "You must select a single file to open as a Virtual File System"
-#~ msgstr "Du mÂ kun vÊlge en fil som skal Âbnes som et Virtuelt Fil System"
+#~ msgstr "Du m√• kun v√¶lge en fil som skal √•bnes som et Virtuelt Fil System"
 
 #~ msgid "Failed to fork() child process"
-#~ msgstr "fork() af b¯rne-process mislykkedes"
+#~ msgstr "fork() af b√∏rne-process mislykkedes"
 
 #~ msgid "Notice"
-#~ msgstr "BemÊrk"
+#~ msgstr "Bem√¶rk"
 
 #~ msgid ""
 #~ "Restart\n"
@@ -5296,9 +6333,6 @@ msgstr ""
 
 #~ msgid "Named pipe"
 #~ msgstr "Navngivet pipe"
-
-#~ msgid "Application"
-#~ msgstr "Program"
 
 #~ msgid "Copy failed"
 #~ msgstr "Kopiering mislykkedes"

--- a/ROX-Filer/src/po/uk.po
+++ b/ROX-Filer/src/po/uk.po
@@ -2,59 +2,64 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ROX-Filer 2.4.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2006-12-04 15:07+0000\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2006-12-04 15:30+0200\n"
 "Last-Translator: Yury Bulka <jblk@icmail.net>\n"
 "Language-Team: Ukrainian <translation-team-uk@lists.sourceforge.net>\n"
+"Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: abox.c:125
-msgid "<dir>"
-msgstr "<тека>"
+#: abox.c:127
+msgid "<src>"
+msgstr ""
 
-#: abox.c:218
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Мовчки"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Quiet"
 msgstr "Мовчки"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Не питати підтвердження для кожної дії"
 
-#: abox.c:454 infobox.c:771 tips:63
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Назва"
 
-#: abox.c:460 menu.c:228
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Тека"
 
-#: abox.c:549
+#: abox.c:546
 msgid "Expression:"
 msgstr "Вираз:"
 
-#: action.c:56
+#: action.c:57
 msgid "See the attr(5) man page for full details."
 msgstr "Дивіться man-сторінку attr(5) для повного роз'яснення"
 
-#: action.c:58
+#: action.c:59
 msgid "See the fsattr(5) man page for full details."
 msgstr "Дивіться man-сторінку fsattr(5) для повного роз'яснення"
 
-#: action.c:60
+#: action.c:61
 msgid "You do not appear to have OS support."
 msgstr "Здається, ви не маєте підтримки OS"
 
-#: action.c:189
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Знайти посилання на вираз"
 
-#: action.c:200
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -127,11 +132,11 @@ msgstr ""
 "знак % в команді замінюється на шлях до даного файлу)\n"
 "<b>prune</b> (неправдивий, забороняє пошук для теки)."
 
-#: action.c:247
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Змінити права"
 
-#: action.c:258
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -190,11 +195,11 @@ msgstr ""
 "\n"
 "Дивіться man-сторінку chmod(1) для детального роз'яснення."
 
-#: action.c:299
+#: action.c:308
 msgid "Set type reference"
 msgstr "Вказати тип"
 
-#: action.c:310
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -223,48 +228,55 @@ msgstr ""
 "пристроях, трубах(pipes) і розетках(sockets), і тільки на \n"
 "певних файлових системах там, де ОС їх підтримує.\n"
 
-#: action.c:417
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Процес завершено.\n"
 
-#: action.c:433
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Сталася помилка\n"
 
-#: action.c:435
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Кількість помилок: %d\n"
 
-#: action.c:459
+#: action.c:516
 msgid "ERROR reading"
 msgstr "ПОМИЛКА читання"
 
-#: action.c:502
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Завершено\n"
 
-#: action.c:558 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "ПОМИЛКА"
 
-#: action.c:712 main.c:684 main.c:691 main.c:705
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Так"
 
-#: action.c:715 main.c:686 main.c:693 main.c:705
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Ні"
 
-#: action.c:733
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -272,7 +284,7 @@ msgstr ""
 "\n"
 "Прошу дочірній процес завершитися...\n"
 
-#: action.c:740
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -280,41 +292,41 @@ msgstr ""
 "\n"
 "Пробую ВБИТИ непотрібний процес...\n"
 
-#: action.c:893
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Порахувати зміст %s?"
 
-#: action.c:929
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Викинути %s'%s'?"
 
-#: action.c:930
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "ЗАХИЩЕНИЙ-ПРОТИ-ЗАПИСУ "
 
-#: action.c:937
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'Викидаю '%s'\n"
 
-#: action.c:950
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'теку '%s' викинуто\n"
 
-#: action.c:983
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?Виштовхнути '%s'?"
 
-#: action.c:990
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Виштовхнути '%s'\n"
 
-#: action.c:1009
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -323,80 +335,95 @@ msgstr ""
 "!%s\n"
 "не вдалося виштовхнути\n"
 
-#: action.c:1028 action.c:1047
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Перевірити '%s'?"
 
-#: action.c:1044
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Неправильний вираз для пошуку, змініть його і спробуйте знову\n"
 
-#: action.c:1054
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(під час перевірки '%s')\n"
 
-#: action.c:1128 action.c:1153
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Змінити права '%s'?"
 
-#: action.c:1134
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Змінюю права '%s'\n"
 
-#: action.c:1151
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Неправильна команда - змініть її і спробуйте знову\n"
 
-#: action.c:1208 action.c:1228
+#: action.c:1332
+#, fuzzy, c-format
+msgid "?Change contents of '%s'?"
+msgstr "?Змінити тип '%s'?"
+
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Змінити тип '%s'?"
 
-#: action.c:1225
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Неправильний тип - змініть його і спробуйте знову\n"
 
-#: action.c:1247
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Змінюю тип '%s' на '%s'\n"
 
-#: action.c:1326
+#: action.c:1397
+#, fuzzy, c-format
+msgid "'Not changing type of directory '%s'\n"
+msgstr "'Змінюю тип '%s' на '%s'\n"
+
+#: action.c:1403
+#, c-format
+msgid "'Non-regular file '%s' not changed\n"
+msgstr ""
+
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' вже існує - %s?"
 
-#: action.c:1328
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "змішати зміст"
 
-#: action.c:1329
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "переписати"
 
-#: action.c:1345
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Всеодно пробую копіювати...\n"
 
-#: action.c:1354
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Скопіювати %s як %s?"
 
-#: action.c:1358
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Копіюю %s як %s\n"
 
-#: action.c:1373
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!ПОМИЛКА: Місце призначення вже існує, але це не тека\n"
 
-#: action.c:1445
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -405,26 +432,7 @@ msgstr ""
 "!%s\n"
 "Неможливо скопіювати '%s'\n"
 
-#: action.c:1489
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' вже існує - переписати?"
-
-#: action.c:1504
-msgid "'Trying move anyway...\n"
-msgstr "'Всеодно пробую перемістити...\n"
-
-#: action.c:1512
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Перемістити %s як %s?"
-
-#: action.c:1516
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Переміщую %s як %s\n"
-
-#: action.c:1524
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -433,45 +441,59 @@ msgstr ""
 "!%s\n"
 "Неможливо перемістити %s як %s\n"
 
-#: action.c:1545
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Всеодно пробую перемістити...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Перемістити %s як %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Переміщую %s як %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!ПОМИЛКА: Не можу перемістити об'єкт в нього самого\n"
 
-#: action.c:1560
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!ПОМИЛКА: Не можу перемістити/переназвати об'єкт в нього самого\n"
 
-#: action.c:1572
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Пов'язую %s як %s\n"
 
-#: action.c:1577
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Пов'язати %s як %s?"
 
-#: action.c:1620
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Монтую %s\n"
 
-#: action.c:1621
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Відмонтовую %s\n"
 
-#: action.c:1624
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?Монтувати %s?"
 
-#: action.c:1625
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?Відмонтувати %s?"
 
-#: action.c:1645
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -480,7 +502,7 @@ msgstr ""
 "!%s\n"
 "Неможливо змонтувати\n"
 
-#: action.c:1646
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -489,11 +511,11 @@ msgstr ""
 "!%s\n"
 "Неможливо відмонтувати\n"
 
-#: action.c:1654
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(виглядає на те, що все таки змонтовано)\n"
 
-#: action.c:1700
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -502,206 +524,230 @@ msgstr ""
 "'\n"
 "Загалом: %s ("
 
-#: action.c:1706
+#: action.c:2108
 msgid "file"
 msgstr "файл"
 
-#: action.c:1706
+#: action.c:2108
 msgid "files"
 msgstr "файли"
 
-#: action.c:1710
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "теки відсутні)\n"
 
-#: action.c:1714
+#: action.c:2116
 msgid "directory"
 msgstr "тека"
 
-#: action.c:1715
+#: action.c:2117
 msgid "directories"
 msgstr "теки"
 
-#: action.c:1756
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Не вибрано жодної точки монтування!\n"
 
-#: action.c:1841
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Інший пошук?"
 
-#: action.c:1871 action.c:1902
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' - символічне посилання\n"
 
-#: action.c:1942
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "Ви повинні вибрати де шукати"
 
-#: action.c:1952 menu.c:219
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Шукати"
 
-#: action.c:1985
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Ви повинні вибрати що рахувати"
 
-#: action.c:1989
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Використання диску"
 
-#: action.c:2025
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Монтувати / відмонтувати"
 
-#: action.c:2040
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr ""
 "ROX-Filer поки що не підтримує точок монтування на вашій системі. Вибачте."
 
-#: action.c:2054 menu.c:207 tips:216
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Викинути"
 
-#: action.c:2066 tips:221
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Насилу"
 
-#: action.c:2066
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Не питати підтвердження для викидання файлів, захищених від запису"
 
-#: action.c:2069 action.c:2126 action.c:2187 action.c:2242 action.c:2280
-#: tips:223
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Скорочено"
 
-#: action.c:2069
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Висвітлювати тільки теки, які викидаю"
 
-#: action.c:2086
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "Ви повинні вибрати предмети, для яких хочете змінити права"
 
-#: action.c:2094
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Зробити доступним для виконання/пошуку)"
 
-#: action.c:2096
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a+x (Зробити недоступним для виконання/пошуку)"
 
-#: action.c:2098
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Дозволити власнику читати і писати)"
 
-#: action.c:2100
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Приватний - доступ тільки для власника)"
 
-#: action.c:2102
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Публічний доступ, не для запису)"
 
-#: action.c:2113 menu.c:181 menu.c:217 tips:78
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Права"
 
-#: action.c:2126 action.c:2187
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Не перелічувати оброблені файли"
 
-#: action.c:2129 action.c:2190 tips:225
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "Рекурсивно"
 
-#: action.c:2129
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Також змінювати зміст підтек"
 
-#: action.c:2133
+#: action.c:2547
 msgid "Command:"
 msgstr "Команда:"
 
-#: action.c:2161
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Ви повинні вибрати предмети, тип яких хочете змінити"
 
-#: action.c:2174
+#: action.c:2590
 msgid "Set type"
 msgstr "Вказати тип"
 
-#: action.c:2190
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Змінювати зміст підтек"
 
-#: action.c:2197 infobox.c:627
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Тип:"
 
-#: action.c:2226 dnd.c:122 menu.c:1986 tips:210
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Копіювати"
 
-#: action.c:2238 action.c:2276 tips:227
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Не питати підтвердження для кожної дії"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Переписувати тільки якщо джерело є новішим за місце призначення."
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Новіший"
 
-#: action.c:2239 action.c:2277 tips:228
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Переписувати тільки якщо джерело є новішим за місце призначення."
 
-#: action.c:2242
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "теки"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Перелічувати тільки теки, котрі копіюються"
 
-#: action.c:2264 dnd.c:123 tips:212
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Перемістити"
 
-#: action.c:2280
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Не перелічувати кожен файл, коли він переміщується"
 
-#: action.c:2300 tips:214
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Створити посилання"
 
-#: action.c:2321 appmenu.c:111
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Виштовхнути"
 
-#: action.c:2385
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Викинути такі предмети, як "
 
-#: action.c:2389
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Викидаю предмет "
 
-#: action.c:2391
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Викидаю предмети"
 
-#: action.c:2410
+#: action.c:2900
 msgid " and "
 msgstr " і "
 
-#: action.c:2419
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr " вплине на деякі предмети на стільниці і панелі - дійсно викинути це?"
 
-#: action.c:2426
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr " вплине на деякі предмети на стільниці і панелі - дійсно викинути їх?"
 
-#: appmenu.c:197
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<відсутня етикетка>"
 
-#: appmenu.c:320
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
@@ -710,82 +756,82 @@ msgstr ""
 "Створіть символічні посилання ні потрібні вам програми в цю теку. Вони "
 "з'являться в меню для всі предметів цього типу (%s/%s)."
 
-#: appmenu.c:364 menu.c:230
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Налаштувати меню..."
 
-#: appmenu.c:421 menu.c:247 toolbar.c:158
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Довідка"
 
-#: bookmarks.c:145
-msgid "Path"
-msgstr "Шлях"
-
-#: bookmarks.c:153
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Назва"
 
-#: bookmarks.c:302
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Шлях"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Неможливо створити закладку для нелокального ресурсу '%s'\n"
 
-#: bookmarks.c:310 bookmarks.c:628
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' не тека"
 
-#: bookmarks.c:516
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Спочатку ви повинні вибрати предмети котрі треба викинути"
 
-#: bookmarks.c:540
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Помістіть курсор над предметом в списку щоб перемістити його"
 
-#: bookmarks.c:560
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Цей предмет вже знаходиться в кінці"
 
-#: bookmarks.c:634
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Не можу створити закладку для нелокальних тек, таких як '%s'"
 
-#: bookmarks.c:776
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Додати нову закладку"
 
-#: bookmarks.c:783
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Редагувати закладку"
 
-#: bookmarks.c:788
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Недавно відвідувані"
 
-#: bulk_rename.c:66
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Переназвати багато файлів"
 
-#: bulk_rename.c:69
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Скинути"
 
-#: bulk_rename.c:74
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "Зробити новий стовпчик копією старого"
 
-#: bulk_rename.c:79
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "_Переназвати"
 
-#: bulk_rename.c:92
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Замінити:"
 
-#: bulk_rename.c:99
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -799,23 +845,25 @@ msgstr ""
 "\\. означає крапку\n"
 "\\.htm$ співпадає з '.htm' в 'index.htm', ітд., ітп."
 
-#: bulk_rename.c:107
+#: bulk_rename.c:109
 msgid "With:"
 msgstr "На:"
 
-#: bulk_rename.c:114
+#: bulk_rename.c:116
+#, fuzzy
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 "Перше співпадання в кожній назві файлу буде замінено цим виразом. Тут "
 "відсутні спеціальні знаки."
 
-#: bulk_rename.c:118
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Прийняти"
 
-#: bulk_rename.c:121
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
@@ -823,43 +871,43 @@ msgstr ""
 "Здійснити пошук і заміну в другому стовпчику. Файли будуть перейменовані "
 "насправді лише після того, як ви клацнете по кнопці Переназвати внизу."
 
-#: bulk_rename.c:140
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Стара назва"
 
-#: bulk_rename.c:149
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Нова назва"
 
-#: bulk_rename.c:257
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr "Не було знайдено жодного співпадання з даним виразом"
 
-#: bulk_rename.c:262
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Одна назва співпала, але результат був той самий"
 
-#: bulk_rename.c:265
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d імен співпало, але результати були ті самі"
 
-#: bulk_rename.c:291
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr "Вкажіть вираз для пошуку, і текст для заміни знайдених результатів."
 
-#: bulk_rename.c:308
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (для '%s')"
 
-#: bulk_rename.c:341
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr "Файл з назвою '%s' вже існує. Перериваю переназивання."
 
-#: bulk_rename.c:346
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -870,12 +918,12 @@ msgstr ""
 "%s\n"
 "Перериваю автоматичне переназивання."
 
-#: bulk_rename.c:408
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "Файл з назвою '%s' вже існує"
 
-#: bulk_rename.c:419
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
@@ -885,7 +933,7 @@ msgstr ""
 "розкидання\n"
 "файлів по різних теках. Продовжити?"
 
-#: bulk_rename.c:434
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Жодна з назв не змінилася. Нема чого робити!"
 
@@ -908,59 +956,79 @@ msgstr ""
 " в нове місце \n"
 "<b>%s</b>\n"
 
-#: dir.c:980
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Не можу описати теку: %s"
 
-#: dir.c:989
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Не можу відкрити теку: %s"
 
-#: display.c:612
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Розмір"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) не вдався"
 
-#: dnd.c:124
-msgid "Link (relative)"
-msgstr "Створити посилання (відносне)"
-
-#: dnd.c:125
-msgid "Link (absolute)"
-msgstr "Створити посилання (абсолютне)"
-
-#: dnd.c:424
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Внутрішня помилка - поганий тип інформації"
 
-#: dnd.c:563
+#: dnd.c:565
 msgid "Drag a directory here to bookmark it."
 msgstr "Перетягніть сюди теку, щоб створити закладку."
 
-#: dnd.c:578
+#: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
 msgstr "Помилка протоколу XDS: назва не повинна містити '/'\n"
 
-#: dnd.c:603
+#: dnd.c:605
 msgid ""
 "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
 "plain) did not contain a leafname\n"
 msgstr ""
 "XdndDirectSave0 ціль надано, але вона (тип text/plain) не містить назви\n"
 
-#: dnd.c:616
+#: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
 msgstr "Вибачте - я потребую тип цілі text/uri-list, або XdndDirectSave0."
 
-#: dnd.c:619
+#: dnd.c:621
 msgid ""
 "Sorry - I require a target type of text/uri-list or application/octet-stream."
 msgstr ""
 "Вибачте - я потребую тип цілі text/uri-list або application/octet-stream."
 
-#: dnd.c:689
+#: dnd.c:691
 #, c-format
 msgid ""
 "Failed to add some items to the pinboard, because they are on a remote "
@@ -973,50 +1041,50 @@ msgstr ""
 "\n"
 "%s"
 
-#: dnd.c:764
+#: dnd.c:766
 msgid "Unknown target"
 msgstr "Невідома ціль"
 
-#: dnd.c:797
+#: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
 msgstr "Віддалена машина не може, або не буде висилати мені дані - вибачте"
 
-#: dnd.c:810
+#: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
 msgstr "Помилка протоколу XDS: код повернення повинен бути 'S', 'F' або 'E'\n"
 
-#: dnd.c:843
+#: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
 msgstr ""
 "Вибачте, не можу показати меню дій для віддаленого файлу / сирих даних."
 
-#: dnd.c:859
+#: dnd.c:861
 msgid "UntitledData"
 msgstr "Неназвані дані"
 
-#: dnd.c:886
+#: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
 msgstr "Помилка збереження файлу: %s"
 
-#: dnd.c:959
+#: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
 msgstr "URI відсутні в text/uri-list (нічого до роботи!)"
 
-#: dnd.c:991
+#: dnd.c:993
 msgid ""
 "Can't get data from remote machine (application/octet-stream not provided)"
 msgstr ""
 "Не можу дістати дані з віддаленої машини (application/octet-stream не надано)"
 
-#: dnd.c:1014
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr ""
 "Деякі з цих файлів знаходяться на іншій машині - вони будуть проігноровані, "
 "вибачте"
 
-#: dnd.c:1021
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
@@ -1024,14 +1092,32 @@ msgstr ""
 "Жоден з цих файлів не знаходиться на локальній машині - я не можу працювати "
 "з багатьма віддаленими файлами - вибачте."
 
-#: dnd.c:1034
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Задана невідома дія"
 
-#: dnd.c:1042
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Помилка добування списку файлу: %s"
+
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Створити посилання (відносне)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Створити посилання (абсолютне)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Створити посилання (відносне)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Створити посилання (абсолютне)"
 
 #: dropbox.c:112
 msgid "Show"
@@ -1062,7 +1148,7 @@ msgstr "Вибачте, ви мусите кинути файл (тільки о
 msgid "Sorry, I can't use '%s' because it's not a local file."
 msgstr "Вибачте, я не можу використовувати '%s', бо це не є локальний файл."
 
-#: dropbox.c:278 pinboard.c:855
+#: dropbox.c:278 pinboard.c:932
 #, c-format
 msgid ""
 "Can't access '%s':\n"
@@ -1071,7 +1157,7 @@ msgstr ""
 "Нема доступу '%s':\n"
 "%s"
 
-#: filer.c:453
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1080,16 +1166,7 @@ msgstr ""
 "Помилка сканування '%s':\n"
 "%s\n"
 
-#: filer.c:457
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Помилка сканування '%s':\n"
-"%s"
-
-#: filer.c:562
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1099,19 +1176,19 @@ msgstr ""
 "\n"
 "Щоб вийняти диск треба його відмонтувати."
 
-#: filer.c:566
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 msgid "No change"
 msgstr "Без змін"
 
-#: filer.c:572 menu.c:858
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Відмонтувати"
 
-#: filer.c:669
-msgid "Directory missing/deleted"
-msgstr "Тека відсутня"
-
-#: filer.c:1033
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
@@ -1122,98 +1199,144 @@ msgstr ""
 "призначити групу. Натисніть %s щоб пере-вибрати ці файли потім.\n"
 "Перевірте чи NumLock увімкнено, якщо ви використовуєте додаткову клавіатурку."
 
-#: filer.c:1269
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Тека '%s' недоступна"
-
-#: filer.c:1421
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Теку '%s' не знайдено."
-
-#: filer.c:1715
-msgid "Cancel"
-msgstr "Скасувати"
-
-#: filer.c:1996
+#: filer.c:2655
 msgid "A"
 msgstr "A"
 
-#: filer.c:1998 find.c:923
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr "G"
 
-#: filer.c:2003
+#: filer.c:2664
 msgid "S"
 msgstr "S"
 
-#: filer.c:2005
+#: filer.c:2669
 msgid "T"
 msgstr "T"
 
-#: filer.c:2015
-msgid "All, "
-msgstr "Все, "
+#: filer.c:2670
+msgid "D"
+msgstr ""
 
-#: filer.c:2018
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
 msgstr "Glob (%s), "
 
-#: filer.c:2026
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Перечитую, "
 
-#: filer.c:2028
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Міні-зображення, "
 
-#: filer.c:2304
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Міні-зображення, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Символічне посилання до"
 
-#: filer.c:2346
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "Назва цього файлу не є в UTF-8. Ви повинні переназвати його.\n"
 
-#: filer.c:2657 menu.c:1976
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "Предмет більше не існує!"
 
-#: filer.c:3366
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Виберіть властивості вигляду для запам'ятовування"
 
-#: filer.c:3373
+#: filer.c:4712
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr ""
+
+#: filer.c:4713
+msgid "<b>Save display settings for directory</b>"
+msgstr ""
+
+#: filer.c:4720
+#, fuzzy
+msgid "Select settings to save"
+msgstr "Виберіть властивості вигляду для запам'ятовування"
+
+#: filer.c:4727
 msgid "Position"
 msgstr "Позиція"
 
-#: filer.c:3378 toolbar.c:133 toolbar.c:137 tips:66
-msgid "Size"
-msgstr "Розмір"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Вікно"
 
-#: filer.c:3383
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Показати приховане"
 
-#: filer.c:3389
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Стиль вигляду"
 
-#: filer.c:3395
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Тип і порядок сортування"
 
-#: filer.c:3400 toolbar.c:141
+#: filer.c:4754
 msgid "Details"
 msgstr "Подробиці"
 
-#: filer.c:3405 tips:117 tips:118
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Міні-зображення"
 
-#: filer.c:3411
+#: filer.c:4765
 msgid "Filter"
 msgstr "Фільтр"
 
@@ -1437,11 +1560,11 @@ msgstr "blocks"
 msgid "Save As:"
 msgstr "Зберегти як:"
 
-#: gtksavebox.c:395
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Неназваний"
 
-#: gtksavebox.c:471
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
@@ -1449,7 +1572,7 @@ msgstr ""
 "віддалена програма хоче використати Пряме Збереження, але я не можу "
 "відчитати XdndDirectSave0 (type text/plain).\n"
 
-#: gtksavebox.c:596
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1457,7 +1580,7 @@ msgstr ""
 "Перетягніть піктограму на вікно з теками\n"
 "(або впишіть повний шлях для збереження)"
 
-#: gui_support.c:329
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1465,13 +1588,13 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:398
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr ""
 "Спроба відчитати XML файл, як текстовий файл. Файл '%s' може бути зіпсованим."
 
-#: gui_support.c:415
+#: gui_support.c:542
 #, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
@@ -1488,16 +1611,16 @@ msgstr ""
 "примусить Rox'а зберегти файл).\n"
 "Майбутні помилки будуть проігноровані."
 
-#: gui_support.c:1007
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Неправильний або відсутній знак нової лінії в даних text/uri-list"
 
-#: gui_support.c:1339
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "Неможливо відкрити файл '%s': %s"
 
-#: gui_support.c:1383
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
@@ -1505,7 +1628,7 @@ msgstr ""
 "Неможливо завантажити зображення '%s': причина не відома, можливо файл "
 "зіпсований"
 
-#: gui_support.c:1434
+#: gui_support.c:1583
 #, fuzzy, c-format
 msgid ""
 "This program (%s) cannot be run, as the 0launch command is not available. It "
@@ -1518,7 +1641,7 @@ msgstr ""
 "\n"
 "http://0install.net/injector.html"
 
-#: i18n.c:36
+#: i18n.c:39
 msgid ""
 "Note that you must save your choices and restart the filer for the new "
 "language setting to take full effect."
@@ -1526,172 +1649,178 @@ msgstr ""
 "потрібно зберегти налаштування, і перезапустити Rox-filer, щоб налаштування "
 "мови вступили в силу."
 
-#: icon.c:76
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(натисніть щоб призначити)"
 
-#: icon.c:131
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:132 menu.c:248
-msgid "About ROX-Filer..."
-msgstr "Про ROX-Filer..."
-
-#: icon.c:133 menu.c:249
-msgid "Show Help Files"
-msgstr "Показати файли довідки"
-
-#: icon.c:134 menu.c:250
-msgid "Manual"
-msgstr "Підручник"
-
-#: icon.c:136 menu.c:226
-msgid "Options..."
-msgstr "Налаштування..."
-
-#: icon.c:137 menu.c:235
-msgid "Home Directory"
-msgstr "Домашня тека"
-
-#: icon.c:138 icon.c:1389 menu.c:203 type.c:216
-msgid "File"
-msgstr "Файл"
-
-#: icon.c:139 menu.c:209 menu.c:871
-msgid "Shift Open"
-msgstr "Відкрити 'напряму'"
-
-#: icon.c:140 menu.c:214
-msgid "Properties"
-msgstr "Властивості"
-
-#: icon.c:141 menu.c:212
-msgid "Set Run Action..."
-msgstr "Вказати дію"
-
-#: icon.c:142 menu.c:213
-msgid "Set Icon..."
-msgstr "Призначити піктограму..."
-
-#: icon.c:143 icon.c:846
-msgid "Edit Item"
-msgstr "Редагувати предмет"
-
-#: icon.c:144
-msgid "Show Location"
-msgstr "Показати місцезнаходження"
-
-#: icon.c:145
-msgid "Remove Item(s)"
-msgstr "Викинути предмет(и)"
-
-#: icon.c:297 menu.c:760
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:310
+#: icon.c:311
 msgid "Nothing"
 msgstr "Ніщо"
 
-#: icon.c:571
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "Місцезнаходження повинно містити хоча б один знак!"
 
-#: icon.c:636
+#: icon.c:641
 #, c-format
 msgid "You must unlock '%s' before removing it"
 msgstr "Ви повинні розблокувати '%s' перед тим як його викинути "
 
-#: icon.c:646
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Спочатку виберіть якісь предмети, які хочете викинути"
 
-#: icon.c:652
+#: icon.c:657
 msgid "An item must be unlocked before it can be removed."
-msgstr "Предмет повинен бути розблокований перед тим як його можна буде викинути"
+msgstr ""
+"Предмет повинен бути розблокований перед тим як його можна буде викинути"
 
-#: icon.c:666
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Ви повинні відкривати меню на предметі"
 
-#: icon.c:691 menu.c:1256
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "Ви можете встановлювати дії тільки над звичайним файлами"
 
-#: icon.c:777
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Натисніть бажану швидку клавішу (напр. Control+F1)"
 
-#: icon.c:799
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Неможливо вловити дані з клавіатури!"
 
-#: icon.c:849
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Редагувати предмет"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Клацання на піктограму відкриває:"
 
-#: icon.c:859
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Арґументи (для програм):"
 
-#: icon.c:873
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "Текст, котрий є під піктограмою:"
 
-#: icon.c:886
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "Запуск клавіатурою:"
 
-#: icon.c:906
+#: icon.c:910
 #, fuzzy
 msgid "Locked"
 msgstr "Розетка"
 
-#: icon.c:911
+#: icon.c:915
 msgid "Locking an item prevents it from being accidentally removed"
 msgstr "Блокування предмету не дає його викинути"
 
-#: infobox.c:111
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Про ROX-Filer..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Показати файли довідки"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Підручник"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Налаштування..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Домашня тека"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Файл"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Відкрити 'напряму'"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Властивості"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Вказати дію"
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Призначити піктограму..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Показати місцезнаходження"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Викинути предмет(и)"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
 msgstr "Ви впевнені що хочете відкрити %d вікон?"
 
-#: infobox.c:112
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Показати інфо?"
 
-#: infobox.c:134 menu.c:765
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(поганий utf-8)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Показати файли _Довідки"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Права</b>"
 
-#: infobox.c:290
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>Зміст показує...</b>"
 
-#: infobox.c:427 infobox.c:568 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Перелічувати тільки теки, котрі копіюються"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "байтів"
 
-#: infobox.c:450
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Неможливо відчитати розмір"
 
-#: infobox.c:511
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' більше не є символічним посиланням"
 
-#: infobox.c:518
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1700,7 +1829,7 @@ msgstr ""
 "Неможливо відв'язати '%s':\n"
 "%s"
 
-#: infobox.c:523
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1711,157 +1840,196 @@ msgstr ""
 "%s\n"
 "(зауважте: старе посилання було викинуто)"
 
-#: infobox.c:547 tips:283
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Помилка:"
 
-#: infobox.c:554
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Справжня тека:"
 
-#: infobox.c:557
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Власник, ґрупа:"
 
-#: infobox.c:564 infobox.c:579 infobox.c:588
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Розмір:"
 
-#: infobox.c:589
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Сканую"
 
-#: infobox.c:614
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Неможливо просканувати"
 
-#: infobox.c:621
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Час зміни:"
 
-#: infobox.c:623
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Час модифікації:"
 
-#: infobox.c:625
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Час доступу:"
 
-#: infobox.c:633
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Розширені властивості:"
 
-#: infobox.c:635
+#: infobox.c:667
 msgid "Present"
 msgstr "Присутні"
 
-#: infobox.c:636
+#: infobox.c:668
 msgid "None"
 msgstr "Відсутні"
 
-#: infobox.c:637
+#: infobox.c:669
 msgid "Not supported"
 msgstr "Не підтримуються"
 
-#: infobox.c:649
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Ціль посилання:"
 
-#: infobox.c:661 infobox.c:664
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Дія відкривання:"
 
-#: infobox.c:661
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Виконати файл"
 
-#: infobox.c:773
+#: infobox.c:805
 #, fuzzy
 msgid "Comment"
 msgstr "Команда:"
 
-#: infobox.c:775
+#: infobox.c:807
 #, fuzzy
 msgid "Execute"
 msgstr "IsExecutable"
 
-#: infobox.c:789
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<поки що нічого>"
 
-#: infobox.c:859
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "file(1) каже... %s"
 
-#: infobox.c:916
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Не можу змінити права: %s"
 
-#: infobox.c:934
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Власник"
 
-#: infobox.c:936
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Ґрупа"
 
-#: infobox.c:938
+#: infobox.c:974
 msgid "World"
 msgstr "Світ"
 
-#: infobox.c:941
+#: infobox.c:977
 msgid "Read"
 msgstr "Читати"
 
-#: infobox.c:943
+#: infobox.c:980
 msgid "Write"
 msgstr "Писати"
 
-#: infobox.c:945
+#: infobox.c:983
 msgid "Exec"
 msgstr "Виконувати"
 
-#: infobox.c:962
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:969
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:976
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Липкий"
 
-#: infobox.c:998
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<ніщо>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Символічне посилання"
 
-#: infobox.c:1001
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "програма ROX"
 
-#: infobox.c:1009
+#: infobox.c:1100
 msgid "mounted"
 msgstr "змонтовано"
 
-#: infobox.c:1009
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "відмонтовано"
 
-#: infobox.c:1013
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Точка монтування для %s (%s)"
 
-#: infobox.c:1016
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Точка монтування (%s)"
 
-#: main.c:93
+#: log.c:54
+#, fuzzy
+msgid "ROX-Filer started"
+msgstr "ROX-Filer"
+
+#: log.c:115
+#, fuzzy, c-format
+msgid "%s on %d items"
+msgstr "%d предметів"
+
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Копіювати..."
+
+#: log.c:139
+#, fuzzy
+msgid "Item"
+msgstr "Редагувати предмет"
+
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Датами"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Налаштування"
+
+#: main.c:95
 msgid ""
 "Copyright (C) 2005 Thomas Leonard.\n"
 "ROX-Filer comes with ABSOLUTELY NO WARRANTY,\n"
@@ -1877,15 +2045,15 @@ msgstr ""
 "згідно з положеннями Загальної Публічної Ліцензії Ґну.\n"
 "Більше інформації про це можна знайти в файлі COPYING.\n"
 
-#: main.c:102
+#: main.c:104
 msgid "Try `ROX-Filer/AppRun --help' for more information.\n"
 msgstr "Спробуйте `ROX-Filer/AppRun --help' задля детальнішої інформації.\n"
 
-#: main.c:105
+#: main.c:107
 msgid "Try `ROX-Filer/AppRun -h' for more information.\n"
 msgstr "Спробуйте `ROX-Filer/AppRun -h' задля детальнішої інформації.\n"
 
-#: main.c:107
+#: main.c:109
 msgid ""
 "NOTE: Your system does not support long options - \n"
 "you must use the short versions instead.\n"
@@ -1895,7 +2063,7 @@ msgstr ""
 "замість них використовуйте короткі версії параметрів.\n"
 "\n"
 
-#: main.c:113
+#: main.c:115
 #, fuzzy, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
@@ -1918,6 +2086,7 @@ msgid ""
 "  -S, --rox-session\tuse default panel and pinboard options, and -n\n"
 "  -t, --top=PANEL\topen PANEL as a top-edge panel\n"
 "  -u, --user\t\tshow user name in each window \n"
+"  -U, --url=URL\t\topen file or directory in URI form\n"
 "  -v, --version\t\tdisplay the version information and exit\n"
 "  -x, --examine=FILE\tFILE has changed - re-examine it\n"
 "\n"
@@ -1950,7 +2119,7 @@ msgstr ""
 "\n"
 "Повідомляйте про збої на "
 
-#: main.c:232
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1962,7 +2131,7 @@ msgstr ""
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Пробую продовжити..."
 
-#: main.c:390
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
@@ -1970,50 +2139,51 @@ msgstr ""
 "Параметр -o більше не використовується. Ви можете увімкнути переадресацію "
 "переписування через вікно налаштувань."
 
-#: main.c:511
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Працюю як користувач '%s'"
 
-#: main.c:676
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Скомпільований з версією GTK %s\n"
 
-#: main.c:677
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Працюю з версією GTK %d.%d.%d\n"
 
-#: main.c:681
+#: main.c:693
 msgid "features set at compile time"
 msgstr "можливості вказуються при компіляції"
 
-#: main.c:682
+#: main.c:694
 msgid "Large File Support"
 msgstr "Підтримка великих файлів"
 
-#: main.c:689
-msgid "Dnotify support"
-msgstr "Підтримка Dnotify"
-
-#: main.c:696
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Бінарна сумісність"
 
-#: main.c:698
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Так (можу працювати з старшими версіями glibc)"
 
-#: main.c:700
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Ні (apsymbols.h не знайдено)"
 
-#: main.c:704
+#: main.c:709
 msgid "Extended attribute support"
 msgstr "Підтримка розширених атрибутів"
 
-#: main.c:833
+#: main.c:856
+#, fuzzy, c-format
+msgid "Unable to read '%s': %s"
+msgstr "Неможливо відкрити файл '%s': %s"
+
+#: main.c:895
 #, c-format
 msgid ""
 "Left-click to run %s.\n"
@@ -2022,231 +2192,323 @@ msgstr ""
 "Ліва кнопка миші: запустити %s.\n"
 "Права кнопка миші: показати список версій."
 
-#: menu.c:177 tips:55
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Помилка створення '%s': %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Зберегти як:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Вигляд"
 
-#: menu.c:178 tips:60
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "Піктограми"
 
-#: menu.c:179
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "Піктограми, з..."
 
-#: menu.c:180 tips:77
-msgid "Sizes"
-msgstr "Розмірами"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Теми піктограм"
 
-#: menu.c:182 tips:267
-msgid "Types"
-msgstr "Типи"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Права"
 
-#: menu.c:183 tips:80
-msgid "Times"
-msgstr "Датами"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Піктограми, з..."
 
-#: menu.c:184 tips:61 tips:95
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "Список"
 
-#: menu.c:186
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "Більші піктограми"
 
-#: menu.c:187
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "Менші піктограми"
 
-#: menu.c:188 tips:74
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Автоматично"
 
-#: menu.c:190
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Сортувати за назвою"
 
-#: menu.c:191
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Сортувати за типом"
 
-#: menu.c:192
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Сортувати за датою"
 
-#: menu.c:193
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Сортувати за датою"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Сортувати за датою"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Сортувати за розміром"
 
-#: menu.c:194
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Права"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "Сортувати за власником"
 
-#: menu.c:195
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "Сортувати за ґрупою"
 
-#: menu.c:196
+#: menu.c:671
 msgid "Reversed"
 msgstr "Зарезервовано"
 
-#: menu.c:198
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "Показувати приховане"
 
-#: menu.c:199
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Показати файли довідки"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "теки відсутні)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "Фільтрувати файли..."
 
-#: menu.c:200
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Фільтрувати файли..."
+
+#: menu.c:681
+msgid "Filter Directories With Files"
+msgstr ""
+
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "Показати міні-зображення"
 
-#: menu.c:201
+#: menu.c:683
 msgid "Refresh"
 msgstr "Освіжити"
 
-#: menu.c:202
+#: menu.c:684
 #, fuzzy
-msgid "Save Current Display Settings..."
+msgid "Refresh Thumbs"
+msgstr "Освіжити"
+
+#: menu.c:686
+#, fuzzy
+msgid "Save Display Settings..."
 msgstr "Зберегти стандартні налаштування..."
 
-#: menu.c:204
-msgid "Copy..."
-msgstr "Копіювати..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Зберегти стандартні налаштування..."
 
-#: menu.c:205
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Рахувати розмір"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "Переназвати..."
 
-#: menu.c:206
+#: menu.c:700
 msgid "Link..."
 msgstr "Посилання..."
 
-#: menu.c:210
+#: menu.c:708
 msgid "Send To..."
 msgstr "Відіслати до..."
 
-#: menu.c:215
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Розширені атрибути"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Рахувати розмір"
 
-#: menu.c:216
+#: menu.c:723
 msgid "Set Type..."
 msgstr "Вказати тип..."
 
-#: menu.c:220 toolbar.c:154
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Виділення"
 
-#: menu.c:221
+#: menu.c:733
 msgid "Select All"
 msgstr "Виділити все"
 
-#: menu.c:222
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "Очистити виділення"
 
-#: menu.c:223
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "Перевернути виділення"
 
-#: menu.c:224
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "Виділити за назвою..."
 
-#: menu.c:225
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Виділити якщо..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Виділити якщо..."
 
-#: menu.c:227
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Новий"
 
-#: menu.c:229
+#: menu.c:752
 msgid "Blank file"
 msgstr "Чистий файл"
 
-#: menu.c:231 tasklist.c:306
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Вікно"
 
-#: menu.c:232
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "Догори, нове вікно"
 
-#: menu.c:233
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "Догори, це вікно"
 
-#: menu.c:234
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "Нове вікно"
 
-#: menu.c:236
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "Показати закладки"
 
-#: menu.c:237
+#: menu.c:766
+#, fuzzy
+msgid "Show Log"
+msgstr "Показати інфо?"
+
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "Іти за символічними посиланнями"
 
-#: menu.c:238
+#: menu.c:769
 msgid "Resize Window"
 msgstr "Адаптувати розмір вікна"
 
-#: menu.c:241
+#: menu.c:771
 msgid "Close Window"
 msgstr "Закрити вікно"
 
-#: menu.c:243
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Вказати шлях..."
 
-#: menu.c:244
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Команда"
 
-#: menu.c:245
+#: menu.c:780
 msgid "Terminal Here"
 msgstr "Термінал тут"
 
-#: menu.c:246
+#: menu.c:782
 msgid "Switch to Terminal"
 msgstr "Переключитися на термінал"
 
-#: menu.c:714
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr ""
-"Ви повинні кнопкою 2, тримаючи Shift, клацнути на файл, щоб відіслати його "
-"кудись"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Налаштувати меню..."
 
-#: menu.c:750
+#: menu.c:976
 msgid "Next Click"
 msgstr "Наступний клік"
 
-#: menu.c:772
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d предметів"
 
-#: menu.c:860
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "Відкрити відмонтованим"
 
-#: menu.c:863
+#: menu.c:1097
 msgid "Show Target"
 msgstr "Показати ціль"
 
-#: menu.c:865
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "Заглянути в середину"
 
-#: menu.c:867
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "Відкрити як текст"
 
-#: menu.c:1027
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2260,15 +2522,15 @@ msgstr ""
 "бібліотеки Сі, або просто тому, що файлова система повинна бути змонтована з "
 "правильним параметром ('user_xattr' на Linux'і)."
 
-#: menu.c:1033
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr "Призначення типу не підтримується для деяких з цих файлів"
 
-#: menu.c:1068
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "_Відносне посилання"
 
-#: menu.c:1074
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2280,44 +2542,57 @@ msgstr ""
 "вимкнено, посилання буде містити шлях від кореневої теки - використовуйте "
 "це, якщо посилання буде переміщуватися, але ціль - ні."
 
-#: menu.c:1144
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "Новий шлях не є абсолютний"
 
-#: menu.c:1210
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr ""
 "Символічне посилання з '%s' вже існує. Замінити його на посилання до '%s'?"
 
-#: menu.c:1216
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Замінити"
 
-#: menu.c:1336 menu.c:1377 menu.c:1437
-msgid "Create"
-msgstr "Створити"
-
-#: menu.c:1337
+#: menu.c:1704
 msgid "NewDir"
 msgstr "Нова тека"
 
-#: menu.c:1351 menu.c:1357
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Помилка створення '%s': %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Створити"
 
-#: menu.c:1378
+#: menu.c:1755
 msgid "NewFile"
 msgstr "Новий файл"
 
-#: menu.c:1396
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "Помилка створення нового файлу: не можу знайти заготовку для %s"
 
-#: menu.c:1467
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Створіть символічні посилання ні потрібні вам програми в цю теку. Вони "
+"з'являться в меню для всі предметів цього типу (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2329,8 +2604,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "Меню 'Відіслати до' дає можливість швидко відіслати якісь файли програмі."
 "Перечислені програми є в наступних теках:\n"
@@ -2344,21 +2620,21 @@ msgstr ""
 "будуть відкриватися тільки для файлів відповідного типу. `.group' "
 "використовуються тільки коли виділено багато файлів."
 
-#: menu.c:1478
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
 msgstr ""
-"Я зараз покажу вам теку 'Відіслати До'. Ви повинні створити тут посилання"
-"(Ctrl+Shift перетягування) на ті програми, які хочете бачити в меню "
+"Я зараз покажу вам теку 'Відіслати До'. Ви повинні створити тут "
+"посилання(Ctrl+Shift перетягування) на ті програми, які хочете бачити в меню "
 "'Відіслати До'."
 
-#: menu.c:1481 menu.c:1521
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr ""
 "Значення змінної середовища CHOICESPATH забороняє налаштування - мені шкода."
 
-#: menu.c:1514
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2377,7 +2653,7 @@ msgstr ""
 "%s\n"
 "%s\n"
 
-#: menu.c:1519
+#: menu.c:1936
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
@@ -2385,15 +2661,21 @@ msgstr ""
 "Я покажу вам вашу теку 'Заготовки'. Ви повинні помістити туди будь-яку "
 "заготовку, яку ви хочете використовувати у rox'і."
 
-#: menu.c:1636
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Налаштувати"
 
-#: menu.c:1702
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Налаштувати меню..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Це вже є канонічною назвою для цієї теки."
 
-#: menu.c:1733
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2401,71 +2683,103 @@ msgstr ""
 "Ви не можете відкрити друге вікно для цієї теки, бо параметр 'Унікальні "
 "вікна' увімкнено в вікні налаштувань."
 
-#: menu.c:1859
-msgid "Copy ... ?"
-msgstr "Копіювати ... ?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1862
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Скопіювати %s як %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Скопіювати %s як %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Переназвати ... ?"
 
-#: menu.c:1865
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Створити посилання ... ?"
 
-#: menu.c:1868
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Відкрити напряму ... ?"
 
-#: menu.c:1871
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Властивості ... ?"
 
-#: menu.c:1874
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Розширені атрибути"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Вказати тип для ... ?"
 
-#: menu.c:1877
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Вказати дію для ... ?"
 
-#: menu.c:1880
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Призначити піктограму для ... ?"
 
-#: menu.c:1883
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Відіслати ... до ... ?"
 
-#: menu.c:1886
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "ВИДАЛИТИ ... ?"
 
-#: menu.c:1889
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Порахувати розмір для ... ?"
 
-#: menu.c:1892
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Призначити права для ... ?"
 
-#: menu.c:1895
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Шукати в середині ... ?"
 
-#: menu.c:1959
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Копіювати ... ?"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Ви не можете робити це одночасно більше ніж над одним предметом"
 
-#: menu.c:1991
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Переназвати"
 
-#: menu.c:1996
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Створити посилання"
 
-#: menu.c:2025
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2487,7 +2801,7 @@ msgstr ""
 "\tgtk-can-change-accels = 1\n"
 "\t(це працює тільки якщо НЕ використовується XSETTINGS)"
 
-#: menu.c:2036
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2507,31 +2821,40 @@ msgstr ""
 "Ця комбінація клавіш з'явиться біля пункту меню, і його можна буде викликати "
 "за допомогою клавіатури."
 
-#: menu.c:2051
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Призначити комбінація клавіш"
 
-#: minibuffer.c:129
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Йти до:"
 
-#: minibuffer.c:130
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Команда:"
 
-#: minibuffer.c:131
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Виділити якщо:"
 
-#: minibuffer.c:132
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Виділити за назвою:"
 
-#: minibuffer.c:133
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Виділити якщо:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Зразок:"
 
-#: minibuffer.c:262
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
@@ -2539,14 +2862,34 @@ msgstr ""
 "Впишіть назву файлу, і я вам його покажу. Натисніть Tab щоб автоматично "
 "доповнити назву файлу.Escape щоб закрити міні-буфер."
 
-#: minibuffer.c:268
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
 "Впишіть команду в стилі командної оболонки, яку потрібно запустити. Клацніть "
 "на файл щоб додати його до буферу."
 
-#: minibuffer.c:273
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Впишіть зразок, щоб виділити всі підходящі файли:\n"
+"\n"
+"? означає будь-який знак\n"
+"* означає скільки завгодно будь-яких знаків\n"
+"[aA] означає 'a' або 'A'\n"
+"[a-z] означає будь-який знак від a до z (малі букви)\n"
+"*.png означає все, що кінчається на '.png'"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2564,50 +2907,63 @@ msgstr ""
 "[a-z] означає будь-який знак від a до z (малі букви)\n"
 "*.png означає все, що кінчається на '.png'"
 
-#: minibuffer.c:285
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
 msgstr ""
 "Впишіть зразок назв файлів, які треба показати. Пустий буфер вимикає фільтр."
 
-#: minibuffer.c:905
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Впишіть зразок назв файлів, які треба показати. Пустий буфер вимикає фільтр."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Неправильний зразок пошуку"
 
-#: mount.c:372
+#: mount.c:103
+#, c-format
+msgid "File system table \"%s\" not found, cannot monitor system mounts"
+msgstr ""
+
+#: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s загалом, %s використано, %s вільно (%.1f %%)"
 
-#: options.c:275
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "ROX-Filer перетворив ваш старий файл налаштувань в новий XML формат"
 
-#: options.c:533 options.c:1258
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(використовувати типове)"
 
-#: options.c:803
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Внутрішня помилка: %s нечитабельний"
 
-#: options.c:914
+#: options.c:929
 msgid "Options"
 msgstr "Налаштування"
 
-#: options.c:959
+#: options.c:974
 msgid "_Revert"
 msgstr "_Повернути"
 
-#: options.c:965
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr ""
 "Повернути всі налаштування до таких, якими вони були, коли відкривалося "
 "вікно налаштувань."
 
-#: options.c:980
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2616,24 +2972,34 @@ msgstr ""
 "Налаштування будуть збережені як:\n"
 "%s"
 
-#: options.c:988
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(збереження заборонене через CHOICESPATH)"
 
-#: options.c:1161 usericons.c:452
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Помилка збереження %s: %s"
 
-#: options.c:1795
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Відсутнє '='"
 
-#: panel.c:438
+#: panel.c:326
+#, fuzzy, c-format
+msgid "Unable to replace '%s'"
+msgstr "Неможливо відкрити файл '%s': %s"
+
+#: panel.c:330
+#, c-format
+msgid "Unable to save '%s'"
+msgstr ""
+
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "Ваш старий файл панелі перетворено в новий XML формат."
 
-#: panel.c:546
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
@@ -2641,20 +3007,20 @@ msgstr ""
 "Ви спробували закрити панель через менеджер вікон - це часто стається "
 "випадково...дійсно закрити?"
 
-#: panel.c:648
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Відсутнє < або > в файлі панелі"
 
-#: panel.c:1533
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Помилка збереження панелі %s: %s"
 
-#: panel.c:1849
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "Аплет завершив роботу навіть не створивши ґрафічного інтерфейсу!"
 
-#: panel.c:1948
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2663,65 +3029,59 @@ msgstr ""
 "Помилка запуску аплета:\n"
 "%s"
 
-#: panel.c:2358
+#: panel.c:2751
+#, fuzzy
+msgid "Are you sure you want to remove this panel from the desktop?"
+msgstr "Ви впевнені що хочете відкрити %d вікон?"
+
+#: panel.c:2754 panel.c:2781
+#, fuzzy
+msgid "Remove Panel"
+msgstr "Викинути предмет(и)"
+
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Налаштування панелі..."
 
-#: panel.c:2450
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Xinerama монітор %d відсутній"
 
-#: panel.c:2525
-msgid "Panel Options"
-msgstr "Налаштування панелі"
+#: panel.c:2897
+msgid "Top"
+msgstr ""
 
-#: panel.c:2540
-#, c-format
-msgid "Panel: %s"
-msgstr "Панель: %s"
-
-#: panel.c:2548
-msgid "Select the panel's position:"
-msgstr "Вибрати позицію панелі:"
-
-#: panel.c:2554
-msgid "Top-edge panel"
-msgstr "Верхня панель"
-
-#: panel.c:2555
-msgid "Top edge"
-msgstr "Верхній край"
-
-#: panel.c:2556
-msgid "Bottom edge panel"
-msgstr "Нижня панель"
-
-#: panel.c:2557
-msgid "Bottom edge"
+#: panel.c:2899
+#, fuzzy
+msgid "Bottom"
 msgstr "Нижній край"
 
-#: panel.c:2558
-msgid "Left edge panel"
-msgstr "Ліва панель"
-
-#: panel.c:2559
-msgid "Left edge"
+#: panel.c:2901
+#, fuzzy
+msgid "Left"
 msgstr "Лівий край"
 
-#: panel.c:2560
-msgid "Right-edge panel"
-msgstr "Права панель"
-
-#: panel.c:2561
-msgid "Right edge"
+#: panel.c:2903
+#, fuzzy
+msgid "Right"
 msgstr "Правий край"
+
+#: panel.c:2905
+#, fuzzy
+msgid "Default"
+msgstr "Типовий розмір:"
+
+#: panel.c:2909
+#, fuzzy
+msgid "Unknown side"
+msgstr "Невідомий"
 
 #: pinboard.c:354
 msgid "Your old pinboard file has been converted to the new XML format."
 msgstr "Ваш старий файл стільниці перетворено в новий XML формат."
 
-#: pinboard.c:637
+#: pinboard.c:711
 msgid ""
 "The backdrop handler must be an application directory. Drag an application "
 "directory into the Set Backdrop dialog box, or (for programmers) pass it to "
@@ -2731,7 +3091,7 @@ msgstr ""
 "програми в діалог вибору тла, або (для програмістів) надайте її методу SOAP "
 "SetBackdropApp."
 
-#: pinboard.c:656
+#: pinboard.c:730
 msgid ""
 "You can only set the backdrop to an image or to a program which knows how to "
 "manage ROX-Filer's backdrop.\n"
@@ -2745,52 +3105,65 @@ msgstr ""
 "Програмісти: файл AppInfo.xml повинен містити елемент CanSetBackdrop, як "
 "описано в підручнику про ROX-Filer."
 
-#: pinboard.c:676
+#: pinboard.c:750
 msgid "Set backdrop"
 msgstr "Призначити тло"
 
-#: pinboard.c:687
+#: pinboard.c:761
 msgid "Choose a style and drag an image in:"
 msgstr "Виберіть стиль і перетягніть сюди зображення:"
 
-#: pinboard.c:700
+#: pinboard.c:774
 msgid "Centre the image without scaling it"
 msgstr "Центрувати зображення, не міняючи його розміру"
 
-#: pinboard.c:701
+#: pinboard.c:775
 msgid "Centre"
 msgstr "Центрувати"
 
-#: pinboard.c:702
+#: pinboard.c:776
 msgid "Scale the image to fit the backdrop area, without distorting it"
 msgstr ""
 "Збільшити зображення щоб покрити всю стільницю, але дотримуватися пропорцій"
 
-#: pinboard.c:704
+#: pinboard.c:778
 msgid "Scale"
 msgstr "Збільшити"
 
-#: pinboard.c:705
+#: pinboard.c:779
+#, fuzzy
+msgid ""
+"Scale the image to fit the backdrop area, regardless of image dimensions - "
+"overscale"
+msgstr ""
+"Збільшити зображення щоб покрити всю стільницю, але дотримуватися пропорцій"
+
+#: pinboard.c:781
+#, fuzzy
+msgid "Fit"
+msgstr "Фільтр"
+
+#: pinboard.c:782
 msgid "Stretch the image to fill the backdrop area"
 msgstr "Розтягнути зображення щоб покрити всю стільницю"
 
-#: pinboard.c:706
+#: pinboard.c:783
 msgid "Stretch"
 msgstr "Розтягнути"
 
-#: pinboard.c:707
+#: pinboard.c:784
 msgid "Tile the image over the backdrop area"
 msgstr "Множити зображення по всій стільниці"
 
-#: pinboard.c:708
+#: pinboard.c:785
 msgid "Tile"
 msgstr "Множити"
 
-#: pinboard.c:713
+#: pinboard.c:790
 msgid "Drop an image here"
 msgstr "Вкиньте сюди зображення"
 
-#: pinboard.c:774
+#: pinboard.c:851
 msgid ""
 "No pinboard was in use... the 'Default' pinboard has been selected. Use 'rox "
 "-p=Default' to turn it on in future."
@@ -2798,30 +3171,35 @@ msgstr ""
 "Жодна стільниця не використовувалася... вибрана стільниця з назвою "
 "'Default'. Використовуйте'rox -p=Default' щоб увімкнути її в майбутньому."
 
-#: pinboard.c:868
+#: pinboard.c:945
 msgid ""
 "Only files (and certain applications) can be used to set the background "
 "image."
 msgstr "Тільки файли (і деякі програми) можна використовувати як тло."
 
-#: pinboard.c:1492
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Відсутнє '>' в назві піктограми"
 
-#: pinboard.c:1501
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Відсутнє ',' після назви піктограми"
 
-#: pinboard.c:1588
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Помилка збереження стільниці %s: %s"
 
-#: pinboard.c:2132
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Тло..."
 
-#: pinboard.c:2225
+#: pinboard.c:2250
+#, fuzzy
+msgid "Add Panel"
+msgstr "Панель"
+
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2832,7 +3210,7 @@ msgstr ""
 "%s\n"
 "Тло вимкнено."
 
-#: pixmaps.c:962
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2841,87 +3219,40 @@ msgstr ""
 "Не можу викинути міні-зображення в %s:\n"
 "%s"
 
-#: pixmaps.c:983
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Нема чого викидати"
 
-#: pixmaps.c:996
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Очистити дисковий кеш міні-зображень"
 
-#: remote.c:660
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Невідомий стиль '%s'"
 
-#: remote.c:682
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Невідомий тип подробиць"
 
-#: remote.c:710
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Невідомий тип сортування '%s'"
 
-#: remote.c:1160
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Спроба виконати невідомий метод SOAP '%s'"
 
-#: rox_gettext.c:93
-#, c-format
-msgid "Invalid .gmo translation file (too short): %s"
-msgstr "Неправильний файл перекладу .gmo (закороткий): %s"
-
-#: rox_gettext.c:106
-#, c-format
-msgid "Invalid .gmo translation file (GNU magic number not found): %s"
-msgstr "Неправильний файл перекладу .gmo (чарівний номер GNU не знайдено): %s"
-
-#: run.c:98 run.c:151
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "Програма %s не знайдена, викинута?"
 
-#: run.c:301
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "Файл відсутній, або я не можу до нього дістатися: %s"
-
-#: run.c:306
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "Я не знаю як відкрити '%s'"
-
-#: run.c:337
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"Програми:\n"
-"Це тека програми - ви можете її запустити, або заглянути в середину(тримаючи "
-"Shift і відкриваючи). Більшість програм надають тут свою довідку, але ця - "
-"ні."
-
-#: run.c:421
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "Не можу відіслати дані до програми: %s"
-
-#: run.c:451
-#, c-format
-msgid "Could not read link: %s"
-msgstr "Не можу прочитати посилання: %s"
-
-#: run.c:479
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr "Неактуальне посилання (або ви не маєте прав щоб піти за ним): %s"
-
-#: run.c:516
+#: run.c:359
 #, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
@@ -2932,7 +3263,7 @@ msgstr ""
 "дію через меню файлу (Файл/Вказати дію), або просто перетягнути цей файл на "
 "потрібну програму.%s"
 
-#: run.c:522
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -2944,7 +3275,64 @@ msgstr ""
 "Зауважте: Якщо це файл-програма, яку ви хочете запускати, ви повинні надати "
 "право виконувати цей файл собі (меню Файл/Права)."
 
-#: run.c:677
+#: run.c:373
+#, c-format
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "Файл відсутній, або я не можу до нього дістатися: %s"
+
+#: run.c:378
+#, c-format
+msgid "I don't know how to open '%s'"
+msgstr "Я не знаю як відкрити '%s'"
+
+#: run.c:409
+#, fuzzy, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' більше не є символічним посиланням"
+
+#: run.c:420
+#, fuzzy, c-format
+msgid "%s not accessable"
+msgstr "Тека '%s' недоступна"
+
+#: run.c:428
+#, fuzzy, c-format
+msgid "Non-local URL %s"
+msgstr "%s не можна виконувати"
+
+#: run.c:445
+#, fuzzy, c-format
+msgid "%s: no handler for %s"
+msgstr "Помилка в програмі %s: %s"
+
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
+msgstr ""
+"Програми:\n"
+"Це тека програми - ви можете її запустити, або заглянути в середину(тримаючи "
+"Shift і відкриваючи). Більшість програм надають тут свою довідку, але ця - "
+"ні."
+
+#: run.c:549
+#, c-format
+msgid "Could not send data to program: %s"
+msgstr "Не можу відіслати дані до програми: %s"
+
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "Не можу прочитати посилання: %s"
+
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
+msgstr "Неактуальне посилання (або ви не маєте прав щоб піти за ним): %s"
+
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -2968,93 +3356,131 @@ msgstr ""
 "хвилюватися. Якщо ні, ви повинні перевірити, або навіть просто викинути "
 "існуючі дії над файлами. "
 
-#: run.c:690
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Виправити \"дірку\" в безпеці)"
 
-#: support.c:272
-msgid "B"
-msgstr "B"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:351
+#: support.c:381
 msgid "byte"
 msgstr "байт"
 
-#: support.c:1567 support.c:1621
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
 msgstr "Не можу відкрити і дослідити файл'%s': %s "
 
-#: support.c:1578 support.c:1632
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
 msgstr "Не можу виконати mmap над файлом '%s': %s"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close"
 msgstr "Закрити"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close filer window"
 msgstr "Закрити вікно файлера"
 
-#: toolbar.c:117
+#: toolbar.c:120
 msgid "Up"
 msgstr "Догори"
 
-#: toolbar.c:117
-msgid "Change to parent directory"
-msgstr "Перейти на рівень вище"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:121
+#: toolbar.c:126
 msgid "Home"
 msgstr "Домівка"
 
-#: toolbar.c:121
-msgid "Change to home directory"
-msgstr "Перейти в домашню теку"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks"
-msgstr "Закладки"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks menu"
-msgstr "Меню закладок"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:129
+#: toolbar.c:138
 msgid "Scan"
 msgstr "Сканувати"
 
-#: toolbar.c:129
-msgid "Rescan directory contents"
-msgstr "Пересканувати зміст теки"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:133
-msgid "Change icon size"
-msgstr "Змінити розмір піктограм"
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Розмір"
 
-#: toolbar.c:137
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Автоматично"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
 msgstr "Авто-адаптація розміру вікна"
 
-#: toolbar.c:141
-msgid "Show extra details"
-msgstr "Показати додаткові подробиці"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Список"
 
-#: toolbar.c:145
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
 msgstr "Сортування"
 
-#: toolbar.c:145
+#: toolbar.c:165
 msgid "Change sort criteria"
 msgstr "Змінити критерію сортування"
 
-#: toolbar.c:149
-msgid "Hidden"
-msgstr "Приховане"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:149
+#: toolbar.c:169
 msgid ""
 "Left: Show/hide hidden files\n"
 "Right: Show/hide thumbnails"
@@ -3062,111 +3488,153 @@ msgstr ""
 "Ліва кнопка миші: показати/сховати приховані файли\n"
 "Права кнопка миші: показати/сховати міні-зображення"
 
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
 
-#: toolbar.c:154
-msgid "Select all/invert selection"
+#: toolbar.c:174
+#, fuzzy
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+"Ліва кнопка миші: показати/сховати приховані файли\n"
+"Права кнопка миші: показати/сховати міні-зображення"
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
 msgstr "Виділити все/перевернути виділення"
 
-#: toolbar.c:158
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
 msgstr "Показати довідку ROX-Filer'а"
 
-#: toolbar.c:221
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
 msgstr " (%u прихованих)"
 
-#: toolbar.c:229 tips:83
+#: toolbar.c:276 tips:79
 msgid "items"
 msgstr "предметів"
 
-#: toolbar.c:229
+#: toolbar.c:276
 msgid "item"
 msgstr "предмет"
 
-#: toolbar.c:232
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
 msgstr "Пусто%s"
 
-#: toolbar.c:251
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
 msgstr "%u виділено (%s)"
 
-#: toolbar.c:423
+#: toolbar.c:535
 msgid "Sort by name"
 msgstr "Сортувати за назвою"
 
-#: toolbar.c:423
+#: toolbar.c:535
 msgid "Sort by type"
 msgstr "Сортувати за типом"
 
-#: toolbar.c:423
+#: toolbar.c:535
 msgid "Sort by date"
 msgstr "Сортувати за датою"
 
-#: toolbar.c:424
+#: toolbar.c:535
 msgid "Sort by size"
 msgstr "Сортувати за розміром"
 
-#: toolbar.c:424
+#: toolbar.c:536
 msgid "Sort by owner"
 msgstr "Сортувати за власником"
 
-#: toolbar.c:424
+#: toolbar.c:536
 msgid "Sort by group"
 msgstr "Сортувати за ґрупою"
 
-#: toolbar.c:458
+#: toolbar.c:568
 msgid "ascending"
 msgstr "зростаючи"
 
-#: toolbar.c:458
+#: toolbar.c:568
 msgid "descending"
 msgstr "спадаючий"
 
-#: type.c:207
+#: toolbar.c:891
+msgid "_N_Items_"
+msgstr ""
+
+#: type.c:221
 msgid "Sym link"
 msgstr "Символічне посилання"
 
-#: type.c:209
+#: type.c:223
 msgid "Mount point"
 msgstr "Точка монтування"
 
-#: type.c:211
+#: type.c:225
 msgid "App dir"
 msgstr "Тека програми"
 
-#: type.c:218
+#: type.c:232
 msgid "Dir"
 msgstr "Тека"
 
-#: type.c:220
+#: type.c:234
 msgid "Char dev"
 msgstr "Знаковий пристрій"
 
-#: type.c:222
+#: type.c:236
 msgid "Block dev"
 msgstr "Блоковий пристрій"
 
-#: type.c:224
+#: type.c:238
 msgid "Pipe"
 msgstr "Труба"
 
-#: type.c:226
+#: type.c:240
 msgid "Socket"
 msgstr "Розетка"
 
-#: type.c:228
+#: type.c:242
 msgid "Door"
 msgstr "Двері"
 
-#: type.c:231
+#: type.c:245
 msgid "Unknown"
 msgstr "Невідомий"
 
-#: type.c:496
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3176,71 +3644,71 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:677
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Це не програма! Дайте мені програму!"
 
-#: type.c:737
+#: type.c:839
 msgid "No run action defined"
 msgstr "Жодна дія не вказана"
 
-#: type.c:741
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Помилка в програмі %s: %s"
 
-#: type.c:756
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Неправильна програма %s (поганий AppRun)"
 
-#: type.c:767
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "%s не можна виконувати"
 
-#: type.c:800
+#: type.c:902
 msgid "Set run action"
 msgstr "Вказати дію"
 
-#: type.c:806
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 "Якщо не призначена дія для специфічного типу, використовувати це як типовий "
 "варіант."
 
-#: type.c:808
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Призначити дію для всіх `%s/<будь-що>'"
 
-#: type.c:812
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Використовувати цю програму для всіх файлів цього типу."
 
-#: type.c:814
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Тільки для типу `%s' (%s/%s)"
 
-#: type.c:820
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Вкиньте сюди потрібну програму"
 
-#: type.c:835
+#: type.c:963
 msgid "OR"
 msgstr "АБО"
 
-#: type.c:842
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Впишіть команду:"
 
-#: type.c:871
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Використовувати команду"
 
-#: type.c:901
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
@@ -3248,43 +3716,29 @@ msgstr ""
 "Дія вже визначена і це досить велика програма - ви впевнені що хочете "
 "викинути її?"
 
-#: type.c:912
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Не можу викинути %s: %s"
 
-#: type.c:949
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "Збереження налаштувань заборонено через змінну CHOICESPATH"
 
-#: type.c:1224
-#, c-format
-msgid ""
-"Icon theme '%s' does not contain MIME icons. Using ROX default theme instead."
-msgstr "Тема піктограм '%s' не містить піктограм MIME. Використовую тему ROX."
-
-#: type.c:1239
-#, c-format
+#: type.c:1395
+#, fuzzy, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
-"%s\n"
-"\n"
-"(this may mean that the ROX theme already exists there, but the 'mime-"
-"application:postscript' icon couldn't be loaded for some reason, or %s is a "
-"link to an invalid directory; try deleting it)"
+"%s"
 msgstr ""
-"Не можу створити символічне посилання '%s':\n"
-"%s\n"
-"\n"
-"(це може означати що тема ROX вже там існує, але піктограма 'mime-"
-"application:postscript'не може бути завантажена, або %s - це посилання на "
-"неіснуючу теку; спробуйте його викинути)"
+"Неможливо відв'язати '%s':\n"
+"%s"
 
-#: usericons.c:179
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "Шлях який ви вписали неправильний. Піктограма не зміниться."
 
-#: usericons.c:189 usericons.c:618
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3294,12 +3748,12 @@ msgstr ""
 "або права не дозволяють?\n"
 "Піктограма не зміниться."
 
-#: usericons.c:235
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Дійсно викинути піктограму '%s'?"
 
-#: usericons.c:239
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3308,32 +3762,32 @@ msgstr ""
 "Не можу викинути '%s':\n"
 "%s"
 
-#: usericons.c:272
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Призначити піктограму"
 
-#: usericons.c:281
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr ""
 "Використати копію зображення як типову піктограму для всіх файлів цих типів."
 
-#: usericons.c:283
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Призначити піктограму для `%s/<anything>'"
 
-#: usericons.c:288
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr ""
 "Використати копію зображення як типову піктограму для всіх файлів цього типу."
 
-#: usericons.c:290
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Для всіх файлів типу `%s' (%s/%s)"
 
-#: usericons.c:296
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
@@ -3342,12 +3796,12 @@ msgstr ""
 "налаштування буде втрачено, якщо зображення або файл переміститься/"
 "переназветься."
 
-#: usericons.c:299
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Тільки для файлу `%s'"
 
-#: usericons.c:307
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
@@ -3358,19 +3812,19 @@ msgstr ""
 "переміщати цю теку.Це зазвичай найкращий варіант, якщо ви маєте право запису "
 "до цієї теки."
 
-#: usericons.c:313
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Копіювати зображення в теку"
 
-#: usericons.c:319
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Вкиньте сюди зображення"
 
-#: usericons.c:589
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "Призначення піктограми заборонене через CHOICESPATH"
 
-#: usericons.c:633
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3379,165 +3833,72 @@ msgstr ""
 "Помилка створення зображення '%s':\n"
 "%s"
 
-#: view_details.c:942
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
 #, fuzzy
 msgid "Mono font"
 msgstr "Точка монтування"
 
-#: view_details.c:943
+#: view_details.c:1019
 msgid "Font for displaying mono-spaced text"
 msgstr "Шрифт для відображення тексту з однаковою шириною знаків (monospace)"
 
-#: view_details.c:1044
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Назва"
 
-#: view_details.c:1047
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Тип"
 
-#: view_details.c:1050
-msgid "_Permissions"
-msgstr "_Права"
-
-#: view_details.c:1055
-msgid "_Owner"
-msgstr "_Власник"
-
-#: view_details.c:1057
-msgid "_Group"
-msgstr "_Ґрупа"
-
-#: view_details.c:1059
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Розмір"
 
-#: view_details.c:1065
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Права"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_Власник"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Ґрупа"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "Остання З_міна"
 
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Розширені атрибути"
+
 #: tips:1
-msgid "Translation"
-msgstr "Переклад"
-
-#: tips:2
-msgid "Language"
-msgstr "Мова"
-
-#: tips:3
-msgid "Use the LANG environment variable"
-msgstr "Використовувати змінну середовища LANG"
-
-#: tips:4
-msgid "Basque"
-msgstr "Баскська"
-
-#: tips:5
-msgid "Chinese (traditional)"
-msgstr "Китайська (традиційна)"
-
-#: tips:6
-msgid "Chinese (simplified)"
-msgstr "Китайська (спрощена)"
-
-#: tips:7
-msgid "Czech"
-msgstr "Чеська"
-
-#: tips:8
-msgid "Danish"
-msgstr "Датська"
-
-#: tips:9
-msgid "Dutch"
-msgstr "Голландська"
-
-#: tips:10
-msgid "English (no translation)"
-msgstr "Англійська (без перекладу)"
-
-#: tips:11
-msgid "Estonian"
-msgstr "Естонська"
-
-#: tips:12
-msgid "Finnish"
-msgstr "Фінська"
-
-#: tips:13
-msgid "French"
-msgstr "Французька"
-
-#: tips:14
-msgid "German"
-msgstr "Німецька"
-
-#: tips:15
-msgid "Hungarian"
-msgstr "Угорська"
-
-#: tips:16
-msgid "Japanese"
-msgstr "Японська"
-
-#: tips:17
-msgid "Norwegian"
-msgstr "Норвезька"
-
-#: tips:18
-msgid "Italian"
-msgstr "Італійська"
-
-#: tips:19
-msgid "Polish"
-msgstr "Польська"
-
-#: tips:20
-msgid "Portuguese (Portugal)"
-msgstr "Португальська (Португалія)"
-
-#: tips:21
-msgid "Portuguese (Brasil)"
-msgstr "Португальська (Бразилія)"
-
-#: tips:22
-msgid "Romanian"
-msgstr "Румунська"
-
-#: tips:23
-msgid "Russian"
-msgstr "Російська"
-
-#: tips:24
-msgid "Spanish"
-msgstr "Іспанська"
-
-#: tips:25
-msgid "Swedish"
-msgstr "Шведська"
-
-#: tips:26
-msgid "Ukrainian"
-msgstr "Українська"
-
-#: tips:27
-#, fuzzy
-msgid "Vietnamese"
-msgstr "Переназвати"
-
-#: tips:28
 msgid "Filer windows"
 msgstr "Вікна файлера"
 
-#: tips:29
+#: tips:2
 msgid "Auto-resize filer windows"
 msgstr "Автоматично адаптувати розмір"
 
-#: tips:30
+#: tips:3
 msgid "Never automatically resize"
 msgstr "Ніколи автоматично не адаптувати розмір"
 
-#: tips:31
+#: tips:4
 msgid ""
 "You'll have to resize windows manually, using the window manager, the "
 "`Resize Window' menu entry or by double-clicking on the window background."
@@ -3546,11 +3907,11 @@ msgstr ""
 "допомогою  'Вікно/Адаптувати розмір вікна', або подвійно клацнувши на тло "
 "вікна."
 
-#: tips:32
+#: tips:5
 msgid "Resize when changing the display style"
 msgstr "Адаптувати розмір під час зміни вигляду"
 
-#: tips:33
+#: tips:6
 msgid ""
 "Changing the size of the icons or which details are displayed will resize "
 "the window for you."
@@ -3558,11 +3919,11 @@ msgstr ""
 "Зміна розміру піктограм або зміна в виборі подробиць для показу адаптує "
 "розмір вікна для вас."
 
-#: tips:34
+#: tips:7
 msgid "Always resize"
 msgstr "Завжди адаптувати розмір вікна"
 
-#: tips:35
+#: tips:8
 msgid ""
 "The filer will resize windows whenever it seems useful (that is, when "
 "changing directory or display style)."
@@ -3570,31 +3931,46 @@ msgstr ""
 "Файлер буде адаптувати розмір вікна коли це буде корисним (під час зміни "
 "місцезнаходження, або вигляду)."
 
-#: tips:36
+#: tips:9
 msgid "Largest window size:"
 msgstr "Найбільший розмір вікна:"
 
-#: tips:37
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
-#: tips:38
+#: tips:11
 msgid ""
 "The largest size, as a percentage of the screen size, that the auto-resizer "
 "will resize a window to."
 msgstr ""
-"Найбільший розмір у відсотках від розміру екрану, до якого файлер "
-"може збільшувати вікно."
+"Найбільший розмір у відсотках від розміру екрану, до якого файлер може "
+"збільшувати вікно."
 
-#: tips:39
+#: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Найбільший розмір вікна:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Найбільший розмір у відсотках від розміру екрану, до якого файлер може "
+"збільшувати вікно."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Поведінка вікна"
 
-#: tips:40
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Короткі заголовки вікон"
 
-#: tips:41
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
@@ -3602,11 +3978,11 @@ msgstr ""
 "Використовувати абревіатури у заголовках вікон замість повних 'Сканую, Міні-"
 "зображення, Все...' "
 
-#: tips:42
+#: tips:18
 msgid "Unique windows"
 msgstr "Унікальні вікна"
 
-#: tips:43
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3614,11 +3990,34 @@ msgstr ""
 "Якщо ви відкриваєте теку яка вже відкрита в іншому вікні, то це інше вікно "
 "закривається"
 
-#: tips:44
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Вікно"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Нове вікно на кнопці 1"
 
-#: tips:45
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3627,11 +4026,11 @@ msgstr ""
 "Клацання кнопкою 1 мишки (зазвичай ліва кнопка) відкриває нове вікно. "
 "Клацання кнопкою 2 (середня) використовує поточне вікно."
 
-#: tips:46
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Навігація з поодинчим клацанням"
 
-#: tips:47 tips:141
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
@@ -3641,11 +4040,11 @@ msgstr ""
 "Controlвиділяє його. Якщо цей параметр вимкнено, одинарне клацання виділяє "
 "предмет; подвійне клацання відкриває його."
 
-#: tips:48
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Подвійний клік на тло адаптує розмір вікна"
 
-#: tips:49
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
@@ -3653,15 +4052,15 @@ msgstr ""
 "Подвійне клацання на тло вікна адаптує розмір вікна, так само, як кнопка "
 "\"Авто-адаптація розміру вікна\" на панелі інструментів."
 
-#: tips:50
+#: tips:30
 msgid "Sorting"
 msgstr "Сортування"
 
-#: tips:51
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Теки на початку списку (для сортування за назвою)"
 
-#: tips:52
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
@@ -3669,11 +4068,11 @@ msgstr ""
 "Якщо увімкнено, теки завжди будуть йти спочатку списку, а тоді все решта "
 "(для сортування за назвою)."
 
-#: tips:53
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Назви з великої букви на початку списку (для сортування за назвою)"
 
-#: tips:54
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
@@ -3681,15 +4080,58 @@ msgstr ""
 "Якщо увімкнено, назви з великої букви завжди будуть йти спочатку списку (для "
 "сортування за назвою)."
 
-#: tips:56
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Теки на початку списку (для сортування за назвою)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "с"
+
+#: tips:38
+#, fuzzy
+msgid "Show extended attribute indicator"
+msgstr "Підтримка розширених атрибутів"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "Типові налаштування для нових вікон"
 
-#: tips:57
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "Запозичувати вигляд з попереднього вікна"
 
-#: tips:58
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
@@ -3697,27 +4139,38 @@ msgstr ""
 "Якщо це увімкнути, параметри вигляду для нового вікна будуть взяті з "
 "попереднього вікна. Якщо вимкнено вони будуть такі, як вказано нижче."
 
-#: tips:59
+#: tips:48
 msgid "View type:"
 msgstr "Тип вигляду:"
 
-#: tips:62
+#: tips:51
 msgid "Sort by:"
 msgstr "Сортувати за:"
 
-#: tips:64 tips:79
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Типом"
 
-#: tips:65
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Датою"
 
-#: tips:67
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Датою"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Датою"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Показувати приховане"
 
-#: tips:68
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
@@ -3725,43 +4178,75 @@ msgstr ""
 "Якщо це активовано, файли, чиї назви починаються з крапки, не будуть "
 "приховуватися.Якщо не активовано, такі файли приховуються."
 
-#: tips:69
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Показувати приховане"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr ""
+"Якщо це активовано, файли, чиї назви починаються з крапки, не будуть "
+"приховуватися.Якщо не активовано, такі файли приховуються."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Величезні"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "пікселів"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "Піктограми"
 
-#: tips:70
+#: tips:67
 msgid "Default size:"
 msgstr "Типовий розмір:"
 
-#: tips:71
+#: tips:68
 msgid "Huge Icons"
 msgstr "Величезні"
 
-#: tips:72 tips:258
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Великі"
 
-#: tips:73 tips:257
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "Малі"
 
-#: tips:75
+#: tips:72
 msgid "Default details:"
 msgstr "Типові подробиці:"
 
-#: tips:76
+#: tips:73
 msgid "No details"
 msgstr "Без подробиць"
 
-#: tips:81
-msgid "Automatic small icons:"
+#: tips:74
+msgid "Sizes"
+msgstr "Розмірами"
+
+#: tips:77
+msgid "Times"
+msgstr "Датами"
+
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "Авто-зменшення піктограм"
 
-#: tips:82
-msgid "Change at:"
-msgstr "Переходити на малі піктограми при:"
-
-#: tips:84
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3771,46 +4256,65 @@ msgstr ""
 "розмір піктограм буде малий. В іншому випадку будуть використані великі "
 "піктограми."
 
-#: tips:85
-msgid "Max width (Large icons):"
-msgstr "Максимальна ширина (великі піктограми):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Великі"
 
-#: tips:86 tips:89
-msgid "pixels"
-msgstr "пікселів"
-
-#: tips:87
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "Текст, ширший ніж це, є розбитий на дві лінійки при великих піктограмах. При "
 "величезних піктограмах, текст розбивається, коли він в 2 рази ширший ніж це."
 
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
+
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
 #: tips:88
-msgid "(Small Icons):"
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr ""
+"Якщо це активувати, великі піктограми будуть організовані в стовпчики, не "
+"лінійки."
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
 msgstr "(Малі піктограми):"
 
-#: tips:90
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "Максимальна ширина тексту біля малих піктограм."
 
-#: tips:91
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "Розміщувати малі піктограми вертикально"
 
-#: tips:92
+#: tips:93
 msgid ""
 "If this option is on, then small icons are arranged in columns, not rows."
 msgstr ""
 "Якщо це активувати, малі піктограми будуть організовані в стовпчики, не "
 "лінійки."
 
-#: tips:93
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "Розміщувати великі піктограми вертикально"
 
-#: tips:94
+#: tips:95
 msgid ""
 "If this option is on, then large icons are arranged in columns, not rows."
 msgstr ""
@@ -3818,19 +4322,27 @@ msgstr ""
 "лінійки."
 
 #: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Показувати заголовки стовпчиків"
 
-#: tips:97
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr ""
 "Якщо це активовано, зверху вікна будуть заголовки стовпців (для списку)."
 
-#: tips:98
+#: tips:102
 msgid "Show full type"
 msgstr "Показувати повний тип"
 
-#: tips:99
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
@@ -3838,39 +4350,141 @@ msgstr ""
 "Якщо ввімкнено, буду показувати повний опис для кожного об'єкту, замість "
 "короткого опису базового типу."
 
-#: tips:100
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Максимальна ширина тексту біля малих піктограм."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Показувати заголовки стовпчиків"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr ""
+"Якщо це активовано, зверху вікна будуть заголовки стовпців (для списку)."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr ""
+"Якщо це активовано, зверху вікна будуть заголовки стовпців (для списку)."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr ""
+"Якщо це активовано, зверху вікна будуть заголовки стовпців (для списку)."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr ""
+"Якщо це активовано, зверху вікна будуть заголовки стовпців (для списку)."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr ""
+"Якщо це активовано, зверху вікна будуть заголовки стовпців (для списку)."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr ""
+"Якщо це активовано, зверху вікна будуть заголовки стовпців (для списку)."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "Остання З_міна"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr ""
+"Якщо це активовано, зверху вікна будуть заголовки стовпців (для списку)."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr ""
+"Якщо це активовано, зверху вікна будуть заголовки стовпців (для списку)."
+
+#: tips:128
+msgid "Last Accessed"
+msgstr ""
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr ""
+"Якщо це активовано, зверху вікна будуть заголовки стовпців (для списку)."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Знаряддя/Мінібуфер"
 
-#: tips:101
+#: tips:131
 msgid "Toolbar"
 msgstr "Знаряддя"
 
-#: tips:102
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Тип знарядь:"
 
-#: tips:103
+#: tips:133
 msgid "No toolbar"
 msgstr "Відсутні"
 
-#: tips:104
+#: tips:134
 msgid "Icons only"
 msgstr "Тільки піктограми"
 
-#: tips:105
+#: tips:135
 msgid "Text under icons"
 msgstr "Текст знизу піктограм"
 
-#: tips:106
+#: tips:136
 msgid "Text beside icons"
 msgstr "Текст збоку піктограм"
 
-#: tips:107
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Тільки зображення"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Показувати суми предметів"
 
-#: tips:108
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3880,15 +4494,15 @@ msgstr ""
 "(якщо взагалі є). Коли є виділення, показувати число виділених предметів, і "
 "їх загальний розмір."
 
-#: tips:109
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Виберіть кнопки, які вам потрібні на панелі знарядь:"
 
-#: tips:110
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "Ширина панелі знарядь призначає мінімальну ширину вікна"
 
-#: tips:111
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
@@ -3896,15 +4510,15 @@ msgstr ""
 "Кожне вікно файлера буде достатньо широким, щоб повністю вмістити панель "
 "знарядь."
 
-#: tips:112
+#: tips:143
 msgid "Minibuffer"
 msgstr "Мінібуфер"
 
-#: tips:113
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Гудок, якщо Tab-доповнення не спрацьовує"
 
-#: tips:114
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
@@ -3914,11 +4528,11 @@ msgstr ""
 "видавати гудок, якщо нічого не відбувається (напр., якщо є кілька підходящих "
 "варіантів і наступна буква змінюється)."
 
-#: tips:115
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Гудок, якщо знайдено кілька підходящих варіантів."
 
-#: tips:116
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
@@ -3927,7 +4541,27 @@ msgstr ""
 "видавати гудок, якщо знайдено кілька підходящих варіантів, навіть якщо було "
 "доповнено кілька букв."
 
-#: tips:119
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Відповідальний за завантаження"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Помилка в програмі %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
@@ -3936,11 +4570,11 @@ msgstr ""
 "нього створюється міні-зображення, яке можна бачити на місці піктограми "
 "файлу."
 
-#: tips:120
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Показувати міні-зображення"
 
-#: tips:121
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
@@ -3948,34 +4582,103 @@ msgstr ""
 "Це - типовий параметр для нових вікон. Використовуйте меню 'Вигляд', щоб "
 "активувати міні-зображення для індивідуальних вікон."
 
-#: tips:122
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Показувати міні-зображення"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "Міні-зображення для відео"
 
-#: tips:123
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Кешування міні-зображень"
 
-#: tips:124
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "Щоб пришвидшити роботу з зображеннями, зґенеровані міні-зображення "
 "зберігаються в прихованій теці ~/.thumbnails. Натисніть тут, щоб викинути "
 "збережені міні-зображення. Вони будуть створені знов при потребі."
 
-#: tips:125
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
 #, fuzzy
 msgid "Manage thumbnails"
 msgstr "Показувати міні-зображення"
 
-#: tips:126 tips:203
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Міні-зображення для відео"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "с"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Стільниця"
 
-#: tips:127
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
@@ -3983,47 +4686,47 @@ msgstr ""
 "Коли використовується стільниця, можна перетягати файли і програми на "
 "стільницю щоб створити посилання на них."
 
-#: tips:128 tips:254
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Вигляд"
 
-#: tips:129
+#: tips:179
 msgid "Foreground:"
 msgstr "Текст:"
 
-#: tips:130
+#: tips:180
 msgid "Text shadow:"
 msgstr "Тінь тексту:"
 
-#: tips:131
+#: tips:181
 msgid "Background:"
 msgstr "Тло:"
 
-#: tips:132
+#: tips:182
 msgid "No shadow"
 msgstr "Без тіні"
 
-#: tips:133
+#: tips:183
 msgid "Thin"
 msgstr "Тонка"
 
-#: tips:134
+#: tips:184
 msgid "Thick"
 msgstr "Жирна"
 
-#: tips:135
+#: tips:185
 msgid "Use custom font:"
 msgstr "Використовувати нетиповий шрифт:"
 
-#: tips:136
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Шрифт, який використовується для тексту біля піктограм"
 
-#: tips:137
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Швидке збільшення зображень"
 
-#: tips:138
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
@@ -4031,19 +4734,19 @@ msgstr ""
 "Виберіть між швидким і повільним методом збільшення (або зменшення) "
 "зображень тла. Повільний метод може дати кращі результати."
 
-#: tips:139
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Поведінка стільниці"
 
-#: tips:140
+#: tips:190
 msgid "Single-click to open"
 msgstr "Поодинчий клік відкриває"
 
-#: tips:142
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Тримати піктограми в межах екрану"
 
-#: tips:143
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
@@ -4051,42 +4754,42 @@ msgstr ""
 "Якщо це активоване, піктограми на стільниці завжди будуть розміщуватися в "
 "межах екрану, включаючи текст."
 
-#: tips:144
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Крок сітки для піктограм:"
 
-#: tips:145
+#: tips:195
 msgid "Fine"
 msgstr "Маленький"
 
-#: tips:146
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr ""
 "Використовувати 2-крапкову сітку для розміщення піктограм на стільниці."
 
-#: tips:147
+#: tips:197
 msgid "Medium"
 msgstr "Середній"
 
-#: tips:148
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr ""
 "Використовувати 16-крапкову сітку для розміщення піктограм на стільниці."
 
-#: tips:149
+#: tips:199
 msgid "Coarse"
 msgstr "Великий"
 
-#: tips:150
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr ""
 "Використовувати 32-крапкову сітку для розміщення піктограм на стільниці."
 
-#: tips:151 tips:153
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Приховані вікна"
 
-#: tips:152
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
@@ -4095,11 +4798,11 @@ msgstr ""
 "Більшість менеджерів вікон можуть приховувати (або 'мінімізувати') вікна, і "
 "деякі програми, включаючи ROX-Filer, можуть показувати приховані вікна."
 
-#: tips:154
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Показувати приховані вікна"
 
-#: tips:155
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
@@ -4109,11 +4812,11 @@ msgstr ""
 "маленької кнопки на стільниці. Потребує сумісного менеджера вікон, і "
 "активної стільниці."
 
-#: tips:156
+#: tips:206
 msgid "Show per workspace"
 msgstr "Показувати тільки з теперішньої стільниці"
 
-#: tips:157
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
@@ -4121,39 +4824,39 @@ msgstr ""
 "Якщо активовано, файлер буде показувати приховані вікна тільки з даної "
 "стільниці."
 
-#: tips:158
+#: tips:208
 msgid "Iconify to the"
 msgstr "Розташовувати"
 
-#: tips:159
+#: tips:209
 msgid "top-left"
 msgstr "зверху зліва"
 
-#: tips:160
+#: tips:210
 msgid "top-right"
 msgstr "зверху справа"
 
-#: tips:161
+#: tips:211
 msgid "bottom-left"
 msgstr "знизу зліва"
 
-#: tips:162
+#: tips:212
 msgid "bottom-right"
 msgstr "знизу справа"
 
-#: tips:163
+#: tips:213
 msgid ", going"
 msgstr ", ідучи"
 
-#: tips:164
+#: tips:214
 msgid "horizontally"
 msgstr "горизонтально"
 
-#: tips:165
+#: tips:215
 msgid "vertically"
 msgstr "вертикально"
 
-#: tips:166
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4165,141 +4868,47 @@ msgstr ""
 "нижню межу щоб уникнути розташування піктограм де не треба. Файлер знає про "
 "свої панелі."
 
-#: tips:167
+#: tips:217
 msgid "Top margin"
 msgstr "Верхня межа"
 
-#: tips:168
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Висота верхньої забороненої поверхні"
 
-#: tips:169
+#: tips:219
 msgid "Bottom margin"
 msgstr "Нижня межа"
 
-#: tips:170
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "Висота нижньої забороненої поверхні"
 
-#: tips:171
+#: tips:221
 #, fuzzy
 msgid "Left margin"
 msgstr "Верхня межа"
 
-#: tips:172
+#: tips:222
 #, fuzzy
 msgid "Width of no-go area at left of screen."
 msgstr "Висота верхньої забороненої поверхні"
 
-#: tips:173
+#: tips:223
 #, fuzzy
 msgid "Right margin"
 msgstr "Нижня межа"
 
-#: tips:174
+#: tips:224
 #, fuzzy
 msgid "Width of no-go area at right of screen."
 msgstr "Висота верхньої забороненої поверхні"
 
-#: tips:175
-msgid "Panels"
-msgstr "Панелі"
-
-#: tips:176
-msgid ""
-"Panels are bars of icons that run along the side of the screen. See the "
-"manual for information about using panels."
-msgstr ""
-"Панелі - це \"дошки\" з піктограмами, які розташовуються скраю екрану. "
-"Дивіться підручник задля детальнішої інформації про панелі."
-
-#: tips:177
-msgid "Panel style"
-msgstr "Стиль панелі"
-
-#: tips:178
-msgid "Image and text"
-msgstr "Зображення і текст"
-
-#: tips:179
-msgid "Every panel icon is shown with an image and some text."
-msgstr "Кожен предмет панелі відображається у вигляді піктограми і тексту."
-
-#: tips:180
-msgid "Image only for applications"
-msgstr "Для програм - тільки зображення"
-
-#: tips:181
-msgid ""
-"Applications have just an image, everything else has both an image and text."
-msgstr ""
-"Програми відображаються як піктограма, все решта - як піктограма і текст."
-
-#: tips:182
-msgid "Image only"
-msgstr "Тільки зображення"
-
-#: tips:183
-msgid "Only the image is shown."
-msgstr "Відображається тільки піктограма."
-
-#: tips:184
-msgid "Panel width (thin)"
-msgstr "Ширина панелі (тонка)"
-
-#: tips:185
-msgid "(thick)"
-msgstr "(широка)"
-
-#: tips:186
-msgid "The size of the panels."
-msgstr "Розмір панель."
-
-#: tips:187
-msgid "Do not cover panel"
-msgstr "Не покривати панель"
-
-#: tips:188
-#, fuzzy
-msgid ""
-"Ask the window manager not to cover panels at all when you maximise windows. "
-"Some window managers may not honour this. If unset, the filer asks for just "
-"a couple of pixels at the edge of the screen to remain uncovered, so that "
-"auto-raising works."
-msgstr ""
-"Просити менеджер вікон не покривати панелі коли ви максимізуєте вікно. Деякі "
-"менеджери вікон можуть не підтримувати цього. Якщо вимкнено, файлер просто "
-"просить не покривати певну кількість пікселів на краї екрану, ось як працює "
-"авто-підняття."
-
-#: tips:189
-msgid "Xinerama"
-msgstr "Xinerama"
-
-#: tips:190
-msgid "Confine to Xinerama monitor"
-msgstr "Обмежувати до монітору Xinerama номер"
-
-#: tips:191
-#, fuzzy
-msgid ""
-"If you have an Xinerama multi-monitor setup, use this option to confine the "
-"panels to one monitor instead of spanning them."
-msgstr ""
-"Якщо використовуються кілька моніторів Xinerama, використовуйте цей параметр "
-"щоб обмежити панель тільки одним монітором, замість роз'єднувати її."
-
-#: tips:192
-msgid ""
-"The monitor the panels are confined to in Xinerama mode (numbered from 0)."
-msgstr ""
-"Монітор на якому розміщувати панелі в режимі Xinerama (нумеровані з 0)."
-
-#: tips:193
+#: tips:225
 msgid "Desktop"
 msgstr "Стільниця"
 
-#: tips:194
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
@@ -4307,59 +4916,52 @@ msgstr ""
 "Коли файлер запущено через менеджер сеансів (такий як ROX-Session) файлер "
 "може відкрити панель і/або стільницю. Тут ви вибираєте які."
 
-#: tips:195
+#: tips:227
 msgid "Panel only"
 msgstr "Тільки панелі"
 
-#: tips:196
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Відображається тільки панель."
 
-#: tips:197
+#: tips:229
 msgid "Pinboard only"
 msgstr "Тільки стільниця"
 
-#: tips:198
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "Відображається тільки стільниця"
 
-#: tips:199
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "Панель і стільниця"
 
-#: tips:200
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "Відображається як панель, так і стільниця"
 
-#: tips:201
-msgid "Panel"
-msgstr "Панель"
-
-#: tips:202
-msgid "Enter the name of the panel to show here."
-msgstr "Впишіть тут назву панелі."
-
-#: tips:204
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "Впишіть тут назву стільниці."
 
-#: tips:205
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr "Зміни матимуть ефект тільки при наступному запуску файлера."
 
-#: tips:206
+#: tips:236
+#, fuzzy
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 "Менеджер сеансів активує ці параметри з використовуючи арґумент -S або --rox-"
 "session."
 
-#: tips:207
+#: tips:237
 msgid "Action windows"
 msgstr "Вікна операцій"
 
-#: tips:208
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4367,92 +4969,118 @@ msgstr ""
 "Вікна операцій з'являються коли ви запускаєте якусь операцію,\n"
 "таку, як копіювання або викидання файлів."
 
-#: tips:209
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Авто-запускати (мовчки) такі дії"
 
-#: tips:211
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Копіювати файли не питаючи підтвердження."
 
-#: tips:213
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Переміщати файли не питаючи підтвердження."
 
-#: tips:215
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Створювати посилання не питаючи підтвердження."
 
-#: tips:217
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Викидати файли не питаючи підтвердження."
 
-#: tips:218
+#: tips:248
 msgid "Mount"
 msgstr "Монтування"
 
-#: tips:219
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Монтувати і відмонотовувати файлові системи не питаючи підтвердження."
 
-#: tips:220
+#: tips:250
 msgid "Default settings"
 msgstr "Типові налаштування"
 
-#: tips:222
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Насилу"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr ""
 "Не питаючи підтвердження під час викидання предметів, захищених від запису."
 
-#: tips:224
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Не відображати так багато інформації у вікнах операцій."
 
-#: tips:226
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Також змінювати зміст підтек."
 
-#: tips:229
+#: tips:263
 #, fuzzy
 msgid "Mount commands"
 msgstr "Точка монтування"
 
-#: tips:230
+#: tips:264
 #, fuzzy
 msgid "Mount command"
 msgstr "Точка монтування"
 
-#: tips:231
+#: tips:265
 msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
-msgstr "Команда, котра буде використовуватися щоб змонтувати файлову систему. Якщо вагаєтеся, використайте \"mount\"."
+msgstr ""
+"Команда, котра буде використовуватися щоб змонтувати файлову систему. Якщо "
+"вагаєтеся, використайте \"mount\"."
 
-#: tips:232
+#: tips:266
 #, fuzzy
 msgid "Unmount command"
 msgstr "Відмонтувати"
 
-#: tips:233
+#: tips:267
 msgid ""
 "The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
 "without the first \"n\")."
 msgstr ""
-"Команда, котра буде використовуватися щоб змонтувати файлову систему. Якщо вагаєтеся, використайте \"mount\""
-"(так, без першого \"n\")."
+"Команда, котра буде використовуватися щоб змонтувати файлову систему. Якщо "
+"вагаєтеся, використайте \"mount\"(так, без першого \"n\")."
 
+#: tips:268
+#, fuzzy
+msgid "Eject command"
+msgstr "Точка монтування"
 
-#: tips:234
+#: tips:269
+#, fuzzy
+msgid "The command used to eject removable media. If unsure, use \"eject\"."
+msgstr ""
+"Команда, котра буде використовуватися щоб змонтувати файлову систему. Якщо "
+"вагаєтеся, використайте \"mount\"."
+
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Дреґ-н-драп"
 
-#: tips:235
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Перетягування на предмети"
 
-#: tips:236
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Дозволяти перетягування на предмети в вікнах файлера"
 
-#: tips:237
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
@@ -4462,11 +5090,11 @@ msgstr ""
 "файлера. Предмет засвітиться під курсором, а вкидання файлу помістить його в "
 "теку, завантажить його в програму."
 
-#: tips:238
+#: tips:276
 msgid "Directories spring open"
 msgstr "Авто-відкривання тек"
 
-#: tips:239
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
@@ -4476,15 +5104,15 @@ msgstr ""
 "предмета на теку, якщо притримати його на певний період часу, ця теку "
 "відкривається."
 
-#: tips:240
+#: tips:278
 msgid "Spring delay:"
 msgstr "Затримка:"
 
-#: tips:241
+#: tips:279
 msgid "ms"
 msgstr "мс"
 
-#: tips:242
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
@@ -4494,19 +5122,19 @@ msgstr ""
 "відкрилася.Попередній параметр повинен бути активований щоб цей мав будь-"
 "який ефект."
 
-#: tips:243
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Коли файли перетягуються лівою кнопкою мишки"
 
-#: tips:244 tips:248
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "показувати меню з можливими діями"
 
-#: tips:245
+#: tips:283
 msgid "Copy the files"
 msgstr "копіювати файли"
 
-#: tips:246
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
@@ -4514,15 +5142,15 @@ msgstr ""
 "Зауважте що ви завжди можете викликати це меню перетягуючи натиснутою "
 "клавішею Alt."
 
-#: tips:247
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Коли файли перетягуються середньою кнопкою мишки"
 
-#: tips:249
+#: tips:287
 msgid "Move the files"
 msgstr "перемістити ці фали"
 
-#: tips:250
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
@@ -4530,11 +5158,11 @@ msgstr ""
 "Зауважте що ви завжди можете викликати це меню перетягуючи натиснутою "
 "клавішею Alt."
 
-#: tips:251
+#: tips:289
 msgid "Download handler"
 msgstr "Відповідальний за завантаження"
 
-#: tips:252
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4546,35 +5174,35 @@ msgstr ""
 "файлерові, місцем призначення стає дана тека. Напр.:\n"
 "xterm -e wget $1"
 
-#: tips:253
+#: tips:291
 msgid "Menus"
 msgstr "Меню"
 
-#: tips:255
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Розмір піктограм в меню:"
 
-#: tips:256
+#: tips:294
 msgid "No Icons"
 msgstr "Без піктограм"
 
-#: tips:259
+#: tips:297
 msgid "Same as current window"
 msgstr "Такий як в даному вікні"
 
-#: tips:260
+#: tips:298
 msgid "Same as default"
 msgstr "Типовий"
 
-#: tips:261
+#: tips:299
 msgid "Behaviour"
 msgstr "Поведінка"
 
-#: tips:262
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Меню 'Файл' на правому клацанні"
 
-#: tips:263
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
@@ -4583,23 +5211,27 @@ msgstr ""
 "кнопкою мишки на виділені файли (головне меню можна буде викликати, "
 "притримавши клавішу Control)."
 
-#: tips:264
+#: tips:302
 msgid "Terminal emulator program"
 msgstr "Програма емуляції терміналу"
 
-#: tips:265
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr "Програма для запуску через пункт меню 'Термінал тут'."
 
-#: tips:266
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Комбінації клавіш"
 
-#: tips:268
+#: tips:305
+msgid "Types"
+msgstr "Типи"
+
+#: tips:306
 msgid "MIME types"
 msgstr "типи MIME"
 
-#: tips:269
+#: tips:307
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
@@ -4607,23 +5239,23 @@ msgstr ""
 "Файлер використовує певні правила, щоб визначати MIME тип для кожного "
 "звичайного файла, і потім вибирає підходящу піктограму для цього типу."
 
-#: tips:270
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "Редагувати правила MIME"
 
-#: tips:271
+#: tips:309
 msgid "Themes"
 msgstr "Теми"
 
-#: tips:272
+#: tips:310
 msgid "Icon theme"
 msgstr "Теми піктограм"
 
-#: tips:273
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "Теми прийнято розміщувати в теці ~/.icons"
 
-#: tips:274
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
@@ -4632,40 +5264,40 @@ msgstr ""
 "кожного типу MIME. Зауважте: піктограми, вибрані цим способом переважають "
 "піктограми теми."
 
-#: tips:275
+#: tips:313
 msgid "Colours"
 msgstr "Кольори"
 
-#: tips:276
+#: tips:314
 msgid "File type colours"
 msgstr "Кольори типів файлів"
 
-#: tips:277
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Кольорувати файли відносно їх типу"
 
-#: tips:278
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr ""
 "Назви файлів (і подробиці) кольоруються зважаючи на тип відповідних файлів."
 
-#: tips:279
+#: tips:317
 msgid "Directory:"
 msgstr "Тека:"
 
-#: tips:280
+#: tips:318
 msgid "Regular file:"
 msgstr "Звичайний файл:"
 
-#: tips:281
+#: tips:319
 msgid "Pipe:"
 msgstr "Труба:"
 
-#: tips:282
+#: tips:320
 msgid "Socket:"
 msgstr "Розетка:"
 
-#: tips:284
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
@@ -4673,49 +5305,78 @@ msgstr ""
 "Помилка, така, як посилання до неіснуючого файлу, або файл, на оцінку якого "
 "файлер не має права."
 
-#: tips:285
+#: tips:323
 msgid "Character device:"
 msgstr "Байтові прилади:"
 
-#: tips:286
+#: tips:324
 msgid "Block device:"
 msgstr "Блокові прилади:"
 
-#: tips:287
+#: tips:325
 msgid "Door:"
 msgstr "Двері:"
 
-#: tips:288
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
-msgstr "Двері - це файли подібні на труби і розетки, і бувають тільки на Solaris."
+msgstr ""
+"Двері - це файли подібні на труби і розетки, і бувають тільки на Solaris."
 
-#: tips:289
+#: tips:327
 msgid "Executable file:"
 msgstr "Файли-програми:"
 
-#: tips:290
+#: tips:328
 msgid "Application directory:"
 msgstr "Тека програми:"
 
-#: tips:291
+#: tips:329
 msgid "Unknown type:"
 msgstr "Невідомий тип:"
 
-#: tips:292
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Тло:"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Використовувати нетиповий шрифт:"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Сумісність"
 
-#: tips:293
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Проблеми з менеджерами вікон"
 
-#: tips:294
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "Не піддаватися на контроль менеджера вікон над стільницею і панелями"
 
-#: tips:295
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4729,12 +5390,12 @@ msgstr ""
 "поверх інших вікон при клацанні на неї, або коли навколо стільниці і панелі "
 "з'являються різні віконні декорації, або коли ви бачите їх у списку вікон."
 
-#: tips:296
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr ""
 "Передавати всі кліки мишки, які попадають на тло стільниці, менеджеру вікон"
 
-#: tips:297
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
@@ -4745,11 +5406,11 @@ msgstr ""
 "попадають на тло стільниці, менеджеру вікон. Клацання на піктограми "
 "залишаються в силі."
 
-#: tips:298
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Гек (hack), пов'язаний з використанням меню стільниці в Blackbox"
 
-#: tips:299
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4761,27 +5422,51 @@ msgstr ""
 "вікон змінюють свою поведінку в наступних версіях, тому це навряд чи вам "
 "пригодиться."
 
-#: tips:300
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "Панель 'обрізає' розміри екрану"
 
-#: tips:301
+#: tips:346
+#, fuzzy
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 "Вимкніть це, якщо панель заслоняє інші вікна проти вашої волі.Цей параметр "
 "вступить в силу тільки після перезавантаження."
 
-#: tips:302
+#: tips:347
+#, fuzzy
+msgid "Panel stays on top"
+msgstr "Стиль панелі"
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Дреґ-н-драп"
 
-#: tips:303
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Не використовувати імена комп'ютерів"
 
-#: tips:304
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4792,15 +5477,11 @@ msgstr ""
 "файлів до програми, біля курсора мишки з'являється знак +, але результат "
 "відсутній."
 
-#: tips:305
-msgid "Extended attributes"
-msgstr "Розширені атрибути"
-
-#: tips:306
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Не використовувати розширені атрибути"
 
-#: tips:307
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4811,6 +5492,408 @@ msgstr ""
 "операційних системах і файлових системах. Коли це активовано, пункт меню "
 "'Вказати тип' вимикається,тип MIME визначається тільки за назвою файлу, і "
 "вікно властивостей не повідомляє про  розширені атрибути файлу."
+
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Нижній край"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "Правий край"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
+#, fuzzy
+msgid "ROX-Filer log viewer"
+msgstr "ROX-Filer"
+
+#: ../Templates.ui.h:2
+msgid "Recently performed actions..."
+msgstr ""
+
+#: ../Templates.ui.h:3
+#, fuzzy
+msgid "Open Directory"
+msgstr "Домашня тека"
+
+#: ../Templates.ui.h:4
+msgid "Panel Options"
+msgstr "Налаштування панелі"
+
+#: ../Templates.ui.h:5
+#, fuzzy
+msgid "Image and Text"
+msgstr "Зображення і текст"
+
+#: ../Templates.ui.h:6
+#, fuzzy
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Кожен предмет панелі відображається у вигляді піктограми і тексту."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Для програм - тільки зображення"
+
+#: ../Templates.ui.h:8
+#, fuzzy
+msgid ""
+"Applications in this panel have just an image, everything else has both an "
+"image and text."
+msgstr ""
+"Програми відображаються як піктограма, все решта - як піктограма і текст."
+
+#: ../Templates.ui.h:9
+msgid "Image only"
+msgstr "Тільки зображення"
+
+#: ../Templates.ui.h:10
+#, fuzzy
+msgid "Only the image is shown for icons in this panel."
+msgstr "Відображається тільки піктограма."
+
+#: ../Templates.ui.h:11
+#, fuzzy
+msgid "Panel width"
+msgstr "Ширина панелі (тонка)"
+
+#: ../Templates.ui.h:12
+#, fuzzy
+msgid "The size of this panel."
+msgstr "Розмір панель."
+
+#: ../Templates.ui.h:13
+msgid "px"
+msgstr ""
+
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Переклад"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "Не покривати панель"
+
+#: ../Templates.ui.h:19
+#, fuzzy
+msgid ""
+"Ask the window manager not to cover this panel when maximising windows, "
+"otherwise leave just 2 pixels at the edge of the screen to allow auto-"
+"raising. Some window managers may not honour this setting."
+msgstr ""
+"Просити менеджер вікон не покривати панелі коли ви максимізуєте вікно. Деякі "
+"менеджери вікон можуть не підтримувати цього. Якщо вимкнено, файлер просто "
+"просить не покривати певну кількість пікселів на краї екрану, ось як працює "
+"авто-підняття."
+
+#: ../Templates.ui.h:20
+#, fuzzy
+msgid "<b>Panel style</b>"
+msgstr "Стиль панелі"
+
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Обмежувати до монітору Xinerama номер"
+
+#: ../Templates.ui.h:22
+#, fuzzy
+msgid ""
+"If you use multiple monitors with Xinerama, use this option to confine the "
+"panel to one monitor."
+msgstr ""
+"Якщо використовуються кілька моніторів Xinerama, використовуйте цей параметр "
+"щоб обмежити панель тільки одним монітором, замість роз'єднувати її."
+
+#: ../Templates.ui.h:23
+#, fuzzy
+msgid ""
+"The monitor this panel is confined to when using Xinerama. The numbering "
+"starts from zero."
+msgstr ""
+"Монітор на якому розміщувати панелі в режимі Xinerama (нумеровані з 0)."
+
+#: ../Templates.ui.h:24
+#, fuzzy
+msgid "<b>Xinerama</b>"
+msgstr "Xinerama"
+
+#: ../Templates.ui.h:25
+msgid "Right edge"
+msgstr "Правий край"
+
+#: ../Templates.ui.h:26
+msgid "Left edge"
+msgstr "Лівий край"
+
+#: ../Templates.ui.h:27
+msgid "Bottom edge"
+msgstr "Нижній край"
+
+#: ../Templates.ui.h:28
+msgid "Top edge"
+msgstr "Верхній край"
+
+#: ../Templates.ui.h:29
+#, fuzzy
+msgid "<b>Position</b>"
+msgstr "<b>Права</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<тека>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' вже існує - переписати?"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Помилка сканування '%s':\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Тека відсутня"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Теку '%s' не знайдено."
+
+#~ msgid "Cancel"
+#~ msgstr "Скасувати"
+
+#~ msgid "All, "
+#~ msgstr "Все, "
+
+#~ msgid "Dnotify support"
+#~ msgstr "Підтримка Dnotify"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr ""
+#~ "Ви повинні кнопкою 2, тримаючи Shift, клацнути на файл, щоб відіслати "
+#~ "його кудись"
+
+#~ msgid "Panel: %s"
+#~ msgstr "Панель: %s"
+
+#~ msgid "Select the panel's position:"
+#~ msgstr "Вибрати позицію панелі:"
+
+#~ msgid "Top-edge panel"
+#~ msgstr "Верхня панель"
+
+#~ msgid "Bottom edge panel"
+#~ msgstr "Нижня панель"
+
+#~ msgid "Left edge panel"
+#~ msgstr "Ліва панель"
+
+#~ msgid "Right-edge panel"
+#~ msgstr "Права панель"
+
+#~ msgid "Invalid .gmo translation file (too short): %s"
+#~ msgstr "Неправильний файл перекладу .gmo (закороткий): %s"
+
+#~ msgid "Invalid .gmo translation file (GNU magic number not found): %s"
+#~ msgstr ""
+#~ "Неправильний файл перекладу .gmo (чарівний номер GNU не знайдено): %s"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Перейти на рівень вище"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Перейти в домашню теку"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Закладки"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Меню закладок"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Пересканувати зміст теки"
+
+#~ msgid "Change icon size"
+#~ msgstr "Змінити розмір піктограм"
+
+#~ msgid "Show extra details"
+#~ msgstr "Показати додаткові подробиці"
+
+#~ msgid "Hidden"
+#~ msgstr "Приховане"
+
+#~ msgid ""
+#~ "Icon theme '%s' does not contain MIME icons. Using ROX default theme "
+#~ "instead."
+#~ msgstr ""
+#~ "Тема піктограм '%s' не містить піктограм MIME. Використовую тему ROX."
+
+#~ msgid ""
+#~ "Failed to create symlink '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(this may mean that the ROX theme already exists there, but the 'mime-"
+#~ "application:postscript' icon couldn't be loaded for some reason, or %s is "
+#~ "a link to an invalid directory; try deleting it)"
+#~ msgstr ""
+#~ "Не можу створити символічне посилання '%s':\n"
+#~ "%s\n"
+#~ "\n"
+#~ "(це може означати що тема ROX вже там існує, але піктограма 'mime-"
+#~ "application:postscript'не може бути завантажена, або %s - це посилання на "
+#~ "неіснуючу теку; спробуйте його викинути)"
+
+#~ msgid "Language"
+#~ msgstr "Мова"
+
+#~ msgid "Use the LANG environment variable"
+#~ msgstr "Використовувати змінну середовища LANG"
+
+#~ msgid "Basque"
+#~ msgstr "Баскська"
+
+#~ msgid "Chinese (traditional)"
+#~ msgstr "Китайська (традиційна)"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Китайська (спрощена)"
+
+#~ msgid "Czech"
+#~ msgstr "Чеська"
+
+#~ msgid "Danish"
+#~ msgstr "Датська"
+
+#~ msgid "Dutch"
+#~ msgstr "Голландська"
+
+#~ msgid "English (no translation)"
+#~ msgstr "Англійська (без перекладу)"
+
+#~ msgid "Estonian"
+#~ msgstr "Естонська"
+
+#~ msgid "Finnish"
+#~ msgstr "Фінська"
+
+#~ msgid "French"
+#~ msgstr "Французька"
+
+#~ msgid "German"
+#~ msgstr "Німецька"
+
+#~ msgid "Hungarian"
+#~ msgstr "Угорська"
+
+#~ msgid "Japanese"
+#~ msgstr "Японська"
+
+#~ msgid "Norwegian"
+#~ msgstr "Норвезька"
+
+#~ msgid "Italian"
+#~ msgstr "Італійська"
+
+#~ msgid "Polish"
+#~ msgstr "Польська"
+
+#~ msgid "Portuguese (Portugal)"
+#~ msgstr "Португальська (Португалія)"
+
+#~ msgid "Portuguese (Brasil)"
+#~ msgstr "Португальська (Бразилія)"
+
+#~ msgid "Romanian"
+#~ msgstr "Румунська"
+
+#~ msgid "Russian"
+#~ msgstr "Російська"
+
+#~ msgid "Spanish"
+#~ msgstr "Іспанська"
+
+#~ msgid "Swedish"
+#~ msgstr "Шведська"
+
+#~ msgid "Ukrainian"
+#~ msgstr "Українська"
+
+#, fuzzy
+#~ msgid "Vietnamese"
+#~ msgstr "Переназвати"
+
+#~ msgid "Change at:"
+#~ msgstr "Переходити на малі піктограми при:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Максимальна ширина (великі піктограми):"
+
+#~ msgid "Panels"
+#~ msgstr "Панелі"
+
+#~ msgid ""
+#~ "Panels are bars of icons that run along the side of the screen. See the "
+#~ "manual for information about using panels."
+#~ msgstr ""
+#~ "Панелі - це \"дошки\" з піктограмами, які розташовуються скраю екрану. "
+#~ "Дивіться підручник задля детальнішої інформації про панелі."
+
+#~ msgid "(thick)"
+#~ msgstr "(широка)"
+
+#~ msgid "Enter the name of the panel to show here."
+#~ msgstr "Впишіть тут назву панелі."
 
 #~ msgid "Choices migration"
 #~ msgstr "Міграція вподобань (Choises)"

--- a/ROX-Filer/src/po/update-po
+++ b/ROX-Filer/src/po/update-po
@@ -5,7 +5,7 @@ echo
 
 (cd ..; python po/tips.py &&
  intltool-extract --type=gettext/glade --update ../Templates.ui &&
- xgettext --keyword=_ --keyword=N_ --output=messages.pot *.c tips ../Templates.ui.h)
+ xgettext --from-code=UTF-8 --keyword=_ --keyword=N_ --output=messages.pot *.c tips ../Templates.ui.h)
 
 echo
 

--- a/ROX-Filer/src/po/vi.po
+++ b/ROX-Filer/src/po/vi.po
@@ -5,38 +5,43 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ROX-Filer 2.7.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2008-04-09 22:11+0700\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "Last-Translator: anhtuan, xomhau\n"
 "Language-Team: vi_VN <out of team>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: abox.c:125
-msgid "<dir>"
-msgstr "<thư mục>"
+#: abox.c:127
+msgid "<src>"
+msgstr ""
 
-#: abox.c:218
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "_Im lặng"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Quiet"
 msgstr "Im lặng"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "Không xác nhận cho mỗi thao tác"
 
-#: abox.c:454 infobox.c:771 tips:36
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "Tên"
 
-#: abox.c:460 menu.c:237
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "Thư mục"
 
-#: abox.c:549
+#: abox.c:546
 msgid "Expression:"
 msgstr "Từ cần tìm:"
 
@@ -52,11 +57,11 @@ msgstr "Xem hướng dẫn trong trang man của fsattr(5)."
 msgid "You do not appear to have OS support."
 msgstr "Có vẻ bạn không có OS được hỗ trợ"
 
-#: action.c:191
+#: action.c:198
 msgid "Find expression reference"
 msgstr "Hướng dẫn tìm kiếm"
 
-#: action.c:202
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -129,11 +134,11 @@ msgstr ""
 "a % in 'command' được thay thế bằng đường dẫn của tập tin hiện tại)\n"
 "<b>prune</b> (nếu false, ngăn không tìm kiếm bên trong thư mục)."
 
-#: action.c:249
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "Hướng dẫn thay đổi quyền hạn"
 
-#: action.c:260
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -191,11 +196,11 @@ msgstr ""
 "\n"
 "Xem hướng dẫn chi tiết trong trang man của chmod(1)."
 
-#: action.c:301
+#: action.c:308
 msgid "Set type reference"
 msgstr "Hướng dẫn thiết đặt loại tập tin"
 
-#: action.c:312
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -218,48 +223,55 @@ msgstr ""
 "thư mục, thiết bị, pipe hay socket và chỉ trên các tập tin hệ\n"
 "thống (file system) được OS hỗ trợ\n"
 
-#: action.c:419
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "Qúa trình kết thúc.\n"
 
-#: action.c:435
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "Có lỗi xảy ra\n"
 
-#: action.c:437
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "Có %d lỗi xảy ra.\n"
 
-#: action.c:461
+#: action.c:516
 msgid "ERROR reading"
 msgstr "LỖI khi đọc"
 
-#: action.c:504
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "Hoàn tất\n"
 
-#: action.c:560 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "LỖI"
 
-#: action.c:714 main.c:693 main.c:700 main.c:714
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "Đồng ý"
 
-#: action.c:717 main.c:695 main.c:702 main.c:714
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "Không đồng ý"
 
-#: action.c:735
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -267,7 +279,7 @@ msgstr ""
 "\n"
 "Yêu cầu quá trình con kết thúc...\n"
 
-#: action.c:742
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -275,42 +287,42 @@ msgstr ""
 "\n"
 "KILL quá trình đang chạy...\n"
 
-#: action.c:895
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?Kiểm kê nội dung của %s?"
 
-#: action.c:931
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?Xoá %s'%s'?"
 
 # Dịch thế nào cho xuôi tai?
-#: action.c:932
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "CHỐNG-GHI"
 
-#: action.c:939
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'Xoá '%s'\n"
 
-#: action.c:952
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'Thư mục '%s' đã bị xoá\n"
 
-#: action.c:985
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?Eject '%s'?"
 
-#: action.c:992
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'Eject '%s'\n"
 
-#: action.c:1011
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -319,95 +331,95 @@ msgstr ""
 "!%s\n"
 "eject đã lỗi\n"
 
-#: action.c:1030 action.c:1049
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?Kiểm tra '%s'?"
 
-#: action.c:1046
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!Điều kiện tìm kiếm không đúng - hãy thay đổi chúng và thử lại\n"
 
-#: action.c:1056
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(kiểm kê '%s')\n"
 
-#: action.c:1130 action.c:1155
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?Thay đổi quyền hạn của '%s'?"
 
-#: action.c:1136
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'Thay đổi quyền hạn của '%s'\n"
 
-#: action.c:1153
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!Lệnh không đúng - hãy thay đổi và thử lại\n"
 
-#: action.c:1211
+#: action.c:1332
 #, c-format
 msgid "?Change contents of '%s'?"
 msgstr "?Thay đổi nội dung của '%s'?"
 
-#: action.c:1214 action.c:1234
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?Thay đổi loại của '%s'?"
 
-#: action.c:1231
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!Loại không đúng - hãy thay đổi và thử lại\n"
 
-#: action.c:1253
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'Thay đổi loại của '%s' đến '%s'\n"
 
-#: action.c:1276
+#: action.c:1397
 #, c-format
 msgid "'Not changing type of directory '%s'\n"
 msgstr "'Không thay đổi kiểu của thư mục '%s'\n"
 
-#: action.c:1282
+#: action.c:1403
 #, c-format
 msgid "'Non-regular file '%s' not changed\n"
 msgstr "Tập tin không-chuẩn '%s' không thay đổi\n"
 
-#: action.c:1342
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' đã tồn tại - %s?"
 
-#: action.c:1344
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "kết hợp nội dung"
 
-#: action.c:1345
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "ghi đè lên"
 
-#: action.c:1361
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'Thử sao chép bằng mọi cách...\n"
 
-#: action.c:1370
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?Sao chép %s như %s?"
 
-#: action.c:1374
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'Sao chép %s như %s\n"
 
-#: action.c:1389
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!LỖI: Đích đã tồn tại, nhưng đó không phải là một thư mục\n"
 
-#: action.c:1461
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -416,26 +428,7 @@ msgstr ""
 "!%s\n"
 "Quá trình sao chép '%s' bị lỗi\n"
 
-#: action.c:1505
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' đã tồn tại - ghi đè lên?"
-
-#: action.c:1520
-msgid "'Trying move anyway...\n"
-msgstr "'Thử di chuyển bằng mọi cách...\n"
-
-#: action.c:1528
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?Chuyển %s như %s?"
-
-#: action.c:1532
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'Đang chuyển %s như %s\n"
-
-#: action.c:1540
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -444,45 +437,59 @@ msgstr ""
 "!%s\n"
 "Lỗi khi di chuyển %s như %s\n"
 
-#: action.c:1561
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'Thử di chuyển bằng mọi cách...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?Chuyển %s như %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'Đang chuyển %s như %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!LỖI: Không thể sao chép đối tượng lên chính nó\n"
 
-#: action.c:1576
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!LỖI: Không thể di chuyển hoặc đổi tên đối tượng vào/như chính nó\n"
 
-#: action.c:1588
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'Tạo liên kết cho %s như %s\n"
 
-#: action.c:1593
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?Tạo liên kết cho %s như %s?"
 
-#: action.c:1636
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'Đang gắn kết %s\n"
 
-#: action.c:1637
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'Hủy gắn kết %s\n"
 
-#: action.c:1640
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?Gắn kết %s?"
 
-#: action.c:1641
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?Hủy gắn kết %s?"
 
-#: action.c:1662
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -491,7 +498,7 @@ msgstr ""
 "!%s\n"
 "Gắn kết đã lỗi\n"
 
-#: action.c:1663
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -500,11 +507,11 @@ msgstr ""
 "!%s\n"
 "Hủy gắn kết đã lỗi\n"
 
-#: action.c:1671
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(dường như đã được gắn kết ở đâu đó)'\n"
 
-#: action.c:1717
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -513,206 +520,230 @@ msgstr ""
 "'\n"
 "Tổng cộng: %s ("
 
-#: action.c:1723
+#: action.c:2108
 msgid "file"
 msgstr "tập tin"
 
-#: action.c:1723
+#: action.c:2108
 msgid "files"
 msgstr "tập tin"
 
-#: action.c:1727
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "không có thư mục)\n"
 
-#: action.c:1731
+#: action.c:2116
 msgid "directory"
 msgstr "thư mục"
 
-#: action.c:1732
+#: action.c:2117
 msgid "directories"
 msgstr "thư mục"
 
-#: action.c:1773
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!Chưa chọn điểm gắn kết\n"
 
-#: action.c:1858
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?Tìm kiếm lại?"
 
-#: action.c:1888 action.c:1919
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' đây là liên kết tượng trưng\n"
 
-#: action.c:1959
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "Bạn cần chọn vài mục để tìm kiếm"
 
-#: action.c:1969 menu.c:228
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "Tìm kiếm"
 
-#: action.c:2002
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "Bạn cần chọn vài mục để kiểm kê"
 
-#: action.c:2006
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "Sử dụng đĩa"
 
-#: action.c:2042
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "Gắn kết / Hủy gắn kết"
 
-#: action.c:2059
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr "ROX-Filer chưa hỗ trợ điểm gắn kết trên hệ thống của bạn. Xin lỗi."
 
-#: action.c:2073 menu.c:216 tips:173
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "Xoá"
 
-#: action.c:2085 tips:178
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "Bắt buộc"
 
-#: action.c:2085
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "Không xác nhận việc xoá của những mục chỉ đọc"
 
-#: action.c:2088 action.c:2147 action.c:2210 action.c:2283 action.c:2323
-#: tips:180
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "Ngắn gọn"
 
-#: action.c:2088
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "Chỉ ghi nhận các thư mục đã xoá"
 
-#: action.c:2107
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "Bạn cần chọn các mục mà bạn muốn thay đổi quyền hạn"
 
-#: action.c:2115
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (Thực thi/Tìm kiếm được)"
 
-#: action.c:2117
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (Không thực thi/Không tìm kiếm được)"
 
-#: action.c:2119
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (Cho phép chủ nhân đọc và ghi)"
 
-#: action.c:2121
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (Riêng tư - chỉ chủ nhân truy nhập)"
 
-#: action.c:2123
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (Tất cả đều truy nhập được, không ghi được)"
 
-#: action.c:2134 menu.c:189 menu.c:226 tips:53
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "Quyền hạn"
 
-#: action.c:2147 action.c:2210
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "Không liệt kê các tập tin đã tiến hành"
 
-#: action.c:2150 action.c:2213 tips:182
+#: action.c:2543 action.c:2608 tips:255
 #, fuzzy
 msgid "Recurse"
 msgstr "Recurse"
 
-#: action.c:2150
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "Thay đổi cả nội dung các thư mục con"
 
-#: action.c:2154
+#: action.c:2547
 msgid "Command:"
 msgstr "Lệnh:"
 
-#: action.c:2184
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "Bạn cần chọn các mục mà bạn muốn thay đổi quyền hạn"
 
-#: action.c:2197
+#: action.c:2590
 msgid "Set type"
 msgstr "Thiết đặt Loại"
 
-#: action.c:2213
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "Thay đổi cả nội dung các thư mục con"
 
-#: action.c:2220 infobox.c:627
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "Loại:"
 
-#: action.c:2267 dnd.c:122 menu.c:2018 tips:167
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "Sao chép"
 
-#: action.c:2279 action.c:2319 tips:184
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "Không xác nhận cho mỗi thao tác"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "Ghi đè lên nếu nguồn mới hơn đích"
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "Mới hơn"
 
-#: action.c:2280 action.c:2320 tips:185
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "Ghi đè lên nếu nguồn mới hơn đích"
 
-#: action.c:2283
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "thư mục"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "Chỉ ghi nhận các thư mục đã được sao chép"
 
-#: action.c:2307 dnd.c:123 tips:169
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "Di chuyển"
 
-#: action.c:2323
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "Không ghi nhận tập tin khi nó được di chuyển"
 
-#: action.c:2346 tips:171
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "Liên kết"
 
-#: action.c:2369 appmenu.c:111 filer.c:593
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "Eject"
 
-#: action.c:2437
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "Xoá các mục này như "
 
-#: action.c:2441
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "Đang xoá mục "
 
-#: action.c:2443
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "Đang xoá các mục "
 
-#: action.c:2462
+#: action.c:2900
 msgid " and "
 msgstr " và "
 
-#: action.c:2471
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr " sẽ ảnh hưởng vài mục trên pinboard và panel - xóa nó?"
 
-#: action.c:2478
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr " sẽ ảnh hưởng vài mục trên pinboard và panel - xóa chúng?"
 
-#: appmenu.c:197
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<không có nhãn>"
 
-#: appmenu.c:319
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
@@ -721,82 +752,82 @@ msgstr ""
 "Tạo liên kết bất kì chương trình nào bạn muốn vào thư mục này. Chúng sẽ xuất "
 "hiện trong menu của mọi mục loại này (%s/%s)."
 
-#: appmenu.c:363 menu.c:239
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "Tinh chỉnh Menu..."
 
-#: appmenu.c:420 menu.c:257 toolbar.c:158
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "Trợ giúp"
 
-#: bookmarks.c:148
-msgid "Path"
-msgstr "Đường dẫn"
-
-#: bookmarks.c:156
+#: bookmarks.c:268
 msgid "Title"
 msgstr "Tựa đề"
 
-#: bookmarks.c:305
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "Đường dẫn"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "Không thể bookmark tài nguyên bên ngoài '%s'\n"
 
-#: bookmarks.c:313 bookmarks.c:631
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s' không phải là thư mục"
 
-#: bookmarks.c:519
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "Trước tiên bạn phải chọn một vài hàng để xoá"
 
-#: bookmarks.c:543
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "Đặt con trỏ trên một mục trong danh sách để di chuyển nó"
 
-#: bookmarks.c:563
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "Mục này đã nằm cuối danh sách"
 
-#: bookmarks.c:637
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "Không thể bookmark các thư mục bên ngoài như '%s'"
 
-#: bookmarks.c:779
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "Thêm Bookmark"
 
-#: bookmarks.c:786
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "Chỉnh sửa Bookmark"
 
-#: bookmarks.c:791
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "Đã truy nhập gần đây"
 
-#: bulk_rename.c:66
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "Đổi tên nhiều tập tin"
 
-#: bulk_rename.c:69
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "Làm lại"
 
-#: bulk_rename.c:74
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "Tạo ở cột Mới một bản sao của cột Cũ"
 
-#: bulk_rename.c:79
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "Đổi _Tên"
 
-#: bulk_rename.c:92
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "Thay thế"
 
-#: bulk_rename.c:99
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -810,23 +841,25 @@ msgstr ""
 "\\. nghĩa là một dấu chấm\n"
 "\\.htm$ nghĩa là '.htm' ví dụ như 'index.htm'"
 
-#: bulk_rename.c:107
+#: bulk_rename.c:109
 msgid "With:"
 msgstr "Với"
 
-#: bulk_rename.c:114
+#: bulk_rename.c:116
+#, fuzzy
 msgid ""
-"The first match in each filename will be replaced by this string. There are "
-"no special characters."
+"The first match in each filename will be replaced by this string. The only "
+"special characters are back-references from \\0 to \\9. To use them "
+"literally, they have to be escaped with a backslash."
 msgstr ""
 "Phần trùng khớp trong mỗi tên tập tin sẽ được thay thế với chuỗi này. Đừng "
 "thêm các kí tự đặc biệt vào đây"
 
-#: bulk_rename.c:118
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "Chấp nhận"
 
-#: bulk_rename.c:121
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
@@ -834,43 +867,43 @@ msgstr ""
 "Tìm-và-thay tên tập tin trong cột Mới. Tập tin chưa được đổi tên cho đến khi "
 "bạn nhấn và nút Đổi Tên bên dưới."
 
-#: bulk_rename.c:140
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "Tên Cũ"
 
-#: bulk_rename.c:149
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "Tên Mới"
 
-#: bulk_rename.c:257
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr "Không có chuỗi (trong cột Mới) khớp với từ đã cho"
 
-#: bulk_rename.c:262
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "Có một tên phù hợp, nhưng kết quả giống nhau"
 
-#: bulk_rename.c:265
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "Có %d tên phù hợp, nhưng kết quả tất cả đều giống nhau"
 
-#: bulk_rename.c:291
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr "Hãy xác định một từ để tìm và một chuỗi thay thế phù hợp."
 
-#: bulk_rename.c:308
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (dùng cho '%s')"
 
-#: bulk_rename.c:341
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr "Một tập tin '%s' đã có. Hủy bỏ đổi tên."
 
-#: bulk_rename.c:346
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -881,12 +914,12 @@ msgstr ""
 "%s\n"
 "Hủy bỏ đổi tên."
 
-#: bulk_rename.c:408
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "Một tập tin '%s' đã có"
 
-#: bulk_rename.c:419
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
@@ -895,7 +928,7 @@ msgstr ""
 "Một vài tên Mới chứa kí tự / (như '%s'). Điều này sẽ tạo ra các tập tin như "
 "các thư mục khác nhau. Tiếp tục?"
 
-#: bulk_rename.c:434
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "Không có tên tập tin được đổi. Không phải làm việc. Khỏe!"
 
@@ -919,42 +952,62 @@ msgstr ""
 "%s\n"
 "%s"
 
-#: dir.c:980
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "Không thể thống kê thư mục: %s"
 
-#: dir.c:989
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "Không thể mở thư mục %s"
 
-#: display.c:629
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "Kích cỡ"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) lỗi: %s"
 
-#: dnd.c:124
-msgid "Link (relative)"
-msgstr "Liên kết (tương đối)"
-
-#: dnd.c:125
-msgid "Link (absolute)"
-msgstr "Liên kết (tuyệt đối)"
-
-#: dnd.c:424
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "Lỗi bên trong - dạng thông tin tồi"
 
-#: dnd.c:563
+#: dnd.c:565
 msgid "Drag a directory here to bookmark it."
 msgstr "Kéo thư mục vào đây để bookmark nó."
 
-#: dnd.c:578
+#: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
 msgstr "Lỗi giao thức XDS: kí tự đầu tên không thể là '/'\n"
 
-#: dnd.c:603
+#: dnd.c:605
 msgid ""
 "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
 "plain) did not contain a leafname\n"
@@ -962,19 +1015,19 @@ msgstr ""
 "Đích XdndDirectSave0 đã cung cấp, nhưng phần tử XdndDirectSave0 (kiểu text/"
 "plain) không chứa leafname\n"
 
-#: dnd.c:616
+#: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
 msgstr ""
 "Xin lỗi - Tôi yêu cầu một loại đích cho text/uri-list hay XdndDirectSave0."
 
-#: dnd.c:619
+#: dnd.c:621
 msgid ""
 "Sorry - I require a target type of text/uri-list or application/octet-stream."
 msgstr ""
 "Xin lỗi - Tôi yêu cầu một loại đích cho text/uri-list hoặc application/octet-"
 "stream."
 
-#: dnd.c:689
+#: dnd.c:691
 #, c-format
 msgid ""
 "Failed to add some items to the pinboard, because they are on a remote "
@@ -986,49 +1039,49 @@ msgstr ""
 "\n"
 "%s"
 
-#: dnd.c:764
+#: dnd.c:766
 msgid "Unknown target"
 msgstr "Đích không biết"
 
-#: dnd.c:797
+#: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
 msgstr "Ứng dụng ở xa không thể hoặc sẽ không gửi dữ liệu cho tôi - sorry"
 
-#: dnd.c:810
+#: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
 msgstr "Lỗi giao thức XDS: mã trả về nên là 'S', 'F' hay 'E'\n"
 
-#: dnd.c:843
+#: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
 msgstr ""
 "Xin lỗi, không thể hiển thị một menu các hành động cho một tập tin ở xa / dữ "
 "liệu thô."
 
-#: dnd.c:859
+#: dnd.c:861
 msgid "UntitledData"
 msgstr "DữliệuKhôngtên"
 
-#: dnd.c:886
+#: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
 msgstr "Lỗi lưu tập tin: %s"
 
-#: dnd.c:959
+#: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
 msgstr "Không có các URI trong text/uri-list (không gì để làm!)"
 
-#: dnd.c:991
+#: dnd.c:993
 msgid ""
 "Can't get data from remote machine (application/octet-stream not provided)"
 msgstr ""
 "Không thể lấy dữ liệu từ máy ở xa (application/octet-stream không cung cấp) "
 
-#: dnd.c:1014
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr "Một vài tập tin đang ở trên máy khác - chúng sẽ được bỏ qua - xin lỗi "
 
-#: dnd.c:1021
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
@@ -1036,14 +1089,32 @@ msgstr ""
 "Không có tập tin nào trên máy nội bộ - Tôi không thể tiến hành trên các tập "
 "tin ở xa - xin lỗi."
 
-#: dnd.c:1034
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "Không biết hành động đã yêu cầu"
 
-#: dnd.c:1042
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "Lỗi lấy danh sách tập tin: %s"
+
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "Liên kết (tương đối)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "Liên kết (tuyệt đối)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "Liên kết (tương đối)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "Liên kết (tuyệt đối)"
 
 #: dropbox.c:112
 msgid "Show"
@@ -1083,7 +1154,7 @@ msgstr ""
 "Không thể truy nhập %s:\n"
 "%s"
 
-#: filer.c:456
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1092,16 +1163,7 @@ msgstr ""
 "Lỗi quét '%s':\n"
 "%s\n"
 
-#: filer.c:460
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"Lỗi quét '%s':\n"
-"%s"
-
-#: filer.c:576
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1111,19 +1173,19 @@ msgstr ""
 "\n"
 "Hủy gắn kết một thiết bị giúp an tòan hơn để lấy đĩa ra."
 
-#: filer.c:580
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 msgid "No change"
 msgstr "Không"
 
-#: filer.c:586 menu.c:872
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "Huỷ gắn kết"
 
-#: filer.c:690
-msgid "Directory missing/deleted"
-msgstr "Thư mục bị lỗi hoặc đã xóa"
-
-#: filer.c:1054
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
@@ -1134,106 +1196,144 @@ msgstr ""
 "nhóm. Nhấn %s trên chính nó để chọn lại tập tin sau đó.\n"
 "Hãy chắc Numlock được bật nếu bạn dùng phím số (keypad)."
 
-#: filer.c:1290
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "Thư mục '%s' không thể truy nhập"
-
-#: filer.c:1442
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "Thư mục '%s' không tìm thấy."
-
-#: filer.c:1742
-msgid "Cancel"
-msgstr "Huỷ"
-
-#: filer.c:2023
+#: filer.c:2655
 msgid "A"
 msgstr "A"
 
-#: filer.c:2025 find.c:923
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr "G"
 
-#: filer.c:2030
+#: filer.c:2664
 msgid "S"
 msgstr "S"
 
-#: filer.c:2032
+#: filer.c:2669
 msgid "T"
 msgstr "T"
 
-#: filer.c:2042
-msgid "All, "
-msgstr "Tất cả, "
+#: filer.c:2670
+msgid "D"
+msgstr ""
 
-#: filer.c:2045
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
 msgstr "Glob (%s), "
 
-#: filer.c:2053
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "Đang quét, "
 
-#: filer.c:2055
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "Thumbs, "
 
-#: filer.c:2331
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "Thumbs, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "Liên kết đến "
 
-#: filer.c:2373
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "Tên tập tin này không là UTF-8. Bạn nên đổi tên nó.\n"
 
-#: filer.c:2684 menu.c:2008
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "Mục này không tồn tại!"
 
-#: filer.c:3411
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "Chọn thuộc tính hiển thị để lưu lại"
 
-#: filer.c:3415
+#: filer.c:4712
+#, fuzzy
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr "Lưu thiết lập hiển thị cho thư mục"
+
+#: filer.c:4713
 msgid "<b>Save display settings for directory</b>"
 msgstr "Lưu thiết lập hiển thị cho thư mục"
 
-#: filer.c:3422
+#: filer.c:4720
 msgid "Select settings to save"
 msgstr "Chọn thiết lập để lưu"
 
-#: filer.c:3429
+#: filer.c:4727
 msgid "Position"
 msgstr "Vị trí"
 
-#: filer.c:3434 toolbar.c:133 toolbar.c:137 tips:39
-msgid "Size"
-msgstr "Kích cỡ"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "Cửa sổ"
 
-#: filer.c:3439
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "Hiện tập tin ẩn"
 
-#: filer.c:3445
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "Kiểu hiện thị"
 
-#: filer.c:3451
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "Sằp xếp theo loại và thứ tự"
 
-#: filer.c:3456 toolbar.c:141
+#: filer.c:4754
 msgid "Details"
 msgstr "Chi tiết"
 
-#: filer.c:3461 tips:92 tips:93
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "Thumbnail"
 
-#: filer.c:3467
+#: filer.c:4765
 msgid "Filter"
 msgstr "Bộ lọc"
 
@@ -1457,11 +1557,11 @@ msgstr "block"
 msgid "Save As:"
 msgstr "Lưu như:"
 
-#: gtksavebox.c:395
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "Khôngtên"
 
-#: gtksavebox.c:471
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
@@ -1469,7 +1569,7 @@ msgstr ""
 "Ứng dụng từ xa muốn dùng Direct Save, nhưng tôi không thể đọc đặc tính "
 "XdndDirectSave0 (lọai text/plain).\n"
 
-#: gtksavebox.c:596
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1477,7 +1577,7 @@ msgstr ""
 "Kéo biểu tượng đến một trình xem thư mục\n"
 "(hoặc nhập tên đường dẫn đầy đủ)"
 
-#: gui_support.c:329
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
@@ -1485,12 +1585,12 @@ msgstr ""
 "\n"
 "---\n"
 
-#: gui_support.c:398
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr "Thử đọc tập tin XML như tập tin text. Tập tin '%s' có thể bị hỏng."
 
-#: gui_support.c:415
+#: gui_support.c:542
 #, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
@@ -1507,16 +1607,16 @@ msgstr ""
 "trở lại).\n"
 "Các lỗi xa hơn sẽ được bỏ qua."
 
-#: gui_support.c:1007
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "Không chính xác hoặc lỗi xuống dòng trong dữ liệu text/uri-list"
 
-#: gui_support.c:1339
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "Lỗi khi mở tập tin '%s': %s"
 
-#: gui_support.c:1383
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
@@ -1524,7 +1624,7 @@ msgstr ""
 "Lỗi khi tải hình ảnh '%s': nguyên nhân không rõ, có thể đó là một tập tin "
 "hỏng"
 
-#: gui_support.c:1434
+#: gui_support.c:1583
 #, c-format
 msgid ""
 "This program (%s) cannot be run, as the 0launch command is not available. It "
@@ -1545,171 +1645,176 @@ msgstr ""
 "Bạn phải lưu lại các chọn lựa và khởi động lại ROX-Filer để thiết đặt ngôn "
 "ngữ mới có đầy đủ hiệu lực."
 
-#: icon.c:76
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(nhấp để thiết đặt)"
 
-#: icon.c:131
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:132 menu.c:258
-msgid "About ROX-Filer..."
-msgstr "Về ROX-Filer..."
-
-#: icon.c:133 menu.c:259
-msgid "Show Help Files"
-msgstr "Hiện Tập Tin Trợ Giúp"
-
-#: icon.c:134 menu.c:260
-msgid "Manual"
-msgstr "Sổ tay"
-
-#: icon.c:136 menu.c:235
-msgid "Options..."
-msgstr "Tuỳ chọn..."
-
-#: icon.c:137 menu.c:244
-msgid "Home Directory"
-msgstr "Thư mục cá nhân"
-
-#: icon.c:138 icon.c:1410 menu.c:212 type.c:223
-msgid "File"
-msgstr "Tập tin"
-
-#: icon.c:139 menu.c:218 menu.c:885
-msgid "Shift Open"
-msgstr "Thay cách Mở"
-
-#: icon.c:140 menu.c:223
-msgid "Properties"
-msgstr "Thuộc tính"
-
-#: icon.c:141 menu.c:221
-msgid "Set Run Action..."
-msgstr "Hành động thực thi..."
-
-#: icon.c:142 menu.c:222
-msgid "Set Icon..."
-msgstr "Thiết đặt Biểu tượng"
-
-#: icon.c:143 icon.c:867
-msgid "Edit Item"
-msgstr "Sửa đổi Mục"
-
-#: icon.c:144
-msgid "Show Location"
-msgstr "Hiện đường dẫn"
-
-#: icon.c:145
-msgid "Remove Item(s)"
-msgstr "Xoá Mục"
-
-#: icon.c:318 log.c:110 menu.c:774
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr "%s '%s'"
 
-#: icon.c:331
+#: icon.c:311
 msgid "Nothing"
 msgstr "<không có gì>"
 
-#: icon.c:592
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "Đường dẫn phải chứa ít nhất một kí tự!"
 
-#: icon.c:657
+#: icon.c:641
 #, c-format
 msgid "You must unlock '%s' before removing it"
 msgstr "Bạn phải unlock '%s' trước khi xóa nó"
 
-#: icon.c:667
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "Bạn phải chọn một vài mục để xóa"
 
-#: icon.c:673
+#: icon.c:657
 msgid "An item must be unlocked before it can be removed."
 msgstr "Một mục phải được unlock trước khi được xóa."
 
-#: icon.c:687
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "Bạn phải mở menu trên một mục"
 
-#: icon.c:712 menu.c:1281
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "Bạn chỉ có thể thiết đặt hành động thực thi cho tập tin thường"
 
-#: icon.c:798
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "Nhấn phím tắt đề nghị (ví dụ, Control+F1)"
 
-#: icon.c:820
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "Lỗi khi nhận lệnh bàn phím!"
 
-#: icon.c:870
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "Sửa đổi Mục"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "Nhấp vào biểu tượng mở:"
 
-#: icon.c:880
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "Tham số bỏ qua (dành cho thực thi được):"
 
-#: icon.c:894
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "Text hiển thị dưới biểu tượng là:"
 
-#: icon.c:907
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "Phím tắt bàn phím là:"
 
-#: icon.c:927
+#: icon.c:910
 msgid "Locked"
 msgstr "Đã khóa"
 
-#: icon.c:932
+#: icon.c:915
 msgid "Locking an item prevents it from being accidentally removed"
 msgstr "Khóa một mục để ngăn nó không bị xóa vô ý"
 
-#: infobox.c:111
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "Về ROX-Filer..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "Hiện Tập Tin Trợ Giúp"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "Sổ tay"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "Tuỳ chọn..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "Thư mục cá nhân"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "Tập tin"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "Thay cách Mở"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "Thuộc tính"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "Hành động thực thi..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "Thiết đặt Biểu tượng"
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "Hiện đường dẫn"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "Xoá Mục"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
 msgstr "Bạn có chắc muốn mở %d cửa sổ?"
 
-#: infobox.c:112
+#: infobox.c:114
 msgid "Show Info"
 msgstr "Hiện thông tin"
 
-#: infobox.c:134 menu.c:779
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(sai utf-8)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "Hiện Trợ _Giúp"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>Quyền hạn</b>"
 
-#: infobox.c:290
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>Nội dung biểu thị...</b>"
 
-#: infobox.c:427 infobox.c:568 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "Chỉ ghi nhận các thư mục đã được sao chép"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "bytes"
 
-#: infobox.c:450
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "Lỗi đọc kích cỡ"
 
-#: infobox.c:511
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' không phải là một liên kết (symlink)"
 
-#: infobox.c:518
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1718,7 +1823,7 @@ msgstr ""
 "Lỗi hủy liên kết '%s':\n"
 "%s"
 
-#: infobox.c:523
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1729,168 +1834,192 @@ msgstr ""
 "%s\n"
 "(liên kết cũ đã được xóa)"
 
-#: infobox.c:547 tips:242
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "Lỗi"
 
-#: infobox.c:554
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "Thư mục thực:"
 
-#: infobox.c:557
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "Sở hữu, nhóm:"
 
-#: infobox.c:564 infobox.c:579 infobox.c:588
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "Kích cỡ:"
 
-#: infobox.c:589
+#: infobox.c:621
 msgid "Scanning"
 msgstr "Quét"
 
-#: infobox.c:614
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "Lỗi quét"
 
-#: infobox.c:621
+#: infobox.c:653
 msgid "Change time:"
 msgstr "Thay đổi cuối:"
 
-#: infobox.c:623
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "Điều chỉnh cuối:"
 
-#: infobox.c:625
+#: infobox.c:657
 msgid "Access time:"
 msgstr "Truy nhập cuối:"
 
-#: infobox.c:633
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "Thuộc tính mở rộng"
 
-#: infobox.c:635
+#: infobox.c:667
 msgid "Present"
 msgstr "Hiện tại"
 
-#: infobox.c:636
+#: infobox.c:668
 msgid "None"
 msgstr "Không có"
 
-#: infobox.c:637
+#: infobox.c:669
 msgid "Not supported"
 msgstr "Không hỗ trợ"
 
-#: infobox.c:649
+#: infobox.c:681
 msgid "Link target:"
 msgstr "Liên kết đích"
 
-#: infobox.c:661 infobox.c:664
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "Thực thi hành động:"
 
-#: infobox.c:661
+#: infobox.c:693
 msgid "Execute file"
 msgstr "Tập tin thực thi"
 
-#: infobox.c:773
+#: infobox.c:805
 msgid "Comment"
 msgstr "Chú giải"
 
-#: infobox.c:775
+#: infobox.c:807
 msgid "Execute"
 msgstr "Thực thi"
 
-#: infobox.c:789
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<chưa có gì>"
 
-#: infobox.c:860
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "file(1) nói... %s"
 
-#: infobox.c:917
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "Không thể thay đổi quyền truy nhập: %s"
 
-#: infobox.c:935
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "Sở hữu"
 
-#: infobox.c:937
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "Nhóm"
 
-#: infobox.c:939
+#: infobox.c:974
 msgid "World"
 msgstr "Khác"
 
-#: infobox.c:942
+#: infobox.c:977
 msgid "Read"
 msgstr "Đọc"
 
-#: infobox.c:944
+#: infobox.c:980
 msgid "Write"
 msgstr "Ghi"
 
-#: infobox.c:946
+#: infobox.c:983
 msgid "Exec"
 msgstr "Thực thi"
 
-#: infobox.c:963
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:970
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:977
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky"
 
-#: infobox.c:999
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<không có gì>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "Liên kết tượng trưng"
 
-#: infobox.c:1002
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "Ứng dụng ROX"
 
-#: infobox.c:1010
+#: infobox.c:1100
 msgid "mounted"
 msgstr "gắn kết"
 
-#: infobox.c:1010
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "huỷ gắn kết"
 
-#: infobox.c:1014
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "Điểm gắn kết cho %s (%s) "
 
-#: infobox.c:1017
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "Điểm gắn kết (%s)"
 
-#: log.c:55
+#: log.c:54
 msgid "ROX-Filer started"
 msgstr "ROX-Filer đã chạy"
 
-#: log.c:112
+#: log.c:115
 #, c-format
 msgid "%s on %d items"
 msgstr "%s trên %d mục"
 
-#: log.c:125
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "Sao chép..."
+
+#: log.c:139
 msgid "Item"
 msgstr "Mục"
 
-#: main.c:94
+#: log.c:165
+#, fuzzy
+msgid "Time"
+msgstr "Thời gian"
+
+#: log.c:170
+#, fuzzy
+msgid "Action"
+msgstr "Tuỳ chọn"
+
+#: main.c:95
 msgid ""
 "Copyright (C) 2005 Thomas Leonard.\n"
 "ROX-Filer comes with ABSOLUTELY NO WARRANTY,\n"
@@ -1906,15 +2035,15 @@ msgstr ""
 "dưới các điều khỏan của giấy phép GNU General Public License.\n"
 "Để biết thêm thông tin hãy xem tập tin có tên COPYING.\n"
 
-#: main.c:103
+#: main.c:104
 msgid "Try `ROX-Filer/AppRun --help' for more information.\n"
 msgstr "Thử `ROX-Filer/AppRun --help' để biết thêm thông tin.\n"
 
-#: main.c:106
+#: main.c:107
 msgid "Try `ROX-Filer/AppRun -h' for more information.\n"
 msgstr "Thử `ROX-Filer/AppRun -h' để biết thêm thông tin.\n"
 
-#: main.c:108
+#: main.c:109
 msgid ""
 "NOTE: Your system does not support long options - \n"
 "you must use the short versions instead.\n"
@@ -1923,7 +2052,7 @@ msgstr ""
 "GHI CHÚ: Hệ thống của bạn không hỗ trợ các tùy chọn dài - \n"
 "bạn phải dùng các phiên bản ngắn thay thế.\n"
 
-#: main.c:114
+#: main.c:115
 #, c-format
 msgid ""
 "Usage: ROX-Filer/AppRun [OPTION]... [FILE]...\n"
@@ -1980,7 +2109,7 @@ msgstr ""
 "Thông báo lỗi đến %s.\n"
 "Trang chủ (bao gồm các phiên bản cập nhật): http://rox.sourceforge.net/\n"
 
-#: main.c:236
+#: main.c:237
 msgid ""
 "We got a BadWindow error from the X server. This might be due to this GTK "
 "bug (during drag-and-drop?):\n"
@@ -1992,62 +2121,58 @@ msgstr ""
 "http://bugzilla.gnome.org/show_bug.cgi?id=152151\n"
 "Đang thử tiếp tục..."
 
-#: main.c:395
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
 msgstr ""
 "Tham số -o bây giờ không dùng. Bạn có thể bật trực tiếp từ hộp Tùy chọn."
 
-#: main.c:524
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "Đang chạy như người dùng '%s'"
 
-#: main.c:685
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr "Đã biên dịch với phiên bản GTK %s\n"
 
-#: main.c:686
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr "Đang chạy với phiên bản GTK %d.%d.%d\n"
 
-#: main.c:690
+#: main.c:693
 msgid "features set at compile time"
 msgstr "các chức năng thiết đặt tại thời điểm biên dịch"
 
-#: main.c:691
+#: main.c:694
 msgid "Large File Support"
 msgstr "Hỗ trợ Tập tin Lớn"
 
-#: main.c:698
-msgid "Dnotify support"
-msgstr "Hỗ trợ Dnotify"
-
-#: main.c:705
+#: main.c:701
 msgid "Binary compatibility"
 msgstr "Nhị phân tương thích"
 
-#: main.c:707
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr "Có (có thể chạy với phiên bản glibc cũ hơn)"
 
-#: main.c:709
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr "Không (apsymbols.h không tìm thấy)"
 
-#: main.c:713
+#: main.c:709
 msgid "Extended attribute support"
 msgstr "Hỗ trợ thuộc tính mở rộng"
 
-#: main.c:864
+#: main.c:856
 #, c-format
 msgid "Unable to read '%s': %s"
 msgstr "Không thể đọc '%s': %s"
 
-#: main.c:900
+#: main.c:895
 #, c-format
 msgid ""
 "Left-click to run %s.\n"
@@ -2056,236 +2181,322 @@ msgstr ""
 "Nhấp-trái để chạy %s.\n"
 "Nhấp-phải để hiện một danh sách phiên bản."
 
-#: menu.c:185 tips:28
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "Lỗi khi tạo '%s': %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "Lưu như:"
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "Hiển thị"
 
-#: menu.c:186 tips:33
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "Xem kiểu biểu tượng"
 
-#: menu.c:187
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "Biểu tượng, Với..."
 
-#: menu.c:188 tips:52
-msgid "Sizes"
-msgstr "Kích cỡ"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "Theme của biểu tượng"
 
-#: menu.c:190 tips:226
-msgid "Types"
-msgstr "Loại"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "Quyền hạn"
 
-#: menu.c:191 tips:55
-msgid "Times"
-msgstr "Thời gian"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "Biểu tượng, Với..."
 
-#: menu.c:192 tips:34 tips:70
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "Xem kiểu danh sách"
 
-#: menu.c:194
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "Biểu tượng lớn hơn"
 
-#: menu.c:195
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "Biểu tượng nhỏ hơn"
 
-#: menu.c:196 tips:49
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "Tự động"
 
-#: menu.c:198
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "Sắp xếp theo Tên"
 
-#: menu.c:199
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "Sắp xếp theo Loại"
 
-#: menu.c:200
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "Sắp xếp theo Ngày"
 
-#: menu.c:201
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "Sắp xếp theo Ngày"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "Sắp xếp theo Ngày"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "Sắp xếp theo Kích Cỡ"
 
-#: menu.c:202
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "Quyền hạn"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "Sắp xếp theo Sở Hữu"
 
-#: menu.c:203
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "Sắp xếp theo Nhóm"
 
-#: menu.c:204
+#: menu.c:671
 msgid "Reversed"
 msgstr "Ngược Lại"
 
-#: menu.c:206
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "Hiện tập tin ẩn"
 
-#: menu.c:207
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "Hiện Tập Tin Trợ Giúp"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "không có thư mục)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "Bộ lọc tập tin"
 
-#: menu.c:208
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "Bộ lọc tập tin"
+
+#: menu.c:681
 msgid "Filter Directories With Files"
 msgstr "Lọc Thư Mục theo Tập tin"
 
-#: menu.c:209
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "Hiện Thumbnail"
 
-#: menu.c:210
+#: menu.c:683
 msgid "Refresh"
 msgstr "Làm mới"
 
-#: menu.c:211
-msgid "Save Current Display Settings..."
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "Làm mới"
+
+#: menu.c:686
+#, fuzzy
+msgid "Save Display Settings..."
 msgstr "Lưu Thiết đặt Hiển thị Hiện tại..."
 
-#: menu.c:213
-msgid "Copy..."
-msgstr "Sao chép..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "Lưu Thiết đặt Hiển thị Hiện tại..."
 
-#: menu.c:214
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "Kiểm kê"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "Đổi tên..."
 
-#: menu.c:215
+#: menu.c:700
 msgid "Link..."
 msgstr "Liên kết..."
 
-#: menu.c:219
+#: menu.c:708
 msgid "Send To..."
 msgstr "Gửi đến..."
 
-#: menu.c:224
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "Các thuộc tính mở rộng"
+
+#: menu.c:721
 msgid "Count"
 msgstr "Kiểm kê"
 
-#: menu.c:225
+#: menu.c:723
 msgid "Set Type..."
 msgstr "Thiết đặt Lọai..."
 
-#: menu.c:229 toolbar.c:154
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "Chọn"
 
-#: menu.c:230
+#: menu.c:733
 msgid "Select All"
 msgstr "Chọn tất cả"
 
-#: menu.c:231
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "Bỏ chọn"
 
-#: menu.c:232
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "Đảo ngược việc chọn"
 
-#: menu.c:233
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "Chọn theo Tên..."
 
-#: menu.c:234
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "Chọn nếu..."
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "Chọn nếu..."
 
-#: menu.c:236
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "Tạo"
 
-#: menu.c:238
+#: menu.c:752
 msgid "Blank file"
 msgstr "Tập tin trống"
 
-#: menu.c:240 tasklist.c:306
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "Cửa sổ"
 
-#: menu.c:241
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "Lên mức cao hơn, Cửa sổ Mới"
 
-#: menu.c:242
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "Lên mức cao hơn , cùng cửa sổ"
 
-#: menu.c:243
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "Cửa sổ mới"
 
-#: menu.c:245
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "Hiện Bookmark"
 
-#: menu.c:246
+#: menu.c:766
 msgid "Show Log"
 msgstr "Hiện Bản ghi"
 
-#: menu.c:247
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "Đi theo các Liên kết"
 
-#: menu.c:248
+#: menu.c:769
 msgid "Resize Window"
 msgstr "Đổi kích thước cửa sổ"
 
-#: menu.c:251
+#: menu.c:771
 msgid "Close Window"
 msgstr "Đóng cửa sổ"
 
-#: menu.c:253
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "Nhập đường dẫn..."
 
-#: menu.c:254
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "Lệnh Shell..."
 
-#: menu.c:255
+#: menu.c:780
 msgid "Terminal Here"
 msgstr "Mở Terminal ở đây"
 
-#: menu.c:256
+#: menu.c:782
 msgid "Switch to Terminal"
 msgstr "Chuyển đến Terminal"
 
-#: menu.c:725
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "Bạn nên dùng Shift+nhấp phải trên một tập tin để đưa nó vào đâu đó"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "Tinh chỉnh Menu..."
 
-#: menu.c:764
+#: menu.c:976
 msgid "Next Click"
 msgstr "Hành động"
 
-#: menu.c:786
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d mục"
 
-#: menu.c:874
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "Mở gắn kết đã hủy"
 
-#: menu.c:877
+#: menu.c:1097
 msgid "Show Target"
 msgstr "Hiện đích"
 
-#: menu.c:879
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "Xem bên trong"
 
-#: menu.c:881
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "Mở như Text"
 
-#: menu.c:1052
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2299,15 +2510,15 @@ msgstr ""
 "đơn giản như các tập tin hệ thống cần thiết để gắn kết với những quyền hạn "
 "tuỳ chọn gắn kết ('user_xattr' trên Linux)."
 
-#: menu.c:1058
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr "Thiết đặt loại không hỗ trợ cho một vài tập tin này"
 
-#: menu.c:1093
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "Liên kết _Tương đối"
 
-#: menu.c:1099
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2319,43 +2530,56 @@ msgstr ""
 "Nếu tắt, đường dẫn từ thư mục gốc (root) sẽ được tích hợp. Dùng chức năng "
 "này nếu liên kếtbị di chuyển nhưng tập tin đích vẫn còn."
 
-#: menu.c:1169
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "Tên đường dẫn mới không tuyệt đối"
 
-#: menu.c:1235
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr "Liên kết từ '%s' đã có. Thay thế nó với một liên kết đến '%s'?"
 
-#: menu.c:1241
+#: menu.c:1546
 msgid "_Replace"
 msgstr "_Thay thế"
 
-#: menu.c:1361 menu.c:1402 menu.c:1462
-msgid "Create"
-msgstr "Tạo"
-
-#: menu.c:1362
+#: menu.c:1704
 msgid "NewDir"
 msgstr "ThưmụcMới"
 
-#: menu.c:1376 menu.c:1382
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "Lỗi khi tạo '%s': %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "Tạo"
 
-#: menu.c:1403
+#: menu.c:1755
 msgid "NewFile"
 msgstr "TậptinMới"
 
-#: menu.c:1421
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "Lỗi tạo tập tin: không thể tìm mẫu cho %s"
 
-#: menu.c:1492
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"Tạo liên kết bất kì chương trình nào bạn muốn vào thư mục này. Chúng sẽ xuất "
+"hiện trong menu của mọi mục loại này (%s/%s)."
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2367,8 +2591,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "Menu `Gửi đến' cung cấp một cách nhanh nhất để đưa vài tập tin đến một ứng "
 "dụng. Các ứng dụng được liệt kê trong các thư mục sau:\n"
@@ -2383,7 +2608,7 @@ msgstr ""
 "được mở cho loại của các tập tin đó. `.group' chỉ được hiển thị khi nhiều "
 "tập tin được chọn."
 
-#: menu.c:1503
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
@@ -2391,11 +2616,11 @@ msgstr ""
 "Bây giờ tôi sẽ hiện thư mục Gửi đến; bạn cần liên kết (Ctrl+Shift kéo) ứng "
 "dụng bất kì bạn muốn vào đó."
 
-#: menu.c:1506 menu.c:1546
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr "Thiết đặt biến CHOICESPATH của bạn không cho phép tùy chỉnh - xin lỗi."
 
-#: menu.c:1539
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2414,7 +2639,7 @@ msgstr ""
 "%s\n"
 "%s\n"
 
-#: menu.c:1544
+#: menu.c:1936
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
@@ -2422,15 +2647,21 @@ msgstr ""
 "Bây giờ tôi sẽ mở thư mục Templates; bạn nên đặt vào đó vài tập tin mẫu mà "
 "bạn muốn."
 
-#: menu.c:1661
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "Tuỳ chọn"
 
-#: menu.c:1734
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "Tinh chỉnh Menu..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "Đã có tên hợp qui tắc cho thư mục này."
 
-#: menu.c:1765
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2438,71 +2669,103 @@ msgstr ""
 "Bạn không thể mở cửa sổ thứ hai để xem thư mục này vì tùy chọn 'Cửa sổ Duy "
 "nhất' đã bật trong cửa sổ 'Tùy chọn'."
 
-#: menu.c:1891
-msgid "Copy ... ?"
-msgstr "Sao chép...?"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1894
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?Sao chép %s như %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?Sao chép %s như %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "Đổi tên ...?"
 
-#: menu.c:1897
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "Liên kết ...?"
 
-#: menu.c:1900
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "Đổi cách Mở ...?"
 
-#: menu.c:1903
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "Thuộc tính của ...?"
 
-#: menu.c:1906
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "Các thuộc tính mở rộng"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "Thiết đặt lọai của ... ?"
 
-#: menu.c:1909
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "Hành động thực thi cho ... ?"
 
-#: menu.c:1912
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "Thiết đặt Biểu tượng cho ... ?"
 
-#: menu.c:1915
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "Gửi ... đến ... ?"
 
-#: menu.c:1918
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "XÓA ... ?"
 
-#: menu.c:1921
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "Kiểm kê kích cỡ của ... ?"
 
-#: menu.c:1924
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "Thiết đặt quyền cho ... ?"
 
-#: menu.c:1927
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "Tìm kiếm bên trong ... ?"
 
-#: menu.c:1991
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "Sao chép...?"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "Bạn không thể làm việc này với nhiều hơn một tập tin cùng lúc"
 
-#: menu.c:2023
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "Đổi tên"
 
-#: menu.c:2028
+#: menu.c:2619
 msgid "Symlink"
 msgstr "Liên kết"
 
-#: menu.c:2057
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2524,7 +2787,7 @@ msgstr ""
 "\tgtk-can-change-accels = 1\n"
 "\t(nó chỉ làm việc nếu bạn KHÔNG dùng XSETTINGS)"
 
-#: menu.c:2068
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2544,31 +2807,40 @@ msgstr ""
 "Phím sẽ hiện ra lần kế trong mục menu và sau này bạn chỉ cần nhấn phím mà "
 "không cần mở menu."
 
-#: menu.c:2083
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "Thiết đặt các phím tắt"
 
-#: minibuffer.c:129
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "Đi đến:"
 
-#: minibuffer.c:130
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "Shell:"
 
-#: minibuffer.c:131
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "Chọn Nếu:"
 
-#: minibuffer.c:132
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "Chọn theo tên:"
 
-#: minibuffer.c:133
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "Chọn Nếu:"
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "Mẫu"
 
-#: minibuffer.c:265
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
@@ -2576,13 +2848,33 @@ msgstr ""
 "Nhập tên một tập tin và tôi sẽ hiển thị cho bạn. Nhấn Tab để hòan thành tên "
 "phù hợp. Nhấn Escape để đóng minibuffer."
 
-#: minibuffer.c:271
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr ""
 "Nhập một lệnh shell để thực thi. Nhấp chọn một tập tin để thêm nó đến bộ đệm."
 
-#: minibuffer.c:276
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"Nhập tên một tập tin mẫu để chọn tất cả tập tin trùng khớp:\n"
+"\n"
+"? nghĩa là kí tự bất kì\n"
+"* nghĩa là không có hoặc là nhiều kí tự\n"
+"[aA] nghĩa là 'a' hay 'A'\n"
+"[a-z] nghĩa là kí tự bất kì từ a đến z (chữ thường)\n"
+"*.png nghĩa là tên bất kì kết thúc bằng '.png'"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2600,14 +2892,22 @@ msgstr ""
 "[a-z] nghĩa là kí tự bất kì từ a đến z (chữ thường)\n"
 "*.png nghĩa là tên bất kì kết thúc bằng '.png'"
 
-#: minibuffer.c:288
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
 msgstr ""
 "Nhập một mẫu để các tập tin trùng khớp hiển thị. Để trống sẽ tắt bộ lọc."
 
-#: minibuffer.c:908
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr ""
+"Nhập một mẫu để các tập tin trùng khớp hiển thị. Để trống sẽ tắt bộ lọc."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "Sai điều kiện tìm kiếm"
 
@@ -2615,41 +2915,41 @@ msgstr "Sai điều kiện tìm kiếm"
 #, c-format
 msgid "File system table \"%s\" not found, cannot monitor system mounts"
 msgstr ""
-"Bảng hệ thống tập tin \"%s\" không tìm thấy, không tìm thấy các"
-"các gắn kết của hệ thống"
+"Bảng hệ thống tập tin \"%s\" không tìm thấy, không tìm thấy cáccác gắn kết "
+"của hệ thống"
 
 #: mount.c:393
 #, c-format
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s tổng, %s dùng, %s trống (%.1f %%)"
 
-#: options.c:275
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr ""
 "ROX-Filer đã chuyển đổi tập tin Tùy chọn của bạn sang định dạng XML mới"
 
-#: options.c:535 options.c:1256
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(sử dụng mặc định)"
 
-#: options.c:805
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "Lỗi bên trong: không thể đọc %s"
 
-#: options.c:914
+#: options.c:929
 msgid "Options"
 msgstr "Tuỳ chọn"
 
-#: options.c:959
+#: options.c:974
 msgid "_Revert"
 msgstr "_Trở lại"
 
-#: options.c:965
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr "Phục hồi tất cả các chọn lựa khi hộp tùy chọn được mở"
 
-#: options.c:980
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2658,34 +2958,34 @@ msgstr ""
 "Các chọn lựa sẽ được lưu như:\n"
 "%s"
 
-#: options.c:988
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(lưu trữ đã tắt bởi CHOICESPATH)"
 
-#: options.c:1161 usericons.c:452
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "Lỗi khi lưu %s: %s"
 
-#: options.c:1793
+#: options.c:1813
 msgid "Missing '='"
 msgstr "Lỗi '='"
 
-#: panel.c:319
+#: panel.c:326
 #, c-format
 msgid "Unable to replace '%s'"
 msgstr "Không thể thay thế '%s'"
 
-#: panel.c:323
+#: panel.c:330
 #, c-format
 msgid "Unable to save '%s'"
 msgstr "Không thể lưu"
 
-#: panel.c:526
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "Tập tin panel cũ đã được chuyển đổi sang định dạng XML mới."
 
-#: panel.c:634
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
@@ -2693,20 +2993,20 @@ msgstr ""
 "Bạn đã cố đóng panel thông qua trình quản lý cửa sổ - Tôi luôn thấy đây là "
 "rủi ro ... đóng nó không??"
 
-#: panel.c:735
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "Lỗi < hay > trong tập tin cấu hình panel"
 
-#: panel.c:1618
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "Lỗi lưu panel %s: %s"
 
-#: panel.c:1934
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "Applet thóat mà không tạo một widget!"
 
-#: panel.c:2030
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2715,44 +3015,44 @@ msgstr ""
 "Lỗi khi chạy applet:\n"
 "%s"
 
-#: panel.c:2655
+#: panel.c:2751
 msgid "Are you sure you want to remove this panel from the desktop?"
 msgstr "Bạn có muốn xoá panel này khỏi desktop?"
 
-#: panel.c:2658 panel.c:2685
+#: panel.c:2754 panel.c:2781
 msgid "Remove Panel"
 msgstr "Xoá Panel"
 
-#: panel.c:2681
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "Cấu hình panel..."
 
-#: panel.c:2767
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "Màn hình Xinerama %d không có"
 
-#: panel.c:2797
+#: panel.c:2897
 msgid "Top"
 msgstr "Cạnh trên"
 
-#: panel.c:2799
+#: panel.c:2899
 msgid "Bottom"
 msgstr "Cạnh dưới"
 
-#: panel.c:2801
+#: panel.c:2901
 msgid "Left"
 msgstr "Cạnh trái"
 
-#: panel.c:2803
+#: panel.c:2903
 msgid "Right"
 msgstr "Cạnh phải"
 
-#: panel.c:2805
+#: panel.c:2905
 msgid "Default"
 msgstr "Mặc định:"
 
-#: panel.c:2809
+#: panel.c:2909
 msgid "Unknown side"
 msgstr "Không biết cạnh"
 
@@ -2853,28 +3153,28 @@ msgid ""
 msgstr ""
 "Chỉ tập tin (và ứng dụng nào đó) có thể được dùng để thiết đặt ảnh nền."
 
-#: pinboard.c:1570
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "Lỗi '>' trong nhãn biểu tượng"
 
-#: pinboard.c:1579
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "Lỗi ',' sau nhãn biểu tượng"
 
-#: pinboard.c:1667
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "Lỗi lưu pinboard %s: %s"
 
-#: pinboard.c:2212
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "Nền..."
 
-#: pinboard.c:2215
+#: pinboard.c:2250
 msgid "Add Panel"
 msgstr "Thêm Panel"
 
-#: pinboard.c:2309
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2885,7 +3185,7 @@ msgstr ""
 "%s\n"
 "Nền đã xóa."
 
-#: pixmaps.c:976
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2894,97 +3194,40 @@ msgstr ""
 "Không thể xóa thumbnail trong %s:\n"
 "%s"
 
-#: pixmaps.c:997
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "Không có thumbnail để xóa"
 
-#: pixmaps.c:1010
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "Làm sạch bộ đệm thumbnail"
 
-#: remote.c:722
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "Không biết kiểu '%s'"
 
-#: remote.c:744
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "Không biết lọai chi tiết '%s'"
 
-#: remote.c:772
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "Không biết lọai sắp xếp '%s'"
 
-#: remote.c:1247
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "Thử gọi phương thức SOAP không biết '%s'"
 
-#: run.c:99 run.c:152
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "Không thấy chương trình %s - đã xóa?"
 
-#: run.c:302
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "Tập tin không có hoặc là tôi không thể truy nhập nó: %s"
-
-#: run.c:307
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "Tôi không biết cách mở '%s'"
-
-#: run.c:338
-#, c-format
-msgid "'%s' is not a valid URI"
-msgstr "'%s' không phải là một URI đúng"
-
-#: run.c:349
-#, c-format
-msgid "%s not accessable"
-msgstr "%s không thể truy nhập"
-
-#: run.c:357
-#, c-format
-msgid "Non-local URL %s"
-msgstr "URL %s không nội bộ"
-
-#: run.c:374
-#, c-format
-msgid "%s: no handler for %s"
-msgstr "%s: không trình điều khiển %s"
-
-#: run.c:394
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"Ứng dụng:\n"
-"Đây là một thư mục ứng dụng - bạn có thể chạy nó như một chương trình hoặc "
-"mở nó ra (giữ phím Shift trong khi mở). Hấu hết ứng dụng hỗ trợ trợ giúp ở "
-"đây nhưng cái này không có."
-
-#: run.c:478
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "Không thể gửi dữ liệu đến chương trình: %s"
-
-#: run.c:508
-#, c-format
-msgid "Could not read link: %s"
-msgstr "Không thể đọc liên kết: %s"
-
-#: run.c:536
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr "Liên kết vỡ (họăc là bạn không có quyền với nó): %s"
-
-#: run.c:573
+#: run.c:359
 #, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
@@ -2995,7 +3238,7 @@ msgstr ""
 "thiết đặt hành động thực thi bằng cách chọn `Hành động Thực thi'' từ menu "
 "Tập tin, hoặc là kéo tập tin đến một ứng dụng.%s"
 
-#: run.c:579
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -3007,7 +3250,64 @@ msgstr ""
 "Ghi chú: Nếu đây là chương trình bạn muốn khởi chạy, bạn cần thiết đặt bit "
 "thực thi bằng cách chọn Quyền hạn từ menu Tập tin."
 
-#: run.c:746
+#: run.c:373
+#, c-format
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "Tập tin không có hoặc là tôi không thể truy nhập nó: %s"
+
+#: run.c:378
+#, c-format
+msgid "I don't know how to open '%s'"
+msgstr "Tôi không biết cách mở '%s'"
+
+#: run.c:409
+#, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' không phải là một URI đúng"
+
+#: run.c:420
+#, c-format
+msgid "%s not accessable"
+msgstr "%s không thể truy nhập"
+
+#: run.c:428
+#, c-format
+msgid "Non-local URL %s"
+msgstr "URL %s không nội bộ"
+
+#: run.c:445
+#, c-format
+msgid "%s: no handler for %s"
+msgstr "%s: không trình điều khiển %s"
+
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
+msgstr ""
+"Ứng dụng:\n"
+"Đây là một thư mục ứng dụng - bạn có thể chạy nó như một chương trình hoặc "
+"mở nó ra (giữ phím Shift trong khi mở). Hấu hết ứng dụng hỗ trợ trợ giúp ở "
+"đây nhưng cái này không có."
+
+#: run.c:549
+#, c-format
+msgid "Could not send data to program: %s"
+msgstr "Không thể gửi dữ liệu đến chương trình: %s"
+
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "Không thể đọc liên kết: %s"
+
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
+msgstr "Liên kết vỡ (họăc là bạn không có quyền với nó): %s"
+
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -3032,93 +3332,131 @@ msgstr ""
 "Bạn nên kiểm lại, hoặc ngay cả xóa đi, các hành động thưc thi đã có trừ phi "
 "bạn tin vào tất cả mọi người dùng máy tính của bạn."
 
-#: run.c:759
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (Sửa chữa vấn đề bảo mật)"
 
-#: support.c:272
-msgid "B"
-msgstr "B"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:351
+#: support.c:381
 msgid "byte"
 msgstr "byte"
 
-#: support.c:1596 support.c:1650
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
 msgstr "Lỗi khi mở và thống kê tập tin '%s': %s"
 
-#: support.c:1607 support.c:1661
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
 msgstr "Lỗi khi mmap tập tin '%s': %s"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close"
 msgstr "Đóng"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close filer window"
 msgstr "Đóng cửa sổ"
 
-#: toolbar.c:117
+#: toolbar.c:120
 msgid "Up"
 msgstr "Lên"
 
-#: toolbar.c:117
-msgid "Change to parent directory"
-msgstr "Đến thư mục cha"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:121
+#: toolbar.c:126
 msgid "Home"
 msgstr "Nhà"
 
-#: toolbar.c:121
-msgid "Change to home directory"
-msgstr "Đến thư mục cá nhân"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks"
-msgstr "Đánh dấu"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks menu"
-msgstr "Trình đơn đánh dấu"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:129
+#: toolbar.c:138
 msgid "Scan"
 msgstr "Quét"
 
-#: toolbar.c:129
-msgid "Rescan directory contents"
-msgstr "Quét lại nội dung thư mục"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:133
-msgid "Change icon size"
-msgstr "Thay đổi kích cỡ Biểu tượng"
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "Kích cỡ"
 
-#: toolbar.c:137
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "Tự động"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
 msgstr "Tự động chọn kích cỡ"
 
-#: toolbar.c:141
-msgid "Show extra details"
-msgstr "Hiện chi tiết"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "Xem kiểu danh sách"
 
-#: toolbar.c:145
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
 msgstr "Sắp xếp"
 
-#: toolbar.c:145
+#: toolbar.c:165
 msgid "Change sort criteria"
 msgstr "Thay đổi tiêu chuẩn sắp xếp"
 
-#: toolbar.c:149
-msgid "Hidden"
-msgstr "Ẩn"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:149
+#: toolbar.c:169
 msgid ""
 "Left: Show/hide hidden files\n"
 "Right: Show/hide thumbnails"
@@ -3126,110 +3464,154 @@ msgstr ""
 "Trái: Hiện/Ẩn các tập tin ẩn\n"
 "Phải: Hiện/Ẩn các thumbnail"
 
-#: toolbar.c:154
-msgid "Select all/invert selection"
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+#, fuzzy
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+"Trái: Hiện/Ẩn các tập tin ẩn\n"
+"Phải: Hiện/Ẩn các thumbnail"
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
 msgstr "Chọn tất cả/đảo ngược lựa chọn"
 
-#: toolbar.c:158
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
 msgstr "Hiện trợ giúp của ROX-Filer"
 
-#: toolbar.c:221
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
 msgstr " (%u ẩn)"
 
-#: toolbar.c:229 tips:58
+#: toolbar.c:276 tips:79
 msgid "items"
 msgstr "mục"
 
-#: toolbar.c:229
+#: toolbar.c:276
 msgid "item"
 msgstr "mục"
 
-#: toolbar.c:232
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
 msgstr "Không có các mục%s"
 
-#: toolbar.c:251
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
 msgstr "%u mục đã được chọn (%s)"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by name"
 msgstr "Sắp xếp theo tên"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by type"
 msgstr "Sắp xếp theo lọai"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by date"
 msgstr "Sắp xếp theo ngày"
 
-#: toolbar.c:446
+#: toolbar.c:535
 msgid "Sort by size"
 msgstr "Sắp xếp theo kích cỡ"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by owner"
 msgstr "Sắp xếp theo sở hữu"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by group"
 msgstr "Sắp xếp theo nhóm"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "ascending"
 msgstr "tăng lên"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "descending"
 msgstr "giảm dần"
 
-#: type.c:214
+#: toolbar.c:891
+#, fuzzy
+msgid "_N_Items_"
+msgstr "Mục"
+
+#: type.c:221
 msgid "Sym link"
 msgstr "Liên kết"
 
-#: type.c:216
+#: type.c:223
 msgid "Mount point"
 msgstr "Điểm gắn kết"
 
-#: type.c:218
+#: type.c:225
 msgid "App dir"
 msgstr "Thư mục Ứng dụng"
 
-#: type.c:225
+#: type.c:232
 msgid "Dir"
 msgstr "Thư mục"
 
-#: type.c:227
+#: type.c:234
 msgid "Char dev"
 msgstr "Thiết bị tượng trưng"
 
-#: type.c:229
+#: type.c:236
 msgid "Block dev"
 msgstr "Khối thiết bị"
 
-#: type.c:231
+#: type.c:238
 msgid "Pipe"
 msgstr "Ống dẫn"
 
-#: type.c:233
+#: type.c:240
 msgid "Socket"
 msgstr "Socket"
 
-#: type.c:235
+#: type.c:242
 msgid "Door"
 msgstr "Cửa"
 
-#: type.c:238
+#: type.c:245
 msgid "Unknown"
 msgstr "Không biết"
 
-#: type.c:554
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3239,71 +3621,71 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:735
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "Đây không là một chương trình. Cho tôi một ứng dụng thay thế!"
 
-#: type.c:795
+#: type.c:839
 msgid "No run action defined"
 msgstr "Không hành động xác định"
 
-#: type.c:799
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "Lỗi trong điều khiển (handler) %s: %s"
 
-#: type.c:814
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "Sai ứng dụng %s (AppRun không đúng)"
 
-#: type.c:825
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "Không thể thực thi %s"
 
-#: type.c:858
+#: type.c:902
 msgid "Set run action"
 msgstr "Thiết lập hành động thực thi"
 
-#: type.c:864
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr ""
 "Nếu một trình điều khiển cho một lọai riêng biệt không thiết đặt, dùng mặc "
 "định này."
 
-#: type.c:866
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "Đặt mặc định cho tất cả `%s/<bất kì>'"
 
-#: type.c:870
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "Dùng ứng dụng này cho tất cả tập tin với lọai MIME này."
 
-#: type.c:872
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "Chỉ cho lọai `%s' (%s/%s)"
 
-#: type.c:878
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "Thả một ứng dụng ở đây"
 
-#: type.c:893
+#: type.c:963
 msgid "OR"
 msgstr "HOẶC"
 
-#: type.c:900
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "Nhập một lệnh shell:"
 
-#: type.c:929
+#: type.c:1000
 msgid "_Use Command"
 msgstr "_Sử dụng lệnh:"
 
-#: type.c:959
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
@@ -3311,16 +3693,16 @@ msgstr ""
 "Một hành động thực thi đã có và là một chương trình rất lớn - bạn có chắc "
 "muốn xóa nó?"
 
-#: type.c:970
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "Không thể xóa %s: %s"
 
-#: type.c:1007
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "Chọn lựa lưu trữ được tắt bởi biến CHOICESPATH"
 
-#: type.c:1309
+#: type.c:1395
 #, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
@@ -3329,11 +3711,11 @@ msgstr ""
 "Lỗi tạo liên kết '%s':\n"
 "%s"
 
-#: usericons.c:179
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "Tên thư mục bạn gán đã có. Biểu tượng không được thay đổi."
 
-#: usericons.c:189 usericons.c:618
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3343,12 +3725,12 @@ msgstr ""
 "hoặc là sai quyền truy nhập?\n"
 "Biểu tượng không được thay đổi."
 
-#: usericons.c:235
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "Xóa biểu tượng '%s'?"
 
-#: usericons.c:239
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3357,30 +3739,30 @@ msgstr ""
 "Không thể xóa '%s':\n"
 "%s"
 
-#: usericons.c:272
+#: usericons.c:281
 msgid "Set icon"
 msgstr "Thiết đặt biểu tượng."
 
-#: usericons.c:281
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr "Dùng một bản sao hình ảnh như mặc định cho tất cả các lọai MIME này."
 
-#: usericons.c:283
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "Thiết đặt biểu tượng cho tất cả `%s/<bất kì>'"
 
-#: usericons.c:288
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "Dùng một bản sao hình ảnh cho lọai MIME này."
 
-#: usericons.c:290
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "Cho tất cả tập tin lọai `%s' (%s/%s)"
 
-#: usericons.c:296
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
@@ -3388,12 +3770,12 @@ msgstr ""
 "Thêm tên tập tin và tên hình ảnh đến danh sách cá nhân. Thiết đặt sẽ mất nếu "
 "hình ảnh hay tập tin bị di chuyển."
 
-#: usericons.c:299
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "Chỉ cho tập tin `%s'"
 
-#: usericons.c:307
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
@@ -3403,19 +3785,19 @@ msgstr ""
 "người dùng sẽ thấy biểu tượng sau đó và bạn có thể di chuyển thư mục. Đây là "
 "tùy chọn tốt nhất nếu bạn có quyền viết với thư mục."
 
-#: usericons.c:313
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "Sao chép hình ảnh vào thư mục"
 
-#: usericons.c:319
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "Thả một tập tin biểu tượng ở đây"
 
-#: usericons.c:589
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "Thiết đặt biểu tượng được tắt bởi CHOICESPATH"
 
-#: usericons.c:633
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3424,41 +3806,57 @@ msgstr ""
 "Lỗi tạo hình ảnh '%s':\n"
 "%s"
 
-#: view_details.c:957
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
 msgid "Mono font"
 msgstr "Mono font"
 
-#: view_details.c:958
+#: view_details.c:1019
 msgid "Font for displaying mono-spaced text"
 msgstr "Font dùng hiển thị văn bản mono-space"
 
-#: view_details.c:1059
+#: view_details.c:1233
 msgid "_Name"
 msgstr "_Tên"
 
-#: view_details.c:1062
+#: view_details.c:1236
 msgid "_Type"
 msgstr "_Loại"
 
-#: view_details.c:1065
-msgid "_Permissions"
-msgstr "_Quyền"
-
-#: view_details.c:1070
-msgid "_Owner"
-msgstr "_Sở hữu"
-
-#: view_details.c:1072
-msgid "_Group"
-msgstr "_Nhóm"
-
-#: view_details.c:1074
+#: view_details.c:1238
 msgid "_Size"
 msgstr "_Kích cỡ"
 
-#: view_details.c:1080
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "_Quyền"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "_Sở hữu"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "_Nhóm"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "_Chỉnh Sửa Cuối"
+
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "Các thuộc tính mở rộng"
 
 #: tips:1
 msgid "Filer windows"
@@ -3508,7 +3906,8 @@ msgstr ""
 msgid "Largest window size:"
 msgstr "Kích cỡ cửa sổ lớn nhất:"
 
-#: tips:10
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
@@ -3521,14 +3920,28 @@ msgstr ""
 "cỡ cửa sổ."
 
 #: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "Kích cỡ cửa sổ lớn nhất:"
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr ""
+"Kích cỡ lớn nhất, tỉ lệ phần trăm với kích cỡ màn hình, khi tự thay đổi kích "
+"cỡ cửa sổ."
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "Trạng thái cửa sổ"
 
-#: tips:13
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "Kí hiệu thanh tiêu đề ngắn"
 
-#: tips:14
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
@@ -3536,11 +3949,11 @@ msgstr ""
 "Dùng các từ đơn thay thế cho các chỉ thị Quét, Tất cả và Thumb trên thanh "
 "tiêu đề."
 
-#: tips:15
+#: tips:18
 msgid "Unique windows"
 msgstr "Cửa sổ duy nhất"
 
-#: tips:16
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3548,11 +3961,34 @@ msgstr ""
 "Nếu bạn mở một thư mục và thư mục đó đã hiển thị trong một cửa sổ khác, khi "
 "đó, tùy chọn này sẽ đóng cửa sổ khác."
 
-#: tips:17
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "Cửa sổ"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "Cửa sổ mới trên nút nhất 1"
 
-#: tips:18
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3561,11 +3997,11 @@ msgstr ""
 "Nhấp trái chuột (nút nhấn 1) trên một thư mục sẽ mở thư mục đó trong một cửa "
 "sổ mới. Nhấp nút giữa chuột (nút giữa) sẽ dùng cửa sổ hiện tại."
 
-#: tips:19
+#: tips:26
 msgid "Single-click navigation"
 msgstr "Nhấp đơn chuột"
 
-#: tips:20 tips:116
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
@@ -3574,11 +4010,11 @@ msgstr ""
 "Nhấp đơn chuột trên một mục sẽ mở mục đó. Giữ Control để chọn mục. Nếu tắt "
 "chức năng này, thì nhấp đơn để chọn mục; nhấp đúp để mở mục đó."
 
-#: tips:21
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "Nhấp đúp trên nền để đổi kích cỡ"
 
-#: tips:22
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
@@ -3586,15 +4022,15 @@ msgstr ""
 "Nhấp đúp chuột trên nền cửa sổ để đổi kích cỡ cửa sổ, điều này tương tự như "
 "nhấp chọn kiểu Tự đổi kích cỡ trên thanh công cụ."
 
-#: tips:23
+#: tips:30
 msgid "Sorting"
 msgstr "Sắp xếp"
 
-#: tips:24
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "Thư mục trước (khi sắp xếp theo tên)"
 
-#: tips:25
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
@@ -3602,11 +4038,11 @@ msgstr ""
 "Bất chức năng này để sắp xếp thư mục trước bất kì thứ gì khi sắp xếp theo "
 "tên."
 
-#: tips:26
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "Tên chữ hoa trước ( khi sắp xếp theo tên)"
 
-#: tips:27
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
@@ -3614,15 +4050,59 @@ msgstr ""
 "Các tập tin bắt đầu với tên chữ hoa sẽ đứng trước các tập tin có tên chữ "
 "thường."
 
-#: tips:29
+#: tips:35
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "Thư mục trước (khi sắp xếp theo tên)"
+
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "Giây"
+
+#: tips:38
+msgid "Show extended attribute indicator"
+msgstr "Hiện dấu hiệu thuộc tính mở rộng"
+
+#: tips:39
+msgid ""
+"If this is on then files which have one or more extended attributes set will "
+"have an emblem added to indicate this."
+msgstr ""
+"Nếu tùy chọn này được chọn khi đó tập tin có một hay nhiều thuộc tính mởrộng "
+"được thiết đặt sẽ có một biểu tượng được thêm để biểu thị."
+
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
 msgid "Default settings for new windows"
 msgstr "Thiết đặt mặc định cho cửa sổ mới"
 
-#: tips:30
+#: tips:46
 msgid "Inherit options from source window"
 msgstr "Giữ lại các tùy chọn từ cửa sổ nguồn"
 
-#: tips:31
+#: tips:47
 msgid ""
 "If this is on then display options for a new window are inherited from the "
 "source window if possible, otherwise they are set to the defaults below."
@@ -3630,27 +4110,38 @@ msgstr ""
 "Các tùy chọn hiển thị cho cửa sổ mới sẽ thừa hưởng từ cửa sổ nguồn nếu có "
 "thể, mặc khác chúng được thiết đặt đến mặc định bên dưới."
 
-#: tips:32
+#: tips:48
 msgid "View type:"
 msgstr "Kiểu xem"
 
-#: tips:35
+#: tips:51
 msgid "Sort by:"
 msgstr "Sắp xếp theo:"
 
-#: tips:37 tips:54
+#: tips:53 tips:76 tips:114
 msgid "Type"
 msgstr "Loại"
 
-#: tips:38
-msgid "Date"
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
 msgstr "Ngày"
 
-#: tips:40
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "Ngày"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "Ngày"
+
+#: tips:58
 msgid "Show hidden files"
 msgstr "Hiện các tập tin ẩn"
 
-#: tips:41
+#: tips:59
 msgid ""
 "If this is on then files whose names start with a dot are shown too, "
 "otherwise they are hidden."
@@ -3658,55 +4149,75 @@ msgstr ""
 "Các tập tin bắt đầu với một dấu chấm trong tên (tập tin ẩn) cũng được hiển "
 "thị, mặt khác, chúng được ẩn."
 
-#: tips:42
-msgid "Show extended attribute indicator"
-msgstr "Hiện dấu hiệu thuộc tính mở rộng"
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "Hiện các tập tin ẩn"
 
-#: tips:43
+#: tips:61
+#, fuzzy
 msgid ""
-"If this is on then files which have one or more extended attributes set will "
-"have an emblem added to indicate this."
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
 msgstr ""
-"Nếu tùy chọn này được chọn khi đó tập tin có một hay nhiều thuộc tính mở"
-"rộng được thiết đặt sẽ có một biểu tượng được thêm để biểu thị." 
+"Các tập tin bắt đầu với một dấu chấm trong tên (tập tin ẩn) cũng được hiển "
+"thị, mặt khác, chúng được ẩn."
 
-#: tips:44
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "Lớn nhất"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "pixels"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "Xem kiểu biểu tượng"
 
-#: tips:45
+#: tips:67
 msgid "Default size:"
 msgstr "Kích cỡ mặc định:"
 
-#: tips:46
+#: tips:68
 msgid "Huge Icons"
 msgstr "Lớn nhất"
 
-#: tips:47 tips:217
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "Lớn"
 
-#: tips:48 tips:216
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "Nhỏ"
 
-#: tips:50
+#: tips:72
 msgid "Default details:"
 msgstr "Chi tiết mặc định:"
 
-#: tips:51
+#: tips:73
 msgid "No details"
 msgstr "Không chi tiết"
 
-#: tips:56
-msgid "Automatic small icons:"
+#: tips:74
+msgid "Sizes"
+msgstr "Kích cỡ"
+
+#: tips:77
+msgid "Times"
+msgstr "Thời gian"
+
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "Biểu tượng tự thu nhỏ:"
 
-#: tips:57
-msgid "Change at:"
-msgstr "Đổi khi có:"
-
-#: tips:59
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3715,66 +4226,93 @@ msgstr ""
 "Nếu tùy chọn này đã chọn: nó sẽ dùng Biểu tượng Nhỏ khi thư mục chứa nhiều "
 "mục, mặc khác, nó sẽ dùng Biểu tượng Lớn."
 
-#: tips:60
-msgid "Max width (Large icons):"
-msgstr "Độ rộng lớn nhất (Biểu tượng Lớn):"
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "Lớn"
 
-#: tips:61 tips:64
-msgid "pixels"
-msgstr "pixels"
-
-#: tips:62
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "Các text rộng hơn số này sẽ được chia thành hai dòng trong kiểu Biểu tượng "
 "Lớn. Trong kiểu Biểu tượng Lớn nhất, text được gói gọn khi rộng hơn số này "
 "50%."
 
-#: tips:63
-msgid "(Small Icons):"
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
+
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
+#: tips:88
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr ""
+"Nếu bật tùy chọn này, các biểu tượng lớn được sắp xếp theo cột, không phải "
+"hàng."
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
 msgstr "(Biểu tượng Nhỏ)"
 
-#: tips:65
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "Độ rộng lớn nhất cho text bên cạnh một Biểu tượng Nhỏ."
 
-#: tips:66
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "Xếp các biểu tượng nhỏ thẳng đứng"
 
-#: tips:67
+#: tips:93
 msgid ""
 "If this option is on, then small icons are arranged in columns, not rows."
 msgstr ""
 "Nếu bật tùy chọn này, các biểu tượng nhỏ được sắp xếp theo cột, không phải "
 "hàng."
 
-#: tips:68
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "Xếp các biểu tượng lớn thẳng đứng"
 
-#: tips:69
+#: tips:95
 msgid ""
 "If this option is on, then large icons are arranged in columns, not rows."
 msgstr ""
 "Nếu bật tùy chọn này, các biểu tượng lớn được sắp xếp theo cột, không phải "
 "hàng."
 
-#: tips:71
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "Hiện các cột tiêu đề"
 
-#: tips:72
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr "Các cột tiêu đề sẽ được hiện trong kiểu xem danh sách."
 
-#: tips:73
+#: tips:102
 msgid "Show full type"
 msgstr "Xem chi tiết loại tập tin"
 
-#: tips:74
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
@@ -3782,39 +4320,133 @@ msgstr ""
 "Nếu bật tùy chọn này, sẽ hiển thị chi tiết miêu tả về loại đối tượng hơn là "
 "một tóm tắt ngắn về loại cơ bản của nó."
 
-#: tips:75
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "Độ rộng lớn nhất cho text bên cạnh một Biểu tượng Nhỏ."
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "Hiện các cột tiêu đề"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr "Các cột tiêu đề sẽ được hiện trong kiểu xem danh sách."
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr "Các cột tiêu đề sẽ được hiện trong kiểu xem danh sách."
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr "Các cột tiêu đề sẽ được hiện trong kiểu xem danh sách."
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr "Các cột tiêu đề sẽ được hiện trong kiểu xem danh sách."
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr "Các cột tiêu đề sẽ được hiện trong kiểu xem danh sách."
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr "Các cột tiêu đề sẽ được hiện trong kiểu xem danh sách."
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "_Chỉnh Sửa Cuối"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr "Các cột tiêu đề sẽ được hiện trong kiểu xem danh sách."
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr "Các cột tiêu đề sẽ được hiện trong kiểu xem danh sách."
+
+#: tips:128
+#, fuzzy
+msgid "Last Accessed"
+msgstr "%s không thể truy nhập"
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr "Các cột tiêu đề sẽ được hiện trong kiểu xem danh sách."
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "Công cụ/Minibuffer"
 
-#: tips:76
+#: tips:131
 msgid "Toolbar"
 msgstr "Thanh công cụ"
 
-#: tips:77
+#: tips:132
 msgid "Toolbar type:"
 msgstr "Kiểu thanh công cụ"
 
-#: tips:78
+#: tips:133
 msgid "No toolbar"
 msgstr "Không có thanh công cụ"
 
-#: tips:79
+#: tips:134
 msgid "Icons only"
 msgstr "Chỉ biểu tượng"
 
-#: tips:80
+#: tips:135
 msgid "Text under icons"
 msgstr "Chữ dưới Biểu tượng"
 
-#: tips:81
+#: tips:136
 msgid "Text beside icons"
 msgstr "Chữ bên cạnh Biểu tượng"
 
-#: tips:82
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "Chỉ panel"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "Hiện tổng số mục"
 
-#: tips:83
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3823,40 +4455,40 @@ msgstr ""
 "Hiện số các mục đã hiển thị trong cửa sổ cũng như số mục ẩn (nếu có). Khi có "
 "sự chọn, hiện số mục đã chọn và kích cỡ của chúng."
 
-#: tips:84
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "Chọn nút bạn muốn trên thanh công cụ:"
 
-#: tips:85
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "Độ rộng của thanh công cụ thiết đặt độ rộng nhỏ nhất của cửa sổ"
 
-#: tips:86
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
 msgstr "Mỗi cửa sổ được ép đủ rộng để hiện tòan bộ thanh công cụ"
 
-#: tips:87
+#: tips:143
 msgid "Minibuffer"
 msgstr "Minibuffer"
 
-#: tips:88
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "Kêu bíp khi Tab-hòan thành lỗi"
 
-#: tips:89
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
 "letter varies)."
 msgstr "Khi dùng 'Nhập Đường dẫn...' và Tab được nhấn, sẽ kêu bíp nếu sai."
 
-#: tips:90
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "Kêu bíp nếu có nhiều trùng khớp"
 
-#: tips:91
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
@@ -3864,7 +4496,27 @@ msgstr ""
 "Khi dùn 'Nhập Đường dẫn...' và Tab được nhấn, sẽ kêu bíp nếu có nhiều tập "
 "tin trùng khớp."
 
-#: tips:94
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "Trình điều khiển tải về"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "Lỗi trong điều khiển (handler) %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
@@ -3872,11 +4524,11 @@ msgstr ""
 "Khi chế độ chân dung được bật, mỗi tập tin hình ảnh trong thư mục được nạp "
 "và một chân dung nhỏ của nó được hiển thị."
 
-#: tips:95
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "Hiện chân dung hình ảnh"
 
-#: tips:96
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
@@ -3884,32 +4536,101 @@ msgstr ""
 "Đây là thiết đặt mặc định cho cửa sổ mới. Dùng menu Hiển thị để bật tắt chức "
 "năng chân dung cho các cửa sổ riêng biệt."
 
-#: tips:97
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "Hiện chân dung hình ảnh"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "Xem chân dung"
 
-#: tips:98
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "Bộ đệm Chân dung"
 
-#: tips:99
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "Để tăng tốc, các chân dung tạo ra sẽ được tích hợp trong thư mục ~/."
 "thumbnails. Nhấp chuột vào đây để xóa bộ đệm. Chúng sẽ được tạo lại nếu cần."
 
-#: tips:100
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
 msgid "Manage thumbnails"
 msgstr "Quản lý các thumbnail"
 
-#: tips:101 tips:158
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "Xem chân dung"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+#, fuzzy
+msgid "sec"
+msgstr "Giây"
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "Pinboard"
 
-#: tips:102
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
@@ -3917,47 +4638,47 @@ msgstr ""
 "Khi dùng một pinboard, bạn có thể kéo tập tin và ứng dụng vào nền của "
 "desktop để tạo lối tắt cho chúng."
 
-#: tips:103 tips:213
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "Bề ngoài"
 
-#: tips:104
+#: tips:179
 msgid "Foreground:"
 msgstr "Kế hoạch gần"
 
-#: tips:105
+#: tips:180
 msgid "Text shadow:"
 msgstr "Bóng text:"
 
-#: tips:106
+#: tips:181
 msgid "Background:"
 msgstr "Nền"
 
-#: tips:107
+#: tips:182
 msgid "No shadow"
 msgstr "Không có bóng text"
 
-#: tips:108
+#: tips:183
 msgid "Thin"
 msgstr "Mỏng"
 
-#: tips:109
+#: tips:184
 msgid "Thick"
 msgstr "Dày"
 
-#: tips:110
+#: tips:185
 msgid "Use custom font:"
 msgstr "Dùng font tuỳ chọn"
 
-#: tips:111
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "Font đã được dùng cho text hiển thị dưới biểu tượng"
 
-#: tips:112
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "Xác định hình ảnh nhanh chóng"
 
-#: tips:113
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
@@ -3965,19 +4686,19 @@ msgstr ""
 "Chọn lựa phương pháp nhanh hay chậm để xác định hình ảnh của nền. Phương "
 "pháp chậm có thể đưa ra kết quả tốt hơn."
 
-#: tips:114
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "Trạng thái pinboard"
 
-#: tips:115
+#: tips:190
 msgid "Single-click to open"
 msgstr "Nhấp đơn để mở"
 
-#: tips:117
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "Giữ biểu tượng trong giới hạn màn hình"
 
-#: tips:118
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
@@ -3985,39 +4706,39 @@ msgstr ""
 "Các biểu tượng pinboard luôn được giữ hòan tòan trong giới hạn màn hình, bao "
 "gồm cả nhãn."
 
-#: tips:119
+#: tips:194
 msgid "Icon grid step:"
 msgstr "Bước lưới biểu tượng: "
 
-#: tips:120
+#: tips:195
 msgid "Fine"
 msgstr "Tốt"
 
-#: tips:121
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "Dùng lưới 2 pixel cho vị trí biểu tượng trên desktop."
 
-#: tips:122
+#: tips:197
 msgid "Medium"
 msgstr "Trung bình"
 
-#: tips:123
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "Dùng lưới 16 pixel cho vị trí biểu tượng trên desktop."
 
-#: tips:124
+#: tips:199
 msgid "Coarse"
 msgstr "Kém"
 
-#: tips:125
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "Dùng lưới 32 pixel cho vị trí biểu tượng trên desktop."
 
-#: tips:126 tips:128
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "Thu nhỏ cửa sổ"
 
-#: tips:127
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
@@ -4027,11 +4748,11 @@ msgstr ""
 "ứng dụng khác, bao gồm cả ROX-Filer, có thể dùng để hiển thị các cửa sổ thu "
 "nhỏ."
 
-#: tips:129
+#: tips:204
 msgid "Show iconified windows"
 msgstr "Hiện cửa sổ thu nhỏ"
 
-#: tips:130
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
@@ -4040,11 +4761,11 @@ msgstr ""
 "ROX-Filer sẽ hiện cửa sổ thu nhỏ như một nút nhỏ trên pinboard. Yêu cầu một "
 "trình quản lý cửa sổ tương thích và pinboard phải được dùng."
 
-#: tips:131
+#: tips:206
 msgid "Show per workspace"
 msgstr "Hiển thị từng khung làm việc"
 
-#: tips:132
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
@@ -4052,39 +4773,39 @@ msgstr ""
 "Nếu bật tùy chọn này, ROX-Filer sẽ chỉ hiển thị các cửa sổ đã thu nhỏ có "
 "trong khung làm việc (ưorkspace) hiện tại."
 
-#: tips:133
+#: tips:208
 msgid "Iconify to the"
 msgstr "Thu nhỏ đến"
 
-#: tips:134
+#: tips:209
 msgid "top-left"
 msgstr "trên-trái"
 
-#: tips:135
+#: tips:210
 msgid "top-right"
 msgstr "trên-phải"
 
-#: tips:136
+#: tips:211
 msgid "bottom-left"
 msgstr "dưới-trái"
 
-#: tips:137
+#: tips:212
 msgid "bottom-right"
 msgstr "dưới-phải"
 
-#: tips:138
+#: tips:213
 msgid ", going"
 msgstr ", theo"
 
-#: tips:139
+#: tips:214
 msgid "horizontally"
 msgstr "phương ngang"
 
-#: tips:140
+#: tips:215
 msgid "vertically"
 msgstr "phương dọc"
 
-#: tips:141
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -4095,43 +4816,43 @@ msgstr ""
 "xuống (ví dụ) thanh panel của Gnome. Bạn có thể xác định một lề trên hay "
 "dưới để đặt biểu tượng ở đó. ROX-Filer nhận biết được panel của nó :)."
 
-#: tips:142
+#: tips:217
 msgid "Top margin"
 msgstr "Lề trên"
 
-#: tips:143
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "Chiều cao của vùng không đi tại đỉnh màn hình"
 
-#: tips:144
+#: tips:219
 msgid "Bottom margin"
 msgstr "Lề dưới"
 
-#: tips:145
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "Chiều cao của vùng không đi tại đáy màn hình."
 
-#: tips:146
+#: tips:221
 msgid "Left margin"
 msgstr "Lề trái"
 
-#: tips:147
+#: tips:222
 msgid "Width of no-go area at left of screen."
 msgstr "Độ rộng của vùng không-di-chuyển phía trái màn hình"
 
-#: tips:148
+#: tips:223
 msgid "Right margin"
 msgstr "Lề phải"
 
-#: tips:149
+#: tips:224
 msgid "Width of no-go area at right of screen."
 msgstr "Độ rộng của vùng không-di-chuyển phía phải màn hình"
 
-#: tips:150
+#: tips:225
 msgid "Desktop"
 msgstr "Desktop"
 
-#: tips:151
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
@@ -4140,63 +4861,52 @@ msgstr ""
 "quản lý tập tin có thể mở một panel và/hay một pinboard. Đây là nơi bạn cấu "
 "hình nó"
 
-#: tips:152
+#: tips:227
 msgid "Panel only"
 msgstr "Chỉ panel"
 
-#: tips:153
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "Chỉ hiện một panel"
 
-#: tips:154
+#: tips:229
 msgid "Pinboard only"
 msgstr "Chỉ pinboard"
 
-#: tips:155
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "Chỉ hiện pinboard"
 
-#: tips:156
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "Panel và pinboard"
 
-#: tips:157
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "Hiện cả panel và pinboard"
 
-#: tips:159
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "Hãy nhập tên của pinboard để hiện."
 
-#: tips:160
-msgid "Panel (obsolete)"
-msgstr "Panel (cũ)"
-
-#: tips:161
-msgid ""
-"Enter the name of the panel to show here. This option is now only used when "
-"upgrading from an old version."
-msgstr ""
-"Nhập tên của panel để hiển thị ở đây. Tuỳ chọn này chỉ được dùng khi "
-"cập nhật từ phiên bản cũ."
-
-#: tips:162
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr "Các thay đổi sẽ có tác dụng trong lần chạy kế tiếp của ROX-Filer."
 
-#: tips:163
+#: tips:236
+#, fuzzy
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 "Trình quản lý phiên khởi chạy các tùy chọn này bằng cách dùng tham số -S "
 "hoặc --rox-session đến rox."
 
-#: tips:164
+#: tips:237
 msgid "Action windows"
 msgstr "Cửa sổ Hành động"
 
-#: tips:165
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
@@ -4204,69 +4914,74 @@ msgstr ""
 "Các cửa sổ hành động xuất hiện khi bạn bắt đầu một thao tác\n"
 "nền như là sao chép hoặc xóa tập tin."
 
-#: tips:166
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "Tự bắt đầu (Không hỏi) những hành động này"
 
-#: tips:168
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "Sao chép tập tin không cần xác nhận."
 
-#: tips:170
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "Di chuyển tập tin không cần xác nhận."
 
-#: tips:172
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "Tạo liên kết đến tập tin không cần xác nhận."
 
-#: tips:174
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "Xóa tập tin không cần xác nhận."
 
-#: tips:175
+#: tips:248
 msgid "Mount"
 msgstr "Gắn kết"
 
-#: tips:176
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "Gắn kết và hủy gắn kết hệ thống tập tin không cần xác nhận."
 
-#: tips:177
+#: tips:250
 msgid "Default settings"
 msgstr "Các thiết đặt mặc định"
 
-#: tips:179
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "Bắt buộc"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "Không xác nhận việc xóa các mục không thể viết."
 
-#: tips:181
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "Không hiển thị quá nhiểu thông tin trong vùng message."
 
-#: tips:183
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "Cũng thay đổi luôn nội dung thư mục con."
 
-#: tips:186
+#: tips:263
 msgid "Mount commands"
 msgstr "Lệnh gắn kết"
 
-#: tips:187
+#: tips:264
 msgid "Mount command"
 msgstr "Lệnh gắn kết"
 
-#: tips:188
+#: tips:265
 msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
 msgstr ""
 "Lệnh dùng để gắn kết một tập tin hệ thống (filesystem). Nếu không chắc, dùng "
 "\"mount\"."
 
-#: tips:189
+#: tips:266
 msgid "Unmount command"
 msgstr "Lệnh huỷ gắn kết"
 
-#: tips:190
+#: tips:267
 msgid ""
 "The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
 "without the first \"n\")."
@@ -4274,27 +4989,35 @@ msgstr ""
 "Lệnh dùng để hủy gắn kết một tập tin hệ thống (filesystem). Nếu không chắc, "
 "dùng \"umount\""
 
-#: tips:191
+#: tips:268
 msgid "Eject command"
 msgstr "Lệnh eject"
 
-#: tips:192
+#: tips:269
 msgid "The command used to eject removable media. If unsure, use \"eject\"."
 msgstr "Lệnh dùng để nhả dụng cụ có thể gỡ. Nếu không chắc, dùng \"eject\"."
 
-#: tips:193
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "Kéo và Thả"
 
-#: tips:194
+#: tips:273
 msgid "Dragging to icons"
 msgstr "Kéo đến biểu tượng"
 
-#: tips:195
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "Cho phép kéo đến biểu tượng trong cửa sổ"
 
-#: tips:196
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
@@ -4304,11 +5027,11 @@ msgstr ""
 "Mục sẽ tô sáng lên và bạn thả tập tin vào thư mục hay nạp nó vào chương "
 "trình."
 
-#: tips:197
+#: tips:276
 msgid "Directories spring open"
 msgstr "Thư mục xuất hiện"
 
-#: tips:198
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
@@ -4317,15 +5040,15 @@ msgstr ""
 "Tùy chọn này yêu cầu tùy chọn trên. Khi thư mục được tô sáng sẽ được mở ra "
 "sau khi giữ tập tin trên nó."
 
-#: tips:199
+#: tips:278
 msgid "Spring delay:"
 msgstr "Độ trễ xuất hiện:"
 
-#: tips:200
+#: tips:279
 msgid "ms"
 msgstr "ms"
 
-#: tips:201
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
@@ -4334,43 +5057,43 @@ msgstr ""
 "Thiết đặt bạn phải giữ tập tin trên thư mục bao lâu, bằng ms, trước khi nó "
 "mở ra."
 
-#: tips:202
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "Khi kéo tập tin với nút trái chuột"
 
-#: tips:203 tips:207
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "Hiện menu các hành động có thể"
 
-#: tips:204
+#: tips:283
 msgid "Copy the files"
 msgstr "Sao chép tập tin"
 
-#: tips:205
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
 msgstr "Bạn vẫn có thể lấy menu bằng cách kéo và giữ phím Alt"
 
-#: tips:206
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "Khi kéo tập tin với nút chuột"
 
-#: tips:208
+#: tips:287
 msgid "Move the files"
 msgstr "Di chuyển tập tin"
 
-#: tips:209
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
 msgstr "Bạn vẫn có thể lấy menu bằng cách kéo và giữ phím Alt"
 
-#: tips:210
+#: tips:289
 msgid "Download handler"
 msgstr "Trình điều khiển tải về"
 
-#: tips:211
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4382,35 +5105,35 @@ msgstr ""
 "tại là đích. Ví dụ:\n"
 "xterm -e wget $1"
 
-#: tips:212
+#: tips:291
 msgid "Menus"
 msgstr "Trình đơn"
 
-#: tips:214
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "Kích cỡ biểu tượng trong menu:"
 
-#: tips:215
+#: tips:294
 msgid "No Icons"
 msgstr "Không biểu tượng"
 
-#: tips:218
+#: tips:297
 msgid "Same as current window"
 msgstr "Như cửa sổ hiện tại"
 
-#: tips:219
+#: tips:298
 msgid "Same as default"
 msgstr "Như mặc định"
 
-#: tips:220
+#: tips:299
 msgid "Behaviour"
 msgstr "Cách chạy"
 
-#: tips:221
+#: tips:300
 msgid "File menu on right-click"
 msgstr "Trình đơn Tập tin khi nhấp chuột phải"
 
-#: tips:222
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
@@ -4418,23 +5141,27 @@ msgstr ""
 "Hiện menu Tập tin thay thế menu chính khi nhấp chuột phải trên tập tin (menu "
 "chính có thể truy nhập bằng cách giữ Ctrl)."
 
-#: tips:223
+#: tips:302
 msgid "Terminal emulator program"
 msgstr "Chương trình giả lập terminal"
 
-#: tips:224
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr "Chương trình để chạy khi bạn chọn 'Mở Terminal ở đây' từ menu."
 
-#: tips:225
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "Phím tắt bàn phím"
 
-#: tips:227
+#: tips:305
+msgid "Types"
+msgstr "Loại"
+
+#: tips:306
 msgid "MIME types"
 msgstr "Loại MIME"
 
-#: tips:228
+#: tips:307
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
@@ -4442,23 +5169,23 @@ msgstr ""
 "ROX-Filer thiết đặt một qui luật để thi hành chính xác lọai MIME cho các tập "
 "tin thường, sau đó chọn biểu tượng cho lọai đó."
 
-#: tips:229
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "Chỉnh sửa luật MIME"
 
-#: tips:230
+#: tips:309
 msgid "Themes"
 msgstr "Theme"
 
-#: tips:231
+#: tips:310
 msgid "Icon theme"
 msgstr "Theme của biểu tượng"
 
-#: tips:232
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "Các theme nên được đặt trong thư mục ~/.icons"
 
-#: tips:233
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
@@ -4467,39 +5194,39 @@ msgstr ""
 "MIME. Ghi nhớ rằng các biểu tượng được thiết đặt theo cách này sẽ ghi đè lên "
 "biểu tượng được chọn trong theme."
 
-#: tips:234
+#: tips:313
 msgid "Colours"
 msgstr "Màu sắc"
 
-#: tips:235
+#: tips:314
 msgid "File type colours"
 msgstr "Màu loại tập tin"
 
-#: tips:236
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "Màu sắc tập tin dưa trên lọai của chúng"
 
-#: tips:237
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr "Tên tập tin (và chi tiết) được tô màu phù hợp với lọai tập tin."
 
-#: tips:238
+#: tips:317
 msgid "Directory:"
 msgstr "Thư mục"
 
-#: tips:239
+#: tips:318
 msgid "Regular file:"
 msgstr "Tập tin thường"
 
-#: tips:240
+#: tips:319
 msgid "Pipe:"
 msgstr "Pipe:"
 
-#: tips:241
+#: tips:320
 msgid "Socket:"
 msgstr "Socket:"
 
-#: tips:243
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
@@ -4507,19 +5234,19 @@ msgstr ""
 "Lỗi, liên kết trỏ đến một tập tin không có hoặc là ROX-Filer không có quyền "
 "truy nhập đến tâp tin"
 
-#: tips:244
+#: tips:323
 msgid "Character device:"
 msgstr "Thiết bị mẫu tự"
 
-#: tips:245
+#: tips:324
 msgid "Block device:"
 msgstr "Thiết bị khối"
 
-#: tips:246
+#: tips:325
 msgid "Door:"
 msgstr "Door:"
 
-#: tips:247
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
@@ -4527,31 +5254,59 @@ msgstr ""
 "Các tập tin door là một nhị phận như socket hay ống dẫn và chỉ có trên "
 "Solaris."
 
-#: tips:248
+#: tips:327
 msgid "Executable file:"
 msgstr "Tập tin thực thi:"
 
-#: tips:249
+#: tips:328
 msgid "Application directory:"
 msgstr "Thư mục ứng dụng:"
 
-#: tips:250
+#: tips:329
 msgid "Unknown type:"
 msgstr "Lọai không biết:"
 
-#: tips:251
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "Nền"
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "Dùng font tuỳ chọn"
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "Tương thích"
 
-#: tips:252
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "Vấn đề trình quản lý cửa sổ"
 
-#: tips:253
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "Lọai bỏ sự điều khiển pinboard và panel của Trình Quản lý cửa sổ"
 
-#: tips:254
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4565,11 +5320,11 @@ msgstr ""
 "và các trang trí khác có vẻ nằm xung quanh cửa sổ hay có chúng trong danh "
 "sách chọn cửa sổ."
 
-#: tips:255
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "Đưa các nhấp chuột vào nền đến Trình Quản lý cửa sổ"
 
-#: tips:256
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
@@ -4579,11 +5334,11 @@ msgstr ""
 "bỏ chọn. Bật chức năng này để đưa các sự việc đến Trình Quản Lý Cửa Sổ. Các "
 "nhấp chuột trên biểu tượng sẽ không được đưa."
 
-#: tips:257
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Hack menu gốc của Blackbox"
 
-#: tips:258
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4595,27 +5350,50 @@ msgstr ""
 "trình quản lý cửa sổ này sẽ thay đổi các xử lý trong các phiên bản mới để "
 "điều này không cần thiết nữa."
 
-#: tips:259
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "Panel là một 'dock'"
 
-#: tips:260
+#: tips:346
+#, fuzzy
 msgid ""
-"Disable this option if the panel stays above other windows against your "
-"wishes. Requires a restart to take effect."
+"Makes sure panels stay against screen edges. Disable this option if the "
+"panel stays above other windows against your wishes. Requires a restart to "
+"take effect."
 msgstr ""
 "Tắt tùy chọn này nếu panel ở trên các cửa sổ khác ngòai sự mong muốn của "
 "bạn. Yêu cầu khởi động lại để có hiệu lực."
 
-#: tips:261
+#: tips:347
+msgid "Panel stays on top"
+msgstr ""
+
+#: tips:348
+msgid ""
+"Keeps the panel above other windows. Enable this option to make sure the "
+"dock option works correctly in some versions of compiz. May require a "
+"restart to take effect."
+msgstr ""
+
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "Kéo và thả"
 
-#: tips:262
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "Không dùng hostnames"
 
-#: tips:263
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4625,15 +5403,11 @@ msgstr ""
 "Dùng nếu khi kéo tập tin hiện một dấu cộng (+) trên chuột nhưng thả không "
 "làm việc."
 
-#: tips:264
-msgid "Extended attributes"
-msgstr "Các thuộc tính mở rộng"
-
-#: tips:265
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "Không dùng các thuộc tính mở rộng"
 
-#: tips:266
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4645,120 +5419,260 @@ msgstr ""
 "loại MIME của tập tin chỉ lấy được từ tên tập tin và thuộc tính của cửa sổ "
 "không thông báo các thuộc tính mở rộng."
 
-#: ../Templates.glade:7
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "Cạnh dưới"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "Cạnh phải"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
 msgid "ROX-Filer log viewer"
 msgstr "Trình xem Bản ghi của ROX-Filer"
 
-#: ../Templates.glade:22
+#: ../Templates.ui.h:2
 msgid "Recently performed actions..."
 msgstr "Những hành động gần đây ..."
 
-#: ../Templates.glade:77
+#: ../Templates.ui.h:3
 msgid "Open Directory"
 msgstr "Mở Thư mục"
 
-#: ../Templates.glade:129
+#: ../Templates.ui.h:4
 msgid "Panel Options"
 msgstr "Cấu hình panel"
 
-#: ../Templates.glade:169
-msgid "Every icon on this panel is shown with an image and some text."
-msgstr "Mỗi biểu tượng trên panel này được hiển thị với một ảnh và vài chữ."
-
-#: ../Templates.glade:170
+#: ../Templates.ui.h:5
 msgid "Image and Text"
 msgstr "Ảnh và chữ"
 
-#: ../Templates.glade:186
+#: ../Templates.ui.h:6
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "Mỗi biểu tượng trên panel này được hiển thị với một ảnh và vài chữ."
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "Chỉ ảnh cho ứng dụng"
+
+#: ../Templates.ui.h:8
 msgid ""
 "Applications in this panel have just an image, everything else has both an "
 "image and text."
 msgstr "Ứng dụng trên panel này chỉ có ảnh, mọi thứ khác có cả ảnh và chữ."
 
-#: ../Templates.glade:187
-msgid "Image only for applications"
-msgstr "Chỉ ảnh cho ứng dụng"
-
-#: ../Templates.glade:205
-msgid "Only the image is shown for icons in this panel."
-msgstr "Chỉ ảnh được hiển thị đối với các biểu tượng trên panel này"
-
-#: ../Templates.glade:206
+#: ../Templates.ui.h:9
 msgid "Image only"
 msgstr "Chỉ ảnh"
 
-#: ../Templates.glade:235
+#: ../Templates.ui.h:10
+msgid "Only the image is shown for icons in this panel."
+msgstr "Chỉ ảnh được hiển thị đối với các biểu tượng trên panel này"
+
+#: ../Templates.ui.h:11
 msgid "Panel width"
 msgstr "Độ rộng của panel"
 
-#: ../Templates.glade:247
+#: ../Templates.ui.h:12
 msgid "The size of this panel."
 msgstr "Kích cỡ của panel này."
 
-#: ../Templates.glade:259
+#: ../Templates.ui.h:13
 msgid "px"
 msgstr "px"
 
-#: ../Templates.glade:278
+#: ../Templates.ui.h:14
+#, fuzzy
+msgid "Transparency"
+msgstr "Bản dịch"
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "Không che lấp panel"
+
+#: ../Templates.ui.h:19
 msgid ""
 "Ask the window manager not to cover this panel when maximising windows, "
 "otherwise leave just 2 pixels at the edge of the screen to allow auto-"
 "raising. Some window managers may not honour this setting."
 msgstr ""
-"Yêu cầu trình quản lý cửa sổ không che lấp panel này khi cửa sổ được"
-"phóng cực đại, mặc khác chỉ đặt 2 pixel tại cạnh màn hình để cho phép tự"
-"động hiện ra. Vài trình quản lý cửa sổ không có thiết lập này."
+"Yêu cầu trình quản lý cửa sổ không che lấp panel này khi cửa sổ đượcphóng "
+"cực đại, mặc khác chỉ đặt 2 pixel tại cạnh màn hình để cho phép tựđộng hiện "
+"ra. Vài trình quản lý cửa sổ không có thiết lập này."
 
-#: ../Templates.glade:279
-msgid "Do not cover panel"
-msgstr "Không che lấp panel"
-
-#: ../Templates.glade:297
+#: ../Templates.ui.h:20
 msgid "<b>Panel style</b>"
 msgstr "<b>Kiểu Panel</b>"
 
-#: ../Templates.glade:331
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "Hạn chế màn hình Xinerama"
+
+#: ../Templates.ui.h:22
 msgid ""
 "If you use multiple monitors with Xinerama, use this option to confine the "
 "panel to one monitor."
 msgstr ""
-"Nếu bạn dùng nhiều màn hình với Xinerama, dùng tùy chọn này để hạn ché panel"
-"đến một màn hình."
+"Nếu bạn dùng nhiều màn hình với Xinerama, dùng tùy chọn này để hạn ché "
+"panelđến một màn hình."
 
-#: ../Templates.glade:332
-msgid "Confine to Xinerama monitor"
-msgstr "Hạn chế màn hình Xinerama"
-
-#: ../Templates.glade:347
+#: ../Templates.ui.h:23
 msgid ""
 "The monitor this panel is confined to when using Xinerama. The numbering "
 "starts from zero."
-msgstr ""
-"Panels bị hạn chế đến màn hình khi dùng Xinerama. Số bắt đầu từ zero."
+msgstr "Panels bị hạn chế đến màn hình khi dùng Xinerama. Số bắt đầu từ zero."
 
-#: ../Templates.glade:372
+#: ../Templates.ui.h:24
 msgid "<b>Xinerama</b>"
 msgstr "<b>Xinerama</b>"
 
-#: ../Templates.glade:407
+#: ../Templates.ui.h:25
 msgid "Right edge"
 msgstr "Cạnh phải"
 
-#: ../Templates.glade:426
+#: ../Templates.ui.h:26
 msgid "Left edge"
 msgstr "Cạnh trái"
 
-#: ../Templates.glade:443
+#: ../Templates.ui.h:27
 msgid "Bottom edge"
 msgstr "Cạnh dưới"
 
-#: ../Templates.glade:462
+#: ../Templates.ui.h:28
 msgid "Top edge"
 msgstr "Cạnh trên"
 
-#: ../Templates.glade:496
+#: ../Templates.ui.h:29
 msgid "<b>Position</b>"
 msgstr "<b>Vị trí</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<thư mục>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' đã tồn tại - ghi đè lên?"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Lỗi quét '%s':\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "Thư mục bị lỗi hoặc đã xóa"
+
+#~ msgid "Directory '%s' is not accessible"
+#~ msgstr "Thư mục '%s' không thể truy nhập"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "Thư mục '%s' không tìm thấy."
+
+#~ msgid "Cancel"
+#~ msgstr "Huỷ"
+
+#~ msgid "All, "
+#~ msgstr "Tất cả, "
+
+#~ msgid "Dnotify support"
+#~ msgstr "Hỗ trợ Dnotify"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr "Bạn nên dùng Shift+nhấp phải trên một tập tin để đưa nó vào đâu đó"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "Đến thư mục cha"
+
+#~ msgid "Change to home directory"
+#~ msgstr "Đến thư mục cá nhân"
+
+#~ msgid "Bookmarks"
+#~ msgstr "Đánh dấu"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "Trình đơn đánh dấu"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "Quét lại nội dung thư mục"
+
+#~ msgid "Change icon size"
+#~ msgstr "Thay đổi kích cỡ Biểu tượng"
+
+#~ msgid "Show extra details"
+#~ msgstr "Hiện chi tiết"
+
+#~ msgid "Hidden"
+#~ msgstr "Ẩn"
+
+#~ msgid "Change at:"
+#~ msgstr "Đổi khi có:"
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "Độ rộng lớn nhất (Biểu tượng Lớn):"
+
+#~ msgid "Panel (obsolete)"
+#~ msgstr "Panel (cũ)"
+
+#~ msgid ""
+#~ "Enter the name of the panel to show here. This option is now only used "
+#~ "when upgrading from an old version."
+#~ msgstr ""
+#~ "Nhập tên của panel để hiển thị ở đây. Tuỳ chọn này chỉ được dùng khi cập "
+#~ "nhật từ phiên bản cũ."
 
 #~ msgid "Panel: %s"
 #~ msgstr "Panel: %s"
@@ -4805,9 +5719,6 @@ msgstr "<b>Vị trí</b>"
 #~ "(điều này nghĩa là theme của ROX đã có ở đó nhưng biểu tượng 'mime-"
 #~ "application:postscript' không thể được nạp hoặc là %s liên kết đến một "
 #~ "thư mục không đúng; hãy thử xóa nó)"
-
-#~ msgid "Translation"
-#~ msgstr "Bản dịch"
 
 #~ msgid "Language"
 #~ msgstr "Ngôn ngữ"

--- a/ROX-Filer/src/po/zh_CN.po
+++ b/ROX-Filer/src/po/zh_CN.po
@@ -8,39 +8,44 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ROX-Filer 2.8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2008-12-29 15:11+0800\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2008-12-29 16:32+0100\n"
 "Last-Translator: Babyfai Cheung<babyfai1@yahoo.com.hk>\n"
 "Language-Team: none\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: abox.c:125
-msgid "<dir>"
-msgstr "<目录>"
+#: abox.c:127
+msgid "<src>"
+msgstr ""
 
-#: abox.c:218
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "静默(_Q)"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Quiet"
 msgstr "静默"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "不用对每次操作进行确认"
 
-#: abox.c:454 infobox.c:771 tips:36
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "名称"
 
-#: abox.c:460 menu.c:237
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "目录"
 
-#: abox.c:549
+#: abox.c:546
 msgid "Expression:"
 msgstr "表示式："
 
@@ -56,11 +61,11 @@ msgstr "详情请参阅 fsattr(5) man page"
 msgid "You do not appear to have OS support."
 msgstr "系统不支持的 OS"
 
-#: action.c:191
+#: action.c:198
 msgid "Find expression reference"
 msgstr "找寻表示式范例"
 
-#: action.c:202
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -135,11 +140,11 @@ msgstr ""
 "在指令'command' 内的 '%' 则代表文件的路径)\n"
 "<b>prune</b> (搜寻条件为否，避免搜寻某一目录的内容)。"
 
-#: action.c:249
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "改变权限资料"
 
-#: action.c:260
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -196,11 +201,11 @@ msgstr ""
 "\n"
 "详细解释请参阅 chmod(1) 的 man page。"
 
-#: action.c:301
+#: action.c:308
 msgid "Set type reference"
 msgstr "设定类型方式"
 
-#: action.c:312
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -228,48 +233,55 @@ msgstr ""
 "目录，装置，管导或套节等类型有效\n"
 "并且只有某些操作系统及文件系统才会有支持\n"
 
-#: action.c:419
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "程序终结 \n"
 
-#: action.c:435
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "发现错误.\n"
 
-#: action.c:437
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "发现 %d 错误\n"
 
-#: action.c:461
+#: action.c:516
 msgid "ERROR reading"
 msgstr "错误读取"
 
-#: action.c:504
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "完成\n"
 
-#: action.c:560 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "错误"
 
-#: action.c:714 main.c:698 main.c:705 main.c:712 main.c:726
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "是"
 
-#: action.c:717 main.c:700 main.c:707 main.c:714 main.c:726
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "否"
 
-#: action.c:735
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -277,7 +289,7 @@ msgstr ""
 "\n"
 "正在终结子程序... \n"
 
-#: action.c:742
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -285,41 +297,41 @@ msgstr ""
 "\n"
 "尝试杀掉已遗失的程序... \n"
 
-#: action.c:895
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?计算内容从 %s?"
 
-#: action.c:931
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?删除 %s'%s'?"
 
-#: action.c:932
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "防写入的"
 
-#: action.c:939
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'正在删除 '%s'\n"
 
-#: action.c:952
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'目录 '%s' 已删除\n"
 
-#: action.c:985
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?弹出 '%s'?"
 
-#: action.c:992
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'正在弹出 '%s'\n"
 
-#: action.c:1011
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -328,95 +340,95 @@ msgstr ""
 "!%s\n"
 "弹出失败\n"
 
-#: action.c:1030 action.c:1049
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?检查 '%s'?"
 
-#: action.c:1046
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!非法的找寻设定-请更改后再尝试\n"
 
-#: action.c:1056
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(正当检查 '%s')\n"
 
-#: action.c:1130 action.c:1155
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?改变 '%s' 的权限?"
 
-#: action.c:1136
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'正在改变 '%s' 的权限\n"
 
-#: action.c:1153
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!非法指令模式-请更改后再试\n"
 
-#: action.c:1211
+#: action.c:1332
 #, c-format
 msgid "?Change contents of '%s'?"
 msgstr "?改变 '%s' 的內容？"
 
-#: action.c:1214 action.c:1234
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?改变 '%s' 的类型？"
 
-#: action.c:1231
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!非法类型-请更改后再试\n"
 
-#: action.c:1253
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'正在改变类型从 '%s' 为 '%s'\n"
 
-#: action.c:1276
+#: action.c:1397
 #, c-format
 msgid "'Not changing type of directory '%s'\n"
 msgstr "'目录 '%s' 中的类型没有改变'\n"
 
-#: action.c:1282
+#: action.c:1403
 #, c-format
 msgid "'Non-regular file '%s' not changed\n"
 msgstr "非常规文件 '%s' 没有改变\n"
 
-#: action.c:1342
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' 经已存在 - %s？"
 
-#: action.c:1344
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "合拼内容"
 
-#: action.c:1345
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "覆盖"
 
-#: action.c:1361
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'尝试硬复制..\n"
 
-#: action.c:1370
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?复制%s 为 %s？"
 
-#: action.c:1374
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'正在复制 %s 为 %s\n"
 
-#: action.c:1389
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!错误: 目标已存在，但不是一个目录\n"
 
-#: action.c:1461
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -425,26 +437,7 @@ msgstr ""
 "!%s\n"
 "复制 '%s' 失败\n"
 
-#: action.c:1505
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' 文件已存在-覆盖？"
-
-#: action.c:1520
-msgid "'Trying move anyway...\n"
-msgstr "'尝试强制移动...\n"
-
-#: action.c:1528
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?移动 %s 为 %s?"
-
-#: action.c:1532
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'正在移动 %s 为 %s\n"
-
-#: action.c:1540
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -453,45 +446,59 @@ msgstr ""
 "!%s\n"
 "移动 %s 到 %s 失败\n"
 
-#: action.c:1561
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'尝试强制移动...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?移动 %s 为 %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'正在移动 %s 为 %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!错误: 不能复制物件到本身内\n"
 
-#: action.c:1576
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!错误: 不能移动/改名物件到本身内\n"
 
-#: action.c:1588
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'链接 %s 为 %s\n"
 
-#: action.c:1593
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?链接 %s 为 %s?"
 
-#: action.c:1636
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'挂载 %s\n"
 
-#: action.c:1637
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'解除挂载 %s\n"
 
-#: action.c:1640
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?挂载 %s?"
 
-#: action.c:1641
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?解除挂载 %s?"
 
-#: action.c:1662
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -500,7 +507,7 @@ msgstr ""
 "!%s\n"
 "挂载失败\n"
 
-#: action.c:1663
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -509,11 +516,11 @@ msgstr ""
 "!%s\n"
 "解除挂载失败\n"
 
-#: action.c:1671
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(经已挂载)\n"
 
-#: action.c:1717
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -522,205 +529,229 @@ msgstr ""
 "'\n"
 "总数：%s ("
 
-#: action.c:1723
+#: action.c:2108
 msgid "file"
 msgstr "文件"
 
-#: action.c:1723
+#: action.c:2108
 msgid "files"
 msgstr "文件"
 
-#: action.c:1727
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "没有目录)\n"
 
-#: action.c:1731
+#: action.c:2116
 msgid "directory"
 msgstr "目录"
 
-#: action.c:1732
+#: action.c:2117
 msgid "directories"
 msgstr "目录"
 
-#: action.c:1773
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!没有挂载点被标记！\n"
 
-#: action.c:1858
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?其他的搜寻？"
 
-#: action.c:1888 action.c:1919
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' 是一符号链接\n"
 
-#: action.c:1959
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "你需要选择一些项目来搜寻"
 
-#: action.c:1969 menu.c:228
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "找寻"
 
-#: action.c:2002
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "你需要选择一些项目来计算"
 
-#: action.c:2006
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "磁盘用量"
 
-#: action.c:2042
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "挂载 / 解除挂载"
 
-#: action.c:2059
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr "ROX-Filer 对系统上的挂载点尚未支持"
 
-#: action.c:2073 menu.c:216 tips:173
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "删除"
 
-#: action.c:2085 tips:178
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "强制"
 
-#: action.c:2085
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "不可确认删除只读的项目"
 
-#: action.c:2088 action.c:2147 action.c:2210 action.c:2283 action.c:2323
-#: tips:180
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "简洁"
 
-#: action.c:2088
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "只记录已删除的目录"
 
-#: action.c:2107
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "你需选择更改权限的项目"
 
-#: action.c:2115
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (使之可执行/可被搜寻)"
 
-#: action.c:2117
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (使之不可执行/不可被搜寻)"
 
-#: action.c:2119
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (给用户写读的权限)"
 
-#: action.c:2121
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (私有化 - 只用户可存取)"
 
-#: action.c:2123
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (共享存取，不可写入)"
 
-#: action.c:2134 menu.c:189 menu.c:226 tips:53
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "权限"
 
-#: action.c:2147 action.c:2210
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "不列出已处理的文件"
 
-#: action.c:2150 action.c:2213 tips:182
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "包含"
 
-#: action.c:2150
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "同时改变子目录的内容"
 
-#: action.c:2154
+#: action.c:2547
 msgid "Command:"
 msgstr "指令："
 
-#: action.c:2184
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "你需选择更改类型的项目"
 
-#: action.c:2197
+#: action.c:2590
 msgid "Set type"
 msgstr "另定类型"
 
-#: action.c:2213
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "改变子目录的内容"
 
-#: action.c:2220 infobox.c:627
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "类型："
 
-#: action.c:2267 dnd.c:122 menu.c:2024 tips:167
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "复制"
 
-#: action.c:2279 action.c:2319 tips:184
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "不用对每次操作进行确认"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "只覆盖旧版本的文件"
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "刷新"
 
-#: action.c:2280 action.c:2320 tips:185
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "只覆盖旧版本的文件"
 
-#: action.c:2283
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "目录"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "只记录已被复制的目录"
 
-#: action.c:2307 dnd.c:123 tips:169
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "移动"
 
-#: action.c:2323
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "不记录每个移动的文件"
 
-#: action.c:2346 tips:171
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "链接"
 
-#: action.c:2369 appmenu.c:111 filer.c:593
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "弹出"
 
-#: action.c:2437
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "删除项目为"
 
-#: action.c:2441
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "删除中"
 
-#: action.c:2443
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "删除中"
 
-#: action.c:2462
+#: action.c:2900
 msgid " and "
 msgstr " 及 "
 
-#: action.c:2471
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr "将影向面板上某些项目 - 真的删除？"
 
-#: action.c:2478
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr "将影向面板上某些项目 - 真的删除？"
 
-#: appmenu.c:197
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<失去标签>"
 
-#: appmenu.c:319
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
@@ -728,82 +759,82 @@ msgid ""
 msgstr ""
 "链接任何合用程序到此目录内，该等程序将会出现于此类型 (%s/%s) 项目的菜单中"
 
-#: appmenu.c:363 menu.c:239
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "自定菜单..."
 
-#: appmenu.c:420 menu.c:257 toolbar.c:158
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "帮助"
 
-#: bookmarks.c:148 log.c:160
-msgid "Path"
-msgstr "路径"
-
-#: bookmarks.c:156
+#: bookmarks.c:268
 msgid "Title"
 msgstr "标题"
 
-#: bookmarks.c:305
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "路径"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "不能书签化非本地的资源 '%s'\n"
 
-#: bookmarks.c:313 bookmarks.c:631
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s'并非一个目录"
 
-#: bookmarks.c:519
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "请先选择行数以删除"
 
-#: bookmarks.c:543
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "将鼠标指向想要移动的项目上"
 
-#: bookmarks.c:563
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "此项目已排在最后"
 
-#: bookmarks.c:637
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "不能书签化非本地目录如 '%s'"
 
-#: bookmarks.c:779
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "加入新书签"
 
-#: bookmarks.c:786
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "编辑书签"
 
-#: bookmarks.c:791
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "最近存取的"
 
-#: bulk_rename.c:66
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "多文件更改名称"
 
-#: bulk_rename.c:69
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "复原"
 
-#: bulk_rename.c:74
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "回复旧有名称"
 
-#: bulk_rename.c:79
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "改名(_R)"
 
-#: bulk_rename.c:92
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "替换："
 
-#: bulk_rename.c:99
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -817,66 +848,66 @@ msgstr ""
 "\\. 对应点号\n"
 "\\.htm$ 对应 '.htm' 于 'index.html', 等等"
 
-#: bulk_rename.c:107
+#: bulk_rename.c:109
 msgid "With:"
 msgstr "改为："
 
-#: bulk_rename.c:114
+#: bulk_rename.c:116
 msgid ""
 "The first match in each filename will be replaced by this string. The only "
 "special characters are back-references from \\0 to \\9. To use them "
 "literally, they have to be escaped with a backslash."
 msgstr ""
-"每个文件名称的对应部份，会先被这字串取代。"
-"而只可使用的正则字符为逆向引用 \\0 至 \\9。"
+"每个文件名称的对应部份，会先被这字串取代。而只可使用的正则字符为逆向引用 \\0 "
+"至 \\9。"
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "套用"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
 msgstr "完成搜寻取代后, 文件名称并未真正改变，必须点击下面 '改名' 的按钮."
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "旧名称"
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "新名称"
 
-#: bulk_rename.c:293
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr "没有可对应的字串"
 
-#: bulk_rename.c:298
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "一个名称已匹配，但结果没有改变"
 
-#: bulk_rename.c:301
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d 个名称已匹配，但结果没有改变"
 
-#: bulk_rename.c:327
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr "请指定一个常规表示式，及一个字串用以置换对应名称."
 
-#: bulk_rename.c:344
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (for '%s')"
 
-#: bulk_rename.c:377
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr "文件 '%s' 经已存在，退出多文件更改名称."
 
-#: bulk_rename.c:382
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -887,12 +918,12 @@ msgstr ""
 "%s\n"
 "退出多文件更改名称."
 
-#: bulk_rename.c:444
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "文件 '%s' 经已存在"
 
-#: bulk_rename.c:455
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
@@ -900,7 +931,7 @@ msgid ""
 msgstr ""
 "有些新名称含有 / 字符 (如 '%s')，这样会使生成的文件终结到不同的目录，继续?"
 
-#: bulk_rename.c:470
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "没有名称被改变！"
 
@@ -924,42 +955,62 @@ msgstr ""
 "%s\n"
 "%s"
 
-#: dir.c:1041
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "不能打开目录：%s"
 
-#: dir.c:1050
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "不能打开目录：%s"
 
-#: display.c:659
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "大小"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) 失败：%s"
 
-#: dnd.c:124
-msgid "Link (relative)"
-msgstr "链接 (相对路径)"
-
-#: dnd.c:125
-msgid "Link (absolute)"
-msgstr "链接 (绝对路径)"
-
-#: dnd.c:424
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "内部错误 -信息已损坏"
 
-#: dnd.c:563
+#: dnd.c:565
 msgid "Drag a directory here to bookmark it."
 msgstr "拖放一个目录到这处，将之纳入书签"
 
-#: dnd.c:578
+#: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
 msgstr "XDS 协定错误: 名称不存在'/'\n"
 
-#: dnd.c:603
+#: dnd.c:605
 msgid ""
 "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
 "plain) did not contain a leafname\n"
@@ -967,16 +1018,16 @@ msgstr ""
 "XdndDirectSave0 目标已提供，但这 XdndDirectSave0 (类别 text/plain) 没有包含一"
 "个分支名称\n"
 
-#: dnd.c:616
+#: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
 msgstr "抱歉 - 需要一个 text/uri-list 类型或一个 XdndDirectSave0."
 
-#: dnd.c:619
+#: dnd.c:621
 msgid ""
 "Sorry - I require a target type of text/uri-list or application/octet-stream."
 msgstr "抱歉 - 需要一个 text/uri-list 或 application/octet-stream 的类型."
 
-#: dnd.c:689
+#: dnd.c:691
 #, c-format
 msgid ""
 "Failed to add some items to the pinboard, because they are on a remote "
@@ -988,59 +1039,77 @@ msgstr ""
 "\n"
 "%s"
 
-#: dnd.c:764
+#: dnd.c:766
 msgid "Unknown target"
 msgstr "不明目标"
 
-#: dnd.c:797
+#: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
 msgstr "远端机器上的程序，不会向本机送出资料 - 抱歉"
 
-#: dnd.c:810
+#: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
 msgstr "XDS错误，回传码必须为'S','F'或'E'\n"
 
-#: dnd.c:843
+#: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
 msgstr "抱歉，不能显示远端机器上的程序菜单。"
 
-#: dnd.c:859
+#: dnd.c:861
 msgid "UntitledData"
 msgstr "未命名资料"
 
-#: dnd.c:886
+#: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
 msgstr "储存: %s 时发生错误"
 
-#: dnd.c:959
+#: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
 msgstr "没有位址在 text/uri-list (没有任何操作！)"
 
-#: dnd.c:991
+#: dnd.c:993
 msgid ""
 "Can't get data from remote machine (application/octet-stream not provided)"
 msgstr "未能在远端机器上获得资料 (application/octet-stream 并未提供)"
 
-#: dnd.c:1014
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr "某些文件是来自另一主机 - 这些会被忽略 - 抱歉"
 
-#: dnd.c:1021
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
 msgstr "没有任何文件是在本机上的 - 不能在多远端机器环境下操作 - 抱歉."
 
-#: dnd.c:1034
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "不明的执行要求"
 
-#: dnd.c:1042
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "错误的文件列表: %s"
+
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "链接 (相对路径)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "链接 (绝对路径)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "链接 (相对路径)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "链接 (绝对路径)"
 
 #: dropbox.c:112
 msgid "Show"
@@ -1078,7 +1147,7 @@ msgstr ""
 "不能存取 '%s':\n"
 "%s"
 
-#: filer.c:456
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1087,16 +1156,7 @@ msgstr ""
 "错误扫描 '%s'：\n"
 "%s\n"
 
-#: filer.c:460
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"错误扫描 '%s'：\n"
-"%s"
-
-#: filer.c:576
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1106,19 +1166,19 @@ msgstr ""
 "\n"
 "解除挂载后才把媒体移出，会较为安全."
 
-#: filer.c:580
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 msgid "No change"
 msgstr "没有改变"
 
-#: filer.c:586 menu.c:872
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "解除挂载"
 
-#: filer.c:690
-msgid "Directory missing/deleted"
-msgstr "目录已删除/或不存在"
-
-#: filer.c:1054
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
@@ -1129,106 +1189,144 @@ msgstr ""
 "重选其他文件.\n"
 "注意，键盘上的 NumLock 必须开启"
 
-#: filer.c:1290
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "目录 '%s' 不接受存取"
-
-#: filer.c:1442
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "找不到目录 '%s' "
-
-#: filer.c:1742
-msgid "Cancel"
-msgstr "取消"
-
-#: filer.c:2023
+#: filer.c:2655
 msgid "A"
 msgstr ""
 
-#: filer.c:2025 find.c:923
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr ""
 
-#: filer.c:2030
+#: filer.c:2664
 msgid "S"
 msgstr ""
 
-#: filer.c:2032
+#: filer.c:2669
 msgid "T"
 msgstr ""
 
-#: filer.c:2042
-msgid "All, "
+#: filer.c:2670
+msgid "D"
 msgstr ""
 
-#: filer.c:2045
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
 msgstr "只匹配(%s) "
 
-#: filer.c:2053
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "重新扫描中, "
 
-#: filer.c:2055
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "显示缩略图, "
 
-#: filer.c:2331
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "显示缩略图, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "链接指向 "
 
-#: filer.c:2373
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "不是正确的 UTF-8 名称，请重新命名.\n"
 
-#: filer.c:2690 menu.c:2014
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "项目已不存在！"
 
-#: filer.c:3417
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "选择显示内容以储存"
 
-#: filer.c:3421
+#: filer.c:4712
+#, fuzzy
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr "<b>储存目录的显示设定</b>"
+
+#: filer.c:4713
 msgid "<b>Save display settings for directory</b>"
 msgstr "<b>储存目录的显示设定</b>"
 
-#: filer.c:3428
+#: filer.c:4720
 msgid "Select settings to save"
 msgstr "选择显示内容设定以储存"
 
-#: filer.c:3435
+#: filer.c:4727
 msgid "Position"
 msgstr "位置"
 
-#: filer.c:3440 toolbar.c:133 toolbar.c:137 tips:39
-msgid "Size"
-msgstr "大小"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "窗口"
 
-#: filer.c:3445
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "显示隐藏档"
 
-#: filer.c:3451
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "显示风格"
 
-#: filer.c:3457
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "以类型排序"
 
-#: filer.c:3462 toolbar.c:141
+#: filer.c:4754
 msgid "Details"
 msgstr "详述"
 
-#: filer.c:3467 tips:92 tips:93
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "缩略图"
 
-#: filer.c:3473
+#: filer.c:4765
 msgid "Filter"
 msgstr "过滤"
 
@@ -1452,17 +1550,17 @@ msgstr ""
 msgid "Save As:"
 msgstr "另存为："
 
-#: gtksavebox.c:395
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "未命名的"
 
-#: gtksavebox.c:471
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
 msgstr ""
 
-#: gtksavebox.c:596
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1470,18 +1568,18 @@ msgstr ""
 "拖放该图标至一个目录查看器内\n"
 "(或输入一个完整路径)"
 
-#: gui_support.c:330
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
 msgstr ""
 
-#: gui_support.c:399
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr "尝试以文本方式读取XML文件。发现文件 '%s' 已损坏."
 
-#: gui_support.c:416
+#: gui_support.c:542
 #, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
@@ -1496,22 +1594,22 @@ msgstr ""
 "原因可能是从旧版本上升级 ROX-Filer，请打开选项窗口并点选储存确定.\n"
 "往后的错误会被忽略."
 
-#: gui_support.c:1008
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "打开 文字/链接 档时发生错误"
 
-#: gui_support.c:1341
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "未能打开文件 '%s': %s"
 
-#: gui_support.c:1385
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
 msgstr "未能载入影像 '%s'： 原因不明，可能是文件损毁"
 
-#: gui_support.c:1450
+#: gui_support.c:1583
 #, c-format
 msgid ""
 "This program (%s) cannot be run, as the 0launch command is not available. It "
@@ -1529,171 +1627,176 @@ msgid ""
 "language setting to take full effect."
 msgstr "请重新启动ROX-Filer，新的语言设定才会完全生效"
 
-#: icon.c:76
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(点击以设定)"
 
-#: icon.c:131
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:132 menu.c:258
-msgid "About ROX-Filer..."
-msgstr "关于 ROX-Filer..."
-
-#: icon.c:133 menu.c:259
-msgid "Show Help Files"
-msgstr "显示帮助档"
-
-#: icon.c:134 menu.c:260
-msgid "Manual"
-msgstr "指南"
-
-#: icon.c:136 menu.c:235
-msgid "Options..."
-msgstr "选项..."
-
-#: icon.c:137 menu.c:244
-msgid "Home Directory"
-msgstr "家目录"
-
-#: icon.c:138 icon.c:1410 menu.c:212 type.c:223
-msgid "File"
-msgstr "文件"
-
-#: icon.c:139 menu.c:218 menu.c:885
-msgid "Shift Open"
-msgstr "以新窗口打开"
-
-#: icon.c:140 menu.c:223
-msgid "Properties"
-msgstr "属性"
-
-#: icon.c:141 menu.c:221
-msgid "Set Run Action..."
-msgstr "设定运行程序..."
-
-#: icon.c:142 menu.c:222
-msgid "Set Icon..."
-msgstr "设定图标..."
-
-#: icon.c:143 icon.c:867
-msgid "Edit Item"
-msgstr "编辑项目"
-
-#: icon.c:144
-msgid "Show Location"
-msgstr "显示位址"
-
-#: icon.c:145
-msgid "Remove Item(s)"
-msgstr "移除项目"
-
-#: icon.c:318 log.c:110 menu.c:774
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr ""
 
-#: icon.c:331
+#: icon.c:311
 msgid "Nothing"
 msgstr "空的"
 
-#: icon.c:592
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "位址名称最少要包含一个字元！"
 
-#: icon.c:657
+#: icon.c:641
 #, c-format
 msgid "You must unlock '%s' before removing it"
 msgstr "必须解除 '%s' 的锁定，才可移除"
 
-#: icon.c:667
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "请先选择项目以删除"
 
-#: icon.c:673
+#: icon.c:657
 msgid "An item must be unlocked before it can be removed."
 msgstr "每个项目必先解除锁定，才可把它移除"
 
-#: icon.c:687
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "请在项目上打开菜单"
 
-#: icon.c:712 menu.c:1285
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "只可对常规文件设定打开的程序"
 
-#: icon.c:798
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "按下所要求的热键 (如 Control+F1)"
 
-#: icon.c:820
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "找取按键错误！"
 
-#: icon.c:870
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "编辑项目"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "点击图标以打开："
 
-#: icon.c:880
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "参数(用于可执行档)："
 
-#: icon.c:894
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "图标下的文字为："
 
-#: icon.c:907
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "设定热键为："
 
-#: icon.c:927
+#: icon.c:910
 msgid "Locked"
 msgstr "锁定"
 
-#: icon.c:932
+#: icon.c:915
 msgid "Locking an item prevents it from being accidentally removed"
 msgstr "锁定一个项目以免被意外删除"
 
-#: infobox.c:111
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "关于 ROX-Filer..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "显示帮助档"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "指南"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "选项..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "家目录"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "文件"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "以新窗口打开"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "属性"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "设定运行程序..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "设定图标..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "显示位址"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "移除项目"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
 msgstr "您想打开 %d 窗口"
 
-#: infobox.c:112
+#: infobox.c:114
 msgid "Show Info"
 msgstr "显示信息"
 
-#: infobox.c:134 menu.c:779
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(不正确的 utf-8)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "显示帮助档(_H)"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>权限</b>"
 
-#: infobox.c:290
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>内容指示为...</b>"
 
-#: infobox.c:427 infobox.c:568 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "只记录已被复制的目录"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "bytes"
 
-#: infobox.c:450
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "未能查看文件之大小"
 
-#: infobox.c:511
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' 不是一个符号链接"
 
-#: infobox.c:518
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1702,7 +1805,7 @@ msgstr ""
 "未能移除符号链接 '%s':\n"
 "%s"
 
-#: infobox.c:523
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1713,172 +1816,186 @@ msgstr ""
 "%s\n"
 "(注意:旧的链接已被删除)"
 
-#: infobox.c:547 tips:242
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "错误："
 
-#: infobox.c:554
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "真正目录："
 
-#: infobox.c:557
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "用户，组别："
 
-#: infobox.c:564 infobox.c:579 infobox.c:588
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "大小："
 
-#: infobox.c:589
+#: infobox.c:621
 msgid "Scanning"
 msgstr "扫描中"
 
-#: infobox.c:614
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "扫描失败"
 
-#: infobox.c:621
+#: infobox.c:653
 msgid "Change time:"
 msgstr "变更时间："
 
-#: infobox.c:623
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "修改时间："
 
-#: infobox.c:625
+#: infobox.c:657
 msgid "Access time:"
 msgstr "存取时间："
 
-#: infobox.c:633
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "扩展属性："
 
-#: infobox.c:635
+#: infobox.c:667
 msgid "Present"
 msgstr "目前"
 
-#: infobox.c:636
+#: infobox.c:668
 msgid "None"
 msgstr "没有"
 
-#: infobox.c:637
+#: infobox.c:669
 msgid "Not supported"
 msgstr "不支持"
 
-#: infobox.c:649
+#: infobox.c:681
 msgid "Link target:"
 msgstr "链接目标："
 
-#: infobox.c:661 infobox.c:664
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "执行程序："
 
-#: infobox.c:661
+#: infobox.c:693
 msgid "Execute file"
 msgstr "执行文件"
 
-#: infobox.c:773
+#: infobox.c:805
 msgid "Comment"
 msgstr "注解"
 
-#: infobox.c:775
+#: infobox.c:807
 msgid "Execute"
 msgstr "运行文件"
 
-#: infobox.c:789
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<还是空的>"
 
-#: infobox.c:860
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "文件(1) 显示...%s"
 
-#: infobox.c:917
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "不能改变 '%s' 的权限"
 
-#: infobox.c:935
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "用户"
 
-#: infobox.c:937
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "组别"
 
-#: infobox.c:939
+#: infobox.c:974
 msgid "World"
 msgstr "其他"
 
-#: infobox.c:942
+#: infobox.c:977
 msgid "Read"
 msgstr "可读"
 
-#: infobox.c:944
+#: infobox.c:980
 msgid "Write"
 msgstr "可写"
 
-#: infobox.c:946
+#: infobox.c:983
 msgid "Exec"
 msgstr "可执行"
 
-#: infobox.c:963
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:970
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:977
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky"
 
-#: infobox.c:999
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<空的>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "是一符号链接"
 
-#: infobox.c:1002
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX 应用程序"
 
-#: infobox.c:1010
+#: infobox.c:1100
 msgid "mounted"
 msgstr "已挂载"
 
-#: infobox.c:1010
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "已解除挂载"
 
-#: infobox.c:1014
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "挂载点为 %s (%s)"
 
-#: infobox.c:1017
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "挂载点 (%s)"
 
-#: log.c:55
+#: log.c:54
 msgid "ROX-Filer started"
 msgstr "ROX-Filer 已启动"
 
-#: log.c:112
+#: log.c:115
 #, c-format
 msgid "%s on %d items"
 msgstr "%s 於 %d 项目"
 
-#: log.c:125
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "复制..."
+
+#: log.c:139
 msgid "Item"
 msgstr "项目"
 
-#: log.c:149
+#: log.c:165
 msgid "Time"
 msgstr "时间"
 
-#: log.c:154
+#: log.c:170
 msgid "Action"
 msgstr "动作"
 
@@ -1946,65 +2063,57 @@ msgid ""
 "Trying to continue..."
 msgstr ""
 
-#: main.c:400
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
 msgstr ""
 
-#: main.c:529
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "执行用户为 '%s'"
 
-#: main.c:690
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr ""
 
-#: main.c:691
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr ""
 
-#: main.c:695
+#: main.c:693
 msgid "features set at compile time"
 msgstr ""
 
-#: main.c:696
+#: main.c:694
 msgid "Large File Support"
 msgstr ""
 
-#: main.c:703
-msgid "Inotify support"
-msgstr ""
-
-#: main.c:710
-msgid "Dnotify support"
-msgstr ""
-
-#: main.c:717
+#: main.c:701
 msgid "Binary compatibility"
 msgstr ""
 
-#: main.c:719
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr ""
 
-#: main.c:721
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr ""
 
-#: main.c:725
+#: main.c:709
 msgid "Extended attribute support"
 msgstr ""
 
-#: main.c:876
+#: main.c:856
 #, c-format
 msgid "Unable to read '%s': %s"
 msgstr "未能打开 '%s': %s"
 
-#: main.c:918
+#: main.c:895
 #, c-format
 msgid ""
 "Left-click to run %s.\n"
@@ -2013,236 +2122,322 @@ msgstr ""
 "左击以运行  %s.\n"
 "右击以显示版本。"
 
-#: menu.c:185 tips:28
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "错误创建 '%s': %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "另存为："
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "显示"
 
-#: menu.c:186 tips:33
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "图标模式"
 
-#: menu.c:187
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "图标，并显示..."
 
-#: menu.c:188 tips:52
-msgid "Sizes"
-msgstr "大小"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "图标布景"
 
-#: menu.c:190 tips:226
-msgid "Types"
-msgstr "类型"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "权限"
 
-#: menu.c:191 tips:55
-msgid "Times"
-msgstr "时间"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "图标，并显示..."
 
-#: menu.c:192 tips:34 tips:70
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "列表模式"
 
-#: menu.c:194
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "较大图标"
 
-#: menu.c:195
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "较小图标"
 
-#: menu.c:196 tips:49
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "自动化"
 
-#: menu.c:198
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "以名称排序"
 
-#: menu.c:199
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "以类型排序"
 
-#: menu.c:200
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "以日期排序"
 
-#: menu.c:201
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "以日期排序"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "以日期排序"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "以大小排序"
 
-#: menu.c:202
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "权限"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "以用户排序"
 
-#: menu.c:203
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "以组别排序"
 
-#: menu.c:204
+#: menu.c:671
 msgid "Reversed"
 msgstr "反向"
 
-#: menu.c:206
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "显示隐藏档"
 
-#: menu.c:207
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "显示帮助档"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "没有目录)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "文件过滤..."
 
-#: menu.c:208
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "文件过滤..."
+
+#: menu.c:681
 msgid "Filter Directories With Files"
 msgstr "文件过滤并忽略目录"
 
-#: menu.c:209
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "显示缩略图"
 
-#: menu.c:210
+#: menu.c:683
 msgid "Refresh"
 msgstr "刷新"
 
-#: menu.c:211
-msgid "Save Current Display Settings..."
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "刷新"
+
+#: menu.c:686
+#, fuzzy
+msgid "Save Display Settings..."
 msgstr "储存当前设定..."
 
-#: menu.c:213
-msgid "Copy..."
-msgstr "复制..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "储存当前设定..."
 
-#: menu.c:214
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "计算"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "改名..."
 
-#: menu.c:215
+#: menu.c:700
 msgid "Link..."
 msgstr "链接..."
 
-#: menu.c:219
+#: menu.c:708
 msgid "Send To..."
 msgstr "传送至..."
 
-#: menu.c:224
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "扩展属性"
+
+#: menu.c:721
 msgid "Count"
 msgstr "计算"
 
-#: menu.c:225
+#: menu.c:723
 msgid "Set Type..."
 msgstr "另定类型..."
 
-#: menu.c:229 toolbar.c:154
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "选择"
 
-#: menu.c:230
+#: menu.c:733
 msgid "Select All"
 msgstr "全选"
 
-#: menu.c:231
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "取消选择"
 
-#: menu.c:232
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "反向选择"
 
-#: menu.c:233
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "以名称选择..."
 
-#: menu.c:234
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "条件式选择"
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "条件式选择"
 
-#: menu.c:236
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "新增"
 
-#: menu.c:238
+#: menu.c:752
 msgid "Blank file"
 msgstr "空文件"
 
-#: menu.c:240 tasklist.c:309
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "窗口"
 
-#: menu.c:241
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "上层，新窗口"
 
-#: menu.c:242
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "上层，窗口"
 
-#: menu.c:243
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "新窗口"
 
-#: menu.c:245
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "显示书签"
 
-#: menu.c:246
+#: menu.c:766
 msgid "Show Log"
 msgstr "操作记录"
 
-#: menu.c:247
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "跟踪符号链接"
 
-#: menu.c:248
+#: menu.c:769
 msgid "Resize Window"
 msgstr "调整窗口大小"
 
-#: menu.c:251
+#: menu.c:771
 msgid "Close Window"
 msgstr "关闭窗口"
 
-#: menu.c:253
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "键入路径..."
 
-#: menu.c:254
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "运行指令..."
 
-#: menu.c:255
+#: menu.c:780
 msgid "Terminal Here"
 msgstr "终端机"
 
-#: menu.c:256
+#: menu.c:782
 msgid "Switch to Terminal"
 msgstr "切换成终端机"
 
-#: menu.c:725
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "你可用鼠标在文件上点击菜单，并同时按下Shift键，打开`传送至'功能"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "自定菜单..."
 
-#: menu.c:764
+#: menu.c:976
 msgid "Next Click"
 msgstr "进阶"
 
-#: menu.c:786
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d 项目"
 
-#: menu.c:874
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "列出已解除挂载项目"
 
-#: menu.c:877
+#: menu.c:1097
 msgid "Show Target"
 msgstr "显示目标"
 
-#: menu.c:879
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "查看内部"
 
-#: menu.c:881
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "以文字模式打开"
 
-#: menu.c:1052
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2254,15 +2449,15 @@ msgstr ""
 "可能是阁下的文件系统或 C 函式库不支持，又或在挂载文件系统时,没有套用正确的参"
 "数，挂载选项 ('user_xattr' on Linux)."
 
-#: menu.c:1058
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr "某些文件不能以此类型设定"
 
-#: menu.c:1095
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "相对链接(_R)"
 
-#: menu.c:1101
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2274,43 +2469,55 @@ msgstr ""
 "关闭时,链接会储存从根目录到目标的路径，这选项适用于当链接移动，但目标不变的时"
 "侯."
 
-#: menu.c:1171
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "新的路径名称属不绝对"
 
-#: menu.c:1239
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr " '%' 的链接档已存在，是否要替换？"
 
-#: menu.c:1245
+#: menu.c:1546
 msgid "_Replace"
 msgstr "替换(_R)"
 
-#: menu.c:1365 menu.c:1406 menu.c:1468
-msgid "Create"
-msgstr "创建"
-
-#: menu.c:1366
+#: menu.c:1704
 msgid "NewDir"
 msgstr "新目录"
 
-#: menu.c:1380 menu.c:1386
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "错误创建 '%s': %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "创建"
 
-#: menu.c:1407
+#: menu.c:1755
 msgid "NewFile"
 msgstr "新文件"
 
-#: menu.c:1425
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "错误创建文件: 找不到样板予 %s"
 
-#: menu.c:1498
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"链接任何合用程序到此目录内，该等程序将会出现于此类型 (%s/%s) 项目的菜单中"
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2322,8 +2529,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "利用'传送至'此功能，你可快速的将要打开的文件发送到某个应用程序上，该等应用程"
 "序在以下的目录内:\n"
@@ -2335,17 +2543,17 @@ msgstr ""
 "您亦可建立子目录 `.text_html', `.text'等等，该子目录只会在打开该类型文件时出"
 "现。 `.group' 只会在选择多个文件时出现."
 
-#: menu.c:1509
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
 msgstr "请将适用的程序以符号链接 (Ctrl+Shift并拖放)到'传送至'的目录内."
 
-#: menu.c:1512 menu.c:1552
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr "不容许自定 CHOICE 路径"
 
-#: menu.c:1545
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2364,21 +2572,27 @@ msgstr ""
 "%s\n"
 "%s\n"
 
-#: menu.c:1550
+#: menu.c:1936
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
 msgstr "现在显示您的样板文件目录；您可放进任何需要的样板文件 ."
 
-#: menu.c:1667
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "自定"
 
-#: menu.c:1740
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "自定菜单..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "此目录已有规范性名称"
 
-#: menu.c:1771
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2386,71 +2600,103 @@ msgstr ""
 "你不能对此目录打开第二个窗口，因为你已在选项->Filer窗口内选了「唯一的窗口」的"
 "功能."
 
-#: menu.c:1897
-msgid "Copy ... ?"
-msgstr "复制...？"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1900
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?复制%s 为 %s？"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?复制%s 为 %s？"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "改名为...？"
 
-#: menu.c:1903
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "符号链接...？"
 
-#: menu.c:1906
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "新窗口打开...？"
 
-#: menu.c:1909
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "属性...？"
 
-#: menu.c:1912
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "扩展属性"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "设定类型...？"
 
-#: menu.c:1915
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "设定执行程序予... ？"
 
-#: menu.c:1918
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "设定图标予...？"
 
-#: menu.c:1921
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "传送...至...？"
 
-#: menu.c:1924
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "移除...？"
 
-#: menu.c:1927
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "计算容量从 ...？"
 
-#: menu.c:1930
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "改变权限予...？"
 
-#: menu.c:1933
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "搜索内部...？"
 
-#: menu.c:1997
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "复制...？"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "不可同时以此方式处理多个项目"
 
-#: menu.c:2029
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "改名"
 
-#: menu.c:2034
+#: menu.c:2619
 msgid "Symlink"
 msgstr "符号链接"
 
-#: menu.c:2063
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2469,7 +2715,7 @@ msgstr ""
 "\tgtk-can-chang-accels = 1\n"
 "\t(this only works if NOT using XSETTINGS)"
 
-#: menu.c:2074
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2489,31 +2735,40 @@ msgstr ""
 "对应的热键会出现在菜单的某个项目上，而日后你想打开这一项目，只须按下热键而不"
 "需先打开菜单."
 
-#: menu.c:2089
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "设定热键"
 
-#: minibuffer.c:129
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "移至："
 
-#: minibuffer.c:130
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "运行："
 
-#: minibuffer.c:131
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "条件匹配："
 
-#: minibuffer.c:132
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "已选择名为："
 
-#: minibuffer.c:133
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "条件匹配："
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "式样："
 
-#: minibuffer.c:265
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
@@ -2521,12 +2776,32 @@ msgstr ""
 "输入文件名称前的字符，按下键盘的 Tab 键，会自动帮您找出匹配的文件，如要关闭小"
 "型命令框，请按下 Esc 键."
 
-#: minibuffer.c:271
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr "在此输入指令，再以鼠标点击文件加进命令框来执行."
 
-#: minibuffer.c:276
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"输入一个文件名称的式样，用以选择匹配的文件：\n"
+"\n"
+"? 代表任何字符\n"
+"* 代表零或更多字符\n"
+"[aA] 代表 'a' 或 'A'\n"
+"[a-z] 代表任何字符从 a 至 z (小阶)\n"
+"*.png 代表任何名称结尾为 '.png')"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2544,13 +2819,20 @@ msgstr ""
 "[a-z] 代表任何字符从 a 至 z (小阶)\n"
 "*.png 代表任何名称结尾为 '.png')"
 
-#: minibuffer.c:288
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
 msgstr "输入一个式样用以匹配要显示的文件，空的选择会关闭过滤规则."
 
-#: minibuffer.c:908
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr "输入一个式样用以匹配要显示的文件，空的选择会关闭过滤规则."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "非法的搜寻定义"
 
@@ -2564,32 +2846,32 @@ msgstr ""
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s 总数, %s 已用, %s 空间 (%.1f %%)"
 
-#: options.c:275
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "你旧的设定资源文件已转为新的XML格式."
 
-#: options.c:535 options.c:1256
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(跟缺省值相同)"
 
-#: options.c:805
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "内部错误：%s 已损坏"
 
-#: options.c:914
+#: options.c:929
 msgid "Options"
 msgstr "选项"
 
-#: options.c:959
+#: options.c:974
 msgid "_Revert"
 msgstr "复原(_R)"
 
-#: options.c:965
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr "储存所有设定"
 
-#: options.c:980
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2598,53 +2880,53 @@ msgstr ""
 "选择将被储存为：\n"
 "%s"
 
-#: options.c:988
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(储存设定被终止,因应 CHOICEPATH)"
 
-#: options.c:1161 usericons.c:452
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "错误储存 %s: %s"
 
-#: options.c:1793
+#: options.c:1813
 msgid "Missing '='"
 msgstr "遗失 '='"
 
-#: panel.c:322
+#: panel.c:326
 #, c-format
 msgid "Unable to replace '%s'"
 msgstr "未能替化 '%s'"
 
-#: panel.c:326
+#: panel.c:330
 #, c-format
 msgid "Unable to save '%s'"
 msgstr ""
 
-#: panel.c:529
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "你的旧面板资源文件已转为新的XML格式."
 
-#: panel.c:637
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
 msgstr "你要从Window Manger中关闭面板，确定要关闭？"
 
-#: panel.c:738
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "没有 < 或 > 于面板的设定档"
 
-#: panel.c:1610
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "错误储存面板 %s: %s"
 
-#: panel.c:1925
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "程序被无故终止！"
 
-#: panel.c:2021
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2653,44 +2935,44 @@ msgstr ""
 "错误执行程序：\n"
 "%s"
 
-#: panel.c:2646
+#: panel.c:2751
 msgid "Are you sure you want to remove this panel from the desktop?"
 msgstr "您想从桌面上移除面板？"
 
-#: panel.c:2649 panel.c:2676
+#: panel.c:2754 panel.c:2781
 msgid "Remove Panel"
 msgstr "移除面板"
 
-#: panel.c:2672
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "面板选项..."
 
-#: panel.c:2757
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "多屏幕显示器 %d 不存在"
 
-#: panel.c:2787
+#: panel.c:2897
 msgid "Top"
 msgstr "顶部"
 
-#: panel.c:2789
+#: panel.c:2899
 msgid "Bottom"
 msgstr "底部"
 
-#: panel.c:2791
+#: panel.c:2901
 msgid "Left"
 msgstr "左边"
 
-#: panel.c:2793
+#: panel.c:2903
 msgid "Right"
 msgstr "右边"
 
-#: panel.c:2795
+#: panel.c:2905
 msgid "Default"
 msgstr "缺省值"
 
-#: panel.c:2799
+#: panel.c:2909
 msgid "Unknown side"
 msgstr "不明的位置"
 
@@ -2785,28 +3067,28 @@ msgid ""
 "image."
 msgstr "只有文件(及某些应用程序)才可用作设定背景"
 
-#: pinboard.c:1602
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "没有 '>' 在图标标签内"
 
-#: pinboard.c:1611
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "没有 ',' 在图标标签后"
 
-#: pinboard.c:1699
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "错误储存桌面 %s: %s"
 
-#: pinboard.c:2244
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "背景..."
 
-#: pinboard.c:2247
+#: pinboard.c:2250
 msgid "Add Panel"
 msgstr "增加面板"
 
-#: pinboard.c:2341
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2817,7 +3099,7 @@ msgstr ""
 "%s\n"
 "背景被移除."
 
-#: pixmaps.c:969
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2826,96 +3108,40 @@ msgstr ""
 "不能删除缩略图于 %s：\n"
 "%s"
 
-#: pixmaps.c:990
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "没有缩略图可供移除"
 
-#: pixmaps.c:1003
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "清除缓存区内的缩略图"
 
-#: remote.c:722
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "不明风格 '%s'"
 
-#: remote.c:744
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "不明详细类型 '%s'"
 
-#: remote.c:772
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "不明排列类型 '%s'"
 
-#: remote.c:1247
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "尝试呼叫不明的 SOAP 方式 '%s'"
 
-#: run.c:99 run.c:152
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "程序 %s 找不到 - 已被删除？"
 
-#: run.c:302
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "文件不存在，或不能被存取：%s"
-
-#: run.c:307
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "不能打开不明的文件 '%s'"
-
-#: run.c:338
-#, c-format
-msgid "'%s' is not a valid URI"
-msgstr "'%s' 不是一个正确位址"
-
-#: run.c:349
-#, c-format
-msgid "%s not accessable"
-msgstr "'%s' 不接受存取"
-
-#: run.c:357
-#, c-format
-msgid "Non-local URL %s"
-msgstr "非本机 位址 %s"
-
-#: run.c:374
-#, c-format
-msgid "%s: no handler for %s"
-msgstr "%s: 没有工具处理 %s"
-
-#: run.c:394
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"应用程序：\n"
-"这是一个执行程序的目录 - 你可执行或打开它(打开时按下Shift键)，但此程序并没有"
-"帮助档."
-
-#: run.c:478
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "不能传送资料至程序：%s"
-
-#: run.c:508
-#, c-format
-msgid "Could not read link: %s"
-msgstr "不能读取链接档：%s"
-
-#: run.c:536
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr "无效的链接档 (或权限问题)：%s"
-
-#: run.c:573
+#: run.c:359
 #, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
@@ -2925,7 +3151,7 @@ msgstr ""
 "没有标记的执行动作对应此类文件 (%s/%s) - 你可在菜单中的 `设定运行程序' 设入程"
 "式，或将此文件拖放到指定的程序上.%s"
 
-#: run.c:579
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -2936,7 +3162,63 @@ msgstr ""
 "\n"
 "注意：假如您想执行这个程序，可能须要在文件菜单内另行设定可执行的权限"
 
-#: run.c:753
+#: run.c:373
+#, c-format
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "文件不存在，或不能被存取：%s"
+
+#: run.c:378
+#, c-format
+msgid "I don't know how to open '%s'"
+msgstr "不能打开不明的文件 '%s'"
+
+#: run.c:409
+#, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' 不是一个正确位址"
+
+#: run.c:420
+#, c-format
+msgid "%s not accessable"
+msgstr "'%s' 不接受存取"
+
+#: run.c:428
+#, c-format
+msgid "Non-local URL %s"
+msgstr "非本机 位址 %s"
+
+#: run.c:445
+#, c-format
+msgid "%s: no handler for %s"
+msgstr "%s: 没有工具处理 %s"
+
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
+msgstr ""
+"应用程序：\n"
+"这是一个执行程序的目录 - 你可执行或打开它(打开时按下Shift键)，但此程序并没有"
+"帮助档."
+
+#: run.c:549
+#, c-format
+msgid "Could not send data to program: %s"
+msgstr "不能传送资料至程序：%s"
+
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "不能读取链接档：%s"
+
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
+msgstr "无效的链接档 (或权限问题)：%s"
+
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -2959,93 +3241,131 @@ msgstr ""
 "假如您认为其他用户是可靠的，便无需理会这问题。否则，您便应该检查或删除所有这"
 "类文件"
 
-#: run.c:766
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (解决安全问题)"
 
-#: support.c:272
-msgid "B"
-msgstr "B"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:351
+#: support.c:381
 msgid "byte"
 msgstr "byte"
 
-#: support.c:1596 support.c:1650
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
 msgstr "未能打开描述文件 '%s': %s"
 
-#: support.c:1607 support.c:1661
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
 msgstr "未能绘制文件 '%s': %s"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close"
 msgstr "关闭"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close filer window"
 msgstr "关闭窗口"
 
-#: toolbar.c:117
+#: toolbar.c:120
 msgid "Up"
 msgstr "往上"
 
-#: toolbar.c:117
-msgid "Change to parent directory"
-msgstr "往上一目录"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:121
+#: toolbar.c:126
 msgid "Home"
 msgstr "家目录"
 
-#: toolbar.c:121
-msgid "Change to home directory"
-msgstr "移至家目录"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks"
-msgstr "书签"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks menu"
-msgstr "书签菜单"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:129
+#: toolbar.c:138
 msgid "Scan"
 msgstr "扫描"
 
-#: toolbar.c:129
-msgid "Rescan directory contents"
-msgstr "重新扫描内容"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:133
-msgid "Change icon size"
-msgstr "改变图标大小"
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "大小"
 
-#: toolbar.c:137
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "自动化"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
 msgstr "自动化大少"
 
-#: toolbar.c:141
-msgid "Show extra details"
-msgstr "更详述"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "列表模式"
 
-#: toolbar.c:145
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
 msgstr "排序"
 
-#: toolbar.c:145
+#: toolbar.c:165
 msgid "Change sort criteria"
 msgstr "改变排序标准"
 
-#: toolbar.c:149
-msgid "Hidden"
-msgstr "隐藏"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:149
+#: toolbar.c:169
 msgid ""
 "Left: Show/hide hidden files\n"
 "Right: Show/hide thumbnails"
@@ -3053,110 +3373,154 @@ msgstr ""
 "左： 显示 隐藏档\n"
 "右： 显示 缩略图"
 
-#: toolbar.c:154
-msgid "Select all/invert selection"
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+#, fuzzy
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+"左： 显示 隐藏档\n"
+"右： 显示 缩略图"
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
 msgstr "全选/反向 选择"
 
-#: toolbar.c:158
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
 msgstr "显示ROX-Filer帮助"
 
-#: toolbar.c:221
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
 msgstr " (%u 隐藏)"
 
-#: toolbar.c:229 tips:58
+#: toolbar.c:276 tips:79
 msgid "items"
 msgstr "项目"
 
-#: toolbar.c:229
+#: toolbar.c:276
 msgid "item"
 msgstr "项目"
 
-#: toolbar.c:232
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
 msgstr "没有项目%s"
 
-#: toolbar.c:251
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
 msgstr "%u 已选择 (%s)"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by name"
 msgstr "以名称排序"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by type"
 msgstr "以类型排序"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by date"
 msgstr "以日期排序"
 
-#: toolbar.c:446
+#: toolbar.c:535
 msgid "Sort by size"
 msgstr "以大小排序"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by owner"
 msgstr "以用户排序"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by group"
 msgstr "以组别排序"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "ascending"
 msgstr "提升"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "descending"
 msgstr "下降"
 
-#: type.c:214
+#: toolbar.c:891
+#, fuzzy
+msgid "_N_Items_"
+msgstr "项目"
+
+#: type.c:221
 msgid "Sym link"
 msgstr "符号链接"
 
-#: type.c:216
+#: type.c:223
 msgid "Mount point"
 msgstr "挂载点"
 
-#: type.c:218
+#: type.c:225
 msgid "App dir"
 msgstr "程序目录"
 
-#: type.c:225
+#: type.c:232
 msgid "Dir"
 msgstr "目录"
 
-#: type.c:227
+#: type.c:234
 msgid "Char dev"
 msgstr "字符装置"
 
-#: type.c:229
+#: type.c:236
 msgid "Block dev"
 msgstr "区块装置"
 
-#: type.c:231
+#: type.c:238
 msgid "Pipe"
 msgstr "管导"
 
-#: type.c:233
+#: type.c:240
 msgid "Socket"
 msgstr "套节"
 
-#: type.c:235
+#: type.c:242
 msgid "Door"
 msgstr "入口"
 
-#: type.c:238
+#: type.c:245
 msgid "Unknown"
 msgstr "不明的"
 
-#: type.c:554
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3166,84 +3530,84 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:735
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "这不是一个程序！请给予一个可执行的程序！"
 
-#: type.c:795
+#: type.c:839
 msgid "No run action defined"
 msgstr "没有执行动作被定义"
 
-#: type.c:799
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "错误于处理工具 %s: %s"
 
-#: type.c:814
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "非法的执行程序 %s (错误执行)"
 
-#: type.c:825
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "非执行性的 %s"
 
-#: type.c:858
+#: type.c:902
 msgid "Set run action"
 msgstr "设定执行的动作"
 
-#: type.c:864
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr "如这些特殊类型还未设立处理工具，便以此为缺省值."
 
-#: type.c:866
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "设为缺省值予全部的 `%s/<anything>'"
 
-#: type.c:870
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "用这个程序来打开属于此 MIME 类型的文件"
 
-#: type.c:872
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "仅对应此类型 `%s' (%s/%s)"
 
-#: type.c:878
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "请拖放一个合适的程序在此处"
 
-#: type.c:893
+#: type.c:963
 msgid "OR"
 msgstr "或"
 
-#: type.c:900
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "请输入指令："
 
-#: type.c:929
+#: type.c:1000
 msgid "_Use Command"
 msgstr "套用指令(_U)"
 
-#: type.c:959
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
 msgstr "一个相同而颇大的程序正在执行中 - 你决定要删除它？"
 
-#: type.c:970
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "不能移除 %s: %s"
 
-#: type.c:1007
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "'Choices' 路径变数错误,储存取消"
 
-#: type.c:1309
+#: type.c:1395
 #, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
@@ -3252,11 +3616,11 @@ msgstr ""
 "未能新增符号链接 '%s':\n"
 "%s"
 
-#: usericons.c:179
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "路径不存在，更改图标失败"
 
-#: usericons.c:189 usericons.c:618
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3265,12 +3629,12 @@ msgstr ""
 "不能载入图档 -- 可能是格式不明，或文件权限错误？\n"
 "更改图标失败."
 
-#: usericons.c:235
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "确认删除图标 '%s'？"
 
-#: usericons.c:239
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3279,41 +3643,41 @@ msgstr ""
 "不能删除 '%s'：\n"
 " %s"
 
-#: usericons.c:272
+#: usericons.c:281
 msgid "Set icon"
 msgstr "设定图标"
 
-#: usericons.c:281
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr "用这个图像作为所有属于此种 MIME 类型的文件的缺省图标."
 
-#: usericons.c:283
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "设定图标予全部的 `%s/<anything>'"
 
-#: usericons.c:288
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "用这个图像作为所有属于此种 MIME 类型的文件的图标"
 
-#: usericons.c:290
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "对应此类型 `%s' (%s/%s)"
 
-#: usericons.c:296
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
 msgstr "加入文件名称或图像名称到个人列表中，假如文件或图像遗失,设置将会无效."
 
-#: usericons.c:299
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "仅对应文件 `%s'"
 
-#: usericons.c:307
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
@@ -3322,19 +3686,19 @@ msgstr ""
 "复制图像进此目录并命名为 '.DirIcon', 让所有用户均可看见这个图标，假如您拥有这"
 "目录的写入权限；这将会是个最好的设置方式."
 
-#: usericons.c:313
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "复制图像至目录"
 
-#: usericons.c:319
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "拖放图标档到此处"
 
-#: usericons.c:589
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "设定图标被终止，因应 Choice 的路径问题"
 
-#: usericons.c:633
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3343,41 +3707,57 @@ msgstr ""
 "错误建立图像 '%s'：\n"
 "%s"
 
-#: view_details.c:957
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
 msgid "Mono font"
 msgstr "等宽字"
 
-#: view_details.c:958
+#: view_details.c:1019
 msgid "Font for displaying mono-spaced text"
 msgstr "用以显示等宽字体的字型"
 
-#: view_details.c:1059
+#: view_details.c:1233
 msgid "_Name"
 msgstr "名称(_N)"
 
-#: view_details.c:1062
+#: view_details.c:1236
 msgid "_Type"
 msgstr "类型(_T)"
 
-#: view_details.c:1065
-msgid "_Permissions"
-msgstr "权限(_P)"
-
-#: view_details.c:1070
-msgid "_Owner"
-msgstr "用户(_O)"
-
-#: view_details.c:1072
-msgid "_Group"
-msgstr "组别(_G)"
-
-#: view_details.c:1074
+#: view_details.c:1238
 msgid "_Size"
 msgstr "大小(_S)"
 
-#: view_details.c:1080
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "权限(_P)"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "用户(_O)"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "组别(_G)"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "最后改动(_M)"
+
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "扩展属性"
 
 #: tips:1
 msgid "Filer windows"
@@ -3421,7 +3801,8 @@ msgstr "当改变图标大小时或叙述时，及转变到其他目录时，窗
 msgid "Largest window size:"
 msgstr "窗口的最大值："
 
-#: tips:10
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
@@ -3432,24 +3813,36 @@ msgid ""
 msgstr "窗口大小自行调整时，会跟据该百份比来限制窗口最大的值"
 
 #: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "窗口的最大值："
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr "窗口大小自行调整时，会跟据该百份比来限制窗口最大的值"
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "窗口行为"
 
-#: tips:13
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "简化标题"
 
-#: tips:14
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
 msgstr "以单字母代替文件及缩略图全名作标题"
 
-#: tips:15
+#: tips:18
 msgid "Unique windows"
 msgstr "唯一的窗口"
 
-#: tips:16
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3457,11 +3850,34 @@ msgstr ""
 "如你要打开一个目录而此目录已经存在于另一窗口内，开启此选项后你已经存在的窗口"
 "便会被关闭."
 
-#: tips:17
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "窗口"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "按鼠标1(左)键以打开新窗口"
 
-#: tips:18
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3469,138 +3885,211 @@ msgid ""
 msgstr ""
 "单击鼠标1(左)键以打开目录于新窗口内，单击鼠标2(中)键会打开目录于原有的窗口内."
 
-#: tips:19
+#: tips:26
 msgid "Single-click navigation"
 msgstr "单击予阅览"
 
-#: tips:20 tips:116
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
 "things."
 msgstr "单击项目以打开及浏览，反之则单击以选择，双击以打开."
 
-#: tips:21
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "双击背景以调整大小"
 
-#: tips:22
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
 msgstr "如开启此功能，双击背景会自行调整窗口大小."
 
-#: tips:23
+#: tips:30
 msgid "Sorting"
 msgstr "排序"
 
-#: tips:24
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "目录先行 (以名称排序)"
 
-#: tips:25
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
 msgstr "如打开此功能，则永远以目录先排序，并忽略其他排序方式及以名称排序."
 
-#: tips:26
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "大小写先行 (以名称排序)"
 
-#: tips:27
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
 msgstr "如打开此功能，则永远以大写名称先行，及小写名称在后."
 
-#: tips:29
-msgid "Default settings for new windows"
-msgstr "缺省新窗口的设定"
-
-#: tips:30
-msgid "Inherit options from source window"
-msgstr "从源窗口中继承选项"
-
-#: tips:31
-msgid ""
-"If this is on then display options for a new window are inherited from the "
-"source window if possible, otherwise they are set to the defaults below."
-msgstr "如打开此功能，则新窗口会从源窗口之风格相同；反之，则以缺省值打开."
-
-#: tips:32
-msgid "View type:"
-msgstr "查看模式："
-
 #: tips:35
-msgid "Sort by:"
-msgstr "排序以："
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "目录先行 (以名称排序)"
 
-#: tips:37 tips:54
-msgid "Type"
-msgstr "类型"
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "伸延"
 
 #: tips:38
-msgid "Date"
-msgstr "日期"
-
-#: tips:40
-msgid "Show hidden files"
-msgstr "显示隐藏档"
-
-#: tips:41
-msgid ""
-"If this is on then files whose names start with a dot are shown too, "
-"otherwise they are hidden."
-msgstr "如启动此功能，点文件也将被显示；否之，点文件会被隐藏."
-
-#: tips:42
 msgid "Show extended attribute indicator"
 msgstr "显示扩展属性指标"
 
-#: tips:43
+#: tips:39
 msgid ""
 "If this is on then files which have one or more extended attributes set will "
 "have an emblem added to indicate this."
 msgstr "此选项可显示文件已设定的 一或多个扩展属性的特徵."
 
-#: tips:44
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
+msgid "Default settings for new windows"
+msgstr "缺省新窗口的设定"
+
+#: tips:46
+msgid "Inherit options from source window"
+msgstr "从源窗口中继承选项"
+
+#: tips:47
+msgid ""
+"If this is on then display options for a new window are inherited from the "
+"source window if possible, otherwise they are set to the defaults below."
+msgstr "如打开此功能，则新窗口会从源窗口之风格相同；反之，则以缺省值打开."
+
+#: tips:48
+msgid "View type:"
+msgstr "查看模式："
+
+#: tips:51
+msgid "Sort by:"
+msgstr "排序以："
+
+#: tips:53 tips:76 tips:114
+msgid "Type"
+msgstr "类型"
+
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
+msgstr "日期"
+
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "日期"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "日期"
+
+#: tips:58
+msgid "Show hidden files"
+msgstr "显示隐藏档"
+
+#: tips:59
+msgid ""
+"If this is on then files whose names start with a dot are shown too, "
+"otherwise they are hidden."
+msgstr "如启动此功能，点文件也将被显示；否之，点文件会被隐藏."
+
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "显示隐藏档"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr "如启动此功能，点文件也将被显示；否之，点文件会被隐藏."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "巨图标"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "像素"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "图标型式"
 
-#: tips:45
+#: tips:67
 msgid "Default size:"
 msgstr "缺省大小："
 
-#: tips:46
+#: tips:68
 msgid "Huge Icons"
 msgstr "巨图标"
 
-#: tips:47 tips:217
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "大图标"
 
-#: tips:48 tips:216
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "小图标"
 
-#: tips:50
+#: tips:72
 msgid "Default details:"
 msgstr "缺省详述："
 
-#: tips:51
+#: tips:73
 msgid "No details"
 msgstr "不详述"
 
-#: tips:56
-msgid "Automatic small icons:"
+#: tips:74
+msgid "Sizes"
+msgstr "大小"
+
+#: tips:77
+msgid "Times"
+msgstr "时间"
+
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "自动小图标化："
 
-#: tips:57
-msgid "Change at:"
-msgstr "改变于："
-
-#: tips:59
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3608,99 +4097,218 @@ msgid ""
 msgstr ""
 "当目录中有太多项目时，会自行以小型图标来显示；反之，则以大型图标来显示."
 
-#: tips:60
-msgid "Max width (Large icons):"
-msgstr "最大宽度 (大图标)："
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "大图标"
 
-#: tips:61 tips:64
-msgid "pixels"
-msgstr "像素"
-
-#: tips:62
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "在大图标模式下，文本文字如比此宽度长，则自动换行。在巨图标模式下，则会比宽度"
 "长百分之五十."
 
-#: tips:63
-msgid "(Small Icons):"
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
+
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
+#: tips:88
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr "开启选项，大型图标会以垂直方式排列"
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
 msgstr "(小图标)："
 
-#: tips:65
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "小图标最大的文本宽度"
 
-#: tips:66
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "小图标垂直排列"
 
-#: tips:67
+#: tips:93
 msgid ""
 "If this option is on, then small icons are arranged in columns, not rows."
 msgstr "开启选项，小型图标会以垂直方式排列"
 
-#: tips:68
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "大图标垂直排列"
 
-#: tips:69
+#: tips:95
 msgid ""
 "If this option is on, then large icons are arranged in columns, not rows."
 msgstr "开启选项，大型图标会以垂直方式排列"
 
-#: tips:71
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "显示行列标题"
 
-#: tips:72
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr "以列表方式浏览时，行列标题会被显示"
 
-#: tips:73
+#: tips:102
 msgid "Show full type"
 msgstr "显示详细类型"
 
-#: tips:74
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr "更详尽的描述每一物件的类型"
 
-#: tips:75
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "小图标最大的文本宽度"
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "显示行列标题"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr "以列表方式浏览时，行列标题会被显示"
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr "以列表方式浏览时，行列标题会被显示"
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr "以列表方式浏览时，行列标题会被显示"
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr "以列表方式浏览时，行列标题会被显示"
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr "以列表方式浏览时，行列标题会被显示"
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr "以列表方式浏览时，行列标题会被显示"
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "最后改动(_M)"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr "以列表方式浏览时，行列标题会被显示"
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr "以列表方式浏览时，行列标题会被显示"
+
+#: tips:128
+#, fuzzy
+msgid "Last Accessed"
+msgstr "'%s' 不接受存取"
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr "以列表方式浏览时，行列标题会被显示"
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "工具/小型命令框"
 
-#: tips:76
+#: tips:131
 msgid "Toolbar"
 msgstr "工具栏"
 
-#: tips:77
+#: tips:132
 msgid "Toolbar type:"
 msgstr "工具栏类别："
 
-#: tips:78
+#: tips:133
 msgid "No toolbar"
 msgstr "不要工具栏"
 
-#: tips:79
+#: tips:134
 msgid "Icons only"
 msgstr "只显示图标"
 
-#: tips:80
+#: tips:135
 msgid "Text under icons"
 msgstr "图标文字在下"
 
-#: tips:81
+#: tips:136
 msgid "Text beside icons"
 msgstr "图标文字在侧"
 
-#: tips:82
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "载入面板"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "显示项目总数"
 
-#: tips:83
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3709,40 +4317,40 @@ msgstr ""
 "在窗口的工具栏显示项目总数，并会显示隐藏档数目；当以右键选文件时，还会显示其"
 "大小."
 
-#: tips:84
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "选择要加入的按钮："
 
-#: tips:85
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "工具栏宽度决定窗口的最小宽度"
 
-#: tips:86
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
 msgstr "每一窗口必须有足够宽度来显示整个工具栏 "
 
-#: tips:87
+#: tips:143
 msgid "Minibuffer"
 msgstr "小型命令框"
 
-#: tips:88
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "哔声 当(Tab-自动完成)操作失败"
 
-#: tips:89
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
 "letter varies)."
 msgstr "当启用`输入路径'小型命令框，在按下 Tab 键时没有作用，则会发出哔的响声"
 
-#: tips:90
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "当找到数个匹配项时发出哔的报警声"
 
-#: tips:91
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
@@ -3750,161 +4358,249 @@ msgstr ""
 "当启用`输入路径'小型命令框，在按下 Tab 键时，找到匹配的数目不止一个时则会发出"
 "哔的报警声声"
 
-#: tips:94
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "下载处理员"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "错误于处理工具 %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
 msgstr "当目录内有影像或图片时，会以缩略图来预览."
 
-#: tips:95
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "显示影像档的缩略图"
 
-#: tips:96
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
 msgstr "这是新窗口的缺省值，可在菜单的显示内自行打开或关闭缩略图."
 
-#: tips:97
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "显示影像档的缩略图"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "影片缩略图"
 
-#: tips:98
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "缩略图缓存区"
 
-#: tips:99
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "为了加速显示，~/.thumbnails 这个目录会自动建立；点击这处以清除缓存区内所有缩"
 "图，当有需要时它会再建立."
 
-#: tips:100
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
 msgid "Manage thumbnails"
 msgstr "管理缩略图"
 
-#: tips:101 tips:158
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "影片缩略图"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+msgid "sec"
+msgstr ""
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "桌面"
 
-#: tips:102
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
 msgstr "当启用桌面时，您可拖放文件或程序到桌面上它们会以捷径型式出现. "
 
-#: tips:103 tips:213
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "外观"
 
-#: tips:104
+#: tips:179
 msgid "Foreground:"
 msgstr "前景："
 
-#: tips:105
+#: tips:180
 msgid "Text shadow:"
 msgstr "文字阴影："
 
-#: tips:106
+#: tips:181
 msgid "Background:"
 msgstr "背景："
 
-#: tips:107
+#: tips:182
 msgid "No shadow"
 msgstr "没有阴影"
 
-#: tips:108
+#: tips:183
 msgid "Thin"
 msgstr "薄"
 
-#: tips:109
+#: tips:184
 msgid "Thick"
 msgstr "厚"
 
-#: tips:110
+#: tips:185
 msgid "Use custom font:"
 msgstr "自定字型："
 
-#: tips:111
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "图标字型"
 
-#: tips:112
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "快速调整影像"
 
-#: tips:113
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
 msgstr "选择快慢方式来调整影像，慢方式可带来更高画质."
 
-#: tips:114
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "桌面行为"
 
-#: tips:115
+#: tips:190
 msgid "Single-click to open"
 msgstr "单击以打开"
 
-#: tips:117
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "限制图标在可见屏幕上"
 
-#: tips:118
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
 msgstr "桌面内的图标和标签全显示在屏幕中"
 
-#: tips:119
+#: tips:194
 msgid "Icon grid step:"
 msgstr "图标等级："
 
-#: tips:120
+#: tips:195
 msgid "Fine"
 msgstr "高质素"
 
-#: tips:121
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "以2像素图标在桌面显示"
 
-#: tips:122
+#: tips:197
 msgid "Medium"
 msgstr "中等"
 
-#: tips:123
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "以16像素图标在桌面显示"
 
-#: tips:124
+#: tips:199
 msgid "Coarse"
 msgstr "粗糙的"
 
-#: tips:125
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "以32像素图标在桌面显示"
 
-#: tips:126 tips:128
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "图标化窗口"
 
-#: tips:127
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
 "windows."
 msgstr "ROX-Filer 可以图标化(或最小化)窗口."
 
-#: tips:129
+#: tips:204
 msgid "Show iconified windows"
 msgstr "图标化窗口"
 
-#: tips:130
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
@@ -3913,49 +4609,49 @@ msgstr ""
 "ROX-Filer 会将图标化(或最小化)窗口，以按钮型式放在桌面上，唯需要一个相容的窗"
 "口管理员配合，并 ROX-Filer 的桌面必须启动."
 
-#: tips:131
+#: tips:206
 msgid "Show per workspace"
 msgstr "只显示当前工作区"
 
-#: tips:132
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
 msgstr "开启此选项，ROX-Filer 只会显示当前工作区内的已图标化(或最小化)窗口"
 
-#: tips:133
+#: tips:208
 msgid "Iconify to the"
 msgstr "图标化后置于"
 
-#: tips:134
+#: tips:209
 msgid "top-left"
 msgstr "左上"
 
-#: tips:135
+#: tips:210
 msgid "top-right"
 msgstr "右上"
 
-#: tips:136
+#: tips:211
 msgid "bottom-left"
 msgstr "左下"
 
-#: tips:137
+#: tips:212
 msgid "bottom-right"
 msgstr "右下"
 
-#: tips:138
+#: tips:213
 msgid ", going"
 msgstr ", 排列"
 
-#: tips:139
+#: tips:214
 msgid "horizontally"
 msgstr "平面"
 
-#: tips:140
+#: tips:215
 msgid "vertically"
 msgstr "垂直"
 
-#: tips:141
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -3965,43 +4661,43 @@ msgstr ""
 "ROX-Filer 可能会忽略您的桌面环境布局，而将图标化窗口放到(例如)Gnome面板上，您"
 "可定义一个最顶或最底的边沿设置，以防止图标被放到这处"
 
-#: tips:142
+#: tips:217
 msgid "Top margin"
 msgstr "顶端边沿"
 
-#: tips:143
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "屏幕顶端至不摆放区的高度"
 
-#: tips:144
+#: tips:219
 msgid "Bottom margin"
 msgstr "底端边沿"
 
-#: tips:145
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "屏幕底端至不摆放区的高度"
 
-#: tips:146
+#: tips:221
 msgid "Left margin"
 msgstr "左边沿"
 
-#: tips:147
+#: tips:222
 msgid "Width of no-go area at left of screen."
 msgstr "屏幕左边至不摆放区的宽度"
 
-#: tips:148
+#: tips:223
 msgid "Right margin"
 msgstr "右边沿"
 
-#: tips:149
+#: tips:224
 msgid "Width of no-go area at right of screen."
 msgstr "屏幕右边至不摆放区的宽度"
 
-#: tips:150
+#: tips:225
 msgid "Desktop"
 msgstr "桌面配置"
 
-#: tips:151
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
@@ -4009,153 +4705,157 @@ msgstr ""
 "在执行 session 管理员(如：ROX-Session)时，ROX-Filer 会启动其面板和桌面。您可"
 "在这处进行设定."
 
-#: tips:152
+#: tips:227
 msgid "Panel only"
 msgstr "载入面板"
 
-#: tips:153
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "只显示载入的面板"
 
-#: tips:154
+#: tips:229
 msgid "Pinboard only"
 msgstr "载入桌面"
 
-#: tips:155
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "只显示载入的桌面"
 
-#: tips:156
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "载入面板及桌面"
 
-#: tips:157
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "面板及桌面同时载入"
 
-#: tips:159
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "在此输入桌面名称"
 
-#: tips:160
-msgid "Panel (obsolete)"
-msgstr "面板(废掉的)"
-
-#: tips:161
-msgid ""
-"Enter the name of the panel to show here. This option is now only used when "
-"upgrading from an old version."
-msgstr "键入面板的名称，此选项只适用於从旧有板本升级的 ROX-Filer"
-
-#: tips:162
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr "改变会在下次 ROX-Filer 启动时生效"
 
-#: tips:163
+#: tips:236
+#, fuzzy
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 "Session 管理器，可在启动 rox 时加入 -S 或 --rox-session 这些参数来打开此功"
 "能。"
 
-#: tips:164
+#: tips:237
 msgid "Action windows"
 msgstr "程序诊断窗口"
 
-#: tips:165
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
 msgstr "程序诊断窗口会在你执行一些程序，如复制或删除文件时，自动出现."
 
-#: tips:166
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "自动打开 (关闭) 诊断这些程序"
 
-#: tips:168
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "复制文件而无须先被确认"
 
-#: tips:170
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "移动文件而无须先被确认"
 
-#: tips:172
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "链接文件而无须先被确认"
 
-#: tips:174
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "删除文件而无须先被确认"
 
-#: tips:175
+#: tips:248
 msgid "Mount"
 msgstr "挂载"
 
-#: tips:176
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "挂载文件而无须先被确认"
 
-#: tips:177
+#: tips:250
 msgid "Default settings"
 msgstr "默认设定"
 
-#: tips:179
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "强制"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "不确认删除只读项目"
 
-#: tips:181
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "简化消息框内资料"
 
-#: tips:183
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "同样改变子目录内容"
 
-#: tips:186
+#: tips:263
 msgid "Mount commands"
 msgstr "挂载指令"
 
-#: tips:187
+#: tips:264
 msgid "Mount command"
 msgstr "挂载指令"
 
-#: tips:188
+#: tips:265
 msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
 msgstr "用以挂载系统的指令，一般是 \"mount\"."
 
-#: tips:189
+#: tips:266
 msgid "Unmount command"
 msgstr "卸载指令"
 
-#: tips:190
+#: tips:267
 msgid ""
 "The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
 "without the first \"n\")."
 msgstr "用以卸载系统的指令，一般是 \"umount\"."
 
-#: tips:191
+#: tips:268
 msgid "Eject command"
 msgstr "褪出光碟指令"
 
-#: tips:192
+#: tips:269
 msgid "The command used to eject removable media. If unsure, use \"eject\"."
 msgstr "用以弹出可移动媒体的指令。一般为 \"eject\". "
 
-#: tips:193
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "鼠标拖放"
 
-#: tips:194
+#: tips:273
 msgid "Dragging to icons"
 msgstr "拖放图标"
 
-#: tips:195
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "容许在窗口间拖放图标"
 
-#: tips:196
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
@@ -4164,11 +4864,11 @@ msgstr ""
 "选项开启后你可将文件在子目录或程序上拖放，该项目会被加亮并拖放进你指定的目录"
 "内，或在你拖进的程序内执行."
 
-#: tips:197
+#: tips:276
 msgid "Directories spring open"
 msgstr "目录弹出并打开"
 
-#: tips:198
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
@@ -4177,15 +4877,15 @@ msgstr ""
 "此选项必须连带上一个选项同时开启，在指向加亮的目录时，使它在按着鼠标一段短时"
 "间内自动打开."
 
-#: tips:199
+#: tips:278
 msgid "Spring delay:"
 msgstr "弹出延迟："
 
-#: tips:200
+#: tips:279
 msgid "ms"
 msgstr "微秒"
 
-#: tips:201
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
@@ -4194,43 +4894,43 @@ msgstr ""
 "此选项是用作是设定：你在加亮的目录上按着鼠标而引发该目录被自动打开的延迟时"
 "间，并会以 ms 微秒来计算"
 
-#: tips:202
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "以鼠标左键拖放"
 
-#: tips:203 tips:207
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "显示一个可用动作的菜单"
 
-#: tips:204
+#: tips:283
 msgid "Copy the files"
 msgstr "复制文件"
 
-#: tips:205
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
 msgstr "注意，如想菜单再出现，可按着左键并同时按下键盘上的 Alt 键"
 
-#: tips:206
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "当以鼠标中键拖放"
 
-#: tips:208
+#: tips:287
 msgid "Move the files"
 msgstr "移动文件"
 
-#: tips:209
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
 msgstr "注意，如想菜单再出现，可按着左键并同时按下键盘上的 Alt 键"
 
-#: tips:210
+#: tips:289
 msgid "Download handler"
 msgstr "下载处理员"
 
-#: tips:211
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4242,57 +4942,61 @@ msgstr ""
 "如:\n"
 "xterm -e wget $1"
 
-#: tips:212
+#: tips:291
 msgid "Menus"
 msgstr "菜单"
 
-#: tips:214
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "菜单上的图标大小:"
 
-#: tips:215
+#: tips:294
 msgid "No Icons"
 msgstr "没有图标"
 
-#: tips:218
+#: tips:297
 msgid "Same as current window"
 msgstr "跟现行窗口相同"
 
-#: tips:219
+#: tips:298
 msgid "Same as default"
 msgstr "跟缺省值相同"
 
-#: tips:220
+#: tips:299
 msgid "Behaviour"
 msgstr "行为"
 
-#: tips:221
+#: tips:300
 msgid "File menu on right-click"
 msgstr "右击为文件菜单"
 
-#: tips:222
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
 msgstr "当右击时以文件菜单代替主菜单显示，(如想显示主菜单请按下 Control 键)."
 
-#: tips:223
+#: tips:302
 msgid "Terminal emulator program"
 msgstr "“终端机”程序"
 
-#: tips:224
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr "当你从菜单选择“终端机”这程序将被启动"
 
-#: tips:225
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "热键"
 
-#: tips:227
+#: tips:305
+msgid "Types"
+msgstr "类型"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME 类型"
 
-#: tips:228
+#: tips:307
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
@@ -4300,23 +5004,23 @@ msgstr ""
 "ROX-Filer是以一众既定规则来对应正确 MIME 类型，并会为每一常规文件的类型，配置"
 "一个合适的图标。"
 
-#: tips:229
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "编辑 MIME 规则"
 
-#: tips:230
+#: tips:309
 msgid "Themes"
 msgstr "布景"
 
-#: tips:231
+#: tips:310
 msgid "Icon theme"
 msgstr "图标布景"
 
-#: tips:232
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "图标布景必须放进 ~/.icons 目录内."
 
-#: tips:233
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
@@ -4324,87 +5028,115 @@ msgstr ""
 "请以“设定图标...”对话框来设定图标的 MIME 类型，注意，此设定会覆写图标布景的设"
 "定."
 
-#: tips:234
+#: tips:313
 msgid "Colours"
 msgstr "颜色"
 
-#: tips:235
+#: tips:314
 msgid "File type colours"
 msgstr "文件类型颜色"
 
-#: tips:236
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "基于文件类型配色"
 
-#: tips:237
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr "文件名称(及详述)会根据它的类型而配色"
 
-#: tips:238
+#: tips:317
 msgid "Directory:"
 msgstr "目录："
 
-#: tips:239
+#: tips:318
 msgid "Regular file:"
 msgstr "常规档："
 
-#: tips:240
+#: tips:319
 msgid "Pipe:"
 msgstr "管导："
 
-#: tips:241
+#: tips:320
 msgid "Socket:"
 msgstr "套节："
 
-#: tips:243
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
 msgstr "错误，此连结所指向的是一个不存在或你的权限不足以查看的文件."
 
-#: tips:244
+#: tips:323
 msgid "Character device:"
 msgstr "字符设备："
 
-#: tips:245
+#: tips:324
 msgid "Block device:"
 msgstr "区块设备："
 
-#: tips:246
+#: tips:325
 msgid "Door:"
 msgstr "入口："
 
-#: tips:247
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
 msgstr "类似套节或管导的单元文件，只会用于 Solaris."
 
-#: tips:248
+#: tips:327
 msgid "Executable file:"
 msgstr "可执行档："
 
-#: tips:249
+#: tips:328
 msgid "Application directory:"
 msgstr "应用程序目录："
 
-#: tips:250
+#: tips:329
 msgid "Unknown type:"
 msgstr "不明类型："
 
-#: tips:251
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "背景："
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "自定字型："
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "兼容性"
 
-#: tips:252
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "窗口管理员问题"
 
-#: tips:253
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "取代窗口管理员对桌面及面板的控制权"
 
-#: tips:254
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4413,11 +5145,11 @@ msgid ""
 "them appear in window-select lists."
 msgstr "某些窗口管理员不支持伸延提示功能，此选项可解决相应问题"
 
-#: tips:255
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "将桌面鼠标功能交给窗口管理员"
 
-#: tips:256
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
@@ -4426,11 +5158,11 @@ msgstr ""
 "在桌面背景上，启用窗口管理员所附带之鼠标功能，但对桌面上的图标，仍由 ROX-"
 "Filer 管理. "
 
-#: tips:257
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Blackbox 根菜单改良"
 
-#: tips:258
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4440,11 +5172,11 @@ msgstr ""
 "Blackbox, Fluxbox 及某些窗口管理员不支持 ROX-Filer 桌面功能，点选此处可文件这"
 "些问题；但新版本的窗口管理员，已无须这个选项."
 
-#: tips:259
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "面板是 'dock'"
 
-#: tips:260
+#: tips:346
 msgid ""
 "Makes sure panels stay against screen edges. Disable this option if the "
 "panel stays above other windows against your wishes. Requires a restart to "
@@ -4453,11 +5185,11 @@ msgstr ""
 "请先确认面板可置放在屏幕边沿。假如您不想面板盖在窗口的上层，关闭选项，并重新"
 "启动."
 
-#: tips:261
+#: tips:347
 msgid "Panel stays on top"
 msgstr "面板置顶"
 
-#: tips:262
+#: tips:348
 msgid ""
 "Keeps the panel above other windows. Enable this option to make sure the "
 "dock option works correctly in some versions of compiz. May require a "
@@ -4466,15 +5198,25 @@ msgstr ""
 "面板会覆盖在窗口上。但某些版本的 compiz 会对 dock 的功能出现错误，此选项须要"
 "重新启动。"
 
-#: tips:263
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "鼠标拖放"
 
-#: tips:264
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "不用主机名称"
 
-#: tips:265
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4483,15 +5225,11 @@ msgstr ""
 "某些旧的应用程序不完全支持拖放来执行的功能，此选项便须要开启，以达致将文件拖"
 "到当鼠标出现 a + 符号的应用程序上."
 
-#: tips:266
-msgid "Extended attributes"
-msgstr "扩展属性"
-
-#: tips:267
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "不用扩展属性"
 
-#: tips:268
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4502,61 +5240,128 @@ msgstr ""
 "'另定类型' 选项亦会解除；MIME 的类别会由文件名或副档名决定；属性窗口亦不会报"
 "告文件的扩展属性."
 
-#: ../Templates.glade:7
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "底部边沿"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "右部边沿"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
 msgid "ROX-Filer log viewer"
 msgstr "ROX-Filer 操作记录"
 
-#: ../Templates.glade:22
+#: ../Templates.ui.h:2
 msgid "Recently performed actions..."
 msgstr "曾经执行过的操作..."
 
-#: ../Templates.glade:77
+#: ../Templates.ui.h:3
 msgid "Open Directory"
 msgstr "打开目录"
 
-#: ../Templates.glade:129
+#: ../Templates.ui.h:4
 msgid "Panel Options"
 msgstr "选项选项"
 
-#: ../Templates.glade:169
-msgid "Every icon on this panel is shown with an image and some text."
-msgstr "面板上每个图示均显示图像及文字"
-
-#: ../Templates.glade:170
+#: ../Templates.ui.h:5
 msgid "Image and Text"
 msgstr "图像及文字"
 
-#: ../Templates.glade:186
+#: ../Templates.ui.h:6
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "面板上每个图示均显示图像及文字"
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "程序档只显示图像"
+
+#: ../Templates.ui.h:8
 msgid ""
 "Applications in this panel have just an image, everything else has both an "
 "image and text."
 msgstr "面板上的程序档只以图像表达，其他的文件则有图像及文字叙述."
 
-#: ../Templates.glade:187
-msgid "Image only for applications"
-msgstr "程序档只显示图像"
-
-#: ../Templates.glade:205
-msgid "Only the image is shown for icons in this panel."
-msgstr "该面板上的图标只显示图像"
-
-#: ../Templates.glade:206
+#: ../Templates.ui.h:9
 msgid "Image only"
 msgstr "只显示图像"
 
-#: ../Templates.glade:235
+#: ../Templates.ui.h:10
+msgid "Only the image is shown for icons in this panel."
+msgstr "该面板上的图标只显示图像"
+
+#: ../Templates.ui.h:11
 msgid "Panel width"
 msgstr "面板宽度"
 
-#: ../Templates.glade:247
+#: ../Templates.ui.h:12
 msgid "The size of this panel."
 msgstr "面板大小"
 
-#: ../Templates.glade:259
+#: ../Templates.ui.h:13
 msgid "px"
 msgstr "px(像素)"
 
-#: ../Templates.glade:278
+#: ../Templates.ui.h:14
+msgid "Transparency"
+msgstr ""
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "不覆盖面板"
+
+#: ../Templates.ui.h:19
 msgid ""
 "Ask the window manager not to cover this panel when maximising windows, "
 "otherwise leave just 2 pixels at the edge of the screen to allow auto-"
@@ -4565,15 +5370,15 @@ msgstr ""
 "指示窗口管理员在最大化时，不覆盖面板。如不选用，只会留下 2 像素的屏幕边沿以自"
 "动提升。但有些窗口管理员会忽略此设定。"
 
-#: ../Templates.glade:279
-msgid "Do not cover panel"
-msgstr "不覆盖面板"
-
-#: ../Templates.glade:297
+#: ../Templates.ui.h:20
 msgid "<b>Panel style</b>"
 msgstr "<b>面板风格</b>"
 
-#: ../Templates.glade:331
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "区限多屏幕显示器"
+
+#: ../Templates.ui.h:22
 msgid ""
 "If you use multiple monitors with Xinerama, use this option to confine the "
 "panel to one monitor."
@@ -4581,36 +5386,101 @@ msgstr ""
 "假如您在 Xorg 设定了 Xinerama(多屏幕功能)，便可在此区限面板被放到某个显示器"
 "上."
 
-#: ../Templates.glade:332
-msgid "Confine to Xinerama monitor"
-msgstr "区限多屏幕显示器"
-
-#: ../Templates.glade:347
+#: ../Templates.ui.h:23
 msgid ""
 "The monitor this panel is confined to when using Xinerama. The numbering "
 "starts from zero."
 msgstr "面板在多屏幕显示时的显示器 (数目从 0开始)."
 
-#: ../Templates.glade:372
+#: ../Templates.ui.h:24
 msgid "<b>Xinerama</b>"
 msgstr "<b>多屏幕功能</b>"
 
-#: ../Templates.glade:407
+#: ../Templates.ui.h:25
 msgid "Right edge"
 msgstr "右部边沿"
 
-#: ../Templates.glade:426
+#: ../Templates.ui.h:26
 msgid "Left edge"
 msgstr "左部边沿"
 
-#: ../Templates.glade:443
+#: ../Templates.ui.h:27
 msgid "Bottom edge"
 msgstr "底部边沿"
 
-#: ../Templates.glade:462
+#: ../Templates.ui.h:28
 msgid "Top edge"
 msgstr "顶部边沿"
 
-#: ../Templates.glade:496
+#: ../Templates.ui.h:29
 msgid "<b>Position</b>"
 msgstr "<b>位置</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<目录>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' 文件已存在-覆盖？"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "错误扫描 '%s'：\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "目录已删除/或不存在"
+
+#~ msgid "Directory '%s' is not accessible"
+#~ msgstr "目录 '%s' 不接受存取"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "找不到目录 '%s' "
+
+#~ msgid "Cancel"
+#~ msgstr "取消"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr "你可用鼠标在文件上点击菜单，并同时按下Shift键，打开`传送至'功能"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "往上一目录"
+
+#~ msgid "Change to home directory"
+#~ msgstr "移至家目录"
+
+#~ msgid "Bookmarks"
+#~ msgstr "书签"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "书签菜单"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "重新扫描内容"
+
+#~ msgid "Change icon size"
+#~ msgstr "改变图标大小"
+
+#~ msgid "Show extra details"
+#~ msgstr "更详述"
+
+#~ msgid "Hidden"
+#~ msgstr "隐藏"
+
+#~ msgid "Change at:"
+#~ msgstr "改变于："
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "最大宽度 (大图标)："
+
+#~ msgid "Panel (obsolete)"
+#~ msgstr "面板(废掉的)"
+
+#~ msgid ""
+#~ "Enter the name of the panel to show here. This option is now only used "
+#~ "when upgrading from an old version."
+#~ msgstr "键入面板的名称，此选项只适用於从旧有板本升级的 ROX-Filer"

--- a/ROX-Filer/src/po/zh_TW.po
+++ b/ROX-Filer/src/po/zh_TW.po
@@ -7,39 +7,44 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ROX-Filer 2.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2008-12-29 15:11+0800\n"
+"POT-Creation-Date: 2021-09-12 13:09+0200\n"
 "PO-Revision-Date: 2008-12-29 16:00+0100\n"
 "Last-Translator: Babyfai Cheung<babyfai1@yahoo.com.hk>\n"
 "Language-Team: none\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: abox.c:125
-msgid "<dir>"
-msgstr "<目錄>"
+#: abox.c:127
+msgid "<src>"
+msgstr ""
 
-#: abox.c:218
+#: abox.c:172 abox.c:174
+msgid "+.Num"
+msgstr ""
+
+#: abox.c:234
 msgid "_Quiet"
 msgstr "默許(_Q)"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Quiet"
 msgstr "默許"
 
-#: abox.c:227
+#: abox.c:247
 msgid "Don't confirm every operation"
 msgstr "不用對每次操作進行確認"
 
-#: abox.c:454 infobox.c:771 tips:36
+#: abox.c:441 infobox.c:803 tips:52 tips:112
 msgid "Name"
 msgstr "名稱"
 
-#: abox.c:460 menu.c:237
+#: abox.c:447 menu.c:751
 msgid "Directory"
 msgstr "目錄"
 
-#: abox.c:549
+#: abox.c:546
 msgid "Expression:"
 msgstr "表示式："
 
@@ -55,11 +60,11 @@ msgstr "詳情請參閱 fsattr(5) man page"
 msgid "You do not appear to have OS support."
 msgstr "系統不支援的 OS"
 
-#: action.c:191
+#: action.c:198
 msgid "Find expression reference"
 msgstr "找尋表示式範例"
 
-#: action.c:202
+#: action.c:209
 msgid ""
 "<u>Quick Start</u>\n"
 "Just put the name of the file you're looking for in single quotes:\n"
@@ -134,11 +139,11 @@ msgstr ""
 "在指令'command' 內的 '%' 則代表檔案的路徑)\n"
 "<b>prune</b> (搜尋條件為否，避免搜尋某一目錄的內容)。"
 
-#: action.c:249
+#: action.c:256
 msgid "Change permissions reference"
 msgstr "改變權限資料"
 
-#: action.c:260
+#: action.c:267
 msgid ""
 "Normally, you can just select a command from the menu (click \n"
 "on the arrow beside the command box). Sometimes, you need more...\n"
@@ -195,11 +200,11 @@ msgstr ""
 "\n"
 "詳細解釋請參閱 chmod(1) 的 man page。"
 
-#: action.c:301
+#: action.c:308
 msgid "Set type reference"
 msgstr "設定類型方式"
 
-#: action.c:312
+#: action.c:319
 msgid ""
 "Normally ROX-Filer determines the type of a regular file\n"
 "by matching it's name against a pattern. To change the\n"
@@ -227,48 +232,55 @@ msgstr ""
 "目錄，裝置，管導或套節等類型有效\n"
 "並且只有某些操作系統及檔案系統才會有支援\n"
 
-#: action.c:419
+#: action.c:459
+#, fuzzy
 msgid ""
 "\n"
-"Process terminated.\n"
+"Process terminated."
 msgstr ""
 "\n"
 "程序終結 \n"
 
-#: action.c:435
-msgid "There was one error.\n"
+#: action.c:479
+#, fuzzy
+msgid " - There was one error."
 msgstr "發現錯誤.\n"
 
-#: action.c:437
-#, c-format
-msgid "There were %d errors.\n"
+#: action.c:481
+#, fuzzy, c-format
+msgid " - There were %d errors."
 msgstr "發現 %d 錯誤\n"
 
-#: action.c:461
+#: action.c:516
 msgid "ERROR reading"
 msgstr "錯誤讀取"
 
-#: action.c:504
+#: action.c:565
+#, fuzzy
 msgid ""
 "'\n"
-"Done\n"
+"Done"
 msgstr ""
 "'\n"
 "完成\n"
 
-#: action.c:560 support.c:395
+#: action.c:621 support.c:425
 msgid "ERROR"
 msgstr "錯誤"
 
-#: action.c:714 main.c:698 main.c:705 main.c:712 main.c:726
+#: action.c:798 main.c:696 main.c:710
 msgid "Yes"
 msgstr "是"
 
-#: action.c:717 main.c:700 main.c:707 main.c:714 main.c:726
+#: action.c:801 main.c:698 main.c:710
 msgid "No"
 msgstr "否"
 
-#: action.c:735
+#: action.c:806
+msgid "Add seq num"
+msgstr ""
+
+#: action.c:824
 msgid ""
 "\n"
 "Asking child process to terminate...\n"
@@ -276,7 +288,7 @@ msgstr ""
 "\n"
 "正在終結子程序... \n"
 
-#: action.c:742
+#: action.c:831
 msgid ""
 "\n"
 "Trying to KILL run-away process...\n"
@@ -284,41 +296,41 @@ msgstr ""
 "\n"
 "嘗試殺掉已遺失之程序... \n"
 
-#: action.c:895
+#: action.c:1008
 #, c-format
 msgid "?Count contents of %s?"
 msgstr "?計算內容從 %s?"
 
-#: action.c:931
+#: action.c:1046
 #, c-format
 msgid "?Delete %s'%s'?"
 msgstr "?刪除 %s'%s'?"
 
-#: action.c:932
+#: action.c:1047
 msgid "WRITE-PROTECTED "
 msgstr "防寫入的"
 
-#: action.c:939
+#: action.c:1055
 #, c-format
 msgid "'Deleting '%s'\n"
 msgstr "'正在刪除 '%s'\n"
 
-#: action.c:952
+#: action.c:1070
 #, c-format
 msgid "'Directory '%s' deleted\n"
 msgstr "'目錄 '%s' 已刪除\n"
 
-#: action.c:985
+#: action.c:1104
 #, c-format
 msgid "?Eject '%s'?"
 msgstr "?彈出 '%s'?"
 
-#: action.c:992
+#: action.c:1111
 #, c-format
 msgid "'Eject '%s'\n"
 msgstr "'正在彈出 '%s'\n"
 
-#: action.c:1011
+#: action.c:1130
 #, c-format
 msgid ""
 "!%s\n"
@@ -327,95 +339,95 @@ msgstr ""
 "!%s\n"
 "彈出失敗\n"
 
-#: action.c:1030 action.c:1049
+#: action.c:1150 action.c:1169
 #, c-format
 msgid "?Check '%s'?"
 msgstr "?檢查 '%s'?"
 
-#: action.c:1046
+#: action.c:1166
 msgid "!Invalid find condition - change it and try again\n"
 msgstr "!非法的找尋設定-請更改後再嘗試\n"
 
-#: action.c:1056
+#: action.c:1176
 #, c-format
 msgid "'(while checking '%s')\n"
 msgstr "'(正當檢查 '%s')\n"
 
-#: action.c:1130 action.c:1155
+#: action.c:1251 action.c:1276
 #, c-format
 msgid "?Change permissions of '%s'?"
 msgstr "?改變 '%s' 的權限？"
 
-#: action.c:1136
+#: action.c:1257
 #, c-format
 msgid "'Changing permissions of '%s'\n"
 msgstr "'正在改變 '%s' 的權限\n"
 
-#: action.c:1153
+#: action.c:1274
 msgid "!Invalid mode command - change it and try again\n"
 msgstr "!非法指令模式-請更改後再試\n"
 
-#: action.c:1211
+#: action.c:1332
 #, c-format
 msgid "?Change contents of '%s'?"
 msgstr "?改變 '%s' 的內容？"
 
-#: action.c:1214 action.c:1234
+#: action.c:1335 action.c:1355
 #, c-format
 msgid "?Change type of '%s'?"
 msgstr "?改變 '%s' 的類型？"
 
-#: action.c:1231
+#: action.c:1352
 msgid "!Invalid type - change it and try again\n"
 msgstr "!非法類型-請更改後再試\n"
 
-#: action.c:1253
+#: action.c:1374
 #, c-format
 msgid "'Changing type of '%s' to '%s'\n"
 msgstr "'正在改變類型從 '%s' 為 '%s'\n"
 
-#: action.c:1276
+#: action.c:1397
 #, c-format
 msgid "'Not changing type of directory '%s'\n"
 msgstr "'目錄 '%s' 的類型沒有改變'\n"
 
-#: action.c:1282
+#: action.c:1403
 #, c-format
 msgid "'Non-regular file '%s' not changed\n"
 msgstr "非常規檔案 '%s' 沒有改變\n"
 
-#: action.c:1342
+#: action.c:1548 action.c:1857
 #, c-format
 msgid "?'%s' already exists - %s?"
 msgstr "?'%s' 經已存在 - %s?"
 
-#: action.c:1344
+#: action.c:1550 action.c:1859
 msgid "merge contents"
 msgstr "合拼內容"
 
-#: action.c:1345
+#: action.c:1551 action.c:1860
 msgid "overwrite"
 msgstr "覆蓋"
 
-#: action.c:1361
+#: action.c:1570
 msgid "'Trying copy anyway...\n"
 msgstr "'嘗試硬複製..\n"
 
-#: action.c:1370
+#: action.c:1579
 #, c-format
 msgid "?Copy %s as %s?"
 msgstr "?複製%s 為 %s?"
 
-#: action.c:1374
+#: action.c:1584 action.c:1717
 #, c-format
 msgid "'Copying %s as %s\n"
 msgstr "'正在複製 %s 為 %s\n"
 
-#: action.c:1389
+#: action.c:1601 action.c:1906
 msgid "!ERROR: Destination already exists, but is not a directory\n"
 msgstr "!錯誤：目標已存在，但不是一個目錄\n"
 
-#: action.c:1461
+#: action.c:1686
 #, c-format
 msgid ""
 "!%s\n"
@@ -424,26 +436,7 @@ msgstr ""
 "!%s\n"
 "複製 '%s' 失敗\n"
 
-#: action.c:1505
-#, c-format
-msgid "?'%s' already exists - overwrite?"
-msgstr "?'%s' 檔案已存在-覆蓋?"
-
-#: action.c:1520
-msgid "'Trying move anyway...\n"
-msgstr "'嘗試強制移動...\n"
-
-#: action.c:1528
-#, c-format
-msgid "?Move %s as %s?"
-msgstr "?移動 %s 為 %s?"
-
-#: action.c:1532
-#, c-format
-msgid "'Moving %s as %s\n"
-msgstr "'正在移動 %s 為 %s\n"
-
-#: action.c:1540
+#: action.c:1769
 #, c-format
 msgid ""
 "!%s\n"
@@ -452,45 +445,59 @@ msgstr ""
 "!%s\n"
 "移動 %s 到 %s 失敗\n"
 
-#: action.c:1561
+#: action.c:1880
+msgid "'Trying move anyway...\n"
+msgstr "'嘗試強制移動...\n"
+
+#: action.c:1889
+#, c-format
+msgid "?Move %s as %s?"
+msgstr "?移動 %s 為 %s?"
+
+#: action.c:1894
+#, c-format
+msgid "'Moving %s as %s\n"
+msgstr "'正在移動 %s 為 %s\n"
+
+#: action.c:1952
 msgid "!ERROR: Can't copy object into itself\n"
 msgstr "!錯誤：不能複製物件到本身內\n"
 
-#: action.c:1576
+#: action.c:1964
 msgid "!ERROR: Can't move/rename object into itself\n"
 msgstr "!錯誤：不能移動/改名物件到本身內\n"
 
-#: action.c:1588
+#: action.c:1973
 #, c-format
 msgid "'Linking %s as %s\n"
 msgstr "'連結 %s 為 %s\n"
 
-#: action.c:1593
+#: action.c:1978
 #, c-format
 msgid "?Link %s as %s?"
 msgstr "?連結 %s 為 %s?"
 
-#: action.c:1636
+#: action.c:2021
 #, c-format
 msgid "'Mounting %s\n"
 msgstr "'掛載 %s\n"
 
-#: action.c:1637
+#: action.c:2022
 #, c-format
 msgid "'Unmounting %s\n"
 msgstr "'解除掛載 %s\n"
 
-#: action.c:1640
+#: action.c:2025
 #, c-format
 msgid "?Mount %s?"
 msgstr "?掛載 %s?"
 
-#: action.c:1641
+#: action.c:2026
 #, c-format
 msgid "?Unmount %s?"
 msgstr "?解除掛載 %s?"
 
-#: action.c:1662
+#: action.c:2047
 #, c-format
 msgid ""
 "!%s\n"
@@ -499,7 +506,7 @@ msgstr ""
 "!%s\n"
 "掛載失敗\n"
 
-#: action.c:1663
+#: action.c:2048
 #, c-format
 msgid ""
 "!%s\n"
@@ -508,11 +515,11 @@ msgstr ""
 "!%s\n"
 "解除掛載失敗\n"
 
-#: action.c:1671
+#: action.c:2056
 msgid "'(seems to be mounted now anyway)\n"
 msgstr "'(經已掛載)\n"
 
-#: action.c:1717
+#: action.c:2102
 #, c-format
 msgid ""
 "'\n"
@@ -521,205 +528,229 @@ msgstr ""
 "'\n"
 "總數：%s("
 
-#: action.c:1723
+#: action.c:2108
 msgid "file"
 msgstr "檔案"
 
-#: action.c:1723
+#: action.c:2108
 msgid "files"
 msgstr "檔案"
 
-#: action.c:1727
+#: action.c:2112
 msgid "no directories)\n"
 msgstr "沒有目錄)\n"
 
-#: action.c:1731
+#: action.c:2116
 msgid "directory"
 msgstr "目錄"
 
-#: action.c:1732
+#: action.c:2117
 msgid "directories"
 msgstr "目錄"
 
-#: action.c:1773
+#: action.c:2155
 msgid "!No mount points selected!\n"
 msgstr "!沒有掛載點被標記!\n"
 
-#: action.c:1858
+#: action.c:2231
 msgid "?Another search?"
 msgstr "?其他的搜尋？"
 
-#: action.c:1888 action.c:1919
+#: action.c:2259 action.c:2291
 #, c-format
 msgid "!'%s' is a symbolic link\n"
 msgstr "!'%s' 是一符號連結\n"
 
-#: action.c:1959
+#: action.c:2342
 msgid "You need to select some items to search through"
 msgstr "你需要選擇一些項目來搜尋"
 
-#: action.c:1969 menu.c:228
+#: action.c:2352 menu.c:728
 msgid "Find"
 msgstr "找尋"
 
-#: action.c:2002
+#: action.c:2387
 msgid "You need to select some items to count"
 msgstr "你需要選擇一些項目來計算"
 
-#: action.c:2006
+#: action.c:2391
 msgid "Disk Usage"
 msgstr "磁碟用量"
 
-#: action.c:2042
+#: action.c:2429
 msgid "Mount / Unmount"
 msgstr "掛載 / 解除掛載"
 
-#: action.c:2059
+#: action.c:2448
 msgid "ROX-Filer does not yet support mount points on your system. Sorry."
 msgstr "ROX-Filer 對系統上的掛載點尚未支援"
 
-#: action.c:2073 menu.c:216 tips:173
+#: action.c:2462 menu.c:701 tips:246
 msgid "Delete"
 msgstr "刪除"
 
-#: action.c:2085 tips:178
+#: action.c:2476 action.c:2680 action.c:2737
 msgid "Force"
 msgstr "強制"
 
-#: action.c:2085
+#: action.c:2476
 msgid "Don't confirm deletion of non-writeable items"
 msgstr "不可確認刪除唯讀的項目"
 
-#: action.c:2088 action.c:2147 action.c:2210 action.c:2283 action.c:2323
-#: tips:180
+#: action.c:2479 action.c:2540 action.c:2605 action.c:2695 action.c:2752
+#: tips:253
 msgid "Brief"
 msgstr "簡潔"
 
-#: action.c:2088
+#: action.c:2479
 msgid "Only log directories being deleted"
 msgstr "祗記錄已刪除的目錄"
 
-#: action.c:2107
+#: action.c:2498
 msgid "You need to select the items whose permissions you want to change"
 msgstr "你需選擇更改權限的項目"
 
-#: action.c:2115
+#: action.c:2506
 msgid "a+x (Make executable/searchable)"
 msgstr "a+x (使之可執行/可被搜尋)"
 
-#: action.c:2117
+#: action.c:2508
 msgid "a-x (Make non-executable/non-searchable)"
 msgstr "a-x (使之不可執行/不可被搜尋)"
 
-#: action.c:2119
+#: action.c:2510
 msgid "u+rw (Give owner read+write)"
 msgstr "u+rw (給用戶寫讀的權限)"
 
-#: action.c:2121
+#: action.c:2512
 msgid "go-rwx (Private - owner access only)"
 msgstr "go-rwx (私有化 - 只用戶可存取)"
 
-#: action.c:2123
+#: action.c:2514
 msgid "go=u-w (Public access, not write)"
 msgstr "go=u-w (共享存取，不可寫入)"
 
-#: action.c:2134 menu.c:189 menu.c:226 tips:53
+#: action.c:2525 menu.c:724 tips:75 tips:118
 msgid "Permissions"
 msgstr "權限"
 
-#: action.c:2147 action.c:2210
+#: action.c:2540 action.c:2605
 msgid "Don't list processed files"
 msgstr "不列出已處理的檔案"
 
-#: action.c:2150 action.c:2213 tips:182
+#: action.c:2543 action.c:2608 tips:255
 msgid "Recurse"
 msgstr "包含"
 
-#: action.c:2150
+#: action.c:2543
 msgid "Also change contents of subdirectories"
 msgstr "同時改變子目錄的內容"
 
-#: action.c:2154
+#: action.c:2547
 msgid "Command:"
 msgstr "指令："
 
-#: action.c:2184
+#: action.c:2577
 msgid "You need to select the items whose type you want to change"
 msgstr "你需選擇更改類型的項目"
 
-#: action.c:2197
+#: action.c:2590
 msgid "Set type"
 msgstr "另定類型"
 
-#: action.c:2213
+#: action.c:2608
 msgid "Change contents of subdirectories"
 msgstr "改變子目錄的內容"
 
-#: action.c:2220 infobox.c:627
+#: action.c:2615 infobox.c:659
 msgid "Type:"
 msgstr "類型："
 
-#: action.c:2267 dnd.c:122 menu.c:2024 tips:167
+#: action.c:2662 dnd.c:1105 menu.c:693 tips:240
 msgid "Copy"
 msgstr "複製"
 
-#: action.c:2279 action.c:2319 tips:184
+#: action.c:2680 action.c:2737
+#, fuzzy
+msgid "Don't confirm over-write."
+msgstr "不用對每次操作進行確認"
+
+#: action.c:2683 action.c:2740 tips:261
+msgid "Ignore Older"
+msgstr ""
+
+#: action.c:2684 action.c:2741 tips:262
+#, fuzzy
+msgid "Silently ignore if source is older than destination."
+msgstr "只覆蓋舊版本的檔案"
+
+#: action.c:2687 action.c:2744 tips:259
 msgid "Newer"
 msgstr "更新"
 
-#: action.c:2280 action.c:2320 tips:185
-msgid "Only over-write if source is newer than destination."
+#: action.c:2688 action.c:2745 tips:260
+#, fuzzy
+msgid "Always over-write if source is newer than destination."
 msgstr "只覆蓋舊版本的檔案"
 
-#: action.c:2283
+#: action.c:2691 action.c:2748 tips:257
+msgid "Merge"
+msgstr ""
+
+#: action.c:2692 action.c:2749 tips:258
+#, fuzzy
+msgid "Always merge directories."
+msgstr "目錄"
+
+#: action.c:2695
 msgid "Only log directories as they are copied"
 msgstr "只記錄已被複製的目錄"
 
-#: action.c:2307 dnd.c:123 tips:169
+#: action.c:2719 dnd.c:1106 tips:242
 msgid "Move"
 msgstr "移動"
 
-#: action.c:2323
+#: action.c:2752
 msgid "Don't log each file as it is moved"
 msgstr "不記錄每個移動的檔案"
 
-#: action.c:2346 tips:171
+#: action.c:2775 tips:244
 msgid "Link"
 msgstr "連結"
 
-#: action.c:2369 appmenu.c:111 filer.c:593
+#: action.c:2800 appmenu.c:120 filer.c:909 infobox.c:1075
 msgid "Eject"
 msgstr "彈出"
 
-#: action.c:2437
+#: action.c:2875
 msgid "Deleting items such as "
 msgstr "刪除項目為"
 
-#: action.c:2441
+#: action.c:2879
 msgid "Deleting the item "
 msgstr "刪除中"
 
-#: action.c:2443
+#: action.c:2881
 msgid "Deleting the items "
 msgstr "刪除中"
 
-#: action.c:2462
+#: action.c:2900
 msgid " and "
 msgstr " 及 "
 
-#: action.c:2471
+#: action.c:2909
 msgid " will affect some items on the pinboard or panel - really delete it?"
 msgstr "將影嚮桌面或面板上某些項目 - 真的刪除？"
 
-#: action.c:2478
+#: action.c:2916
 msgid " will affect some items on the pinboard or panel - really delete them?"
 msgstr "將影嚮桌面或面板上某些項目 - 真的刪除？"
 
-#: appmenu.c:197
+#: appmenu.c:206
 msgid "<missing label>"
 msgstr "<失去標簽>"
 
-#: appmenu.c:319
+#: appmenu.c:317
 #, c-format
 msgid ""
 "Symlink any programs you want into this directory. They will appear in the "
@@ -727,82 +758,82 @@ msgid ""
 msgstr ""
 "連結任何合用程式到此目錄內，該等程式將會出現於此類型 (%s/%s) 項目的選單中"
 
-#: appmenu.c:363 menu.c:239
+#: appmenu.c:331 menu.c:753
 msgid "Customise Menu..."
 msgstr "自定選單..."
 
-#: appmenu.c:420 menu.c:257 toolbar.c:158
+#: appmenu.c:386 menu.c:785 toolbar.c:202
 msgid "Help"
 msgstr "說明"
 
-#: bookmarks.c:148 log.c:160
-msgid "Path"
-msgstr "路徑"
-
-#: bookmarks.c:156
+#: bookmarks.c:268
 msgid "Title"
 msgstr "標題"
 
-#: bookmarks.c:305
+#: bookmarks.c:276 log.c:176
+msgid "Path"
+msgstr "路徑"
+
+#: bookmarks.c:466
 #, c-format
 msgid "Can't bookmark non-local resource '%s'\n"
 msgstr "不能書簽化非本機的資源 '%s'\n"
 
-#: bookmarks.c:313 bookmarks.c:631
+#: bookmarks.c:474 bookmarks.c:823
 #, c-format
 msgid "'%s' isn't a directory"
 msgstr "'%s'並非一個目錄"
 
-#: bookmarks.c:519
+#: bookmarks.c:711
 msgid "You should first select some rows to delete"
 msgstr "請先選擇行數以刪除"
 
-#: bookmarks.c:543
+#: bookmarks.c:735
 msgid "Put the cursor on an entry in the list to move it"
 msgstr "將鼠標指向想要移動的項目上"
 
-#: bookmarks.c:563
+#: bookmarks.c:755
 msgid "This item is already at the end"
 msgstr "此項目已排在最後"
 
-#: bookmarks.c:637
+#: bookmarks.c:829
 #, c-format
 msgid "Can't bookmark non-local directories like '%s'"
 msgstr "不能書簽化非本機目錄如 '%s'"
 
-#: bookmarks.c:779
+#: bookmarks.c:998
 msgid "Add New Bookmark"
 msgstr "加入新書簽"
 
-#: bookmarks.c:786
+#: bookmarks.c:1005
 msgid "Edit Bookmarks"
 msgstr "編輯書簽"
 
-#: bookmarks.c:791
+#: bookmarks.c:1010
 msgid "Recently Visited"
 msgstr "最近存取的"
 
-#: bulk_rename.c:66
+#: bulk_rename.c:69
 msgid "Bulk rename files"
 msgstr "多檔案更改名稱"
 
-#: bulk_rename.c:69
+#: bulk_rename.c:72
 msgid "Reset"
 msgstr "復原"
 
-#: bulk_rename.c:74
+#: bulk_rename.c:77
 msgid "Make the New column a copy of Old"
 msgstr "回復舊有名稱"
 
-#: bulk_rename.c:79
+#: bulk_rename.c:82
 msgid "_Rename"
 msgstr "改名(_R)"
 
-#: bulk_rename.c:92
+#: bulk_rename.c:95
 msgid "Replace:"
 msgstr "替換："
 
-#: bulk_rename.c:99
+#: bulk_rename.c:102
 msgid ""
 "This is a regular expression to search for.\n"
 "^ matches the start of a filename\n"
@@ -816,66 +847,66 @@ msgstr ""
 "\\. 對應點號\n"
 "\\.htm$ 對應 '.htm' 於 'index.html', 等等"
 
-#: bulk_rename.c:107
+#: bulk_rename.c:109
 msgid "With:"
 msgstr "改為："
 
-#: bulk_rename.c:114
+#: bulk_rename.c:116
 msgid ""
 "The first match in each filename will be replaced by this string. The only "
 "special characters are back-references from \\0 to \\9. To use them "
 "literally, they have to be escaped with a backslash."
 msgstr ""
-"每個檔案名稱的對應部份，會先被這字串取代。"
-"而只可使用的正則字符為逆向引用 \\0 至 \\9。"
+"每個檔案名稱的對應部份，會先被這字串取代。而只可使用的正則字符為逆向引用 \\0 "
+"至 \\9。"
 
-#: bulk_rename.c:120
+#: bulk_rename.c:122
 msgid "Apply"
 msgstr "套用"
 
-#: bulk_rename.c:123
+#: bulk_rename.c:125
 msgid ""
 "Do a search-and-replace in the New column. The files are not actually "
 "renamed until you click on the Rename button below."
 msgstr "完成搜尋取代後, 檔案名稱並未真正改變，必須點擊下面 '改名' 的按鈕."
 
-#: bulk_rename.c:142
+#: bulk_rename.c:144
 msgid "Old name"
 msgstr "舊名稱"
 
-#: bulk_rename.c:151
+#: bulk_rename.c:153
 msgid "New name"
 msgstr "新名稱"
 
-#: bulk_rename.c:293
+#: bulk_rename.c:295
 msgid "No strings (in the New column) matched the given expression"
 msgstr "沒有可對應的字串"
 
-#: bulk_rename.c:298
+#: bulk_rename.c:300
 msgid "One name matched, but the result was the same"
 msgstr "一個名稱已匹配，但結果沒有改變"
 
-#: bulk_rename.c:301
+#: bulk_rename.c:303
 #, c-format
 msgid "%d names matched, but the results were all the same"
 msgstr "%d 個名稱已匹配，但結果沒有改變"
 
-#: bulk_rename.c:327
+#: bulk_rename.c:330
 msgid ""
 "Specify a regular expression to match, and a string to replace matches with."
 msgstr "請指定一個常規表示式，及一個字串用以置換對應名稱."
 
-#: bulk_rename.c:344
+#: bulk_rename.c:347
 #, c-format
 msgid "%s (for '%s')"
 msgstr "%s (for '%s')"
 
-#: bulk_rename.c:377
+#: bulk_rename.c:380
 #, c-format
 msgid "A file called '%s' already exists. Aborting bulk rename."
 msgstr "檔案 '%s' 經已存在，退出多檔案更改名稱."
 
-#: bulk_rename.c:382
+#: bulk_rename.c:385
 #, c-format
 msgid ""
 "Failed to rename '%s' as '%s':\n"
@@ -886,12 +917,12 @@ msgstr ""
 "%s\n"
 "退出多檔案更改名稱."
 
-#: bulk_rename.c:444
+#: bulk_rename.c:447
 #, c-format
 msgid "A file called '%s' already exists"
 msgstr "檔案 '%s' 經已存在"
 
-#: bulk_rename.c:455
+#: bulk_rename.c:458
 #, c-format
 msgid ""
 "Some of the New names contain / characters (eg '%s'). This will cause the "
@@ -899,7 +930,7 @@ msgid ""
 msgstr ""
 "有些新名稱含有 / 字符 (如 '%s')，這樣會使生成的檔案終結到不同的目錄，繼續？"
 
-#: bulk_rename.c:470
+#: bulk_rename.c:473
 msgid "None of the names have changed. Nothing to do!"
 msgstr "沒有名稱被改變！"
 
@@ -923,42 +954,62 @@ msgstr ""
 "%s\n"
 "%s"
 
-#: dir.c:1041
+#: dir.c:1077
 #, c-format
 msgid "Can't stat directory: %s"
 msgstr "不能打開目錄：%s"
 
-#: dir.c:1050
+#: dir.c:1087
 #, c-format
 msgid "Can't open directory: %s"
 msgstr "不能打開目錄：%s"
 
-#: display.c:659
+#: display.c:704 tips:57 tips:116
+msgid "Size"
+msgstr "大小"
+
+#: display.c:705
+msgid "┤"
+msgstr ""
+
+#: display.c:706
+msgid "┐"
+msgstr ""
+
+#: display.c:707
+msgid "┘"
+msgstr ""
+
+#: display.c:709
+msgid "├"
+msgstr ""
+
+#: display.c:709
+msgid "┌"
+msgstr ""
+
+#: display.c:710
+msgid "┼"
+msgstr ""
+
+#: display.c:958
 #, c-format
 msgid "lstat(2) failed: %s"
 msgstr "lstat(2) 失敗：%s"
 
-#: dnd.c:124
-msgid "Link (relative)"
-msgstr "連結 (相對路徑)"
-
-#: dnd.c:125
-msgid "Link (absolute)"
-msgstr "連結 (絕對路徑)"
-
-#: dnd.c:424
+#: dnd.c:423
 msgid "Internal error - bad info type"
 msgstr "內部錯誤 - 訊息已損壞"
 
-#: dnd.c:563
+#: dnd.c:565
 msgid "Drag a directory here to bookmark it."
 msgstr "拖放一個目錄到這處，將之納入書簽"
 
-#: dnd.c:578
+#: dnd.c:580
 msgid "XDS protocol error: leafname may not contain '/'\n"
 msgstr "XDS 協定錯誤：名稱不存在'/'\n"
 
-#: dnd.c:603
+#: dnd.c:605
 msgid ""
 "XdndDirectSave0 target provided, but the atom XdndDirectSave0 (type text/"
 "plain) did not contain a leafname\n"
@@ -966,16 +1017,16 @@ msgstr ""
 "XdndDirectSave0 目標已提供，但這 XdndDirectSave0 (類別 text/plain) 沒有包含一"
 "個分支名稱\n"
 
-#: dnd.c:616
+#: dnd.c:618
 msgid "Sorry - I require a target type of text/uri-list or XdndDirectSave0."
 msgstr "抱歉 - 需要一個 text/uri-list 類型或一個 XdndDirectSave0."
 
-#: dnd.c:619
+#: dnd.c:621
 msgid ""
 "Sorry - I require a target type of text/uri-list or application/octet-stream."
 msgstr "抱歉 - 需要一個 text/uri-list 或 application/octet-stream 的類型."
 
-#: dnd.c:689
+#: dnd.c:691
 #, c-format
 msgid ""
 "Failed to add some items to the pinboard, because they are on a remote "
@@ -987,59 +1038,77 @@ msgstr ""
 "\n"
 "%s"
 
-#: dnd.c:764
+#: dnd.c:766
 msgid "Unknown target"
 msgstr "不明目標"
 
-#: dnd.c:797
+#: dnd.c:799
 msgid "Remote app can't or won't send me the data - sorry"
 msgstr "遠端機器上的程式，不會向本機送出資料 - 抱歉"
 
-#: dnd.c:810
+#: dnd.c:812
 msgid "XDS protocol error: return code should be 'S', 'F' or 'E'\n"
 msgstr "XDS錯誤，回傳碼必須為'S','F'或'E'\n"
 
-#: dnd.c:843
+#: dnd.c:845
 msgid "Sorry, can't display a menu of actions for a remote file / raw data."
 msgstr "抱歉，不能顯示遠端機器上的程式選單. "
 
-#: dnd.c:859
+#: dnd.c:861
 msgid "UntitledData"
 msgstr "未命名資料"
 
-#: dnd.c:886
+#: dnd.c:888
 #, c-format
 msgid "Error saving file: %s"
 msgstr "儲存：%s 時發生錯誤"
 
-#: dnd.c:959
+#: dnd.c:961
 msgid "No URIs in the text/uri-list (nothing to do!)"
 msgstr "沒有位址在 text/uri-list (沒有任何操作!)"
 
-#: dnd.c:991
+#: dnd.c:993
 msgid ""
 "Can't get data from remote machine (application/octet-stream not provided)"
 msgstr "未能在遠端機器上獲得資料 (application/octet-stream 並未提供)"
 
-#: dnd.c:1014
+#: dnd.c:1015 menu.c:2406
 msgid ""
 "Some of these files are on a different machine - they will be ignored - sorry"
 msgstr "某些檔案是來自另一主機 - 這些會被忽略 - 抱歉"
 
-#: dnd.c:1021
+#: dnd.c:1024 menu.c:2414
 msgid ""
 "None of these files are on the local machine - I can't operate on multiple "
 "remote files - sorry."
 msgstr "沒有任何檔案是在本機上的 - 不能在多遠端機器 環境下操作 - 抱歉."
 
-#: dnd.c:1034
+#: dnd.c:1040
 msgid "Unknown action requested"
 msgstr "不明的執行要求"
 
-#: dnd.c:1042
+#: dnd.c:1049 menu.c:2432
 #, c-format
 msgid "Error getting file list: %s"
 msgstr "錯誤的檔案列表：%s"
+
+#: dnd.c:1107
+msgid "Link (relative)"
+msgstr "連結 (相對路徑)"
+
+#: dnd.c:1108
+msgid "Link (absolute)"
+msgstr "連結 (絕對路徑)"
+
+#: dnd.c:1109
+#, fuzzy
+msgid "Link (relative, sym path)"
+msgstr "連結 (相對路徑)"
+
+#: dnd.c:1110
+#, fuzzy
+msgid "Link (absolute, sym path)"
+msgstr "連結 (絕對路徑)"
 
 #: dropbox.c:112
 msgid "Show"
@@ -1077,7 +1146,7 @@ msgstr ""
 "不能存取 '%s'：\n"
 "%s"
 
-#: filer.c:456
+#: filer.c:718
 #, c-format
 msgid ""
 "Error scanning '%s':\n"
@@ -1086,16 +1155,7 @@ msgstr ""
 "錯誤檢視 '%s'：\n"
 "%s\n"
 
-#: filer.c:460
-#, c-format
-msgid ""
-"Error scanning '%s':\n"
-"%s"
-msgstr ""
-"錯誤檢視 '%s'：\n"
-"%s"
-
-#: filer.c:576
+#: filer.c:884
 msgid ""
 "Do you want to unmount this device?\n"
 "\n"
@@ -1105,19 +1165,19 @@ msgstr ""
 "\n"
 "解除掛載後才把媒體移出，會較為安全."
 
-#: filer.c:580
+#: filer.c:889
+msgid "Perform the same action in future for this mount point"
+msgstr ""
+
+#: filer.c:896
 msgid "No change"
 msgstr "沒有改變"
 
-#: filer.c:586 menu.c:872
+#: filer.c:902 infobox.c:1073 menu.c:1092
 msgid "Unmount"
 msgstr "解除掛載"
 
-#: filer.c:690
-msgid "Directory missing/deleted"
-msgstr "目錄已刪除/或不存在"
-
-#: filer.c:1054
+#: filer.c:1490
 #, c-format
 msgid ""
 "Group %s is not set. Select some files and press Ctrl+%s to set the group. "
@@ -1128,106 +1188,144 @@ msgstr ""
 "重選其他檔案.\n"
 "注意，鍵盤上的 NumLock 必須開啟"
 
-#: filer.c:1290
-#, c-format
-msgid "Directory '%s' is not accessible"
-msgstr "目錄 '%s' 不接受存取"
-
-#: filer.c:1442
-#, c-format
-msgid "Directory '%s' not found."
-msgstr "找不到目錄 '%s' "
-
-#: filer.c:1742
-msgid "Cancel"
-msgstr "取消"
-
-#: filer.c:2023
+#: filer.c:2655
 msgid "A"
 msgstr ""
 
-#: filer.c:2025 find.c:923
+#: filer.c:2656 filer.c:2668
+msgid "!"
+msgstr ""
+
+#: filer.c:2659 find.c:923
 msgid "G"
 msgstr ""
 
-#: filer.c:2030
+#: filer.c:2664
 msgid "S"
 msgstr ""
 
-#: filer.c:2032
+#: filer.c:2669
 msgid "T"
 msgstr ""
 
-#: filer.c:2042
-msgid "All, "
+#: filer.c:2670
+msgid "D"
 msgstr ""
 
-#: filer.c:2045
+#: filer.c:2671
+msgid "F"
+msgstr ""
+
+#: filer.c:2681
+msgid "ALL, "
+msgstr ""
+
+#: filer.c:2681
+msgid "Not ALL, "
+msgstr ""
+
+#: filer.c:2686
 #, c-format
 msgid "Glob (%s), "
 msgstr "只匹配 (%s), "
 
-#: filer.c:2053
+#: filer.c:2694
 msgid "Scanning, "
 msgstr "從新檢視中, "
 
-#: filer.c:2055
+#: filer.c:2697
 msgid "Thumbs, "
 msgstr "顯示縮圖, "
 
-#: filer.c:2331
+#: filer.c:2697
+#, fuzzy
+msgid "Not Thumbs, "
+msgstr "顯示縮圖, "
+
+#: filer.c:2698
+msgid "Dirs only, "
+msgstr ""
+
+#: filer.c:2699
+msgid "Files only, "
+msgstr ""
+
+#: filer.c:3174
 msgid "Symbolic link to "
 msgstr "連結指向 "
 
-#: filer.c:2373
+#: filer.c:3216
 msgid "This filename is not valid UTF-8. You should rename it.\n"
 msgstr "不是正確的 UTF-8 名稱，請重新命名.\n"
 
-#: filer.c:2690 menu.c:2014
+#: filer.c:3647 menu.c:2599
 msgid "Item no longer exists!"
 msgstr "項目已不存在！"
 
-#: filer.c:3417
+#: filer.c:4451
+msgid "▼"
+msgstr ""
+
+#: filer.c:4451
+msgid "▽"
+msgstr ""
+
+#: filer.c:4462
+msgid "▷"
+msgstr ""
+
+#: filer.c:4462
+msgid "▶"
+msgstr ""
+
+#: filer.c:4707
 msgid "Select display properties to save"
 msgstr "選擇顯示內容以儲存"
 
-#: filer.c:3421
+#: filer.c:4712
+#, fuzzy
+msgid "<b>Save display settings for parent directory/*</b>"
+msgstr "<b>儲存目錄的顯示設定</b>"
+
+#: filer.c:4713
 msgid "<b>Save display settings for directory</b>"
 msgstr "<b>儲存目錄的顯示設定</b>"
 
-#: filer.c:3428
+#: filer.c:4720
 msgid "Select settings to save"
 msgstr "選擇設定以儲存"
 
-#: filer.c:3435
+#: filer.c:4727
 msgid "Position"
 msgstr "位置"
 
-#: filer.c:3440 toolbar.c:133 toolbar.c:137 tips:39
-msgid "Size"
-msgstr "大小"
+#: filer.c:4732
+#, fuzzy
+msgid "Window size"
+msgstr "窗口"
 
-#: filer.c:3445
+#: filer.c:4737
 msgid "Show hidden"
 msgstr "顯示隱藏檔"
 
-#: filer.c:3451
-msgid "Display style"
+#: filer.c:4743
+#, fuzzy
+msgid "Display style (Icon size)"
 msgstr "顯示風格"
 
-#: filer.c:3457
+#: filer.c:4749
 msgid "Sort type and order"
 msgstr "以類型排序"
 
-#: filer.c:3462 toolbar.c:141
+#: filer.c:4754
 msgid "Details"
 msgstr "詳述"
 
-#: filer.c:3467 tips:92 tips:93
+#: filer.c:4759 tips:152 tips:153
 msgid "Thumbnails"
 msgstr "縮圖"
 
-#: filer.c:3473
+#: filer.c:4765
 msgid "Filter"
 msgstr "過濾"
 
@@ -1451,17 +1549,17 @@ msgstr ""
 msgid "Save As:"
 msgstr "另存為："
 
-#: gtksavebox.c:395
+#: gtksavebox.c:401
 msgid "Unnamed"
 msgstr "未命名的"
 
-#: gtksavebox.c:471
+#: gtksavebox.c:477
 msgid ""
 "Remote application wants to use Direct Save, but I can't read the "
 "XdndDirectSave0 (type text/plain) property.\n"
 msgstr ""
 
-#: gtksavebox.c:596
+#: gtksavebox.c:602
 msgid ""
 "Drag the icon to a directory viewer\n"
 "(or enter a full pathname)"
@@ -1469,18 +1567,18 @@ msgstr ""
 "拖放該圖示至一個目錄檢視器內\n"
 "(或輸入一個完整路徑)"
 
-#: gui_support.c:330
+#: gui_support.c:456
 msgid ""
 "\n"
 "---\n"
 msgstr ""
 
-#: gui_support.c:399
+#: gui_support.c:525
 #, c-format
 msgid "Attempt to read an XML file as a text file. File '%s' may be corrupted."
 msgstr "嘗試以文字檔開啟XML文件。發現文件 '%s' 已損壞."
 
-#: gui_support.c:416
+#: gui_support.c:542
 #, c-format
 msgid ""
 "Error in '%s' file at line %d: \n"
@@ -1495,22 +1593,22 @@ msgstr ""
 "原因可能是從舊版本上升級 ROX-Filer. 請打開選項窗口並點選儲存確定.\n"
 "往後的錯誤會被忽略."
 
-#: gui_support.c:1008
+#: gui_support.c:1140
 msgid "Incorrect or missing line break in text/uri-list data"
 msgstr "開啟 文字/連結 檔時發生錯誤"
 
-#: gui_support.c:1341
+#: gui_support.c:1473
 #, c-format
 msgid "Failed to open file '%s': %s"
 msgstr "未能開啟檔案 '%s': %s"
 
-#: gui_support.c:1385
+#: gui_support.c:1517
 #, c-format
 msgid ""
 "Failed to load image '%s': reason not known, probably a corrupt image file"
 msgstr "未能載入影像 '%s': 原因不明，可能是檔案損毀"
 
-#: gui_support.c:1450
+#: gui_support.c:1583
 #, c-format
 msgid ""
 "This program (%s) cannot be run, as the 0launch command is not available. It "
@@ -1528,171 +1626,176 @@ msgid ""
 "language setting to take full effect."
 msgstr "請重新啟動ROX-Filer，新的語言設定才會完全生效"
 
-#: icon.c:76
+#: icon.c:77
 msgid "(click to set)"
 msgstr "(點擊以設定)"
 
-#: icon.c:131
-msgid "ROX-Filer"
-msgstr "ROX-Filer"
-
-#: icon.c:132 menu.c:258
-msgid "About ROX-Filer..."
-msgstr "關於 ROX-Filer..."
-
-#: icon.c:133 menu.c:259
-msgid "Show Help Files"
-msgstr "顯示說明檔"
-
-#: icon.c:134 menu.c:260
-msgid "Manual"
-msgstr "指南"
-
-#: icon.c:136 menu.c:235
-msgid "Options..."
-msgstr "選項..."
-
-#: icon.c:137 menu.c:244
-msgid "Home Directory"
-msgstr "家目錄"
-
-#: icon.c:138 icon.c:1410 menu.c:212 type.c:223
-msgid "File"
-msgstr "檔案"
-
-#: icon.c:139 menu.c:218 menu.c:885
-msgid "Shift Open"
-msgstr "以新窗口開啟"
-
-#: icon.c:140 menu.c:223
-msgid "Properties"
-msgstr "訊息"
-
-#: icon.c:141 menu.c:221
-msgid "Set Run Action..."
-msgstr "設定執行檔..."
-
-#: icon.c:142 menu.c:222
-msgid "Set Icon..."
-msgstr "設定圖示..."
-
-#: icon.c:143 icon.c:867
-msgid "Edit Item"
-msgstr "編輯項目"
-
-#: icon.c:144
-msgid "Show Location"
-msgstr "顯示位址"
-
-#: icon.c:145
-msgid "Remove Item(s)"
-msgstr "移除項目"
-
-#: icon.c:318 log.c:110 menu.c:774
+#: icon.c:298 log.c:111 menu.c:986
 #, c-format
 msgid "%s '%s'"
 msgstr ""
 
-#: icon.c:331
+#: icon.c:311
 msgid "Nothing"
 msgstr "空的"
 
-#: icon.c:592
+#: icon.c:576
 msgid "The location must contain at least one character!"
 msgstr "位址名稱最少要包含一個字元"
 
-#: icon.c:657
+#: icon.c:641
 #, c-format
 msgid "You must unlock '%s' before removing it"
 msgstr "必須解除 '%s' 的鎖定，才可移除"
 
-#: icon.c:667
+#: icon.c:651
 msgid "You must first select some items to remove"
 msgstr "請先選擇項目以刪除"
 
-#: icon.c:673
+#: icon.c:657
 msgid "An item must be unlocked before it can be removed."
 msgstr "每個項目必先解除鎖定，才可把它移除"
 
-#: icon.c:687
+#: icon.c:671
 msgid "You must open the menu over an item"
 msgstr "請在項目上開啟選單"
 
-#: icon.c:712 menu.c:1285
+#: icon.c:696 menu.c:1586
 msgid "You can only set the run action for a regular file"
 msgstr "只可對常規檔案設定開啟的程式"
 
-#: icon.c:798
+#: icon.c:781
 msgid "Press the desired shortcut (eg, Control+F1)"
 msgstr "按下所要求的熱鍵 (如 Control+F1)"
 
-#: icon.c:820
+#: icon.c:803
 msgid "Failed to get keyboard grab!"
 msgstr "找取按鍵錯誤"
 
-#: icon.c:870
+#: icon.c:850 icon.c:1408
+msgid "Edit Item"
+msgstr "編輯項目"
+
+#: icon.c:853
 msgid "Clicking the icon opens:"
 msgstr "點擊圖示以開啟："
 
-#: icon.c:880
+#: icon.c:863
 msgid "Arguments to pass (for executables):"
 msgstr "參數(用於可執行檔)："
 
-#: icon.c:894
+#: icon.c:877
 msgid "The text displayed under the icon is:"
 msgstr "圖示下的訊息為："
 
-#: icon.c:907
+#: icon.c:890
 msgid "The keyboard shortcut is:"
 msgstr "設定熱鍵為："
 
-#: icon.c:927
+#: icon.c:910
 msgid "Locked"
 msgstr "鎖定"
 
-#: icon.c:932
+#: icon.c:915
 msgid "Locking an item prevents it from being accidentally removed"
 msgstr "鎖定一個項目以免被意外刪除"
 
-#: infobox.c:111
+#: icon.c:1387
+msgid "ROX-Filer"
+msgstr "ROX-Filer"
+
+#: icon.c:1392 menu.c:787 menu.c:790
+msgid "About ROX-Filer..."
+msgstr "關於 ROX-Filer..."
+
+#: icon.c:1393 menu.c:788
+msgid "Show Help Files"
+msgstr "顯示說明檔"
+
+#: icon.c:1394
+msgid "Manual"
+msgstr "指南"
+
+#: icon.c:1396 menu.c:745
+msgid "Options..."
+msgstr "選項..."
+
+#: icon.c:1397 menu.c:762
+msgid "Home Directory"
+msgstr "家目錄"
+
+#: icon.c:1399 type.c:230
+msgid "File"
+msgstr "檔案"
+
+#: icon.c:1401 menu.c:707 menu.c:1105
+msgid "Shift Open"
+msgstr "以新窗口開啟"
+
+#: icon.c:1402 menu.c:719
+msgid "Properties"
+msgstr "訊息"
+
+#: icon.c:1403 menu.c:712
+msgid "Set Run Action..."
+msgstr "設定執行檔..."
+
+#: icon.c:1404 menu.c:714
+msgid "Set Icon..."
+msgstr "設定圖示..."
+
+#: icon.c:1409
+msgid "Show Location"
+msgstr "顯示位址"
+
+#: icon.c:1410
+msgid "Remove Item(s)"
+msgstr "移除項目"
+
+#: infobox.c:113
 #, c-format
 msgid "Are you sure you want to open %d windows?"
 msgstr "您想開啟 %d 窗口？"
 
-#: infobox.c:112
+#: infobox.c:114
 msgid "Show Info"
 msgstr "顯示訊息"
 
-#: infobox.c:134 menu.c:779
+#: infobox.c:136 menu.c:991
 msgid "(bad utf-8)"
 msgstr "(不正確的 utf-8)"
 
-#: infobox.c:259
+#: infobox.c:278
 msgid "Show _Help Files"
 msgstr "顯示說明檔(_H)"
 
-#: infobox.c:272
+#: infobox.c:291
 msgid "<b>Permissions</b>"
 msgstr "<b>權限</b>"
 
-#: infobox.c:290
+#: infobox.c:309
 msgid "<b>Contents indicate...</b>"
 msgstr "<b>內容指示為...</b>"
 
-#: infobox.c:427 infobox.c:568 support.c:349
+#: infobox.c:319
+#, fuzzy
+msgid "<b>When all directories are closed</b>"
+msgstr "只記錄已被複製的目錄"
+
+#: infobox.c:455 infobox.c:600 support.c:379
 msgid "bytes"
 msgstr "bytes"
 
-#: infobox.c:450
+#: infobox.c:480
 msgid "Failed to read size"
 msgstr "未能檢視檔案之大小"
 
-#: infobox.c:511
+#: infobox.c:543
 #, c-format
 msgid "'%s' is no longer a symlink"
 msgstr "'%s' 不是一個符號連結"
 
-#: infobox.c:518
+#: infobox.c:550
 #, c-format
 msgid ""
 "Failed to unlink '%s':\n"
@@ -1701,7 +1804,7 @@ msgstr ""
 "未能移除符號連結 '%s'：\n"
 "%s"
 
-#: infobox.c:523
+#: infobox.c:555
 #, c-format
 msgid ""
 "Failed to create symlink from '%s':\n"
@@ -1712,172 +1815,186 @@ msgstr ""
 "%s\n"
 "(注意:舊的連結已被刪除)"
 
-#: infobox.c:547 tips:242
+#: infobox.c:579 tips:321
 msgid "Error:"
 msgstr "錯誤："
 
-#: infobox.c:554
+#: infobox.c:586
 msgid "Real directory:"
 msgstr "真正目錄："
 
-#: infobox.c:557
+#: infobox.c:589
 msgid "Owner, Group:"
 msgstr "用戶，組別："
 
-#: infobox.c:564 infobox.c:579 infobox.c:588
+#: infobox.c:596 infobox.c:611 infobox.c:620
 msgid "Size:"
 msgstr "大小："
 
-#: infobox.c:589
+#: infobox.c:621
 msgid "Scanning"
 msgstr "檢視中"
 
-#: infobox.c:614
+#: infobox.c:646
 msgid "Failed to scan"
 msgstr "檢視失敗"
 
-#: infobox.c:621
+#: infobox.c:653
 msgid "Change time:"
 msgstr "變更時間："
 
-#: infobox.c:623
+#: infobox.c:655
 msgid "Modify time:"
 msgstr "修改時間："
 
-#: infobox.c:625
+#: infobox.c:657
 msgid "Access time:"
 msgstr "存取時間："
 
-#: infobox.c:633
+#: infobox.c:665
 msgid "Extended attributes:"
 msgstr "伸延屬性："
 
-#: infobox.c:635
+#: infobox.c:667
 msgid "Present"
 msgstr "目前"
 
-#: infobox.c:636
+#: infobox.c:668
 msgid "None"
 msgstr "沒有"
 
-#: infobox.c:637
+#: infobox.c:669
 msgid "Not supported"
 msgstr "不支援"
 
-#: infobox.c:649
+#: infobox.c:681
 msgid "Link target:"
 msgstr "連結目標："
 
-#: infobox.c:661 infobox.c:664
+#: infobox.c:693 infobox.c:696
 msgid "Run action:"
 msgstr "執行程序："
 
-#: infobox.c:661
+#: infobox.c:693
 msgid "Execute file"
 msgstr "執行檔案"
 
-#: infobox.c:773
+#: infobox.c:805
 msgid "Comment"
 msgstr "註解"
 
-#: infobox.c:775
+#: infobox.c:807
 msgid "Execute"
 msgstr "執行檔案"
 
-#: infobox.c:789
+#: infobox.c:822
 msgid "<nothing yet>"
 msgstr "<還是空的>"
 
-#: infobox.c:860
+#: infobox.c:895
 #, c-format
 msgid "file(1) says... %s"
 msgstr "檔案(1) 顯示...%s"
 
-#: infobox.c:917
+#: infobox.c:952
 #, c-format
 msgid "Could not change permissions: %s"
 msgstr "不能改變 '%s' 的權限"
 
-#: infobox.c:935
+#: infobox.c:970 tips:120
 msgid "Owner"
 msgstr "用戶"
 
-#: infobox.c:937
+#: infobox.c:972 tips:122
 msgid "Group"
 msgstr "組別"
 
-#: infobox.c:939
+#: infobox.c:974
 msgid "World"
 msgstr "其他"
 
-#: infobox.c:942
+#: infobox.c:977
 msgid "Read"
 msgstr "可讀"
 
-#: infobox.c:944
+#: infobox.c:980
 msgid "Write"
 msgstr "可寫"
 
-#: infobox.c:946
+#: infobox.c:983
 msgid "Exec"
 msgstr "可執行"
 
-#: infobox.c:963
+#: infobox.c:1001
 msgid "SUID"
 msgstr "SUID"
 
-#: infobox.c:970
+#: infobox.c:1008
 msgid "SGID"
 msgstr "SGID"
 
-#: infobox.c:977
+#: infobox.c:1015
 msgid "Sticky"
 msgstr "Sticky"
 
-#: infobox.c:999
+#: infobox.c:1071
+#, fuzzy
+msgid "Do nothing"
+msgstr "<空的>"
+
+#: infobox.c:1077
+msgid "Ask"
+msgstr ""
+
+#: infobox.c:1089
 msgid "Symbolic link"
 msgstr "是一符號連結"
 
-#: infobox.c:1002
+#: infobox.c:1092
 msgid "ROX application"
 msgstr "ROX 應用程式"
 
-#: infobox.c:1010
+#: infobox.c:1100
 msgid "mounted"
 msgstr "已掛載"
 
-#: infobox.c:1010
+#: infobox.c:1100
 msgid "unmounted"
 msgstr "已解除掛載"
 
-#: infobox.c:1014
+#: infobox.c:1104
 #, c-format
 msgid "Mount point for %s (%s)"
 msgstr "掛載點為 %s (%s)"
 
-#: infobox.c:1017
+#: infobox.c:1107
 #, c-format
 msgid "Mount point (%s)"
 msgstr "掛載點 (%s)"
 
-#: log.c:55
+#: log.c:54
 msgid "ROX-Filer started"
 msgstr "ROX-Filer 已啟動"
 
-#: log.c:112
+#: log.c:115
 #, c-format
 msgid "%s on %d items"
 msgstr "%s 於 %d 項目"
 
-#: log.c:125
+#: log.c:132
+#, fuzzy
+msgid "..."
+msgstr "複製..."
+
+#: log.c:139
 msgid "Item"
 msgstr "項目"
 
-#: log.c:149
+#: log.c:165
 msgid "Time"
 msgstr "時間"
 
-#: log.c:154
+#: log.c:170
 msgid "Action"
 msgstr "動作"
 
@@ -1945,65 +2062,57 @@ msgid ""
 "Trying to continue..."
 msgstr ""
 
-#: main.c:400
+#: main.c:399
 msgid ""
 "The -o argument is no longer used. You can turn on override redirect from "
 "the Options box instead."
 msgstr ""
 
-#: main.c:529
+#: main.c:528
 #, c-format
 msgid "Running as user '%s'"
 msgstr "執行用戶為 '%s'"
 
-#: main.c:690
+#: main.c:688
 #, c-format
 msgid "Compiled with GTK version %s\n"
 msgstr ""
 
-#: main.c:691
+#: main.c:689
 #, c-format
 msgid "Running with GTK version %d.%d.%d\n"
 msgstr ""
 
-#: main.c:695
+#: main.c:693
 msgid "features set at compile time"
 msgstr ""
 
-#: main.c:696
+#: main.c:694
 msgid "Large File Support"
 msgstr ""
 
-#: main.c:703
-msgid "Inotify support"
-msgstr ""
-
-#: main.c:710
-msgid "Dnotify support"
-msgstr ""
-
-#: main.c:717
+#: main.c:701
 msgid "Binary compatibility"
 msgstr ""
 
-#: main.c:719
+#: main.c:703
 msgid "Yes (can run with older glibc versions)"
 msgstr ""
 
-#: main.c:721
+#: main.c:705
 msgid "No (apsymbols.h not found)"
 msgstr ""
 
-#: main.c:725
+#: main.c:709
 msgid "Extended attribute support"
 msgstr "伸延屬性支援"
 
-#: main.c:876
+#: main.c:856
 #, c-format
 msgid "Unable to read '%s': %s"
 msgstr "未能檢視 '%s': %s"
 
-#: main.c:918
+#: main.c:895
 #, c-format
 msgid ""
 "Left-click to run %s.\n"
@@ -2012,236 +2121,322 @@ msgstr ""
 "滑鼠左擊以執行 %s.\n"
 "滑鼠右擊以顯示版本"
 
-#: menu.c:185 tips:28
+#: main.c:942 menu.c:1723 menu.c:1729
+#, c-format
+msgid "Error creating '%s': %s"
+msgstr "錯誤創建 '%s': %s"
+
+#: main.c:973
+#, fuzzy
+msgid "Save"
+msgstr "另存為："
+
+#: main.c:978
+msgid "Start script"
+msgstr ""
+
+#: main.c:1003
+msgid ""
+"Click to save a script to run ROX-Filer.\n"
+"If you are using Zero Install you should use 0alias instead."
+msgstr ""
+
+#: menu.c:639
 msgid "Display"
 msgstr "顯示"
 
-#: menu.c:186 tips:33
+#: menu.c:641 tips:49
 msgid "Icons View"
 msgstr "圖示模式"
 
-#: menu.c:187
-msgid "Icons, With..."
+#: menu.c:642
+#, fuzzy
+msgid "Icons With Sizes"
 msgstr "圖示，並顯示..."
 
-#: menu.c:188 tips:52
-msgid "Sizes"
-msgstr "大小"
+#: menu.c:643
+#, fuzzy
+msgid "Icons With Times"
+msgstr "圖示佈景"
 
-#: menu.c:190 tips:226
-msgid "Types"
-msgstr "類型"
+#: menu.c:644
+#, fuzzy
+msgid "Icons With Permissions"
+msgstr "權限"
 
-#: menu.c:191 tips:55
-msgid "Times"
-msgstr "時間"
+#: menu.c:645
+#, fuzzy
+msgid "Icons With Types"
+msgstr "圖示，並顯示..."
 
-#: menu.c:192 tips:34 tips:70
+#: menu.c:647 tips:50 tips:98 tips:99
 msgid "List View"
 msgstr "列表模式"
 
-#: menu.c:194
+#: menu.c:651
 msgid "Bigger Icons"
 msgstr "較大圖示"
 
-#: menu.c:195
+#: menu.c:653
 msgid "Smaller Icons"
 msgstr "較小圖示"
 
-#: menu.c:196 tips:49
+#: menu.c:655 tips:71
 msgid "Automatic"
 msgstr "自動化"
 
-#: menu.c:198
+#: menu.c:661
 msgid "Sort by Name"
 msgstr "以名稱排序"
 
-#: menu.c:199
+#: menu.c:662
 msgid "Sort by Type"
 msgstr "以類型排序"
 
-#: menu.c:200
-msgid "Sort by Date"
+#: menu.c:663
+#, fuzzy
+msgid "Sort by Date (atime)"
 msgstr "以日期排序"
 
-#: menu.c:201
+#: menu.c:664
+#, fuzzy
+msgid "Sort by Date (ctime)"
+msgstr "以日期排序"
+
+#: menu.c:665
+#, fuzzy
+msgid "Sort by Date (mtime)"
+msgstr "以日期排序"
+
+#: menu.c:666
 msgid "Sort by Size"
 msgstr "以大小排序"
 
-#: menu.c:202
+#: menu.c:667 toolbar.c:536
+#, fuzzy
+msgid "Sort by permissions"
+msgstr "權限"
+
+#: menu.c:668
 msgid "Sort by Owner"
 msgstr "以用戶排序"
 
-#: menu.c:203
+#: menu.c:669
 msgid "Sort by Group"
 msgstr "以組別排序"
 
-#: menu.c:204
+#: menu.c:671
 msgid "Reversed"
 msgstr "反向"
 
-#: menu.c:206
+#: menu.c:675
 msgid "Show Hidden"
 msgstr "顯示隱藏檔"
 
-#: menu.c:207
+#: menu.c:677
+#, fuzzy
+msgid "Show Only Files"
+msgstr "顯示說明檔"
+
+#: menu.c:678
+#, fuzzy
+msgid "Show Only Directories"
+msgstr "沒有目錄)\n"
+
+#: menu.c:679
 msgid "Filter Files..."
 msgstr "檔案過濾..."
 
-#: menu.c:208
+#: menu.c:680
+#, fuzzy
+msgid "Temp Filter..."
+msgstr "檔案過濾..."
+
+#: menu.c:681
 msgid "Filter Directories With Files"
 msgstr "檔案過濾並忽略目錄"
 
-#: menu.c:209
+#: menu.c:682
 msgid "Show Thumbnails"
 msgstr "顯示縮圖"
 
-#: menu.c:210
+#: menu.c:683
 msgid "Refresh"
 msgstr "更新"
 
-#: menu.c:211
-msgid "Save Current Display Settings..."
+#: menu.c:684
+#, fuzzy
+msgid "Refresh Thumbs"
+msgstr "更新"
+
+#: menu.c:686
+#, fuzzy
+msgid "Save Display Settings..."
 msgstr "儲存現行設定..."
 
-#: menu.c:213
-msgid "Copy..."
-msgstr "複製..."
+#: menu.c:687
+#, fuzzy
+msgid "Save Display Settings to parent ..."
+msgstr "儲存現行設定..."
 
-#: menu.c:214
+#: menu.c:695
+#, fuzzy
+msgid "Cut"
+msgstr "計算"
+
+#: menu.c:697
+msgid "Duplicate..."
+msgstr ""
+
+#: menu.c:699
 msgid "Rename..."
 msgstr "改名..."
 
-#: menu.c:215
+#: menu.c:700
 msgid "Link..."
 msgstr "連結..."
 
-#: menu.c:219
+#: menu.c:708
 msgid "Send To..."
 msgstr "傳送至..."
 
-#: menu.c:224
+#: menu.c:717
+#, fuzzy
+msgid "Extended attributes..."
+msgstr "伸延屬性"
+
+#: menu.c:721
 msgid "Count"
 msgstr "計算"
 
-#: menu.c:225
+#: menu.c:723
 msgid "Set Type..."
 msgstr "另定類型..."
 
-#: menu.c:229 toolbar.c:154
+#: menu.c:731 toolbar.c:179
 msgid "Select"
 msgstr "選擇"
 
-#: menu.c:230
+#: menu.c:733
 msgid "Select All"
 msgstr "全選"
 
-#: menu.c:231
+#: menu.c:735
 msgid "Clear Selection"
 msgstr "取消選擇"
 
-#: menu.c:232
+#: menu.c:736
 msgid "Invert Selection"
 msgstr "反向選擇"
 
-#: menu.c:233
+#: menu.c:737
 msgid "Select by Name..."
 msgstr "以名稱選擇..."
 
-#: menu.c:234
+#: menu.c:739
+#, fuzzy
+msgid "Reg Select..."
+msgstr "條件式選擇"
+
+#: menu.c:741
 msgid "Select If..."
 msgstr "條件式選擇"
 
-#: menu.c:236
+#: menu.c:746
+msgid "Paste"
+msgstr ""
+
+#: menu.c:749 toolbar.c:184
 msgid "New"
 msgstr "新增"
 
-#: menu.c:238
+#: menu.c:752
 msgid "Blank file"
 msgstr "空檔案"
 
-#: menu.c:240 tasklist.c:309
+#: menu.c:756 tasklist.c:305
 msgid "Window"
 msgstr "窗口"
 
-#: menu.c:241
+#: menu.c:758
 msgid "Parent, New Window"
 msgstr "上層，新窗口"
 
-#: menu.c:242
+#: menu.c:759
 msgid "Parent, Same Window"
 msgstr "上層，窗口"
 
-#: menu.c:243
+#: menu.c:761 tips:44
 msgid "New Window"
 msgstr "新窗口"
 
-#: menu.c:245
+#: menu.c:764
 msgid "Show Bookmarks"
 msgstr "顯示書簽"
 
-#: menu.c:246
+#: menu.c:766
 msgid "Show Log"
 msgstr "操作記錄"
 
-#: menu.c:247
+#: menu.c:768
 msgid "Follow Symbolic Links"
 msgstr "跟蹤符號連結"
 
-#: menu.c:248
+#: menu.c:769
 msgid "Resize Window"
 msgstr "調整窗口大小"
 
-#: menu.c:251
+#: menu.c:771
 msgid "Close Window"
 msgstr "關閉窗口"
 
-#: menu.c:253
+#: menu.c:776
 msgid "Enter Path..."
 msgstr "鍵入路徑..."
 
-#: menu.c:254
+#: menu.c:778
 msgid "Shell Command..."
 msgstr "執行指令..."
 
-#: menu.c:255
+#: menu.c:780
 msgid "Terminal Here"
 msgstr "終端機"
 
-#: menu.c:256
+#: menu.c:782
 msgid "Switch to Terminal"
 msgstr "切換成終端機"
 
-#: menu.c:725
-msgid "You should Shift+Menu click over a file to send it somewhere"
-msgstr "你可用滑鼠在檔案上點擊選單，並同時按下Shift鍵，開啟`傳送至'功能"
+#: menu.c:793
+#, fuzzy
+msgid "Customise Dir Menu..."
+msgstr "自定選單..."
 
-#: menu.c:764
+#: menu.c:976
 msgid "Next Click"
 msgstr "進階"
 
-#: menu.c:786
+#: menu.c:998
 #, c-format
 msgid "%d items"
 msgstr "%d 項目"
 
-#: menu.c:874
+#: menu.c:1094
 msgid "Open unmounted"
 msgstr "列出已解除掛載項目"
 
-#: menu.c:877
+#: menu.c:1097
 msgid "Show Target"
 msgstr "顯示目標"
 
-#: menu.c:879
+#: menu.c:1099
 msgid "Look Inside"
 msgstr "察看內部"
 
-#: menu.c:881
+#: menu.c:1101
 msgid "Open As Text"
 msgstr "以文字模式開啟"
 
-#: menu.c:1052
+#: menu.c:1320
 msgid ""
 "Extended attributes, used to store types, are not supported for this file or "
 "files.\n"
@@ -2253,15 +2448,15 @@ msgstr ""
 "可能是閣下的檔案系統或 C 函式庫不支援，又或在掛載檔案系統時,沒有套用正確的參"
 "數，掛載選項 ('user_xattr' on Linux)."
 
-#: menu.c:1058
+#: menu.c:1326
 msgid "Setting type not supported for some of these files"
 msgstr "某些檔案不能以此類型設定"
 
-#: menu.c:1095
+#: menu.c:1364
 msgid "_Relative link"
 msgstr "相對路徑(_R)"
 
-#: menu.c:1101
+#: menu.c:1370
 msgid ""
 "If on, the symlink will store the path from the symlink to the target file. "
 "Use this if the symlink and the target will be moved together.\n"
@@ -2273,43 +2468,55 @@ msgstr ""
 "關閉時,連結會儲存從根目錄到目標的路徑，這選項適用於當連結移動，但目標不變的時"
 "侯."
 
-#: menu.c:1171
+#: menu.c:1382
+msgid "_Sym path"
+msgstr ""
+
+#: menu.c:1388
+msgid "If on, the symlink will use target path as Sym path."
+msgstr ""
+
+#: menu.c:1460
 msgid "New pathname is not absolute"
 msgstr "新的路徑名稱屬不絕對"
 
-#: menu.c:1239
+#: menu.c:1540
 #, c-format
 msgid "Symlink from '%s' already exists. Replace it with a link to '%s'?"
 msgstr " '%' 的連結檔已存在，是否要替換？"
 
-#: menu.c:1245
+#: menu.c:1546
 msgid "_Replace"
 msgstr "替換(_R)"
 
-#: menu.c:1365 menu.c:1406 menu.c:1468
-msgid "Create"
-msgstr "創建"
-
-#: menu.c:1366
+#: menu.c:1704
 msgid "NewDir"
 msgstr "新目錄"
 
-#: menu.c:1380 menu.c:1386
-#, c-format
-msgid "Error creating '%s': %s"
-msgstr "錯誤創建 '%s': %s"
+#: menu.c:1706 menu.c:1757 menu.c:1827
+msgid "Create"
+msgstr "創建"
 
-#: menu.c:1407
+#: menu.c:1755
 msgid "NewFile"
 msgstr "新檔案"
 
-#: menu.c:1425
+#: menu.c:1779
 #, c-format
 msgid "Error creating file: could not find the template for %s"
 msgstr "錯誤創建檔案: 找不到樣板予 %s"
 
-#: menu.c:1498
-#, c-format
+#: menu.c:1847
+#, fuzzy
+msgid ""
+"Symlink any programs you want into this directory. \n"
+"\n"
+"Tip: Directories and `Set Icon' may make it more usefull."
+msgstr ""
+"連結任何合用程式到此目錄內，該等程式將會出現於此類型 (%s/%s) 項目的選單中"
+
+#: menu.c:1883
+#, fuzzy, c-format
 msgid ""
 "The `Send To' menu provides a quick way to send some files to an "
 "application. The applications listed are those in the following "
@@ -2321,8 +2528,9 @@ msgid ""
 "\n"
 "Advanced use:\n"
 "You can also create subdirectories called `.text_html', `.text', etc which "
-"will only be shown for files of that type. `.group' is shown only when "
-"multiple files are selected."
+"will only be shown for files of that type and shared with the file menu. In "
+"addition, `.group' is shown only when multiple files are selected. `.all' is "
+"all."
 msgstr ""
 "利用'傳送至'此功能，你可快速的將要開啟的檔案送到某個應用程式上，該等應用程式"
 "在以下的目錄內：\n"
@@ -2334,17 +2542,17 @@ msgstr ""
 "您亦可建立子目錄 `.text_html', `.text'等等，該子目錄只會在開啟該類型檔案時出"
 "現。 `.group' 只會 在選擇多個檔案時出現."
 
-#: menu.c:1509
+#: menu.c:1895
 msgid ""
 "I'll show you your SendTo directory now; you should symlink (Ctrl+Shift "
 "drag) any applications you want into it."
 msgstr "請將適用的程式以符號連結 (Ctrl+Shift並 拖放)到'傳送至'的目錄內."
 
-#: menu.c:1512 menu.c:1552
+#: menu.c:1898 menu.c:1938
 msgid "Your CHOICESPATH variable setting prevents customisations - sorry."
 msgstr "不容許自定 CHOICE 路徑"
 
-#: menu.c:1545
+#: menu.c:1931
 #, c-format
 msgid ""
 "Any files placed in your Templates directories will appear on the `New' "
@@ -2363,21 +2571,27 @@ msgstr ""
 "%s\n"
 "%s\n"
 
-#: menu.c:1550
+#: menu.c:1936
 msgid ""
 "I'll show you your Templates directory now; you should place any template "
 "files you want inside it."
 msgstr "現在顯示您的樣板檔案目錄；您可放進任何需要的樣板檔案 ."
 
-#: menu.c:1667
-msgid "Customise"
+#: menu.c:2081
+#, fuzzy
+msgid "Customise..."
 msgstr "自定"
 
-#: menu.c:1740
+#: menu.c:2106
+#, fuzzy
+msgid "Customise Dir menu..."
+msgstr "自定選單..."
+
+#: menu.c:2169
 msgid "This is already the canonical name for this directory."
 msgstr "此目錄已有規範性名稱"
 
-#: menu.c:1771
+#: menu.c:2200
 msgid ""
 "You can't open a second view onto this directory because the `Unique "
 "Windows' option is turned on in the Options window."
@@ -2385,71 +2599,103 @@ msgstr ""
 "你不能對此目錄開啟第二個窗口，因為你已在選項->Filer窗口內選了「唯一的窗口」的"
 "功能."
 
-#: menu.c:1897
-msgid "Copy ... ?"
-msgstr "複製...？"
+#: menu.c:2348
+msgid "The clipboard is empty."
+msgstr ""
 
-#: menu.c:1900
+#: menu.c:2384
+#, fuzzy, c-format
+msgid "Copy of %s"
+msgstr "?複製%s 為 %s?"
+
+#: menu.c:2390
+#, fuzzy, c-format
+msgid "Copy(%d) of %s"
+msgstr "?複製%s 為 %s?"
+
+#: menu.c:2456
+msgid "Duplicate ... ?"
+msgstr ""
+
+#: menu.c:2459
 msgid "Rename ... ?"
 msgstr "改名為...？"
 
-#: menu.c:1903
+#: menu.c:2462
 msgid "Symlink ... ?"
 msgstr "符號連結...？"
 
-#: menu.c:1906
+#: menu.c:2465
 msgid "Shift Open ... ?"
 msgstr "新窗口開啟...？"
 
-#: menu.c:1909
+#: menu.c:2468
 msgid "Properties of ... ?"
 msgstr "訊息...？"
 
-#: menu.c:1912
+#: menu.c:2472
+#, fuzzy
+msgid "Extended attributes of ... ?"
+msgstr "伸延屬性"
+
+#: menu.c:2476
 msgid "Set type of ... ?"
 msgstr "設定類型...？"
 
-#: menu.c:1915
+#: menu.c:2479
 msgid "Set run action for ... ?"
 msgstr "設定執行程式予... ？"
 
-#: menu.c:1918
+#: menu.c:2482
 msgid "Set icon for ... ?"
 msgstr "設定圖示予...？"
 
-#: menu.c:1921
+#: menu.c:2485
 msgid "Send ... to ... ?"
 msgstr "傳送...至...？"
 
-#: menu.c:1924
+#: menu.c:2488
 msgid "DELETE ... ?"
 msgstr "移除...？"
 
-#: menu.c:1927
+#: menu.c:2491
 msgid "Count the size of ... ?"
 msgstr "計算容量從 ...？"
 
-#: menu.c:1930
+#: menu.c:2494
 msgid "Set permissions on ... ?"
 msgstr "改變權限予...？"
 
-#: menu.c:1933
+#: menu.c:2497
 msgid "Search inside ... ?"
 msgstr "搜索內部...？"
 
-#: menu.c:1997
+#: menu.c:2500
+#, fuzzy
+msgid "Copy ... to clipboard ?"
+msgstr "複製...？"
+
+#: menu.c:2503
+msgid "Cut ... to clipboard ?"
+msgstr ""
+
+#: menu.c:2582
 msgid "You cannot do this to more than one item at a time"
 msgstr "不可同時以此方式處理多個項目"
 
-#: menu.c:2029
+#: menu.c:2609
+msgid "Duplicate"
+msgstr ""
+
+#: menu.c:2614
 msgid "Rename"
 msgstr "改名"
 
-#: menu.c:2034
+#: menu.c:2619
 msgid "Symlink"
 msgstr "符號連結"
 
-#: menu.c:2063
+#: menu.c:2654
 msgid ""
 "User-definable shortcuts are disabled by default in Gtk2, and you have not "
 "enabled them. You can turn this feature on by:\n"
@@ -2468,7 +2714,7 @@ msgstr ""
 "\tgtk-can-chang-accels = 1\n"
 "\t(只可在不用 XSETTINGS 的情況下)"
 
-#: menu.c:2074
+#: menu.c:2665
 msgid ""
 "To set a keyboard short-cut for a menu item:\n"
 "\n"
@@ -2488,31 +2734,40 @@ msgstr ""
 "對應的熱鍵會出現在選單的某個項目上，而日後你想開啟這項目，祗須按下熱鍵而不需"
 "先開啟選單."
 
-#: menu.c:2089
+#: menu.c:2680
 msgid "Set keyboard shortcuts"
 msgstr "設定熱鍵"
 
-#: minibuffer.c:129
+#: minibuffer.c:140
 msgid "Goto:"
 msgstr "移至："
 
-#: minibuffer.c:130
+#: minibuffer.c:141
 msgid "Shell:"
 msgstr "執行："
 
-#: minibuffer.c:131
+#: minibuffer.c:142
 msgid "Select If:"
 msgstr "條件匹配："
 
-#: minibuffer.c:132
+#: minibuffer.c:143
 msgid "Select Named:"
 msgstr "已選擇名為："
 
-#: minibuffer.c:133
+#: minibuffer.c:144
+#, fuzzy
+msgid "Reg Select (i):"
+msgstr "條件匹配："
+
+#: minibuffer.c:145
 msgid "Pattern:"
 msgstr "式樣："
 
-#: minibuffer.c:265
+#: minibuffer.c:146
+msgid "Temp Filter (reg-i):"
+msgstr ""
+
+#: minibuffer.c:320
 msgid ""
 "Enter the name of a file and I'll display it for you. Press Tab to fill in "
 "the longest match. Escape to close the minibuffer."
@@ -2520,12 +2775,32 @@ msgstr ""
 "輸入檔案名稱前的字符，按下鍵盤的 Tab 鍵，會自動幫您找出匹配的檔案，如要關閉小"
 "型命令框，請按下 Esc 鍵."
 
-#: minibuffer.c:271
+#: minibuffer.c:326
 msgid ""
 "Enter a shell command to execute. Click on a file to add it to the buffer."
 msgstr "在此輸入指令，再以滑鼠點擊檔案加進命令框來執行."
 
-#: minibuffer.c:276
+#: minibuffer.c:331
+#, fuzzy
+msgid ""
+"Enter a file name pattern to select all matching files:\n"
+"\n"
+". means any character\n"
+".* means zero or more characters\n"
+"[a-z] means any character from a to z\n"
+"\\.png$ means any name ending in '.png'\n"
+"\n"
+"Shift + Enter: switch to Temp Filter."
+msgstr ""
+"輸入一個檔案名稱的式樣，用以選擇匹配的檔案:\n"
+"\n"
+"? 代表任何字符\n"
+"* 代表零或更多字符\n"
+"[aA] 代表 'a' 或 'A'\n"
+"[a-z] 代表任何字符從 a 至 z (小階)\n"
+"*.png 代表任何名稱結尾為 '.png')"
+
+#: minibuffer.c:340
 msgid ""
 "Enter a file name pattern to select all matching files:\n"
 "\n"
@@ -2543,13 +2818,20 @@ msgstr ""
 "[a-z] 代表任何字符從 a 至 z (小階)\n"
 "*.png 代表任何名稱結尾為 '.png')"
 
-#: minibuffer.c:288
+#: minibuffer.c:352
 msgid ""
 "Enter a pattern to match for files to be shown.  An empty filter turns the "
 "filter off."
 msgstr "輸入一個式樣用以匹配要顯示的檔案，空的選擇會關閉過濾規則."
 
-#: minibuffer.c:908
+#: minibuffer.c:358
+#, fuzzy
+msgid ""
+"Enter a pattern to match for files to be shown and press Enter Key.\n"
+"It is active until the minibuffer is closed."
+msgstr "輸入一個式樣用以匹配要顯示的檔案，空的選擇會關閉過濾規則."
+
+#: minibuffer.c:1045
 msgid "Invalid Find condition"
 msgstr "非法的搜尋定義"
 
@@ -2563,32 +2845,32 @@ msgstr "找不到檔案系統表格 \"%s\" ，未能顯示掛載的系統"
 msgid "%s total, %s used, %s free (%.1f %%)"
 msgstr "%s 總數, %s 已用, %s 空間 (%.1f %%)"
 
-#: options.c:275
+#: options.c:272
 msgid "ROX-Filer has converted your Options file to the new XML format"
 msgstr "你的舊設定檔案已轉為新的XML格式."
 
-#: options.c:535 options.c:1256
+#: options.c:560 options.c:1250
 msgid "(use default)"
 msgstr "(跟預設值相同)"
 
-#: options.c:805
+#: options.c:844
 #, c-format
 msgid "Internal error: %s unreadable"
 msgstr "內部錯誤: %s 已損壞"
 
-#: options.c:914
+#: options.c:929
 msgid "Options"
 msgstr "選項"
 
-#: options.c:959
+#: options.c:974
 msgid "_Revert"
 msgstr "復原(_R)"
 
-#: options.c:965
+#: options.c:981
 msgid "Restore all choices to how they were when the Options box was opened."
 msgstr "儲存所有設定"
 
-#: options.c:980
+#: options.c:996
 #, c-format
 msgid ""
 "Choices will be saved as:\n"
@@ -2597,53 +2879,53 @@ msgstr ""
 "選擇將被儲存為：\n"
 " %s"
 
-#: options.c:988
+#: options.c:1004
 msgid "(saving disabled by CHOICESPATH)"
 msgstr "(儲存設定被終止,因應 CHOICEPATH)"
 
-#: options.c:1161 usericons.c:452
+#: options.c:1160 usericons.c:461
 #, c-format
 msgid "Error saving %s: %s"
 msgstr "錯誤儲存 %s: %s"
 
-#: options.c:1793
+#: options.c:1813
 msgid "Missing '='"
 msgstr "遺失 '='"
 
-#: panel.c:322
+#: panel.c:326
 #, c-format
 msgid "Unable to replace '%s'"
 msgstr "未能替代 '%s'"
 
-#: panel.c:326
+#: panel.c:330
 #, c-format
 msgid "Unable to save '%s'"
 msgstr "未能儲存 '%s'"
 
-#: panel.c:529
+#: panel.c:562
 msgid "Your old panel file has been converted to the new XML format."
 msgstr "你的舊面板資源檔案已轉為新的XML格式."
 
-#: panel.c:637
+#: panel.c:670
 msgid ""
 "You have tried to close a panel via the window manager - I usually find that "
 "this is accidental... really close?"
 msgstr "你要從Window Manger中關閉面板，確定要關閉？"
 
-#: panel.c:738
+#: panel.c:771
 msgid "Missing < or > in panel config file"
 msgstr "沒有 < 或 > 於面板的設定檔"
 
-#: panel.c:1610
+#: panel.c:1655
 #, c-format
 msgid "Error saving panel %s: %s"
 msgstr "錯誤儲存面板 %s: %s"
 
-#: panel.c:1925
+#: panel.c:1981
 msgid "Applet quit without ever creating a widget!"
 msgstr "程序被無故終止！"
 
-#: panel.c:2021
+#: panel.c:2077
 #, c-format
 msgid ""
 "Error running applet:\n"
@@ -2652,44 +2934,44 @@ msgstr ""
 "錯誤執行程序：\n"
 "%s"
 
-#: panel.c:2646
+#: panel.c:2751
 msgid "Are you sure you want to remove this panel from the desktop?"
 msgstr "您是否決定移除此面板？"
 
-#: panel.c:2649 panel.c:2676
+#: panel.c:2754 panel.c:2781
 msgid "Remove Panel"
 msgstr "移除面板"
 
-#: panel.c:2672
+#: panel.c:2777
 msgid "Panel Options..."
 msgstr "面板選項..."
 
-#: panel.c:2757
+#: panel.c:2862
 #, c-format
 msgid "Xinerama monitor %d unavailable"
 msgstr "多螢幕顯示器 %d 不存在"
 
-#: panel.c:2787
+#: panel.c:2897
 msgid "Top"
 msgstr "頂部"
 
-#: panel.c:2789
+#: panel.c:2899
 msgid "Bottom"
 msgstr "底部"
 
-#: panel.c:2791
+#: panel.c:2901
 msgid "Left"
 msgstr "左邊"
 
-#: panel.c:2793
+#: panel.c:2903
 msgid "Right"
 msgstr "右邊"
 
-#: panel.c:2795
+#: panel.c:2905
 msgid "Default"
 msgstr "預設"
 
-#: panel.c:2799
+#: panel.c:2909
 msgid "Unknown side"
 msgstr "不明位置"
 
@@ -2784,28 +3066,28 @@ msgid ""
 "image."
 msgstr "只有檔案(及某些應用程式)才可用作設定背景"
 
-#: pinboard.c:1602
+#: pinboard.c:1607
 msgid "Missing '>' in icon label"
 msgstr "沒有 '>' 在圖示標簽內"
 
-#: pinboard.c:1611
+#: pinboard.c:1616
 msgid "Missing ',' after icon label"
 msgstr "沒有 ',' 在圖示標簽後"
 
-#: pinboard.c:1699
+#: pinboard.c:1704
 #, c-format
 msgid "Error saving pinboard %s: %s"
 msgstr "錯誤儲存桌面 %s: %s"
 
-#: pinboard.c:2244
+#: pinboard.c:2247
 msgid "Backdrop..."
 msgstr "背景..."
 
-#: pinboard.c:2247
+#: pinboard.c:2250
 msgid "Add Panel"
 msgstr "增加面板"
 
-#: pinboard.c:2341
+#: pinboard.c:2344
 #, c-format
 msgid ""
 "Error loading backdrop image:\n"
@@ -2816,7 +3098,7 @@ msgstr ""
 "%s\n"
 "背景被移除."
 
-#: pixmaps.c:969
+#: pixmaps.c:1227
 #, c-format
 msgid ""
 "Can't delete thumbnails in %s:\n"
@@ -2825,96 +3107,40 @@ msgstr ""
 "不能刪除縮圖於 %s:\n"
 "%s"
 
-#: pixmaps.c:990
+#: pixmaps.c:1258
 msgid "There are no thumbnails to delete"
 msgstr "沒有縮圖可供移除"
 
-#: pixmaps.c:1003
+#: pixmaps.c:1271
 msgid "Purge thumbnails disk cache"
 msgstr "清除緩存區內的縮圖"
 
-#: remote.c:722
+#: remote.c:764
 #, c-format
 msgid "Unknown style '%s'"
 msgstr "不明風格 '%s'"
 
-#: remote.c:744
+#: remote.c:786
 #, c-format
 msgid "Unknown details type '%s'"
 msgstr "不明詳細類型 '%s'"
 
-#: remote.c:772
+#: remote.c:815
 #, c-format
 msgid "Unknown sorting type '%s'"
 msgstr "不明排列類型 '%s'"
 
-#: remote.c:1247
+#: remote.c:1286
 #, c-format
 msgid "Attempt to invoke unknown SOAP method '%s'"
 msgstr "嘗試呼叫不明的 SOAP 方式 '%s'"
 
-#: run.c:99 run.c:152
+#: run.c:97 run.c:151
 #, c-format
 msgid "Program %s not found - deleted?"
 msgstr "程序 %s 找不到 - 已被刪除？"
 
-#: run.c:302
-#, c-format
-msgid "File doesn't exist, or I can't access it: %s"
-msgstr "檔案不存在，或不能被你存取：%s"
-
-#: run.c:307
-#, c-format
-msgid "I don't know how to open '%s'"
-msgstr "不能開啟不明的檔案 '%s'"
-
-#: run.c:338
-#, c-format
-msgid "'%s' is not a valid URI"
-msgstr "'%s' 不是一個正確位址"
-
-#: run.c:349
-#, c-format
-msgid "%s not accessable"
-msgstr "'%s' 不接受存取"
-
-#: run.c:357
-#, c-format
-msgid "Non-local URL %s"
-msgstr "非本機 位址 %s"
-
-#: run.c:374
-#, c-format
-msgid "%s: no handler for %s"
-msgstr "%s: 沒有工具處理 %s"
-
-#: run.c:394
-msgid ""
-"Application:\n"
-"This is an application directory - you can run it as a program, or open it "
-"(hold down Shift while you open it). Most applications provide their own "
-"help here, but this one doesn't."
-msgstr ""
-"應用程式：\n"
-"這是一個執行程式的目錄 - 你可執行或開啟它(開啟時按下Shift鍵). 但此程式並沒有"
-"說明檔."
-
-#: run.c:478
-#, c-format
-msgid "Could not send data to program: %s"
-msgstr "不能傳送資料至程式：%s"
-
-#: run.c:508
-#, c-format
-msgid "Could not read link: %s"
-msgstr "不能讀取連結檔：%s"
-
-#: run.c:536
-#, c-format
-msgid "Broken symlink (or you don't have permission to follow it): %s"
-msgstr "無效的連結檔 (或權限問題)：%s"
-
-#: run.c:573
+#: run.c:359
 #, c-format
 msgid ""
 "No run action specified for files of this type (%s/%s) - you can set a run "
@@ -2924,7 +3150,7 @@ msgstr ""
 "沒有標記的執行動作對應此類檔案 (%s/%s) - 你可在選單中的 `設定執行檔' 設入程"
 "式，或將此檔案拖放到指定的程式上.%s"
 
-#: run.c:579
+#: run.c:365
 msgid ""
 "\n"
 "\n"
@@ -2935,7 +3161,63 @@ msgstr ""
 "\n"
 "注意：假如您想執行這個程式，可能須要在檔案選單內另行設定可執行的權限"
 
-#: run.c:753
+#: run.c:373
+#, c-format
+msgid "File doesn't exist, or I can't access it: %s"
+msgstr "檔案不存在，或不能被你存取：%s"
+
+#: run.c:378
+#, c-format
+msgid "I don't know how to open '%s'"
+msgstr "不能開啟不明的檔案 '%s'"
+
+#: run.c:409
+#, c-format
+msgid "'%s' is not a valid URI"
+msgstr "'%s' 不是一個正確位址"
+
+#: run.c:420
+#, c-format
+msgid "%s not accessable"
+msgstr "'%s' 不接受存取"
+
+#: run.c:428
+#, c-format
+msgid "Non-local URL %s"
+msgstr "非本機 位址 %s"
+
+#: run.c:445
+#, c-format
+msgid "%s: no handler for %s"
+msgstr "%s: 沒有工具處理 %s"
+
+#: run.c:465
+msgid ""
+"Application:\n"
+"This is an application directory - you can run it as a program, or open it "
+"(hold down Shift while you open it). Most applications provide their own "
+"help here, but this one doesn't."
+msgstr ""
+"應用程式：\n"
+"這是一個執行程式的目錄 - 你可執行或開啟它(開啟時按下Shift鍵). 但此程式並沒有"
+"說明檔."
+
+#: run.c:549
+#, c-format
+msgid "Could not send data to program: %s"
+msgstr "不能傳送資料至程式：%s"
+
+#: run.c:578
+#, c-format
+msgid "Could not read link: %s"
+msgstr "不能讀取連結檔：%s"
+
+#: run.c:606
+#, c-format
+msgid "Broken symlink (or you don't have permission to follow it): %s"
+msgstr "無效的連結檔 (或權限問題)：%s"
+
+#: run.c:785
 #, c-format
 msgid ""
 "Executable '%s' is world-writeable! Refusing to run. Please change the "
@@ -2958,93 +3240,131 @@ msgstr ""
 "假如您認為其他用戶是可靠的，便無需理會這問題。否則，您便應該檢查或刪除所有這"
 "類檔案"
 
-#: run.c:766
+#: run.c:798
 msgid "go-w (Fix security problem)"
 msgstr "go-w (解決安全問題)"
 
-#: support.c:272
-msgid "B"
-msgstr "B"
+#: support.c:288
+msgid " "
+msgstr ""
 
-#: support.c:351
+#: support.c:381
 msgid "byte"
 msgstr "byte"
 
-#: support.c:1596 support.c:1650
+#: support.c:1531 support.c:1585
 #, c-format
 msgid "Failed to open and stat file '%s': %s"
 msgstr "未能開啟及描述檔案 '%s': %s"
 
-#: support.c:1607 support.c:1661
+#: support.c:1542 support.c:1596
 #, c-format
 msgid "Failed to mmap file '%s': %s"
 msgstr "未能繪制檔案 '%s': %s"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close"
 msgstr "關閉"
 
-#: toolbar.c:113
+#: toolbar.c:116
 msgid "Close filer window"
 msgstr "關閉窗口"
 
-#: toolbar.c:117
+#: toolbar.c:120
 msgid "Up"
 msgstr "往上"
 
-#: toolbar.c:117
-msgid "Change to parent directory"
-msgstr "往上一目錄"
+#: toolbar.c:120
+msgid ""
+"Change to parent directory\n"
+"  Right: Open parent directory\n"
+"  Middle: Change to parent in real path"
+msgstr ""
 
-#: toolbar.c:121
+#: toolbar.c:126
 msgid "Home"
 msgstr "家目錄"
 
-#: toolbar.c:121
-msgid "Change to home directory"
-msgstr "移至家目錄"
+#: toolbar.c:126
+msgid ""
+"Change to home directory\n"
+"  Right: Open home directory\n"
+"  Middle: Change to first bookmark"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks"
-msgstr "書簽"
+#: toolbar.c:132
+msgid "Jump"
+msgstr ""
 
-#: toolbar.c:125
-msgid "Bookmarks menu"
-msgstr "書簽選單"
+#: toolbar.c:132
+msgid ""
+"Bookmarks menu\n"
+"  Right: Edit Bookmarks\n"
+"  Middle: Jump to last visited directory"
+msgstr ""
 
-#: toolbar.c:129
+#: toolbar.c:138
 msgid "Scan"
 msgstr "檢視"
 
-#: toolbar.c:129
-msgid "Rescan directory contents"
-msgstr "重新檢視內容"
+#: toolbar.c:138
+msgid ""
+"Rescan directory contents\n"
+"  Middle: Delete/re-create thumbnail cache"
+msgstr ""
 
-#: toolbar.c:133
-msgid "Change icon size"
-msgstr "改變圖示大小"
+#: toolbar.c:143
+#, fuzzy
+msgid "Size┼"
+msgstr "大小"
 
-#: toolbar.c:137
+#: toolbar.c:143
+msgid ""
+"Change icon size\n"
+"  Right: Change to smaller\n"
+"  Middle: Change to Auto Size\n"
+"  Scroll: Temporary huge zoom\n"
+"Current size:\n"
+"  ┘ : Huge\n"
+"  ┤ : Large\n"
+"  ┐ : Small\n"
+"  ┌, ├ : Auto"
+msgstr ""
+
+#: toolbar.c:155
+#, fuzzy
+msgid "Auto"
+msgstr "自動化"
+
+#: toolbar.c:155
 msgid "Automatic size mode"
 msgstr "自動化大少"
 
-#: toolbar.c:141
-msgid "Show extra details"
-msgstr "更詳述"
+#: toolbar.c:159
+#, fuzzy
+msgid "List"
+msgstr "列表模式"
 
-#: toolbar.c:145
+#: toolbar.c:159
+msgid ""
+"Show extra details\n"
+"  Right: Rotate Icons with details\n"
+"  Middle: Return to normal Icons View"
+msgstr ""
+
+#: toolbar.c:165
 msgid "Sort"
 msgstr "排序"
 
-#: toolbar.c:145
+#: toolbar.c:165
 msgid "Change sort criteria"
 msgstr "改變排序標準"
 
-#: toolbar.c:149
-msgid "Hidden"
-msgstr "隱藏"
+#: toolbar.c:169
+msgid "Hide"
+msgstr ""
 
-#: toolbar.c:149
+#: toolbar.c:169
 msgid ""
 "Left: Show/hide hidden files\n"
 "Right: Show/hide thumbnails"
@@ -3052,110 +3372,154 @@ msgstr ""
 "左： 顯示 隱藏檔\n"
 "右： 顯示 縮圖"
 
-#: toolbar.c:154
-msgid "Select all/invert selection"
+#: toolbar.c:174
+msgid "Dirs"
+msgstr ""
+
+#: toolbar.c:174
+#, fuzzy
+msgid ""
+"Left: Show only directories\n"
+"Right: Show only files"
+msgstr ""
+"左： 顯示 隱藏檔\n"
+"右： 顯示 縮圖"
+
+#: toolbar.c:179
+#, fuzzy
+msgid ""
+"Left: Select all\n"
+"Right: Invert selection"
 msgstr "全選/反向 選擇"
 
-#: toolbar.c:158
+#: toolbar.c:184
+msgid ""
+"Left: New Directory\n"
+"Middle: New Blank file\n"
+"Right: Menu"
+msgstr ""
+
+#: toolbar.c:190
+msgid "○"
+msgstr ""
+
+#: toolbar.c:190
+msgid ""
+"Save Current Display Settings...\n"
+"  Right: for parent/* \n"
+"  Middle: Clear to default settings\n"
+"Under:\n"
+"  ▽: No settings\n"
+"  ▼: Own settings\n"
+"  ▶: Parent settings\n"
+"  ▷: Far parent settings"
+msgstr ""
+
+#: toolbar.c:202
 msgid "Show ROX-Filer help"
 msgstr "顯示 ROX-Filer 說明"
 
-#: toolbar.c:221
+#: toolbar.c:270
 #, c-format
 msgid " (%u hidden)"
 msgstr " (%u 隱藏)"
 
-#: toolbar.c:229 tips:58
+#: toolbar.c:276 tips:79
 msgid "items"
 msgstr "項目"
 
-#: toolbar.c:229
+#: toolbar.c:276
 msgid "item"
 msgstr "項目"
 
-#: toolbar.c:232
+#: toolbar.c:279
 #, c-format
 msgid "No items%s"
 msgstr "沒有項目%s"
 
-#: toolbar.c:251
+#: toolbar.c:298
 #, c-format
 msgid "%u selected (%s)"
 msgstr "%u 已選擇 (%s)"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by name"
 msgstr "以名稱排序"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by type"
 msgstr "以類型排序"
 
-#: toolbar.c:445
+#: toolbar.c:535
 msgid "Sort by date"
 msgstr "以日期排序"
 
-#: toolbar.c:446
+#: toolbar.c:535
 msgid "Sort by size"
 msgstr "以大小排序"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by owner"
 msgstr "以用戶排序"
 
-#: toolbar.c:446
+#: toolbar.c:536
 msgid "Sort by group"
 msgstr "以組別排序"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "ascending"
 msgstr "提升"
 
-#: toolbar.c:480
+#: toolbar.c:568
 msgid "descending"
 msgstr "下降"
 
-#: type.c:214
+#: toolbar.c:891
+#, fuzzy
+msgid "_N_Items_"
+msgstr "項目"
+
+#: type.c:221
 msgid "Sym link"
 msgstr "符號連結"
 
-#: type.c:216
+#: type.c:223
 msgid "Mount point"
 msgstr "掛載點"
 
-#: type.c:218
+#: type.c:225
 msgid "App dir"
 msgstr "程序目錄"
 
-#: type.c:225
+#: type.c:232
 msgid "Dir"
 msgstr "目錄"
 
-#: type.c:227
+#: type.c:234
 msgid "Char dev"
 msgstr "字符裝置"
 
-#: type.c:229
+#: type.c:236
 msgid "Block dev"
 msgstr "區塊裝置"
 
-#: type.c:231
+#: type.c:238
 msgid "Pipe"
 msgstr "管導"
 
-#: type.c:233
+#: type.c:240
 msgid "Socket"
 msgstr "套節"
 
-#: type.c:235
+#: type.c:242
 msgid "Door"
 msgstr "入口"
 
-#: type.c:238
+#: type.c:245
 msgid "Unknown"
 msgstr "不明的"
 
-#: type.c:554
+#: type.c:583
 msgid ""
 "Enter a shell command which will load \"$@\" into a suitable program. Eg:\n"
 "\n"
@@ -3165,84 +3529,84 @@ msgstr ""
 "\n"
 "gimp \"$@\""
 
-#: type.c:735
+#: type.c:779
 msgid "This is not a program! Give me an application instead!"
 msgstr "這不是一個程式！請給予一個可執行的程式！"
 
-#: type.c:795
+#: type.c:839
 msgid "No run action defined"
 msgstr "沒有執行動作被定義"
 
-#: type.c:799
+#: type.c:843
 #, c-format
 msgid "Error in handler %s: %s"
 msgstr "錯誤於處理工具 %s: %s"
 
-#: type.c:814
+#: type.c:858
 #, c-format
 msgid "Invalid application %s (bad AppRun)"
 msgstr "非法的執行程式 %s (錯誤執行)"
 
-#: type.c:825
+#: type.c:869
 #, c-format
 msgid "Non-executable %s"
 msgstr "非可執行性的 %s"
 
-#: type.c:858
+#: type.c:902
 msgid "Set run action"
 msgstr "設定執行的動作"
 
-#: type.c:864
+#: type.c:908
 msgid ""
 "If a handler for the specific type isn't set up, use this as the default."
 msgstr "如這些特殊類型還未設立處理工具, 便以此為預設值."
 
-#: type.c:866
+#: type.c:910
 #, c-format
 msgid "Set default for all `%s/<anything>'"
 msgstr "設為預設值予全部的 `%s/<anything>'"
 
-#: type.c:870
+#: type.c:914
 msgid "Use this application for all files with this MIME type."
 msgstr "用這個程式來開啟屬於此 MIME 類型的檔案"
 
-#: type.c:872
+#: type.c:916
 #, c-format
 msgid "Only for the type `%s' (%s/%s)"
 msgstr "僅對應此類型 `%s' (%s/%s)"
 
-#: type.c:878
+#: type.c:922
 msgid "Drop a suitable application here"
 msgstr "請拖放一個合適的程式在此處"
 
-#: type.c:893
+#: type.c:963
 msgid "OR"
 msgstr "或"
 
-#: type.c:900
+#: type.c:971
 msgid "Enter a shell command:"
 msgstr "請輸入指令："
 
-#: type.c:929
+#: type.c:1000
 msgid "_Use Command"
 msgstr "套用指令(_U)"
 
-#: type.c:959
+#: type.c:1030
 msgid ""
 "A run action already exists and is quite a big program - are you sure you "
 "want to delete it?"
 msgstr "一個相同而頗大的程序正在執行中 - 你決定要刪除它？"
 
-#: type.c:970
+#: type.c:1041
 #, c-format
 msgid "Can't remove %s: %s"
 msgstr "不能移除 %s: %s"
 
-#: type.c:1007
+#: type.c:1078
 msgid "Choices saving is disabled by CHOICESPATH variable"
 msgstr "'Choice' 路徑變數錯誤,儲存取消"
 
-#: type.c:1309
+#: type.c:1395
 #, c-format
 msgid ""
 "Failed to create symlink '%s':\n"
@@ -3251,11 +3615,11 @@ msgstr ""
 "未能新增符號連結 '%s'：\n"
 "%s"
 
-#: usericons.c:179
+#: usericons.c:188
 msgid "The pathname you gave does not exist. The icon has not been changed."
 msgstr "路徑不存在，更改圖示失敗"
 
-#: usericons.c:189 usericons.c:618
+#: usericons.c:198 usericons.c:644
 msgid ""
 "Unable to load image file -- maybe it's not in a format I understand, or "
 "maybe the permissions are wrong?\n"
@@ -3264,12 +3628,12 @@ msgstr ""
 "不能載入圖檔 -- 可能是格式不明，或檔案權限錯誤？\n"
 "更改圖示失敗."
 
-#: usericons.c:235
+#: usericons.c:244
 #, c-format
 msgid "Really delete icon '%s'?"
 msgstr "確認刪除圖示 '%s'？"
 
-#: usericons.c:239
+#: usericons.c:248
 #, c-format
 msgid ""
 "Can't delete '%s':\n"
@@ -3278,41 +3642,41 @@ msgstr ""
 "不能刪除 '%s'：\n"
 " %s"
 
-#: usericons.c:272
+#: usericons.c:281
 msgid "Set icon"
 msgstr "設定圖示"
 
-#: usericons.c:281
+#: usericons.c:290
 msgid ""
 "Use a copy of the image as the default for all files of these MIME types."
 msgstr "用這個圖像作為所有屬於此種 MIME 類型的檔案的預設圖示."
 
-#: usericons.c:283
+#: usericons.c:292
 #, c-format
 msgid "Set icon for all `%s/<anything>'"
 msgstr "設定圖示予全部的 `%s/<anything>'"
 
-#: usericons.c:288
+#: usericons.c:297
 msgid "Use a copy of the image for all files of this MIME type."
 msgstr "用這個圖像作為所有屬於此種 MIME 類型的檔案的圖示"
 
-#: usericons.c:290
+#: usericons.c:299
 #, c-format
 msgid "For all files of type `%s' (%s/%s)"
 msgstr "對應此類型 `%s' (%s/%s)"
 
-#: usericons.c:296
+#: usericons.c:305
 msgid ""
 "Add the file and image filenames to your personal list. The setting will be "
 "lost if the image or the file is moved."
 msgstr "加入檔案名稱或圖像名稱到個人列表中，假如檔案或圖像遺失,設置將會無效."
 
-#: usericons.c:299
+#: usericons.c:308
 #, c-format
 msgid "Only for the file `%s'"
 msgstr "僅對應檔案 `%s'"
 
-#: usericons.c:307
+#: usericons.c:316
 msgid ""
 "Copy the image inside the directory, as a hidden file called '.DirIcon'. All "
 "users will then see the icon, and you can move the directory around safely. "
@@ -3321,19 +3685,19 @@ msgstr ""
 "複製圖像進此目錄並命名為 '.DirIcon', 讓所有用戶均可看見這個圖示，假如您擁有這"
 "目錄的寫入權限；這將會是個最好的設置方式."
 
-#: usericons.c:313
+#: usericons.c:322
 msgid "Copy image into directory"
 msgstr "複製圖像至目錄"
 
-#: usericons.c:319
+#: usericons.c:328
 msgid "Drop an icon file here"
 msgstr "拖放圖示檔到此處"
 
-#: usericons.c:589
+#: usericons.c:615
 msgid "Setting icon disabled by CHOICESPATH"
 msgstr "設定圖示被終止，因應 Choice 的路徑問題"
 
-#: usericons.c:633
+#: usericons.c:659
 #, c-format
 msgid ""
 "Error creating image '%s':\n"
@@ -3342,41 +3706,57 @@ msgstr ""
 "錯誤建立圖像 '%s'：\n"
 "%s"
 
-#: view_details.c:957
+#: view_collection.c:326
+msgid "- Double click here to close the windows"
+msgstr ""
+
+#: view_details.c:1018
 msgid "Mono font"
 msgstr "等寬字體"
 
-#: view_details.c:958
+#: view_details.c:1019
 msgid "Font for displaying mono-spaced text"
 msgstr "用以顯示等寬字體的字型"
 
-#: view_details.c:1059
+#: view_details.c:1233
 msgid "_Name"
 msgstr "名稱(_N)"
 
-#: view_details.c:1062
+#: view_details.c:1236
 msgid "_Type"
 msgstr "類型(_T)"
 
-#: view_details.c:1065
-msgid "_Permissions"
-msgstr "權限(_P)"
-
-#: view_details.c:1070
-msgid "_Owner"
-msgstr "用戶(_O)"
-
-#: view_details.c:1072
-msgid "_Group"
-msgstr "組別(_G)"
-
-#: view_details.c:1074
+#: view_details.c:1238
 msgid "_Size"
 msgstr "大小(_S)"
 
-#: view_details.c:1080
+#: view_details.c:1244
+msgid "_Permissions"
+msgstr "權限(_P)"
+
+#: view_details.c:1250
+msgid "_Owner"
+msgstr "用戶(_O)"
+
+#: view_details.c:1252
+msgid "_Group"
+msgstr "組別(_G)"
+
+#: view_details.c:1254
 msgid "Last _Modified"
 msgstr "最後改動(_M)"
+
+#: view_details.c:1260
+msgid "Last _Changed"
+msgstr ""
+
+#: view_details.c:1266
+msgid "Last _Accessed"
+msgstr ""
+
+#: xtypes.c:802
+msgid "Extended attributes"
+msgstr "伸延屬性"
 
 #: tips:1
 msgid "Filer windows"
@@ -3420,7 +3800,8 @@ msgstr "當改變圖示大小時或敘述時，及轉變到其他目錄時，窗
 msgid "Largest window size:"
 msgstr "窗口的最大值："
 
-#: tips:10
+#: tips:10 tips:13 tips:333 ../Templates.ui.h:17
+#, no-c-format
 msgid "%"
 msgstr "%"
 
@@ -3431,24 +3812,36 @@ msgid ""
 msgstr "窗口大小自行調整時，會跟據該百份比來限制窗口最大的值"
 
 #: tips:12
+#, fuzzy
+msgid "Largest window width:"
+msgstr "窗口的最大值："
+
+#: tips:14
+#, fuzzy
+msgid ""
+"The largest width, as a percentage of the screen size, that the auto-resizer "
+"will resize a window to."
+msgstr "窗口大小自行調整時，會跟據該百份比來限制窗口最大的值"
+
+#: tips:15
 msgid "Window behaviour"
 msgstr "窗口行為"
 
-#: tips:13
+#: tips:16
 msgid "Short titlebar flags"
 msgstr "簡化標題"
 
-#: tips:14
+#: tips:17
 msgid ""
 "Use single letters instead of words for Scanning, All and Thumbs indicators "
 "in the titlebar."
 msgstr "以單字母代替檔案及縮圖全名作標題"
 
-#: tips:15
+#: tips:18
 msgid "Unique windows"
 msgstr "唯一的窗口"
 
-#: tips:16
+#: tips:19
 msgid ""
 "If you open a directory and that directory is already displayed in another "
 "window, then this option causes the other window to be closed."
@@ -3456,11 +3849,34 @@ msgstr ""
 "如你要開啟一個目錄而此目錄已經存在於另一窗口內，開啟此選項後你已經存在的窗口"
 "便會被關閉."
 
-#: tips:17
+#: tips:20
+msgid "Close window when dir missing"
+msgstr ""
+
+#: tips:21
+msgid ""
+"If a directory that is open in a window disappears, (deleted or unmounted) "
+"automatically close window."
+msgstr ""
+
+#: tips:22
+#, fuzzy
+msgid "Window Link"
+msgstr "窗口"
+
+#: tips:23
+msgid ""
+"If this is on and you open a directory by middle button, the new window and "
+"the source window are toggled into link mode. In link mode, left-click a "
+"directory to open it in a window placed to the right of the source window. "
+"If this value is off, ctrl + middle button toggles the linked window."
+msgstr ""
+
+#: tips:24
 msgid "New window on button 1"
 msgstr "按滑鼠1(左)鍵以開啟新窗口"
 
-#: tips:18
+#: tips:25
 msgid ""
 "Clicking with mouse button 1 (usually the left button) opens a directory in "
 "a new window with this turned on. Clicking with the button-2 (middle) will "
@@ -3468,138 +3884,211 @@ msgid ""
 msgstr ""
 "單擊滑鼠1(左)鍵以開啟目錄於新窗口內，單擊滑鼠2(中)鍵會開啟目錄於原有的窗口內."
 
-#: tips:19
+#: tips:26
 msgid "Single-click navigation"
 msgstr "單擊予閱覽"
 
-#: tips:20 tips:116
+#: tips:27 tips:191
 msgid ""
 "Clicking on an item opens it with this on. Hold down Control to select the "
 "item instead. If off, clicking once selects an item; double click to open "
 "things."
 msgstr "單擊項目以開啟及瀏覽，反之則單擊以選擇，雙擊以開啟."
 
-#: tips:21
+#: tips:28
 msgid "Double-click on background resizes"
 msgstr "雙擊背景以調整大小"
 
-#: tips:22
+#: tips:29
 msgid ""
 "If on then double clicking on the window background resizes the window, just "
 "like clicking on the Automatic size mode button in the toolbar."
 msgstr "如開啟此功能，雙擊背景會自行調整窗口大小."
 
-#: tips:23
+#: tips:30
 msgid "Sorting"
 msgstr "排序"
 
-#: tips:24
+#: tips:31
 msgid "Directories come first (for sort by name)"
 msgstr "目錄先行 (以名稱排序)"
 
-#: tips:25
+#: tips:32
 msgid ""
 "If this is on then directories will always appear before anything else when "
 "sorting by name."
 msgstr "如開啟此功能，則永遠以目錄先排序，並忽略其他排序方式及以名稱排序."
 
-#: tips:26
+#: tips:33
 msgid "Capitalised names first (for sort by name)"
 msgstr "大小寫先行 (以名稱排序)"
 
-#: tips:27
+#: tips:34
 msgid ""
 "If on, all filenames starting with a capital letter come before filenames "
 "starting with lowercase ones."
 msgstr "如開啟此功能，則永遠以大寫名稱先行，及小寫名稱在後."
 
-#: tips:29
-msgid "Default settings for new windows"
-msgstr "預設新窗口的設定"
-
-#: tips:30
-msgid "Inherit options from source window"
-msgstr "從源窗口中繼承選項"
-
-#: tips:31
-msgid ""
-"If this is on then display options for a new window are inherited from the "
-"source window if possible, otherwise they are set to the defaults below."
-msgstr "如開啟此功能，則新窗口會從源窗口之風格相同；反之，則以預設值開啟."
-
-#: tips:32
-msgid "View type:"
-msgstr "檢視模式："
-
 #: tips:35
-msgid "Sort by:"
-msgstr "排序以："
+#, fuzzy
+msgid "Newly comes first (for sort by Date)"
+msgstr "目錄先行 (以名稱排序)"
 
-#: tips:37 tips:54
-msgid "Type"
-msgstr "類型"
+#: tips:36
+msgid "If on, the Sort by Dates are reversed."
+msgstr ""
+
+#: tips:37 tips:354
+#, fuzzy
+msgid "etc"
+msgstr "伸延"
 
 #: tips:38
-msgid "Date"
-msgstr "日期"
-
-#: tips:40
-msgid "Show hidden files"
-msgstr "顯示隱藏檔"
-
-#: tips:41
-msgid ""
-"If this is on then files whose names start with a dot are shown too, "
-"otherwise they are hidden."
-msgstr "如啟動此功能，會顯示所有點檔案；否之，點檔案會被隱藏."
-
-#: tips:42
 msgid "Show extended attribute indicator"
 msgstr "顯示伸延屬性指標"
 
-#: tips:43
+#: tips:39
 msgid ""
 "If this is on then files which have one or more extended attributes set will "
 "have an emblem added to indicate this."
 msgstr "此選項可顯示檔案已設定的 一或多個伸延屬性的特徵."
 
-#: tips:44
+#: tips:40
+msgid "Hide the message bar Running as user 'root'"
+msgstr ""
+
+#: tips:41
+msgid ""
+"This hides the bar even with the command-line option -u, --user if user is "
+"the root."
+msgstr ""
+
+#: tips:42
+msgid "Time and date format"
+msgstr ""
+
+#: tips:43
+msgid "Set time and date format for Properties window and extra details view."
+msgstr ""
+
+#: tips:45
+msgid "Default settings for new windows"
+msgstr "預設新窗口的設定"
+
+#: tips:46
+msgid "Inherit options from source window"
+msgstr "從源窗口中繼承選項"
+
+#: tips:47
+msgid ""
+"If this is on then display options for a new window are inherited from the "
+"source window if possible, otherwise they are set to the defaults below."
+msgstr "如開啟此功能，則新窗口會從源窗口之風格相同；反之，則以預設值開啟."
+
+#: tips:48
+msgid "View type:"
+msgstr "檢視模式："
+
+#: tips:51
+msgid "Sort by:"
+msgstr "排序以："
+
+#: tips:53 tips:76 tips:114
+msgid "Type"
+msgstr "類型"
+
+#: tips:54
+#, fuzzy
+msgid "Date (m)"
+msgstr "日期"
+
+#: tips:55
+#, fuzzy
+msgid "Date (c)"
+msgstr "日期"
+
+#: tips:56
+#, fuzzy
+msgid "Date (a)"
+msgstr "日期"
+
+#: tips:58
+msgid "Show hidden files"
+msgstr "顯示隱藏檔"
+
+#: tips:59
+msgid ""
+"If this is on then files whose names start with a dot are shown too, "
+"otherwise they are hidden."
+msgstr "如啟動此功能，會顯示所有點檔案；否之，點檔案會被隱藏."
+
+#: tips:60
+#, fuzzy
+msgid "Enable .hidden file"
+msgstr "顯示隱藏檔"
+
+#: tips:61
+#, fuzzy
+msgid ""
+"If this is on then, in addition to files whose names start with a dot, also "
+"items listed in \".hidden\" file will be treated as hidden."
+msgstr "如啟動此功能，會顯示所有點檔案；否之，點檔案會被隱藏."
+
+#: tips:62
+#, fuzzy
+msgid "Huge Icons size:"
+msgstr "巨圖示"
+
+#: tips:63 tips:82 tips:85 tips:90 tips:109 tips:364 tips:367
+msgid "pixels"
+msgstr "像素"
+
+#: tips:64
+msgid "Resolution depends on 'Thumbnails->Cache File Size'."
+msgstr ""
+
+#: tips:65 tips:66
 msgid "Icon View"
 msgstr "圖示型式"
 
-#: tips:45
+#: tips:67
 msgid "Default size:"
 msgstr "預設大小："
 
-#: tips:46
+#: tips:68
 msgid "Huge Icons"
 msgstr "巨圖示"
 
-#: tips:47 tips:217
+#: tips:69 tips:296
 msgid "Large Icons"
 msgstr "大圖示"
 
-#: tips:48 tips:216
+#: tips:70 tips:295
 msgid "Small Icons"
 msgstr "小圖示"
 
-#: tips:50
+#: tips:72
 msgid "Default details:"
 msgstr "預設詳述："
 
-#: tips:51
+#: tips:73
 msgid "No details"
 msgstr "不詳述"
 
-#: tips:56
-msgid "Automatic small icons:"
+#: tips:74
+msgid "Sizes"
+msgstr "大小"
+
+#: tips:77
+msgid "Times"
+msgstr "時間"
+
+#: tips:78
+#, fuzzy
+msgid "Automatic small icons: Change at:"
 msgstr "自動小圖示化："
 
-#: tips:57
-msgid "Change at:"
-msgstr "改變於："
-
-#: tips:59
+#: tips:80
 msgid ""
 "When automatic icon sizing is selected: If the directory contains this many "
 "items then it will be shown using Small Icons, otherwise Large Icons will be "
@@ -3607,99 +4096,218 @@ msgid ""
 msgstr ""
 "當目錄中有太多項目時，會自行以小型圖示來顯示；反之，則以大型圖示來開啟."
 
-#: tips:60
-msgid "Max width (Large icons):"
-msgstr "最大寬度 (大圖示)："
+#: tips:81
+#, fuzzy
+msgid "Large Icons: (Max width):"
+msgstr "大圖示"
 
-#: tips:61 tips:64
-msgid "pixels"
-msgstr "像素"
-
-#: tips:62
-msgid ""
-"Text wider than this is broken onto two lines in Large Icons mode. In Huge "
-"Icons mode, text is wrapped when 50% wider than this."
+#: tips:83
+#, fuzzy
+msgid "Text wider than this is broken onto two lines in Large Icons mode."
 msgstr ""
 "在大圖示模式下，訊息文字如比此寬度為長，則自動換行。在巨圖示模式下，則會比寬"
 "度多長百份之五十."
 
-#: tips:63
-msgid "(Small Icons):"
+#: tips:84
+msgid "(Wrapped, Details):"
+msgstr ""
+
+#: tips:86
+msgid ""
+"Maximum length for Large Icons mode and Details. This can be changed "
+"temporarily by right dragging of the toolbar."
+msgstr ""
+
+#: tips:87
+msgid "Wrap by characters"
+msgstr ""
+
+#: tips:88
+#, fuzzy
+msgid ""
+"If this option is on, file names will wrap by characters instead of words."
+msgstr "打開選項，大型圖示會以直行方式排列"
+
+#: tips:89
+#, fuzzy
+msgid "Small Icons (Max width):"
 msgstr "(小圖示)："
 
-#: tips:65
+#: tips:91
 msgid "Maximum width for the text beside a Small Icon."
 msgstr "小圖示最大的訊息寬度"
 
-#: tips:66
+#: tips:92
 msgid "Order small icons vertically"
 msgstr "小圖示垂直排列"
 
-#: tips:67
+#: tips:93
 msgid ""
 "If this option is on, then small icons are arranged in columns, not rows."
 msgstr "打開選項，小型圖示會以直行方式排列"
 
-#: tips:68
+#: tips:94
 msgid "Order large icons vertically"
 msgstr "大圖示垂直排列"
 
-#: tips:69
+#: tips:95
 msgid ""
 "If this option is on, then large icons are arranged in columns, not rows."
 msgstr "打開選項，大型圖示會以直行方式排列"
 
-#: tips:71
+#: tips:96
+msgid "Scroll speed: 1/"
+msgstr ""
+
+#: tips:97
+msgid "view"
+msgstr ""
+
+#: tips:100
 msgid "Show column headings"
 msgstr "顯示行列標題"
 
-#: tips:72
+#: tips:101
 msgid "If this is on then column headings will be shown in the list view."
 msgstr "以列表方式瀏覽時，行列標題會被顯示"
 
-#: tips:73
+#: tips:102
 msgid "Show full type"
 msgstr "顯示詳細類型"
 
-#: tips:74
+#: tips:103
 msgid ""
 "If this is on then the full description of each object's type will be show "
 "rather than a short summary of its basic type."
 msgstr "更詳盡的描述每一物件的類型"
 
-#: tips:75
+#: tips:104
+msgid "Only icons and names are clickable"
+msgstr ""
+
+#: tips:105
+msgid "For lasso."
+msgstr ""
+
+#: tips:106
+msgid "Save columns order"
+msgstr ""
+
+#: tips:107
+msgid "If this is on reordering columns is saved"
+msgstr ""
+
+#: tips:108
+msgid "Name column width (Max):"
+msgstr ""
+
+#: tips:110
+#, fuzzy
+msgid "Maximum width for the Name Column."
+msgstr "小圖示最大的訊息寬度"
+
+#: tips:111
+#, fuzzy
+msgid "Show Columns"
+msgstr "顯示行列標題"
+
+#: tips:113
+#, fuzzy
+msgid "If this is on then Name column will be shown in the list view."
+msgstr "以列表方式瀏覽時，行列標題會被顯示"
+
+#: tips:115
+#, fuzzy
+msgid "If this is on then Type column will be shown in the list view."
+msgstr "以列表方式瀏覽時，行列標題會被顯示"
+
+#: tips:117
+#, fuzzy
+msgid "If this is on then Size column will be shown in the list view."
+msgstr "以列表方式瀏覽時，行列標題會被顯示"
+
+#: tips:119
+#, fuzzy
+msgid "If this is on then Permissions column will be shown in the list view."
+msgstr "以列表方式瀏覽時，行列標題會被顯示"
+
+#: tips:121
+#, fuzzy
+msgid "If this is on then Owner column will be shown in the list view."
+msgstr "以列表方式瀏覽時，行列標題會被顯示"
+
+#: tips:123
+#, fuzzy
+msgid "If this is on then Group column will be shown in the list view."
+msgstr "以列表方式瀏覽時，行列標題會被顯示"
+
+#: tips:124
+#, fuzzy
+msgid "Last Modified"
+msgstr "最後改動(_M)"
+
+#: tips:125
+#, fuzzy
+msgid "If this is on then Last Modified column will be shown in the list view."
+msgstr "以列表方式瀏覽時，行列標題會被顯示"
+
+#: tips:126
+msgid "Last Changed"
+msgstr ""
+
+#: tips:127
+#, fuzzy
+msgid "If this is on then Last Changed column will be shown in the list view."
+msgstr "以列表方式瀏覽時，行列標題會被顯示"
+
+#: tips:128
+#, fuzzy
+msgid "Last Accessed"
+msgstr "'%s' 不接受存取"
+
+#: tips:129
+#, fuzzy
+msgid "If this is on then Last Accessed column will be shown in the list view."
+msgstr "以列表方式瀏覽時，行列標題會被顯示"
+
+#: tips:130
 msgid "Tools/Minibuffer"
 msgstr "工具/小型命令框"
 
-#: tips:76
+#: tips:131
 msgid "Toolbar"
 msgstr "工具欄"
 
-#: tips:77
+#: tips:132
 msgid "Toolbar type:"
 msgstr "工具欄類別："
 
-#: tips:78
+#: tips:133
 msgid "No toolbar"
 msgstr "不要工具欄"
 
-#: tips:79
+#: tips:134
 msgid "Icons only"
 msgstr "只顯示圖示"
 
-#: tips:80
+#: tips:135
 msgid "Text under icons"
 msgstr "圖示訊息在下"
 
-#: tips:81
+#: tips:136
 msgid "Text beside icons"
 msgstr "圖示訊息在側"
 
-#: tips:82
+#: tips:137
+#, fuzzy
+msgid "Text only"
+msgstr "載入面板"
+
+#: tips:138
 msgid "Show totals of items"
 msgstr "顯示項目總數"
 
-#: tips:83
+#: tips:139
 msgid ""
 "Show the number of items displayed in a filer window, as well as the number "
 "of hidden items (if any). When there's a selection, show the number of "
@@ -3708,40 +4316,40 @@ msgstr ""
 "在窗口的工具欄顯示項目總數，並會顯示隱藏檔數目；當以右鍵選檔案時，還會顯示其"
 "大小."
 
-#: tips:84
+#: tips:140
 msgid "Select the buttons you want on the bar:"
 msgstr "選擇要加入的按鈕："
 
-#: tips:85
+#: tips:141
 msgid "Width of toolbar sets minimum width of window"
 msgstr "工具欄寬度決定窗口的最少寬度"
 
-#: tips:86
+#: tips:142
 msgid ""
 "Each filer window is constrained to be wide enough to show the whole of the "
 "toolbar"
 msgstr "每一窗口必須有足夠寬度來顯示整個工具欄 "
 
-#: tips:87
+#: tips:143
 msgid "Minibuffer"
 msgstr "小型命令框"
 
-#: tips:88
+#: tips:144
 msgid "Beep if Tab-completion fails"
 msgstr "嗶聲 當(Tab-自動完成)操作失敗"
 
-#: tips:89
+#: tips:145
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if "
 "nothing happens (eg, because there are several possibilities and the next "
 "letter varies)."
 msgstr "當啟用`輸入路徑'小型命令框，在按下 Tab 鍵時沒有作用，則會發出嗶的響聲"
 
-#: tips:90
+#: tips:146
 msgid "Beep if there are several matches"
 msgstr "嗶聲 當找到匹配的數目太多"
 
-#: tips:91
+#: tips:147
 msgid ""
 "When using the `Enter Path...' minibuffer and Tab is pressed, beep if there "
 "is more than one matching file, even though some more letters were added."
@@ -3749,161 +4357,249 @@ msgstr ""
 "當啟用`輸入路徑...'小型命令框，在按下 Tab 鍵時，找到匹配的數目太多則會發出嗶"
 "的響聲"
 
-#: tips:94
+#: tips:148
+#, fuzzy
+msgid "Stdout handler"
+msgstr "下載處理員"
+
+#: tips:149
+msgid ""
+"This will be run when Mini Shell puts out string to stdout. $1 is the string."
+msgstr ""
+
+#: tips:150
+#, fuzzy
+msgid "Errout handler"
+msgstr "錯誤於處理工具 %s: %s"
+
+#: tips:151
+msgid ""
+"This will be run when Mini Shell puts out string to errout. $1 is the string."
+msgstr ""
+
+#: tips:154
 msgid ""
 "When thumbnails are turned on, each image file in a directory is loaded and "
 "a small thumbnail of it is shown."
 msgstr "當目錄內有影像或圖片時，會以縮圖來預覽."
 
-#: tips:95
+#: tips:155
 msgid "Show image thumbnails"
 msgstr "顯示影像檔的縮圖"
 
-#: tips:96
+#: tips:156
 msgid ""
 "This is the default setting for new windows. Use the Display menu to turn "
 "thumbnails on and off for individual windows."
 msgstr "這是新窗口的預設值，可在選單的顯示內自行開啟或關閉縮圖."
 
-#: tips:97
+#: tips:157
+#, fuzzy
+msgid "Show image thumbnail for directory."
+msgstr "顯示影像檔的縮圖"
+
+#: tips:158
+msgid ""
+"When no items in a sub-directory have a thumbnail, this process tries to "
+"create a thumbnail. If you don't like the choice, visit the sub-directory "
+"and middle-click the scan button in the toolbar to choose the first item."
+msgstr ""
+
+#: tips:159
 msgid "Video thumbnails"
 msgstr "影片縮圖"
 
-#: tips:98
+#: tips:160
 msgid "Thumbnails cache"
 msgstr "縮圖緩存區"
 
-#: tips:99
+#: tips:161
+#, fuzzy
 msgid ""
 "To speed things up, the generated thumbnails are stored in the hidden ~/."
-"thumbnails directory. Click here to remove all the cached thumbnails. They "
-"will be created again as needed."
+"cache/thumbnails directory. Click here to remove all the cached thumbnails. "
+"They will be created again as needed."
 msgstr ""
 "為了加速顯示，~/.thumbnails 這個目錄會自動建立；點擊這處以清除緩存區內所有縮"
 "圖，當有需要時它會再建立."
 
-#: tips:100
+#: tips:162
+msgid "being left over "
+msgstr ""
+
+#: tips:163
+msgid "days"
+msgstr ""
+
+#: tips:164
+msgid "0 is all."
+msgstr ""
+
+#: tips:165
 msgid "Manage thumbnails"
 msgstr "縮圖管理"
 
-#: tips:101 tips:158
+#: tips:166
+msgid "Cache File Size:"
+msgstr ""
+
+#: tips:167
+msgid "Small (64px)"
+msgstr ""
+
+#: tips:168
+msgid "Normal (128px)"
+msgstr ""
+
+#: tips:169
+msgid "Large (256px)"
+msgstr ""
+
+#: tips:170
+msgid "Huge (512px)"
+msgstr ""
+
+#: tips:171
+#, fuzzy
+msgid "Use JPEG for thumbnails"
+msgstr "影片縮圖"
+
+#: tips:172
+msgid ""
+"Small file size and about 4-6 times faster, but without alpha channel "
+"transparency."
+msgstr ""
+
+#: tips:173
+msgid "Purge Time for Memory Cache:"
+msgstr ""
+
+#: tips:174
+msgid "sec"
+msgstr ""
+
+#: tips:175
+msgid "Purge Time for Memory cache. If you have an SSD, 0 is recommended"
+msgstr ""
+
+#: tips:176 tips:233
 msgid "Pinboard"
 msgstr "桌面"
 
-#: tips:102
+#: tips:177
 msgid ""
 "When using a pinboard, you can drag files and applications onto the desktop "
 "background to create shortcuts to them."
 msgstr "當啟用桌面時，您可拖放檔案或程式到桌面上它們會以捷徑型式出現. "
 
-#: tips:103 tips:213
+#: tips:178 tips:292
 msgid "Appearance"
 msgstr "外觀"
 
-#: tips:104
+#: tips:179
 msgid "Foreground:"
 msgstr "前景："
 
-#: tips:105
+#: tips:180
 msgid "Text shadow:"
 msgstr "文字陰影："
 
-#: tips:106
+#: tips:181
 msgid "Background:"
 msgstr "背景："
 
-#: tips:107
+#: tips:182
 msgid "No shadow"
 msgstr "沒有陰影"
 
-#: tips:108
+#: tips:183
 msgid "Thin"
 msgstr "薄"
 
-#: tips:109
+#: tips:184
 msgid "Thick"
 msgstr "厚"
 
-#: tips:110
+#: tips:185
 msgid "Use custom font:"
 msgstr "自定字型："
 
-#: tips:111
+#: tips:186
 msgid "The font used for the text displayed under the icons"
 msgstr "圖示字型"
 
-#: tips:112
+#: tips:187
 msgid "Fast scaling of images"
 msgstr "快速調整影像"
 
-#: tips:113
+#: tips:188
 msgid ""
 "Choose between the fast or slow method of scaling backdrop images.  The slow "
 "method can give better results."
 msgstr "選擇快慢方式來調整影像，慢方式可帶來更高畫質."
 
-#: tips:114
+#: tips:189
 msgid "Pinboard behaviour"
 msgstr "桌面行為"
 
-#: tips:115
+#: tips:190
 msgid "Single-click to open"
 msgstr "單擊予開啟"
 
-#: tips:117
+#: tips:192
 msgid "Keep icons within screen limits"
 msgstr "限制圖示在可見螢幕上"
 
-#: tips:118
+#: tips:193
 msgid ""
 "If this is set, pinboard icons are always kept completely within screen "
 "limits, including the label."
 msgstr "桌面內的圖示和標簽全顯示在螢幕中"
 
-#: tips:119
+#: tips:194
 msgid "Icon grid step:"
 msgstr "圖示等級："
 
-#: tips:120
+#: tips:195
 msgid "Fine"
 msgstr "高質素"
 
-#: tips:121
+#: tips:196
 msgid "Use a 2-pixel grid for positioning icons on the desktop."
 msgstr "以2像素圖示在桌面顯示"
 
-#: tips:122
+#: tips:197
 msgid "Medium"
 msgstr "中等"
 
-#: tips:123
+#: tips:198
 msgid "Use a 16-pixel grid for positioning icons on the desktop."
 msgstr "以16像素圖示在桌面顯示"
 
-#: tips:124
+#: tips:199
 msgid "Coarse"
 msgstr "粗糙的"
 
-#: tips:125
+#: tips:200
 msgid "Use a 32-pixel grid for positioning icons on the desktop."
 msgstr "以32像素圖示在桌面顯示"
 
-#: tips:126 tips:128
+#: tips:201 tips:203
 msgid "Iconified windows"
 msgstr "圖示化窗口"
 
-#: tips:127
+#: tips:202
 msgid ""
 "Most window managers provide a way to iconify (or 'minimise') windows, and "
 "various programs, including ROX-Filer, can be used to display the iconified "
 "windows."
 msgstr "ROX-Filer 可以圖示化(或最小化)窗口."
 
-#: tips:129
+#: tips:204
 msgid "Show iconified windows"
 msgstr "圖示化窗口"
 
-#: tips:130
+#: tips:205
 msgid ""
 "If this option is on, the filer will show each iconified window as a small "
 "button on the pinboard. Requires a compatible window manager, and the "
@@ -3912,49 +4608,49 @@ msgstr ""
 "ROX-Filer 會將圖示化(或最小化)窗口，以按鈕型式放在桌面上，唯需要一個相容的窗"
 "口管理員配合，並 ROX-Filer 的桌面必須啟動."
 
-#: tips:131
+#: tips:206
 msgid "Show per workspace"
 msgstr "只顯示當前工作區"
 
-#: tips:132
+#: tips:207
 msgid ""
 "If this option is on, the filer will only show iconified windows associated "
 "with the current workspace."
 msgstr "打開此選項，ROX-Filer 只會顯示當前工作區內的已圖示化(或最小化)窗口"
 
-#: tips:133
+#: tips:208
 msgid "Iconify to the"
 msgstr "圖示化後置於"
 
-#: tips:134
+#: tips:209
 msgid "top-left"
 msgstr "左上"
 
-#: tips:135
+#: tips:210
 msgid "top-right"
 msgstr "右上"
 
-#: tips:136
+#: tips:211
 msgid "bottom-left"
 msgstr "左下"
 
-#: tips:137
+#: tips:212
 msgid "bottom-right"
 msgstr "右下"
 
-#: tips:138
+#: tips:213
 msgid ", going"
 msgstr ", 排列"
 
-#: tips:139
+#: tips:214
 msgid "horizontally"
 msgstr "平面"
 
-#: tips:140
+#: tips:215
 msgid "vertically"
 msgstr "垂直"
 
-#: tips:141
+#: tips:216
 msgid ""
 "Sometimes the filer doesn't know about your desktop furniture and puts "
 "iconified windows under (for example) the Gnome panel. You can define a top "
@@ -3964,43 +4660,43 @@ msgstr ""
 "ROX-Filer 可能會忽略您的桌面環境佈局，而將圖示化窗口放到(例如)Gnome面板上，您"
 "可定義一個最頂或最底的邊沿設置，以防止圖示被放到這處"
 
-#: tips:142
+#: tips:217
 msgid "Top margin"
 msgstr "頂端邊沿"
 
-#: tips:143
+#: tips:218
 msgid "Height of no-go area at top of screen."
 msgstr "螢幕頂端至不擺放區的高度"
 
-#: tips:144
+#: tips:219
 msgid "Bottom margin"
 msgstr "底端邊沿"
 
-#: tips:145
+#: tips:220
 msgid "Height of no-go area at bottom of screen."
 msgstr "螢幕底端至不擺放區的高度"
 
-#: tips:146
+#: tips:221
 msgid "Left margin"
 msgstr "左邊沿"
 
-#: tips:147
+#: tips:222
 msgid "Width of no-go area at left of screen."
 msgstr "螢幕左邊至不擺放區的寬度"
 
-#: tips:148
+#: tips:223
 msgid "Right margin"
 msgstr "右邊沿"
 
-#: tips:149
+#: tips:224
 msgid "Width of no-go area at right of screen."
 msgstr "螢幕右邊至不擺放區的寬度"
 
-#: tips:150
+#: tips:225
 msgid "Desktop"
 msgstr "桌面配置"
 
-#: tips:151
+#: tips:226
 msgid ""
 "When run by a session manager program (such as ROX-Session) the filer can "
 "open up a panel and/or the pinboard.  Here you configure which."
@@ -4008,153 +4704,157 @@ msgstr ""
 "在執行 session 管理員(如：ROX-Session)時，ROX-Filer 會啟動其面板和桌面。您可"
 "在這處進行設定."
 
-#: tips:152
+#: tips:227
 msgid "Panel only"
 msgstr "載入面板"
 
-#: tips:153
+#: tips:228
 msgid "Only a panel is shown."
 msgstr "只顯示載入的面板"
 
-#: tips:154
+#: tips:229
 msgid "Pinboard only"
 msgstr "載入桌面"
 
-#: tips:155
+#: tips:230
 msgid "Only the pinboard is shown."
 msgstr "只顯示載入的桌面"
 
-#: tips:156
+#: tips:231
 msgid "Panel and pinboard"
 msgstr "載入面板及桌面"
 
-#: tips:157
+#: tips:232
 msgid "Both a panel and a pinboard are shown."
 msgstr "面板及桌面同時載入"
 
-#: tips:159
+#: tips:234
 msgid "Enter the name of the pinboard to show here."
 msgstr "在此輸入桌面名稱"
 
-#: tips:160
-msgid "Panel (obsolete)"
-msgstr "面板(廢棄)"
-
-#: tips:161
-msgid ""
-"Enter the name of the panel to show here. This option is now only used when "
-"upgrading from an old version."
-msgstr "鍵入要顯示的面板名稱。此選項只適用於從舊版本升級的 ROX-Filer"
-
-#: tips:162
+#: tips:235
 msgid "Changes here take effect the next time the filer is run."
 msgstr "改變會在下次 ROX-Filer 啟動時生效"
 
-#: tips:163
+#: tips:236
+#, fuzzy
 msgid ""
-"The session manager activates these options by using the -S or --rox-session "
-"argument to rox."
+"The session manager activates these options by\n"
+"using the -S or --rox-session argument to rox."
 msgstr ""
 "Session 管理器，可在啟動 rox 時加入 -S 或 --rox-session 這些參數來開啟此功"
 "能。"
 
-#: tips:164
+#: tips:237
 msgid "Action windows"
 msgstr "程序診斷窗口"
 
-#: tips:165
+#: tips:238
 msgid ""
 "Action windows appear when you start a background\n"
 "operation, such as copying or deleting some files."
 msgstr "程序診斷窗口會在你執行一些程序，如複製或刪除檔案時自動出現."
 
-#: tips:166
+#: tips:239
 msgid "Auto-start (Quiet) these actions"
 msgstr "自動開啟 (關閉) 診斷這些程序"
 
-#: tips:168
+#: tips:241
 msgid "Copy files without confirming first."
 msgstr "複製檔案而無須先被確認"
 
-#: tips:170
+#: tips:243
 msgid "Move files without confirming first."
 msgstr "移動檔案而無須先被確認"
 
-#: tips:172
+#: tips:245
 msgid "Create links to files without confirming first."
 msgstr "連結檔案而無須先被確認"
 
-#: tips:174
+#: tips:247
 msgid "Delete files without confirming first."
 msgstr "刪除檔案而無須先被確認"
 
-#: tips:175
+#: tips:248
 msgid "Mount"
 msgstr "掛載"
 
-#: tips:176
+#: tips:249
 msgid "Mount and unmount filesystems without confirming first."
 msgstr "掛載檔案而無須先被確認"
 
-#: tips:177
+#: tips:250
 msgid "Default settings"
 msgstr "默認設定"
 
-#: tips:179
+#: tips:251
+#, fuzzy
+msgid "Force Del"
+msgstr "強制"
+
+#: tips:252
 msgid "Don't confirm deletion of non-writeable items."
 msgstr "不確認刪除唯讀項目"
 
-#: tips:181
+#: tips:254
 msgid "Don't display so much information in the message area."
 msgstr "簡化訊息框內資料"
 
-#: tips:183
+#: tips:256
 msgid "Also change contents of subdirectories."
 msgstr "同樣改變子目錄內容"
 
-#: tips:186
+#: tips:263
 msgid "Mount commands"
 msgstr "掛載指令"
 
-#: tips:187
+#: tips:264
 msgid "Mount command"
 msgstr "掛載指令"
 
-#: tips:188
+#: tips:265
 msgid "The command used to mount a filesystem. If unsure, use \"mount\"."
 msgstr "用以掛載檔字系統的指令。一般為 \"mount\". "
 
-#: tips:189
+#: tips:266
 msgid "Unmount command"
 msgstr "解除掛載指令"
 
-#: tips:190
+#: tips:267
 msgid ""
 "The command used to unmount a filesystem. If unsure, use \"umount\" (yes, "
 "without the first \"n\")."
 msgstr "用以掛載檔字系統的指令。一般為 \"umount\". "
 
-#: tips:191
+#: tips:268
 msgid "Eject command"
 msgstr "褪出光碟指令"
 
-#: tips:192
+#: tips:269
 msgid "The command used to eject removable media. If unsure, use \"eject\"."
 msgstr "用以褪出可移除媒體的指令。一般為 \"eject\". "
 
-#: tips:193
+#: tips:270
+msgid "Wink"
+msgstr ""
+
+#: tips:271
+msgid "Wink last move/copy/linked item"
+msgstr ""
+
+#: tips:272
 msgid "Drag and Drop"
 msgstr "滑鼠拖放"
 
-#: tips:194
+#: tips:273
 msgid "Dragging to icons"
 msgstr "拖放圖示"
 
-#: tips:195
+#: tips:274
 msgid "Allow dragging to icons in filer windows"
 msgstr "容許在窗口間拖放圖示"
 
-#: tips:196
+#: tips:275
 msgid ""
 "When this is on you can drag a file over a sub-directory or program in a "
 "filer window. The item will highlight when you do this and dropping the file "
@@ -4163,11 +4863,11 @@ msgstr ""
 "選項開啟後你可將檔案在子目錄或程式上拖放，該項目會被加亮並拖放進你指定的目錄"
 "內，或在你拖進的程式內執行."
 
-#: tips:197
+#: tips:276
 msgid "Directories spring open"
 msgstr "目錄彈出並開啟"
 
-#: tips:198
+#: tips:277
 msgid ""
 "This option, which requires the above option to be turned on too, causes the "
 "highlighted directory to 'spring open' after the file is held over it for a "
@@ -4176,15 +4876,15 @@ msgstr ""
 "此選項必須連帶上一個選項同時開啟，在指向加亮的目錄時，使它在按著滑鼠一段短時"
 "間內自動開啟."
 
-#: tips:199
+#: tips:278
 msgid "Spring delay:"
 msgstr "彈出延遲:"
 
-#: tips:200
+#: tips:279
 msgid "ms"
 msgstr "微秒"
 
-#: tips:201
+#: tips:280
 msgid ""
 "This option sets how long, in ms, you must hold a file over a directory "
 "before it will spring open. The above option must be turned on for this to "
@@ -4193,43 +4893,43 @@ msgstr ""
 "此選項是用作是設定：你在加亮的目錄上按著滑鼠而引發該目錄被自動開啟的延遲時"
 "間，並會以 ms 微秒來計算"
 
-#: tips:202
+#: tips:281
 msgid "When dragging files with the left mouse button"
 msgstr "以滑鼠左鍵拖放"
 
-#: tips:203 tips:207
+#: tips:282 tips:286
 msgid "Show a menu of possible actions"
 msgstr "顯示一個可用動作的選單"
 
-#: tips:204
+#: tips:283
 msgid "Copy the files"
 msgstr "複製檔案"
 
-#: tips:205
+#: tips:284
 msgid ""
 "Note that you can still get the menu to appear, by dragging with Alt held "
 "down."
 msgstr "注意，如想選單再出現，可按著左鍵並同時按下鍵盤上的 Alt 鍵"
 
-#: tips:206
+#: tips:285
 msgid "When dragging files with the middle mouse button"
 msgstr "當以滑鼠中鍵拖放"
 
-#: tips:208
+#: tips:287
 msgid "Move the files"
 msgstr "移動檔案"
 
-#: tips:209
+#: tips:288
 msgid ""
 "Note that you can still get the menu to appear, by dragging with the left "
 "button and holding down the Alt key."
 msgstr "注意，如想選單再出現，可按著左鍵並同時按下鍵盤上的 Alt 鍵"
 
-#: tips:210
+#: tips:289
 msgid "Download handler"
 msgstr "下載處理員"
 
-#: tips:211
+#: tips:290
 msgid ""
 "When you drag a file from a web browser or other remote source, this program "
 "will be run to download it. $1 is the URI dragged to the filer, and the "
@@ -4241,57 +4941,61 @@ msgstr ""
 "如:\n"
 "xterm -e wget $1"
 
-#: tips:212
+#: tips:291
 msgid "Menus"
 msgstr "選單"
 
-#: tips:214
+#: tips:293
 msgid "Size of icons in menus:"
 msgstr "選單上的圖示大小:"
 
-#: tips:215
+#: tips:294
 msgid "No Icons"
 msgstr "沒有圖示"
 
-#: tips:218
+#: tips:297
 msgid "Same as current window"
 msgstr "跟現行窗口相同"
 
-#: tips:219
+#: tips:298
 msgid "Same as default"
 msgstr "跟預設值相同"
 
-#: tips:220
+#: tips:299
 msgid "Behaviour"
 msgstr "行為"
 
-#: tips:221
+#: tips:300
 msgid "File menu on right-click"
 msgstr "右擊為檔案選單"
 
-#: tips:222
+#: tips:301
 msgid ""
 "Show the File menu instead of the main menu when right-clicking with files "
 "selected (the main menu can be accessed by holding down Control)."
 msgstr "當右擊時以檔案選單代替主選單顯示，(如想顯示主選單請按下Control 鍵)."
 
-#: tips:223
+#: tips:302
 msgid "Terminal emulator program"
 msgstr "“終端機”程式"
 
-#: tips:224
+#: tips:303
 msgid "The program to launch when you choose `Terminal Here' from the menu."
 msgstr "當你從選單選擇“終端機”這程式將被啟動"
 
-#: tips:225
+#: tips:304
 msgid "Keyboard shortcuts"
 msgstr "熱鍵"
 
-#: tips:227
+#: tips:305
+msgid "Types"
+msgstr "類型"
+
+#: tips:306
 msgid "MIME types"
 msgstr "MIME 類型"
 
-#: tips:228
+#: tips:307
 msgid ""
 "The filer uses a set of rules to work out the correct MIME type for each "
 "regular file, and then chooses a suitable icon for that type."
@@ -4299,23 +5003,23 @@ msgstr ""
 "ROX-Filer是以一眾既定規則來對應正確 MIME 類型，並會為每一常規檔案的類型，配置"
 "一個合適的圖示。"
 
-#: tips:229
+#: tips:308
 msgid "Edit MIME rules"
 msgstr "編輯 MIME 規則"
 
-#: tips:230
+#: tips:309
 msgid "Themes"
 msgstr "佈景"
 
-#: tips:231
+#: tips:310
 msgid "Icon theme"
 msgstr "圖示佈景"
 
-#: tips:232
+#: tips:311
 msgid "Themes should be placed inside the ~/.icons directory."
 msgstr "圖示佈景必須放進 ~/.icons 目錄內."
 
-#: tips:233
+#: tips:312
 msgid ""
 "Use the 'Set Icon...' dialog box to set the icon for each MIME type. Note "
 "that icons set this way override those from the selected theme."
@@ -4323,87 +5027,115 @@ msgstr ""
 "請以“設定圖示...”對話框來設定圖示的 MIME 類型.注意，此設定會覆寫圖示佈景的設"
 "定."
 
-#: tips:234
+#: tips:313
 msgid "Colours"
 msgstr "顏色"
 
-#: tips:235
+#: tips:314
 msgid "File type colours"
 msgstr "檔案類型顏色"
 
-#: tips:236
+#: tips:315
 msgid "Colour files based on their types"
 msgstr "基於檔案類型配色"
 
-#: tips:237
+#: tips:316
 msgid "Filenames (and details) are coloured according to the file's type."
 msgstr "檔案名稱(及詳述)會根據它的類型而配色"
 
-#: tips:238
+#: tips:317
 msgid "Directory:"
 msgstr "目錄："
 
-#: tips:239
+#: tips:318
 msgid "Regular file:"
 msgstr "常規檔："
 
-#: tips:240
+#: tips:319
 msgid "Pipe:"
 msgstr "管導："
 
-#: tips:241
+#: tips:320
 msgid "Socket:"
 msgstr "套節："
 
-#: tips:243
+#: tips:322
 msgid ""
 "Error, such as a symlink which points to a non-existant file, or a file "
 "which the filer does not have permission to examine."
 msgstr "錯誤，此連結所指向的是一個不存在或你的權限不足以查看的檔案."
 
-#: tips:244
+#: tips:323
 msgid "Character device:"
 msgstr "字符設備："
 
-#: tips:245
+#: tips:324
 msgid "Block device:"
 msgstr "區塊設備："
 
-#: tips:246
+#: tips:325
 msgid "Door:"
 msgstr "入口："
 
-#: tips:247
+#: tips:326
 msgid ""
 "Door files are a bit like sockets or pipes, and have only been seen on "
 "Solaris."
 msgstr "類似套節或管導的單元檔案，只會用於 Solaris."
 
-#: tips:248
+#: tips:327
 msgid "Executable file:"
 msgstr "可執行檔："
 
-#: tips:249
+#: tips:328
 msgid "Application directory:"
 msgstr "應用程式目錄："
 
-#: tips:250
+#: tips:329
 msgid "Unknown type:"
 msgstr "不明類型："
 
-#: tips:251
+#: tips:330
+#, fuzzy
+msgid "Background colour"
+msgstr "背景："
+
+#: tips:331
+#, fuzzy
+msgid "Use custom background colour:"
+msgstr "自定字型："
+
+#: tips:332
+msgid "Transparency:"
+msgstr ""
+
+#: tips:334
+msgid ""
+"This depends on your environment. Basically if your windows have shadows, "
+"then they can also be transparent."
+msgstr ""
+
+#: tips:335
 msgid "Compatibility"
 msgstr "相容性"
 
-#: tips:252
+#: tips:336
+msgid "Command line program"
+msgstr ""
+
+#: tips:337
+msgid "Make script"
+msgstr ""
+
+#: tips:338
 msgid "Window manager problems"
 msgstr "窗口管理員問題"
 
-#: tips:253
+#: tips:339
 msgid "Override window manager control of the pinboard and panels"
 msgstr "取代窗口管理員對桌面及面板的控制權"
 
-#: tips:254
+#: tips:340
 msgid ""
 "Some window managers don't support the new Extended Window Manager Hints "
 "system, and so treat the pinboard and panels like normal windows. Turn this "
@@ -4412,11 +5144,11 @@ msgid ""
 "them appear in window-select lists."
 msgstr "某些窗口管理員不支援伸延提示功能，此選項可解決相應問題"
 
-#: tips:255
+#: tips:341
 msgid "Pass all backdrop mouse clicks to window manager"
 msgstr "將桌面滑鼠功能交給窗口管理員"
 
-#: tips:256
+#: tips:342
 msgid ""
 "Normally, right clicking on the desktop background will open the pinboard "
 "menu and left clicking will clear the selection. Turn this on to forward the "
@@ -4425,11 +5157,11 @@ msgstr ""
 "在桌面背景上，啟用窗口管理員所附帶之滑鼠功能，但對桌面上的圖示，仍由 ROX-"
 "Filer 管理. "
 
-#: tips:257
+#: tips:343
 msgid "Blackbox root menus hack"
 msgstr "Blackbox 根選單改良"
 
-#: tips:258
+#: tips:344
 msgid ""
 "Blackbox, Fluxbox and similar window managers do not yet work well with the "
 "ROX-Filer pinboard. This option enables some workarounds. These window "
@@ -4439,11 +5171,11 @@ msgstr ""
 "Blackbox, Fluxbox 及某些窗口管理員不支援 ROX-Filer 桌面功能，點選此處可解決這"
 "些問題；但新版本的窗口管理員，已無須這個選項."
 
-#: tips:259
+#: tips:345
 msgid "Panel is a 'dock'"
 msgstr "面板是 'dock'"
 
-#: tips:260
+#: tips:346
 msgid ""
 "Makes sure panels stay against screen edges. Disable this option if the "
 "panel stays above other windows against your wishes. Requires a restart to "
@@ -4452,11 +5184,11 @@ msgstr ""
 "請先確定面板置放在螢幕的邊沿。假如您不想面板覆蓋在窗口上，關閉選項，並重新啟"
 "動。"
 
-#: tips:261
+#: tips:347
 msgid "Panel stays on top"
 msgstr "面板置上"
 
-#: tips:262
+#: tips:348
 msgid ""
 "Keeps the panel above other windows. Enable this option to make sure the "
 "dock option works correctly in some versions of compiz. May require a "
@@ -4464,15 +5196,25 @@ msgid ""
 msgstr ""
 "面板可覆蓋窗口，請注意有些 compiz 的版本未必可正確運行。或須要重新啟動。"
 
-#: tips:263
+#: tips:349
+msgid "Panel confined to work area"
+msgstr ""
+
+#: tips:350
+msgid ""
+"Keeps the panel confined to the work area specified by the Extended Window "
+"Manager Specification. Applies to new panels."
+msgstr ""
+
+#: tips:351
 msgid "Drag and drop"
 msgstr "滑鼠拖放"
 
-#: tips:264
+#: tips:352
 msgid "Don't use hostnames"
 msgstr "不用主機名稱"
 
-#: tips:265
+#: tips:353
 msgid ""
 "Some older applications don't support XDND fully and may need to have this "
 "option turned on. Use this if dragging files to an application shows a + "
@@ -4481,15 +5223,11 @@ msgstr ""
 "某些舊的應用程式不完全支援拖放來執行的功能，此選項便須要開啟，以達致將檔案拖"
 "到當鼠標出現 a + 符號的應用程式上."
 
-#: tips:266
-msgid "Extended attributes"
-msgstr "伸延屬性"
-
-#: tips:267
+#: tips:355
 msgid "Don't use extended attributes"
 msgstr "不用伸延屬性"
 
-#: tips:268
+#: tips:356
 msgid ""
 "This disables the use of extended attributes available in newer operating "
 "systems and file systems.  With this option set the 'Set Type' menu entry is "
@@ -4500,61 +5238,128 @@ msgstr ""
 "'另定類型' 選項亦會解除；MIME 的類別會由檔案名或副檔名決定；訊息窗口亦不會報"
 "告檔案的伸延屬性."
 
-#: ../Templates.glade:7
+#: tips:357
+msgid "Fast width calculating"
+msgstr ""
+
+#: tips:358
+msgid ""
+"If this is on, string width calculations will be faster but less accurate in "
+"Small Icons mode."
+msgstr ""
+
+#: tips:359
+msgid "Purge Dir Cache"
+msgstr ""
+
+#: tips:360
+msgid "Don't check this if you haven't problems with RAM."
+msgstr ""
+
+#: tips:361
+msgid "Take control of window move on auto-resize"
+msgstr ""
+
+#: tips:362
+msgid ""
+"When this is on, rox rather than the window manager, handles window move. "
+"When this is off, pointer warp on auto-move is disabled."
+msgstr ""
+
+#: tips:363
+#, fuzzy
+msgid "Bottom gap:"
+msgstr "底部邊沿"
+
+#: tips:365 tips:368
+msgid ""
+"For the overridden auto-move in the auto-resize and the display settings."
+msgstr ""
+
+#: tips:366
+#, fuzzy
+msgid "Right gap:"
+msgstr "右部邊沿"
+
+#: tips:369
+msgid "Disable pointer warp"
+msgstr ""
+
+#: tips:370
+msgid ""
+"Check this if you don't want your mouse pointer to be moved on window shrink/"
+"auto-move."
+msgstr ""
+
+#: ../Templates.ui.h:1
 msgid "ROX-Filer log viewer"
 msgstr "ROX-Filer 操作記錄"
 
-#: ../Templates.glade:22
+#: ../Templates.ui.h:2
 msgid "Recently performed actions..."
 msgstr "曾經執行過的操作..."
 
-#: ../Templates.glade:77
+#: ../Templates.ui.h:3
 msgid "Open Directory"
 msgstr "打開目錄"
 
-#: ../Templates.glade:129
+#: ../Templates.ui.h:4
 msgid "Panel Options"
 msgstr "面板選項"
 
-#: ../Templates.glade:169
-msgid "Every icon on this panel is shown with an image and some text."
-msgstr "面板上每個圖示均顯示圖像及文字"
-
-#: ../Templates.glade:170
+#: ../Templates.ui.h:5
 msgid "Image and Text"
 msgstr "圖像及文字"
 
-#: ../Templates.glade:186
+#: ../Templates.ui.h:6
+msgid "Every icon on this panel is shown with an image and some text."
+msgstr "面板上每個圖示均顯示圖像及文字"
+
+#: ../Templates.ui.h:7
+msgid "Image only for applications"
+msgstr "程式檔只顯示圖像"
+
+#: ../Templates.ui.h:8
 msgid ""
 "Applications in this panel have just an image, everything else has both an "
 "image and text."
 msgstr "程式檔只以圖像表達，其他的檔案則有圖像及文字敘述."
 
-#: ../Templates.glade:187
-msgid "Image only for applications"
-msgstr "程式檔只顯示圖像"
-
-#: ../Templates.glade:205
-msgid "Only the image is shown for icons in this panel."
-msgstr "面板圖示只顯示該圖像"
-
-#: ../Templates.glade:206
+#: ../Templates.ui.h:9
 msgid "Image only"
 msgstr "只顯示圖像"
 
-#: ../Templates.glade:235
+#: ../Templates.ui.h:10
+msgid "Only the image is shown for icons in this panel."
+msgstr "面板圖示只顯示該圖像"
+
+#: ../Templates.ui.h:11
 msgid "Panel width"
 msgstr "面板寬度"
 
-#: ../Templates.glade:247
+#: ../Templates.ui.h:12
 msgid "The size of this panel."
 msgstr "面板的大小"
 
-#: ../Templates.glade:259
+#: ../Templates.ui.h:13
 msgid "px"
 msgstr "px(像素)"
 
-#: ../Templates.glade:278
+#: ../Templates.ui.h:14
+msgid "Transparency"
+msgstr ""
+
+#: ../Templates.ui.h:15
+msgid ""
+"This depends on your environment. Basically if your windows had shadows, "
+"then you'll get transparent view."
+msgstr ""
+
+#: ../Templates.ui.h:18
+msgid "Do not cover panel"
+msgstr "不覆蓋面板"
+
+#: ../Templates.ui.h:19
 msgid ""
 "Ask the window manager not to cover this panel when maximising windows, "
 "otherwise leave just 2 pixels at the edge of the screen to allow auto-"
@@ -4563,15 +5368,15 @@ msgstr ""
 "要在窗口最大化時，不覆蓋面板，反之，螢幕只會留下 2 像素的微小區域以自動提升，"
 "但某些窗口管理器會忽略此設定。"
 
-#: ../Templates.glade:279
-msgid "Do not cover panel"
-msgstr "不覆蓋面板"
-
-#: ../Templates.glade:297
+#: ../Templates.ui.h:20
 msgid "<b>Panel style</b>"
 msgstr "<b>面板風格</b>"
 
-#: ../Templates.glade:331
+#: ../Templates.ui.h:21
+msgid "Confine to Xinerama monitor"
+msgstr "區限多螢幕顯示器"
+
+#: ../Templates.ui.h:22
 msgid ""
 "If you use multiple monitors with Xinerama, use this option to confine the "
 "panel to one monitor."
@@ -4579,39 +5384,104 @@ msgstr ""
 "假如您在 Xorg 設定了 Xinerama(多螢幕功能)，便可在此區限面板被放到某個顯示器"
 "上."
 
-#: ../Templates.glade:332
-msgid "Confine to Xinerama monitor"
-msgstr "區限多螢幕顯示器"
-
-#: ../Templates.glade:347
+#: ../Templates.ui.h:23
 msgid ""
 "The monitor this panel is confined to when using Xinerama. The numbering "
 "starts from zero."
 msgstr "面板在多螢幕顯示時的顯示器。(數目從 0開始)."
 
-#: ../Templates.glade:372
+#: ../Templates.ui.h:24
 msgid "<b>Xinerama</b>"
 msgstr "<b>多螢幕功能</b>"
 
-#: ../Templates.glade:407
+#: ../Templates.ui.h:25
 msgid "Right edge"
 msgstr "右部邊沿"
 
-#: ../Templates.glade:426
+#: ../Templates.ui.h:26
 msgid "Left edge"
 msgstr "左部邊沿"
 
-#: ../Templates.glade:443
+#: ../Templates.ui.h:27
 msgid "Bottom edge"
 msgstr "底部邊沿"
 
-#: ../Templates.glade:462
+#: ../Templates.ui.h:28
 msgid "Top edge"
 msgstr "頂部邊沿"
 
-#: ../Templates.glade:496
+#: ../Templates.ui.h:29
 msgid "<b>Position</b>"
 msgstr "<b>位置</b>"
+
+#~ msgid "<dir>"
+#~ msgstr "<目錄>"
+
+#~ msgid "?'%s' already exists - overwrite?"
+#~ msgstr "?'%s' 檔案已存在-覆蓋?"
+
+#~ msgid ""
+#~ "Error scanning '%s':\n"
+#~ "%s"
+#~ msgstr ""
+#~ "錯誤檢視 '%s'：\n"
+#~ "%s"
+
+#~ msgid "Directory missing/deleted"
+#~ msgstr "目錄已刪除/或不存在"
+
+#~ msgid "Directory '%s' is not accessible"
+#~ msgstr "目錄 '%s' 不接受存取"
+
+#~ msgid "Directory '%s' not found."
+#~ msgstr "找不到目錄 '%s' "
+
+#~ msgid "Cancel"
+#~ msgstr "取消"
+
+#~ msgid "You should Shift+Menu click over a file to send it somewhere"
+#~ msgstr "你可用滑鼠在檔案上點擊選單，並同時按下Shift鍵，開啟`傳送至'功能"
+
+#~ msgid "B"
+#~ msgstr "B"
+
+#~ msgid "Change to parent directory"
+#~ msgstr "往上一目錄"
+
+#~ msgid "Change to home directory"
+#~ msgstr "移至家目錄"
+
+#~ msgid "Bookmarks"
+#~ msgstr "書簽"
+
+#~ msgid "Bookmarks menu"
+#~ msgstr "書簽選單"
+
+#~ msgid "Rescan directory contents"
+#~ msgstr "重新檢視內容"
+
+#~ msgid "Change icon size"
+#~ msgstr "改變圖示大小"
+
+#~ msgid "Show extra details"
+#~ msgstr "更詳述"
+
+#~ msgid "Hidden"
+#~ msgstr "隱藏"
+
+#~ msgid "Change at:"
+#~ msgstr "改變於："
+
+#~ msgid "Max width (Large icons):"
+#~ msgstr "最大寬度 (大圖示)："
+
+#~ msgid "Panel (obsolete)"
+#~ msgstr "面板(廢棄)"
+
+#~ msgid ""
+#~ "Enter the name of the panel to show here. This option is now only used "
+#~ "when upgrading from an old version."
+#~ msgstr "鍵入要顯示的面板名稱。此選項只適用於從舊版本升級的 ROX-Filer"
 
 #~ msgid "(thick)"
 #~ msgstr "(厚)"


### PR DESCRIPTION
I just noticed that **src/po/update-po** script no longer works and doesn't actually update *.po files.
It's becasue of the use of non-ASCII characters like these in display.c:

```
"Current size:\n"
"  ┘ : Huge\n"
"  ┤ : Large\n"
"  ┐ : Small\n"
"  ┌, ├ : Auto"
```

The fix is to use `--from-code=UTF-8`.
I also updated all *.po files.
