### PR TITLE
fix #229

### DIFF
--- a/ROX-Filer/src/minibuffer.c
+++ b/ROX-Filer/src/minibuffer.c
@@ -218,14 +218,14 @@ void minibuffer_show(FilerWindow *filer_window, MiniType mini_type, guint keyval
 			item = cursor.peek(&cursor);
 			pos = 0;
 			if (view_count_selected(filer_window->view) > 0)
-				gtk_entry_set_text(mini, " \"$@\"");
+				gtk_entry_set_text(mini, " \"$@\" ");
 			else if (item)
 			{
 				guchar *escaped;
 				guchar *tmp;
 
 				escaped = shell_escape(item->leafname);
-				tmp = g_strconcat(" ", escaped, NULL);
+				tmp = g_strconcat(" ", escaped, " ", NULL);
 				g_free(escaped);
 				gtk_entry_set_text(mini, tmp);
 				g_free(tmp);
@@ -301,6 +301,7 @@ void minibuffer_add(FilerWindow *filer_window, const gchar *leafname)
 		gtk_editable_insert_text(edit, " ", 1, &pos);
 
 	gtk_editable_insert_text(edit, esc, strlen(esc), &pos);
+	gtk_editable_insert_text(edit, " ", 1, &pos);
 	gtk_editable_set_position(edit, pos);
 
 	g_free(esc);


### PR DESCRIPTION
Pad the item inserted into the minibuffer with a space on both sides.
This fix helps in the following cases:

1. User selects one or more items and starts the minibuffer.
2. Minibuffer is already started and user clicks an item.
3. Minibuffer is already started and ends with a space and user drops
   some items from the same or another window onto the minibuffer.

Comment:
In (3) rox can't directly change dropped items because the drop action
is built into the entry widget therefore rox can't control it. However,
by adding a space _after_ the items that rox can control (1 and 2),
also the usability of drop actions is improved.