### PR TITLE
Make `rox -U file:///path#anchor` open in browser

### DIFF
--- a/ROX-Filer/src/run.c
+++ b/ROX-Filer/src/run.c
@@ -401,7 +401,7 @@ gboolean run_by_uri(const gchar *uri, gchar **errmsg)
 	gboolean retval;
 	gchar *tmp, *tmp2;
 	gchar *scheme;
-	gchar *cmd;
+	gchar *cmd = NULL;
 
 	scheme=get_uri_scheme((EscapedPath *) uri);
 	if(!scheme)
@@ -413,6 +413,23 @@ gboolean run_by_uri(const gchar *uri, gchar **errmsg)
 
 	if(strcmp(scheme, "file")==0) {
 		tmp=get_local_path((EscapedPath *) uri);
+		if(tmp) {
+			if(!g_file_test(tmp, G_FILE_TEST_EXISTS)) {
+				/* is uri a file://...#anchor ? */
+				gchar *p = strchr(tmp, '#');
+				if (p != NULL) {
+					*p = '\0';
+					if(g_file_test(tmp, G_FILE_TEST_EXISTS)) {
+						/* will open uri in browser */
+						g_free(scheme);
+						scheme = g_strdup("http");
+					}
+					*p = '#';
+				}
+			}
+		}
+	}
+	if(strcmp(scheme, "file")==0) {
 		if(tmp) {
 			tmp2=pathdup(tmp);
 			retval=run_by_path(tmp2);


### PR DESCRIPTION
**ROX-Filer before this patch**

(1) open local html file in browser:
* rox /usr/share/doc/app/userguide-en.html
* rox -U file:///usr/share/doc/app/userguide-en.html

(2) soap error:
* rox -U file:///usr/share/doc/app/userguide-en.html#anchor
```xml
<?xml version="1.0"?>
<env:Envelope xmlns:env="http://www.w3.org/2001/12/soap-envelope"><env:Body xmlns:rox="http://rox.sourceforge.net/SOAP/ROX-Filer"><env:Fault xmlns:rpc="http://www.w3.org/2001/12/soap-rpc" xmlns:env="http://www.w3.org/2001/12/soap-envelope"><faultcode>Failed</faultcode><faultstring>/usr/share/doc/app/userguide-en.html#anchor not accessable</faultstring></env:Fault></env:Body></env:Envelope>
```

(3) `delayed_error` "File doesn't exist, or I can't access it":
* rox file:///usr/share/doc/app/userguide-en.html
* rox file:///usr/share/doc/app/userguide-en.html#anchor
* /usr/share/doc/app/userguide-en.html#anchor

**ROX-Filer after this patch**

Case (2) isn't an error anymore: file opens in http browser, which understands the `#anchor` suffix.
No change to case (3), which remains an error.