### PR TITLE
in small-icons view, file size details are moved to the left side of the icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 
 Changes
+
+- **compared to jun7/rox-filer: in small-icons view, file size details**
+  **are now shown at left of the icon instead of at the far right end**
+  
 - **Short cut keys around Copy and Paste are changed**
 
 - https://github.com/jun7/rox-filer/wiki/Changes
@@ -59,3 +63,4 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 Please report any bugs to the [rox-devel mailing list](http://rox.sourceforge.net/desktop/lists).
+

--- a/ROX-Filer/src/display.c
+++ b/ROX-Filer/src/display.c
@@ -1052,7 +1052,17 @@ static char *getdetails(FilerWindow *filer_window,
 //		if (item->base_type != TYPE_DIRECTORY)
 		{
 			if (filer_window->display_style == SMALL_ICONS)
-				buf = g_strdup(format_size_aligned(item->size));
+			{
+				buf = g_strdup(format_size_aligned(item->size)); // 5 chars
+				if (buf[4]==' ') // align right
+				{
+					buf[4]=buf[3];
+					buf[3]=buf[2];
+					buf[2]=buf[1];
+					buf[1]=buf[0];
+					buf[0]=' ';
+				}
+			}
 			else
 				buf = g_strchomp(g_strdup(format_size(item->size)));
 		}

--- a/ROX-Filer/src/filer.c
+++ b/ROX-Filer/src/filer.c
@@ -2188,14 +2188,16 @@ static gint set_font(GtkWidget *widget)
 		g_object_unref(font);
 		g_object_unref(fontb);
 
+		// "█" U+2588 Full Block Unicode Character
+
 		//font height is diffrent between cairo and pango
-		PangoLayout *layout = gtk_widget_create_pango_layout(widget, "|");
+		PangoLayout *layout = gtk_widget_create_pango_layout(widget, "█");
 		pango_layout_get_pixel_size(layout, NULL, &fw_font_height);
 		g_object_unref(layout);
 
 		//monospace for details
 		PangoFontDescription *monospace = pango_font_description_from_string("monospace");
-		layout = gtk_widget_create_pango_layout(widget, "|");
+		layout = gtk_widget_create_pango_layout(widget, "█");
 		pango_layout_set_font_description(layout, monospace);
 		pango_layout_get_pixel_size(layout, &fw_mono_width, &fw_mono_height);
 		g_object_unref(layout);

--- a/ROX-Filer/src/view_collection.c
+++ b/ROX-Filer/src/view_collection.c
@@ -1055,13 +1055,19 @@ static void small_full_template(GdkRectangle *area, CollectionItem *colitem,
 	int icon_dy = 1;
 	int text_dy = 0;
 
+	int detail_alignment;
+
 	if (details_first)
 	{
 		int cursor_x = area->x;
 		details_x = cursor_x; cursor_x += details_width;
 		icon_x = cursor_x; cursor_x += icon_width;
 		text_x = cursor_x; cursor_x += text_width;
-		details_dy = -2; // visually move DETAILS_SIZE upwards to break visual line with item to the left
+		details_dy = -2; // visually move DETAILS_SIZE upwards to break visual text line with item to the left
+		detail_alignment = 2; // aligned at center
+
+		details_dy = 0; // or align boxes at bottom. this might accidentally appear to be the same.
+		detail_alignment = 3; // aligned at bottom
 	}
 	else
 	{
@@ -1070,6 +1076,7 @@ static void small_full_template(GdkRectangle *area, CollectionItem *colitem,
 		text_x = cursor_x; cursor_x += text_width;
 		details_x = cursor_x; cursor_x += details_width;
 		details_dy = 0;
+		detail_alignment = 1; // align text boxes at their top edge. this seems to align their inner text.
 	}
 
 	template->icon.x = icon_x + margin/2;
@@ -1083,7 +1090,18 @@ static void small_full_template(GdkRectangle *area, CollectionItem *colitem,
 	template->leafname.height = view->name_height;
 
 	template->details.x = details_x;
-	template->details.y = area->y + (area->height - template->details.height) / 2 + details_dy;
+	switch (detail_alignment) {
+	case 1: // allign upper^edge^of^details to upper^edge^of^text
+		template->details.y = template->leafname.y;
+		break;
+	case 2: // allign center-of-details to center-of-text
+		template->details.y = area->y + (area->height - template->details.height) / 2 + details_dy;
+		break;
+	case 3: // allign lower_edge_of_details to lower_edge_of_text
+		template->details.y = template->leafname.y + (view->name_height - template->details.height);
+		break;
+	}
+	template->details.y += details_dy;
 }
 
 #define INSIDE(px, py, area, ladj, radj)	\

--- a/ROX-Filer/src/view_collection.c
+++ b/ROX-Filer/src/view_collection.c
@@ -1036,16 +1036,50 @@ static void small_template(GdkRectangle *area, CollectionItem *colitem,
 static void small_full_template(GdkRectangle *area, CollectionItem *colitem,
 			   ViewCollection *view_collection, Template *template)
 {
-	int	col_width = view_collection->collection->item_width;
-	GdkRectangle temparea = *area;
+	bool details_first = (view_collection->filer_window->details_type == DETAILS_SIZE);
 
-	temparea.width = col_width - template->details.width;
+	ViewData *view = (ViewData *) colitem->view_data;
+	int margin = 2;
 
-	small_template(&temparea, colitem, view_collection, template);
+	int total_width = view_collection->collection->item_width;
 
-	template->details.x = area->x + col_width - template->details.width;
-	template->details.y =
-		area->y + area->height / 2 - template->details.height / 2;
+	int details_width = template->details.width;
+	int icon_width = small_width + margin; // icon incl margins
+	int text_width = total_width - details_width - icon_width; // max_text_width
+
+	int details_x;
+	int icon_x;
+	int text_x;
+	int details_dy;
+	if (details_first)
+	{
+		int cursor_x = area->x;
+		details_x = cursor_x; cursor_x += details_width;
+		icon_x = cursor_x; cursor_x += icon_width;
+		text_x = cursor_x; cursor_x += text_width;
+		details_dy = -2; // visually move DETAILS_SIZE upwards to break visual line with item to the left
+	}
+	else
+	{
+		int cursor_x = area->x;
+		icon_x = cursor_x; cursor_x += icon_width;
+		text_x = cursor_x; cursor_x += text_width;
+		details_x = cursor_x; cursor_x += details_width;
+		details_dy = 0;
+	}
+
+	template->icon.x = icon_x + margin/2;
+	template->icon.y = area->y + 1;
+	template->icon.width = icon_width - margin/2;
+	template->icon.height = small_height;
+
+	template->leafname.x = text_x;
+	template->leafname.y = area->y + area->height / 2 - view->name_height / 2;
+	template->leafname.width = MIN(text_width, view->name_width);
+	template->leafname.height = view->name_height;
+
+	template->details.x = details_x;
+	template->details.y = area->y + area->height / 2 - template->details.height / 2 + details_dy;
 }
 
 #define INSIDE(px, py, area, ladj, radj)	\

--- a/ROX-Filer/src/view_collection.c
+++ b/ROX-Filer/src/view_collection.c
@@ -1050,7 +1050,11 @@ static void small_full_template(GdkRectangle *area, CollectionItem *colitem,
 	int details_x;
 	int icon_x;
 	int text_x;
+
 	int details_dy;
+	int icon_dy = 1;
+	int text_dy = 0;
+
 	if (details_first)
 	{
 		int cursor_x = area->x;
@@ -1069,17 +1073,17 @@ static void small_full_template(GdkRectangle *area, CollectionItem *colitem,
 	}
 
 	template->icon.x = icon_x + margin/2;
-	template->icon.y = area->y + 1;
+	template->icon.y = area->y + (area->height - small_height) / 2 + icon_dy;
 	template->icon.width = icon_width - margin/2;
 	template->icon.height = small_height;
 
 	template->leafname.x = text_x;
-	template->leafname.y = area->y + area->height / 2 - view->name_height / 2;
+	template->leafname.y = area->y + (area->height - view->name_height) / 2 + text_dy;
 	template->leafname.width = MIN(text_width, view->name_width);
 	template->leafname.height = view->name_height;
 
 	template->details.x = details_x;
-	template->details.y = area->y + area->height / 2 - template->details.height / 2 + details_dy;
+	template->details.y = area->y + (area->height - template->details.height) / 2 + details_dy;
 }
 
 #define INSIDE(px, py, area, ladj, radj)	\


### PR DESCRIPTION
I mainly use (small-)icon-view with file size detail.
For years, I was not happy with that huge gap between the left-aligned file names on the left and file sizes shown at the far right end. I have changed that today.

- The file size detail is now shown to the left of the icon, other details are still shown at the right end like before.
- The file size detail is moved 2 pixel upwards, in order to break the visual line to its left neighbor item.
- The file size 5-char string is now right-aligned (" 1234" instead of "1234 " for small files).

![rox](https://github.com/jun7/rox-filer/assets/1792779/2f61bad7-d2bc-4649-8981-8b144e866eea)

