### PR TITLE
save resources by checking if .hidden file exists

### DIFF
--- a/ROX-Filer/src/filer.c
+++ b/ROX-Filer/src/filer.c
@@ -3946,6 +3946,24 @@ static inline gboolean is_hidden(const char *dir, DirItem *item)
 	 * which contains a list of items to hide in a given directory
 	*/
 	if (o_enable_dot_hidden_file.int_value) {
+		static gchar *prev_dir = NULL;
+		static gboolean dot_hidden_file_exists = FALSE;
+		gchar *dot_hidden_path;
+
+		/* If current dir != previous dir, check if the .hidden file exists
+		 * and bail out early if not, to save resources.
+		 * If current dir == previous dir, no need to check, reuse the previous
+		 * value of the static dot_hidden_file_exists variable.
+		 */
+		if (g_strcmp0(prev_dir, dir) != 0) {
+			if(prev_dir) g_free(prev_dir);
+			prev_dir = g_strdup(dir);
+			dot_hidden_path = g_build_filename(dir, ".hidden", NULL);
+			dot_hidden_file_exists = g_file_test(dot_hidden_path, G_FILE_TEST_IS_REGULAR);
+			g_free(dot_hidden_path);
+		}
+		if (!dot_hidden_file_exists) return FALSE;
+
 		gchar		*path;
 		GFile		*file = NULL;
 		GFileInfo	*info = NULL;


### PR DESCRIPTION
I noticed that when I have "Enable .hidden file" option enabled and there's some substantial I/O load on my external WD drive (USB 2.0), accessing a directory on it with ~650 items takes noticeably longer than usual or with ".hidden" option disabled. And there's no .hidden file anywhere on that drive.
I think it's because g_file_query_info/g_file_info_get_is_hidden are requiring/producing additional I/O load for each and every file and it's completely unnecessary if there's no .hidden file to begin with.
So, I've added a test to check whether .hidden file exists in currently processed directory, before proceeding with the above.
Additionaly, the check is done only when the current directory is different than the previous one, so it happens only once for a given dir.

I've been running it for a couple of days doing similar things as before and the difference is noticeable - when I'm copying a large file to that drive and try to enter that dir with ~650 items, it doesn't take 5-10 seconds anymore, but is almost instantaneous.
It also feels a little snappier for other dirs.

I think the patch itself is relatively "ok" (that's the best I could come up with, anyway), but of course I'll leave the final judgement to you.