### PR TITLE
thumbnail_program(): return path only if executable

### DIFF
--- a/ROX-Filer/src/pixmaps.c
+++ b/ROX-Filer/src/pixmaps.c
@@ -709,15 +709,19 @@ static gchar *thumbnail_program(MIME_type *type)
 	leaf = g_strconcat(type->media_type, "_", type->subtype, NULL);
 	path = choices_find_xdg_path_load(leaf, "MIME-thumb", SITE);
 	g_free(leaf);
-	if (path)
+	if (path && g_file_test(path, G_FILE_TEST_IS_EXECUTABLE))
 	{
 		return path;
 	}
 
 	path = choices_find_xdg_path_load(type->media_type, "MIME-thumb",
 					  SITE);
-
-	return path;
+	if (path && g_file_test(path, G_FILE_TEST_IS_EXECUTABLE))
+	{
+		return path;
+	}
+	
+	return NULL;
 }
 
 /* Load path and create the thumbnail


### PR DESCRIPTION
Hey Jun,

There's a minor problem with external thumbnailers.
To reproduce:

1. Create a new thumbnailer script, e.g. for PDFs, named **application_pdf** in _MIME-thumb_ directory:

```
#!/bin/sh
# create thumbnail for PDF
# $1-path to source, $2-path to output, $3-pixel size 

exec pdftocairo -singlefile -scale-to "$3" "$1" -png "${2%.*}"
```

2. Don't make it executable, or make it non-executable, if it already is,
3. Make sure to do "Thumbnails -> Purge thumbnails disk cache",
3. Enter a directory that contains some PDFs and enable Thumbnails,
4. Nothing happens (seemingly), which is expected,
5. Now, make that script executable, re-enter the above direcory and enable Thubmnails,
6. Nothing happens, no thumbnails are being created, which is unexpected.

The problem seems to be that even when the thumbnailer program/script is not executable, ROX still calls it (not generating any thumbnails, though), but what's worse, ROX remembers to not create thumbnails the next time you enter that directory (unless you restart ROX).

Not sure if there's a better way, but the fix that works for me is to simply check if the _thumbnail_program_ is actually executable and only then return its path.