### PR TITLE
Fix xattr emblems on files in upperdir when using overlay

### DIFF
--- a/ROX-Filer/src/xtypes.c
+++ b/ROX-Filer/src/xtypes.c
@@ -108,6 +108,7 @@ int xattr_supported(const char *path)
 
 int xattr_have(const char *path)
 {
+	static char buf[128];
 	ssize_t nent;
 
 	RETURN_IF_IGNORED(FALSE);
@@ -116,7 +117,7 @@ int xattr_have(const char *path)
 		return FALSE;
 
 	errno=0;
-	nent=dyn_listxattr(path, NULL, 0);
+	nent=dyn_listxattr(path, buf, sizeof(buf));
 
 	if(nent<0 && errno==ERANGE)
 		return TRUE;


### PR DESCRIPTION
overlay is special, because it uses xattrs for internal stuff. aufs and other file systems don't have this problem, as far as I see.

See https://github.com/puppylinux-woof-CE/rox-filer/pull/8.